### PR TITLE
jars end with POC instead of SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ allprojects {
     apply plugin: 'eclipse'
 
     group = 'com.newrelic.agent.java'
-    version = agentVersion + (project.findProperty("release") == "true" ? "" : "-SNAPSHOT")
+    //TODO: "-POC" must not be merged into main. Revert to "-SNAPSHOT"
+    version = agentVersion + (project.findProperty("release") == "true" ? "" : "-POC")
 
     idea.module {
         outputDir file('build/classes/main')

--- a/buildSrc/src/main/java/com/nr/builder/publish/PublishConfig.java
+++ b/buildSrc/src/main/java/com/nr/builder/publish/PublishConfig.java
@@ -59,7 +59,8 @@ public class PublishConfig {
         URI releasesRepoUri = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/");
         URI snapshotsRepoUrl = URI.create("https://oss.sonatype.org/content/repositories/snapshots/");
         repo.setUrl(
-                projectVersion.endsWith("SNAPSHOT")
+                //TODO: "POC" must not be merged into main. Revert to "SNAPSHOT"
+                projectVersion.endsWith("POC")
                         ? snapshotsRepoUrl
                         : releasesRepoUri
         );

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # The agent version.
-agentVersion=attach-1.0.0
+agentVersion=attach
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
The dynamic attach team requested to remove the unique timestamps from the snapshot jars. The timestamps are added by Maven automatically if a jar is published with "SNAPSHOT" as the suffix.

Not sure if this is the right approach.  This changes the jar suffix to "POC".  