### PR TITLE
action to publish release

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,11 +1,12 @@
-name: Test release action
+name: Publish release version explicitly
 
 on:
-  push:
-    branches: [ publish-release ]
+  release:
+    types:
+      - published
 
 jobs:
-  publish_snapshot:
+  publish_release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#12 Adds action to publish release versions

Tested and manually verified the repo contents and repo does `Close` with validation success in sonatype staging.