### PR TITLE
Expose the mbean that contains the linking metadata.

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -16,6 +16,7 @@ import com.newrelic.agent.config.JarResource;
 import com.newrelic.agent.config.JavaVersionUtils;
 import com.newrelic.agent.core.CoreService;
 import com.newrelic.agent.core.CoreServiceImpl;
+import com.newrelic.agent.jmx.LinkingMetadataRegistration;
 import com.newrelic.agent.logging.AgentLogManager;
 import com.newrelic.agent.logging.IAgentLogger;
 import com.newrelic.agent.service.ServiceFactory;
@@ -24,7 +25,6 @@ import com.newrelic.agent.service.ServiceManagerImpl;
 import com.newrelic.agent.stats.StatsService;
 import com.newrelic.agent.stats.StatsWorks;
 import com.newrelic.agent.util.asm.ClassStructure;
-import com.newrelic.api.agent.Logger;
 import com.newrelic.bootstrap.BootstrapLoader;
 import com.newrelic.weave.utils.Streams;
 import org.objectweb.asm.ClassReader;
@@ -167,6 +167,8 @@ public final class Agent {
 
             logAnyFilesFoundInEndorsedDirs();
 
+            registerAgentMBeans();
+
             if (serviceManager.getConfigService().getDefaultAgentConfig().isStartupTimingEnabled()) {
                 recordPremainTime(serviceManager.getStatsService(), startTime);
             }
@@ -197,6 +199,11 @@ public final class Agent {
             t.printStackTrace();
             System.exit(1);
         }
+    }
+
+    private static void registerAgentMBeans() {
+        // This registers the mbean that exposes linking metadata
+        new LinkingMetadataRegistration(LOG).registerLinkingMetadata();
     }
 
     private static boolean tryToInitializeServiceManager(Instrumentation inst) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadata.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadata.java
@@ -1,0 +1,19 @@
+package com.newrelic.agent.jmx;
+
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.Logger;
+import com.newrelic.api.agent.NewRelic;
+
+import java.util.Map;
+import java.util.logging.Level;
+
+public class LinkingMetadata implements LinkingMetadataMBean {
+
+    @Override
+    public Map<String, String> readLinkingMetadata() {
+        Agent agent = NewRelic.getAgent();
+        Logger logger = agent.getLogger();
+        logger.log(Level.INFO, "JmxLinkingMetadata: Fetching linking metadata from the agent...");
+        return agent.getLinkingMetadata();
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadata.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadata.java
@@ -13,7 +13,7 @@ public class LinkingMetadata implements LinkingMetadataMBean {
     public Map<String, String> readLinkingMetadata() {
         Agent agent = NewRelic.getAgent();
         Logger logger = agent.getLogger();
-        logger.log(Level.INFO, "JmxLinkingMetadata: Fetching linking metadata from the agent...");
+        logger.log(Level.INFO, "JMX LinkingMetadata: Fetching linking metadata from the agent...");
         return agent.getLinkingMetadata();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataMBean.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataMBean.java
@@ -1,0 +1,9 @@
+package com.newrelic.agent.jmx;
+
+import java.util.Map;
+
+public interface LinkingMetadataMBean {
+
+    Map<String, String> readLinkingMetadata();
+
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
@@ -1,0 +1,38 @@
+package com.newrelic.agent.jmx;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.newrelic.api.agent.Logger;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.logging.Level;
+
+public class LinkingMetadataRegistration {
+
+    public static final String MBEAN_NAME = "com.newrelic.jfr:type=LinkingMetadata";
+    private final Logger logger;
+
+    public LinkingMetadataRegistration(Logger logger) {
+        this.logger = logger;
+    }
+
+    public void registerLinkingMetadata() {
+        try {
+            MBeanServer server = getMbeanServer();
+            ObjectName name = new ObjectName(MBEAN_NAME);
+            logger.log(Level.INFO, "JMX LinkingMetadata started, registering MBean: " + name);
+            Object bean = new LinkingMetadata();
+            server.registerMBean(bean, name);
+            logger.log(Level.INFO, "JMX LinkingMetadata bean registered");
+        } catch (Exception e) {
+            logger.log(Level.INFO, "Error registering JMX LinkingMetadata MBean", e);
+        }
+    }
+
+    @VisibleForTesting
+    protected MBeanServer getMbeanServer() {
+        return ManagementFactory.getPlatformMBeanServer();
+    }
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/LinkingMetadataRegistrationTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/LinkingMetadataRegistrationTest.java
@@ -1,0 +1,58 @@
+package com.newrelic.agent.jmx;
+
+import com.newrelic.api.agent.Logger;
+import org.junit.Test;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.util.logging.Level;
+
+import static com.newrelic.agent.jmx.LinkingMetadataRegistration.MBEAN_NAME;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LinkingMetadataRegistrationTest {
+
+    @Test
+    public void testRegisterHappyPath() throws Exception {
+        ObjectName name = new ObjectName(MBEAN_NAME);
+        Logger logger = mock(Logger.class);
+        final MBeanServer fakeServer = mock(MBeanServer.class);
+
+        LinkingMetadataRegistration testClass = new LinkingMetadataRegistration(logger) {
+            @Override
+            protected MBeanServer getMbeanServer() {
+                return fakeServer;
+            }
+        };
+
+        testClass.registerLinkingMetadata();
+        verify(fakeServer).registerMBean(isA(LinkingMetadataMBean.class), eq(name));
+    }
+
+    @Test
+    public void testExceptionsAreHandled() throws Exception {
+        ObjectName name = new ObjectName(MBEAN_NAME);
+        RuntimeException exception = new RuntimeException("Bad beans exception");
+
+        Logger logger = mock(Logger.class);
+        final MBeanServer fakeServer = mock(MBeanServer.class);
+        when(fakeServer.registerMBean(isA(LinkingMetadataMBean.class), eq(name))).thenThrow(exception);
+
+        LinkingMetadataRegistration testClass = new LinkingMetadataRegistration(logger) {
+            @Override
+            protected MBeanServer getMbeanServer() {
+                return fakeServer;
+            }
+        };
+
+        testClass.registerLinkingMetadata();
+        //success
+        verify(logger).log(eq(Level.INFO), eq("JmxLinkingMetadata started, registering MBean: com.newrelic.jfr:type=LinkingMetadata"));
+        verify(logger).log(eq(Level.INFO), eq("ERROR REGISTERING JmxLinkingMetadata MBean"), eq(exception));
+    }
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/LinkingMetadataRegistrationTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/LinkingMetadataRegistrationTest.java
@@ -51,8 +51,8 @@ public class LinkingMetadataRegistrationTest {
 
         testClass.registerLinkingMetadata();
         //success
-        verify(logger).log(eq(Level.INFO), eq("JmxLinkingMetadata started, registering MBean: com.newrelic.jfr:type=LinkingMetadata"));
-        verify(logger).log(eq(Level.INFO), eq("ERROR REGISTERING JmxLinkingMetadata MBean"), eq(exception));
+        verify(logger).log(eq(Level.INFO), eq("JMX LinkingMetadata started, registering MBean: com.newrelic.jfr:type=LinkingMetadata"));
+        verify(logger).log(eq(Level.INFO), eq("Error registering JMX LinkingMetadata MBean"), eq(exception));
     }
 
 }


### PR DESCRIPTION
We have a need in JFR to be able to fetch the entity guid from the agent.  This change exposes a new MBean that contains the linking metadata, so that the JFR Daemon may leverage the entity guid.