### PR TITLE
Use -Prelease convention for release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ After building, Java agent artifacts are located here:
 - Agent: `java_agent/newrelic-agent/build/newrelicJar/newrelic.jar`
 - Agent API: `java_agent/newrelic-api/build/libs/newrelic-api.jar`
 
-#### Agent version
-
-The Java agent version defaults to `6.DEV-SNAPSHOT` for developer builds. You can change this in the `gradle.properties` file. To avoid confusion, we recommend against using version numbers for developer builds that look like production releases.
-
 ## IntelliJ IDEA setup
 
 We recommend using IntelliJ IDEA for development on this project. Configure as follows:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'com.newrelic.agent.java'
-    version = agentVersion
+    version = agentVersion + (project.findProperty("release") == "true" ? "" : "-SNAPSHOT")
 
     idea.module {
         outputDir file('build/classes/main')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # The agent version.
-agentVersion = 6.DEV-SNAPSHOT
+agentVersion=6.0.0
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
tested at the command-line.

```
% rm -fR ~/.m2/repository && ./gradlew publishToMavenLocal && find ~/.m2/repository -type f

> Task :newrelic-agent:javadoc
/Users/jalder/repos/newrelic-java-agent/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeValidator.java:175: warning - @return tag has no arguments.
1 warning

BUILD SUCCESSFUL in 29s
950 actionable tasks: 481 executed, 469 up-to-date
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0-SNAPSHOT/newrelic-agent-6.0.0-SNAPSHOT-javadoc.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0-SNAPSHOT/newrelic-agent-6.0.0-SNAPSHOT-sources.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0-SNAPSHOT/newrelic-agent-6.0.0-SNAPSHOT.pom
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0-SNAPSHOT/maven-metadata-local.xml
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0-SNAPSHOT/newrelic-agent-6.0.0-SNAPSHOT.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/maven-metadata-local.xml
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0-SNAPSHOT/newrelic-api-6.0.0-SNAPSHOT.pom
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0-SNAPSHOT/newrelic-api-6.0.0-SNAPSHOT.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0-SNAPSHOT/newrelic-api-6.0.0-SNAPSHOT-javadoc.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0-SNAPSHOT/newrelic-api-6.0.0-SNAPSHOT-sources.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0-SNAPSHOT/maven-metadata-local.xml
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/maven-metadata-local.xml
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-java/6.0.0-SNAPSHOT/newrelic-java-6.0.0-SNAPSHOT.pom
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-java/6.0.0-SNAPSHOT/newrelic-java-6.0.0-SNAPSHOT.zip
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-java/6.0.0-SNAPSHOT/maven-metadata-local.xml
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-java/maven-metadata-local.xml
jalder@C02YF1WRJG5M newrelic-java-agent % rm -fR ~/.m2/repository && ./gradlew publishToMavenLocal -Prelease=true && find ~/.m2/repository -type f

> Task :newrelic-agent:javadoc
/Users/jalder/repos/newrelic-java-agent/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeValidator.java:175: warning - @return tag has no arguments.
1 warning

BUILD SUCCESSFUL in 27s
950 actionable tasks: 481 executed, 469 up-to-date
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0/newrelic-agent-6.0.0.pom
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0/newrelic-agent-6.0.0-sources.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0/newrelic-agent-6.0.0-javadoc.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/6.0.0/newrelic-agent-6.0.0.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-agent/maven-metadata-local.xml
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0/newrelic-api-6.0.0.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0/newrelic-api-6.0.0.pom
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0/newrelic-api-6.0.0-javadoc.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/6.0.0/newrelic-api-6.0.0-sources.jar
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-api/maven-metadata-local.xml
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-java/6.0.0/newrelic-java-6.0.0.pom
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-java/6.0.0/newrelic-java-6.0.0.zip
/Users/jalder/.m2/repository/com/newrelic/agent/java/newrelic-java/maven-metadata-local.xml
```