### PR TITLE
Remove SSL configuration. The agent hasnt allowed plaintext connectio…

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Deployments.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Deployments.java
@@ -50,7 +50,7 @@ public class Deployments {
 
         String uri = "/deployments.xml";
         String payload = getDeploymentPayload(appName, cmd);
-        String protocol = "http" + (config.isSSL() ? "s" : "");
+        String protocol = "https";
         URL url = new URL(protocol, config.getApiHost(), config.getApiPort(), uri);
 
         System.out.println(MessageFormat.format("Opening connection to {0}:{1}", config.getApiHost(), Integer.toString(config.getApiPort())));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
@@ -157,9 +157,8 @@ public class AgentConfigFactory {
         agentData.remove(COLLECT_SLOW_QUERIES_FROM);
         Object serverRecordSql = agentData.remove(RECORD_SQL);
 
-        // handle high security - ssl needs to stay off and record_sql must stay as obfuscated or off
+        // handle high security - record_sql must stay as obfuscated or off
         if (isHighSecurity(settingsConfig.getProperty(AgentConfigImpl.HIGH_SECURITY))) {
-            agentData.remove(AgentConfigImpl.IS_SSL);
             // check record sql
             if (isValidRecordSqlValue(serverRecordSql)) {
                 addServerProp(RECORD_SQL, serverRecordSql, settings);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ConfigServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ConfigServiceImpl.java
@@ -297,9 +297,9 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService,
 
     private void logIfHighSecurityServerAndLocal(String appName, AgentConfig agentConfig, Map<String, Object> serverData) {
         if (agentConfig.isHighSecurity() && serverData.containsKey(AgentConfigFactory.HIGH_SECURITY)) {
-            String msg = MessageFormat.format("The agent is in high security mode for {0}: {1} setting is \"{2}\". {3} setting is \"{4}\"."
+            String msg = MessageFormat.format("The agent is in high security mode for {0}: {1} setting is \"{2}\"."
                             + " Disabling the collection of request parameters, message queue parameters, and user attributes.", appName,
-                    AgentConfigFactory.RECORD_SQL, agentConfig.getTransactionTracerConfig().getRecordSql(), AgentConfigImpl.IS_SSL, agentConfig.isSSL());
+                    AgentConfigFactory.RECORD_SQL, agentConfig.getTransactionTracerConfig().getRecordSql());
             Agent.LOG.info(msg);
         }
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/DataSenderConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/DataSenderConfig.java
@@ -15,8 +15,6 @@ public interface DataSenderConfig {
 
     int getPort();
 
-    boolean isSSL();
-
     String getInsertApiKey();
 
     boolean isAuditMode();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
@@ -64,7 +64,7 @@ public class DataSenderFactory {
         }
 
         private ApacheHttpClientWrapper buildApacheHttpClientWrapper(DataSenderConfig config, Logger logger) {
-            SSLContext sslContext = ApacheSSLManager.createSSLContext(config.isSSL(), config.getCaBundlePath());
+            SSLContext sslContext = ApacheSSLManager.createSSLContext(config.getCaBundlePath());
 
             ApacheProxyManager proxyManager = new ApacheProxyManager(
                     config.getProxyHost(),

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
@@ -69,6 +69,7 @@ public class DataSenderImpl implements DataSender {
 
     private static final String MODULE_TYPE = "Jars";
     private static final int PROTOCOL_VERSION = 17;
+    private static final String PROTOCOL = "https";
     private static final String BEFORE_LICENSE_KEY_URI_PATTERN = "/agent_listener/invoke_raw_method?method={0}";
     private static final String AFTER_LICENSE_KEY_URI_PATTERN = "&marshal_format=json&protocol_version=";
     private static final String LICENSE_KEY_URI_PATTERN = "&license_key={0}";
@@ -78,7 +79,6 @@ public class DataSenderImpl implements DataSender {
     public static final String GZIP_ENCODING = "gzip";
     private static final String IDENTITY_ENCODING = "identity";
     private static final String EXCEPTION_MAP_RETURN_VALUE_KEY = "return_value";
-    private static final String SSL_KEY = "ssl";
     private static final Object NO_AGENT_RUN_ID = null;
     private static final String NULL_RESPONSE = "null";
     private static final int COMPRESSION_LEVEL = Deflater.DEFAULT_COMPRESSION;
@@ -103,7 +103,7 @@ public class DataSenderImpl implements DataSender {
     private final String originalHost;
     private volatile String redirectHost;
     private final int port;
-    private volatile String protocol;
+
     private volatile boolean auditMode;
     private Set<String> auditModeEndpoints;
     private final IAgentLogger logger;
@@ -132,9 +132,6 @@ public class DataSenderImpl implements DataSender {
         originalHost = config.getHost();
         redirectHost = config.getHost();
         port = config.getPort();
-
-        protocol = config.isSSL() ? "https" : "http";
-        logger.info(MessageFormat.format("Setting protocol to \"{0}\"", protocol));
 
         String licenseKeyUri = MessageFormat.format(LICENSE_KEY_URI_PATTERN, config.getLicenseKey());
         noAgentRunIdUriPattern = BEFORE_LICENSE_KEY_URI_PATTERN + licenseKeyUri + AFTER_LICENSE_KEY_URI_PATTERN + PROTOCOL_VERSION;
@@ -262,11 +259,6 @@ public class DataSenderImpl implements DataSender {
             setAgentRunId(runId);
         } else {
             throw new UnexpectedException(MessageFormat.format("Missing {0} connection parameter", ConnectionResponse.AGENT_RUN_ID_KEY));
-        }
-        Object ssl = data.get(SSL_KEY);
-        if (Boolean.TRUE.equals(ssl)) {
-            logger.info("Setting protocol to \"https\"");
-            protocol = "https";
         }
         configService.setLaspPolicies(policiesJson);
 
@@ -552,7 +544,7 @@ public class DataSenderImpl implements DataSender {
             throw new MaxPayloadException(msg);
         }
 
-        final URL url = new URL(protocol, host, port, uri);
+        final URL url = new URL(PROTOCOL, host, port, uri);
         HttpClientWrapper.Request request = createRequest(method, encoding, url, data);
 
         httpClientWrapper.captureSupportabilityMetrics(ServiceFactory.getStatsService(), host);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheSSLManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheSSLManager.java
@@ -26,10 +26,10 @@ import java.util.LinkedList;
 import java.util.logging.Level;
 
 public class ApacheSSLManager {
-    public static SSLContext createSSLContext(boolean useSSL, String caBundlePath) {
+    public static SSLContext createSSLContext(String caBundlePath) {
         SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
         try {
-            if (useSSL && (caBundlePath != null)) {
+            if (caBundlePath != null) {
                 sslContextBuilder.loadTrustMaterial(getKeyStore(caBundlePath), null);
             }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
@@ -117,7 +117,6 @@ public class RPMServiceTest {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
         map.put("port", https ? MOCK_COLLECTOR_HTTPS_PORT : MOCK_COLLECTOR_HTTP_PORT);
-        map.put("ssl", https);
         map.put("license_key", "deadbeefcafebabe8675309babecafe1beefdead");
         map.put(AgentConfigImpl.APP_NAME, "MyApplication");
         map.put(AgentConfigImpl.LABELS, "one:two;three:four");
@@ -654,7 +653,6 @@ public class RPMServiceTest {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
         map.put("port", MOCK_COLLECTOR_HTTP_PORT);
-        map.put("ssl", false);
         map.put("license_key", "deadbeefcafebabe8675309babecafe1beefdead");
         map.put(AgentConfigImpl.APP_NAME, appName);
         createServiceManager(map);
@@ -667,7 +665,6 @@ public class RPMServiceTest {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
         map.put("port", MOCK_COLLECTOR_HTTP_PORT);
-        map.put("ssl", false);
         map.put("license_key", "deadbeefcafebabe8675309babecafe1beefdead");
         map.put(AgentConfigImpl.PUT_FOR_DATA_SEND_PROPERTY, true);
         map.put(AgentConfigImpl.APP_NAME, appName);
@@ -1093,7 +1090,6 @@ public class RPMServiceTest {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
         map.put("port", MOCK_COLLECTOR_HTTPS_PORT);
-        map.put("ssl", false);
         map.put("license_key", "xxxxxxxxxxxxxxxxxxxxxxxxxxx");
         map.put(AgentConfigImpl.APP_NAME, "MyApplication");
         createServiceManager(map);
@@ -1106,7 +1102,6 @@ public class RPMServiceTest {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
         map.put("port", MOCK_COLLECTOR_HTTPS_PORT);
-        map.put("ssl", false);
         map.put("license_key", "xxxxxxxxxxxxxxxxxxxxxxxxxxx");
         map.put(AgentConfigImpl.APP_NAME, "MyApplication");
         map.put(AgentConfigImpl.PUT_FOR_DATA_SEND_PROPERTY, true);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
@@ -63,7 +63,6 @@ import com.newrelic.agent.transport.HttpError;
 import com.newrelic.agent.transport.IDataSenderFactory;
 import com.newrelic.agent.utilization.UtilizationService;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -87,7 +86,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -116,7 +118,7 @@ public class RPMServiceTest {
     public static Map<String, Object> createStagingMap(boolean https, boolean isHighSec, boolean putForDataSend) {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
-        map.put("port", https ? MOCK_COLLECTOR_HTTPS_PORT : MOCK_COLLECTOR_HTTP_PORT);
+        map.put("port", MOCK_COLLECTOR_HTTPS_PORT);
         map.put("license_key", "deadbeefcafebabe8675309babecafe1beefdead");
         map.put(AgentConfigImpl.APP_NAME, "MyApplication");
         map.put(AgentConfigImpl.LABELS, "one:two;three:four");
@@ -266,11 +268,11 @@ public class RPMServiceTest {
             assertNotNull(settings);
             Map<String, Object> theSettings = (Map<String, Object>) settings;
             // these two properties need to be sent up for rum
-            Assert.assertEquals("rum", theSettings.get("browser_monitoring.loader"));
+            assertEquals("rum", theSettings.get("browser_monitoring.loader"));
             assertNotNull(theSettings.get("browser_monitoring.debug"));
             assertNotNull(values.get("high_security"));
-            Assert.assertFalse((Boolean) values.get("high_security"));
-            Assert.assertEquals(ImmutableMap.of("one", "two", "three", "four"), ((LabelsConfig) values.get("labels")).getLabels());
+            assertFalse((Boolean) values.get("high_security"));
+            assertEquals(ImmutableMap.of("one", "two", "three", "four"), ((LabelsConfig) values.get("labels")).getLabels());
         } finally {
             if (svc != null) {
                 svc.shutdown();
@@ -305,11 +307,11 @@ public class RPMServiceTest {
             assertNotNull(settings);
             Map<String, Object> theSettings = (Map<String, Object>) settings;
             // these two properties need to be sent up for rum
-            Assert.assertEquals("rum", theSettings.get("browser_monitoring.loader"));
+            assertEquals("rum", theSettings.get("browser_monitoring.loader"));
             assertNotNull(theSettings.get("browser_monitoring.debug"));
             assertNotNull(values.get("high_security"));
-            Assert.assertTrue((Boolean) values.get("high_security"));
-            Assert.assertEquals(ImmutableMap.of("one", "two", "three", "four"), ((LabelsConfig) values.get("labels")).getLabels());
+            assertTrue((Boolean) values.get("high_security"));
+            assertEquals(ImmutableMap.of("one", "two", "three", "four"), ((LabelsConfig) values.get("labels")).getLabels());
         } finally {
             if (svc != null) {
                 svc.shutdown();
@@ -346,7 +348,7 @@ public class RPMServiceTest {
         svc.launch();
         List<NormalizationRule> rules = NormalizationRuleFactory.getUrlRules("MyApplication", new NormalizationRuleConfig(data.get()).getUrlRules());
 
-        Assert.assertFalse("We are not getting metric normalization rules!", rules.isEmpty());
+        assertFalse("We are not getting metric normalization rules!", rules.isEmpty());
 
         svc.shutdown();
     }
@@ -384,7 +386,7 @@ public class RPMServiceTest {
         List<String> appNames = singletonList("MyApplication");
         RPMService svc = new RPMService(appNames, null, connectionListener, Collections.<AgentConnectionEstablishedListener>emptyList());
         svc.launch();
-        Assert.assertTrue(connected.get());
+        assertTrue(connected.get());
 
         svc.shutdown();
     }
@@ -442,17 +444,17 @@ public class RPMServiceTest {
         svc.start();
         svc.launch();
 
-        Assert.assertEquals(1L, connectLatch.get().getCount());
-        Assert.assertEquals(2L, shutdownLatch.get().getCount());
+        assertEquals(1L, connectLatch.get().getCount());
+        assertEquals(2L, shutdownLatch.get().getCount());
 
         ServiceFactory.getEnvironmentService().getEnvironment().setServerPort(8080);
         connectLatch.get().await(30, TimeUnit.SECONDS);
 
-        Assert.assertEquals(0L, connectLatch.get().getCount());
-        Assert.assertEquals(1L, shutdownLatch.get().getCount());
+        assertEquals(0L, connectLatch.get().getCount());
+        assertEquals(1L, shutdownLatch.get().getCount());
 
         svc.shutdown();
-        Assert.assertEquals(0L, shutdownLatch.get().getCount());
+        assertEquals(0L, shutdownLatch.get().getCount());
     }
 
     @Test(timeout = 30000)
@@ -475,12 +477,12 @@ public class RPMServiceTest {
         RPMService svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
         svc.launch();
 
-        Assert.assertTrue(ServiceFactory.getTransactionTraceService().isEnabled());
+        assertTrue(ServiceFactory.getTransactionTraceService().isEnabled());
 
         svc.reconnect();
         svc.launch();
 
-        Assert.assertTrue(ServiceFactory.getTransactionTraceService().isEnabled());
+        assertTrue(ServiceFactory.getTransactionTraceService().isEnabled());
 
         svc.shutdown();
     }
@@ -516,13 +518,13 @@ public class RPMServiceTest {
             }
             svc.harvest(harvestStatsEngine);
             Stats stats3 = harvestStatsEngine.getStats(MetricNames.AGENT_METRICS_COUNT);
-            Assert.assertEquals(0, stats3.getCallCount());
+            assertEquals(0, stats3.getCallCount());
 
             ResponseTimeStats stats = harvestStatsEngine.getResponseTimeStats(MetricNames.SUPPORTABILITY_METRIC_HARVEST_TRANSMIT);
-            Assert.assertEquals(1, stats.getCallCount());
-            Assert.assertTrue(stats.getTotal() > 0);
+            assertEquals(1, stats.getCallCount());
+            assertTrue(stats.getTotal() > 0);
             Stats stats2 = harvestStatsEngine.getStats(MetricNames.SUPPORTABILITY_METRIC_HARVEST_COUNT);
-            Assert.assertEquals(1, stats2.getCallCount());
+            assertEquals(1, stats2.getCallCount());
         } finally {
             svc.shutdown();
         }
@@ -569,7 +571,7 @@ public class RPMServiceTest {
             throw e;
         }
 
-        Assert.assertEquals(traces, dataSenderFactory.getLastDataSender().getTraces());
+        assertEquals(traces, dataSenderFactory.getLastDataSender().getTraces());
 
         svc.shutdown();
     }
@@ -584,7 +586,7 @@ public class RPMServiceTest {
         RPMService svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
         svc.launch();
 
-        Assert.assertEquals(TransactionNamingScheme.LEGACY, svc.getTransactionNamingScheme());
+        assertEquals(TransactionNamingScheme.LEGACY, svc.getTransactionNamingScheme());
     }
 
     @Test(timeout = 30000)
@@ -624,7 +626,7 @@ public class RPMServiceTest {
 
         IProfile profile2 = new Profile(parameters);
         List<Long> ids = svc.sendProfileData(Arrays.<ProfileData>asList(profile, profile2));
-        Assert.assertEquals(2, ids.size());
+        assertEquals(2, ids.size());
     }
 
     @Test(timeout = 30000)
@@ -644,7 +646,7 @@ public class RPMServiceTest {
     private void doGetApplicationName() {
         List<String> appNames = singletonList("MyApplication");
         RPMService svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
-        Assert.assertEquals("MyApplication", svc.getApplicationName());
+        assertEquals("MyApplication", svc.getApplicationName());
     }
 
     @Test(timeout = 30000)
@@ -675,16 +677,16 @@ public class RPMServiceTest {
     private void doIsMainApp(String appName, Map<String, Object> map) {
         List<String> appNames = singletonList(appName);
         RPMService svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
-        Assert.assertTrue(svc.isMainApp());
+        assertTrue(svc.isMainApp());
 
         map.put(AgentConfigImpl.ENABLE_AUTO_APP_NAMING, true);
         appNames = singletonList("Bogus");
         svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
-        Assert.assertFalse(svc.isMainApp());
+        assertFalse(svc.isMainApp());
 
         appNames = singletonList(appName);
         svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
-        Assert.assertTrue(svc.isMainApp());
+        assertTrue(svc.isMainApp());
     }
 
     @Test(timeout = 30000)
@@ -709,7 +711,7 @@ public class RPMServiceTest {
 
         List<List<?>> commands = svc.getAgentCommands();
 
-        Assert.assertEquals(0, commands.size());
+        assertEquals(0, commands.size());
     }
 
     @Test(timeout = 30000)
@@ -760,7 +762,6 @@ public class RPMServiceTest {
         commandResults.put(8675309L, Collections.emptyMap()); // invalid id
         try {
             svc.sendCommandResults(commandResults);
-//            Assert.fail();
         } catch (RuntimeException ignored) {
             //ignored
         }
@@ -789,14 +790,14 @@ public class RPMServiceTest {
         appNames.add("MyApp1");
         appNames.add("MyApp2");
         RPMService svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
-        Assert.assertEquals("MyApp1", svc.getApplicationName());
+        assertEquals("MyApp1", svc.getApplicationName());
         svc.launch();
 
         Map<String, Object> startupOptions = dataSenderFactory.getLastDataSender().getStartupOtions();
         List<String> result = (List<String>) startupOptions.get("app_name");
-        Assert.assertEquals(2, result.size());
-        Assert.assertEquals("MyApp1", result.get(0));
-        Assert.assertEquals("MyApp2", result.get(1));
+        assertEquals(2, result.size());
+        assertEquals("MyApp1", result.get(0));
+        assertEquals("MyApp2", result.get(1));
 
         svc.shutdown();
     }
@@ -874,7 +875,7 @@ public class RPMServiceTest {
                     errorSentCount.incrementAndGet();
 
                     // Check that the raw data sent is less than the collector limit of 1MB (1000000 bytes)
-                    Assert.assertTrue(rawDataSent.length < 1000000);
+                    assertTrue(rawDataSent.length < 1000000);
                 }
             }
 
@@ -882,7 +883,7 @@ public class RPMServiceTest {
             public void dataReceived(String method, String encoding, String uri, Map<?, ?> rawDataReceived) {
                 if (method.equals("error_data")) {
                     // The collector should let us know it only recieved 2 error traces (instead of 5)
-                    Assert.assertEquals(2L, rawDataReceived.get("return_value"));
+                    assertEquals(2L, rawDataReceived.get("return_value"));
                 }
             }
         }, Collections.<AgentConnectionEstablishedListener>emptyList());
@@ -905,7 +906,7 @@ public class RPMServiceTest {
         Thread.sleep(500);
 
         // one set of errors should get sent because the first will error out
-        Assert.assertEquals(1, errorSentCount.get());
+        assertEquals(1, errorSentCount.get());
 
         svc.shutdown();
     }
@@ -950,7 +951,7 @@ public class RPMServiceTest {
         svc.launch();
         StatsEngine statsEngine = ServiceFactory.getStatsService().getStatsEngineForHarvest("MyApplication");
         MetricName metricName = MetricName.create("Supportability/Collector/HttpCode/200");
-        Assert.assertTrue(statsEngine.getMetricNames().contains(metricName));
+        assertTrue(statsEngine.getMetricNames().contains(metricName));
         svc.shutdown();
     }
 
@@ -1062,15 +1063,6 @@ public class RPMServiceTest {
         List<MetricData> data = createMetricData(statsEngine, 10);
         assertNotNull(data);
 
-        // List<MetricSpec> metricSpecs = svc.sendMetricData(System.currentTimeMillis() - 60000,
-        // System.currentTimeMillis(), data);
-        // Assert.assertEquals(10, metricSpecs.size());
-
-        // second time we should have metric ids, so no new metric specs will be returned
-        // metricSpecs = svc.sendMetricData(System.currentTimeMillis() - 60000, System
-        // .currentTimeMillis(), createMetricData(svc.getStatsEngine(), 10));
-        // Assert.assertEquals(0, metricSpecs.size());
-
         svc.shutdown();
     }
 
@@ -1158,7 +1150,7 @@ public class RPMServiceTest {
             svc.sendTransactionTraceData(traces);
         } finally {
             latch.await(10, TimeUnit.SECONDS);
-            Assert.assertTrue(dataSender.isConnected());
+            assertTrue(dataSender.isConnected());
         }
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
@@ -141,7 +141,6 @@ public class AgentConfigImplTest {
     @Test
     public void apiPortDefaultSSL() throws Exception {
         Map<String, Object> localMap = new HashMap<>();
-        localMap.put(AgentConfigImpl.IS_SSL, true);
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
         assertEquals(AgentConfigImpl.DEFAULT_SSL_PORT, config.getApiPort());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/HighSecurityTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/HighSecurityTest.java
@@ -9,11 +9,14 @@ package com.newrelic.agent.config;
 
 import com.newrelic.agent.Mocks;
 import com.newrelic.agent.database.SqlObfuscator;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class HighSecurityTest {
     
@@ -29,11 +32,11 @@ public class HighSecurityTest {
         localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
-        Assert.assertEquals(!AgentConfigImpl.DEFAULT_HIGH_SECURITY, config.isHighSecurity());
+        assertEquals(!AgentConfigImpl.DEFAULT_HIGH_SECURITY, config.isHighSecurity());
         // record sql should be off or obfuscated
-        Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
+        assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
     }
 
     @Test
@@ -46,11 +49,11 @@ public class HighSecurityTest {
         localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
-        Assert.assertTrue(config.isHighSecurity());
+        assertTrue(config.isHighSecurity());
         // record sql should be off or obfuscated
-        Assert.assertEquals(SqlObfuscator.OFF_SETTING, config.getTransactionTracerConfig().getRecordSql());
+        assertEquals(SqlObfuscator.OFF_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
     }
 
     @Test
@@ -63,10 +66,10 @@ public class HighSecurityTest {
         localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
-        Assert.assertFalse(config.isHighSecurity());
-        Assert.assertEquals("raw", config.getTransactionTracerConfig().getRecordSql());
+        assertFalse(config.isHighSecurity());
+        assertEquals("raw", config.getTransactionTracerConfig().getRecordSql());
         // list to keep should be empty since high_security is disabled
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
     }
 
     @Test
@@ -78,11 +81,11 @@ public class HighSecurityTest {
         localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
-        Assert.assertEquals(true, config.getValue(AgentConfigImpl.HIGH_SECURITY));
+        assertEquals(true, config.getValue(AgentConfigImpl.HIGH_SECURITY));
         // record sql should be off or obfuscated
-        Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getValue("transaction_tracer.record_sql"));
+        assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getValue("transaction_tracer.record_sql"));
         // permitted-module should be present
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
     }
 
     @Test
@@ -103,11 +106,11 @@ public class HighSecurityTest {
             localMap.put(AgentConfigImpl.HIGH_SECURITY, Boolean.TRUE);
             AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
-            Assert.assertEquals(true, config.getValue(AgentConfigImpl.HIGH_SECURITY));
+            assertEquals(true, config.getValue(AgentConfigImpl.HIGH_SECURITY));
             // record sql should be off or obfuscated
-            Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getValue("transaction_tracer.record_sql"));
+            assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getValue("transaction_tracer.record_sql"));
             // permitted-module should be present
-            Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+            assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
         } finally {
             Mocks.createSystemPropertyProvider(new HashMap<String, String>());
         }
@@ -125,10 +128,10 @@ public class HighSecurityTest {
             localMap.put(AgentConfigImpl.HIGH_SECURITY, AgentConfigImpl.DEFAULT_HIGH_SECURITY);
             AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
-            Assert.assertTrue(config.isHighSecurity());
-            Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
+            assertTrue(config.isHighSecurity());
+            assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
             // list to keep should be empty since high_security is disabled
-            Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
+            assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
         } finally {
             Mocks.createSystemPropertyProvider(new HashMap<String, String>());
         }
@@ -139,7 +142,7 @@ public class HighSecurityTest {
         Map<String, Object> localMap = new HashMap<>();
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
-        Assert.assertFalse(config.isHighSecurity());
+        assertFalse(config.isHighSecurity());
     }
 
     @Test
@@ -162,11 +165,11 @@ public class HighSecurityTest {
             serverMap.put(AgentConfigImpl.HIGH_SECURITY, Boolean.FALSE);
             AgentConfig config = AgentConfigFactory.createAgentConfig(new HashMap<String, Object>(), serverMap, null);
 
-            Assert.assertTrue(config.isHighSecurity());
+            assertTrue(config.isHighSecurity());
             // record sql should be off or obfuscated
-            Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
+            assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
             // permitted-module should be present
-            Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+            assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
         } finally {
             Mocks.createSystemPropertyProvider(new HashMap<String, String>());
         }
@@ -189,10 +192,10 @@ public class HighSecurityTest {
             localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
             AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
 
-            Assert.assertFalse(config.isHighSecurity());
-            Assert.assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
+            assertFalse(config.isHighSecurity());
+            assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
             // list to keep should be empty since high_security is disabled
-            Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
+            assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
         } finally {
             Mocks.createSystemPropertyProvider(new HashMap<String, String>());
         }
@@ -215,10 +218,10 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
 
         // off setting okay with high security
-        Assert.assertTrue(config.isHighSecurity());
-        Assert.assertEquals(SqlObfuscator.OFF_SETTING, config.getTransactionTracerConfig().getRecordSql());
+        assertTrue(config.isHighSecurity());
+        assertEquals(SqlObfuscator.OFF_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
 
     }
 
@@ -239,10 +242,10 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
 
         // no high security change from server
-        Assert.assertTrue(config.isHighSecurity());
-        Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
+        assertTrue(config.isHighSecurity());
+        assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
 
     }
 
@@ -263,10 +266,10 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
 
         // no high security change from server - takes local properties
-        Assert.assertFalse(config.isHighSecurity());
-        Assert.assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
+        assertFalse(config.isHighSecurity());
+        assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // list to keep should be empty since high_security is disabled
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
 
     }
 
@@ -289,11 +292,11 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
 
         // make sure null do not throw exceptions
-        Assert.assertTrue(config.isHighSecurity());
-        Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
+        assertTrue(config.isHighSecurity());
+        assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should NOT be present (we don't accept list from server) but permitted-module-2 should be present
-        Assert.assertFalse(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE_2));
+        assertFalse(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE_2));
     }
 
     @Test
@@ -310,9 +313,9 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
 
         // picks up server settings since high security mode is off
-        Assert.assertTrue(config.isHighSecurity());
-        Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
+        assertTrue(config.isHighSecurity());
+        assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // list to keep should be empty since high_security is disabled
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
+        assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
     }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/HighSecurityTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/HighSecurityTest.java
@@ -30,28 +30,6 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
         Assert.assertEquals(!AgentConfigImpl.DEFAULT_HIGH_SECURITY, config.isHighSecurity());
-        // with high security true - ssl should be true
-        Assert.assertTrue(config.isSSL());
-        // record sql should be off or obfuscated
-        Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
-        // permitted-module should be present
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
-    }
-
-    @Test
-    public void isEnableHighSecuritySslOff() throws Exception {
-        Map<String, Object> localMap = new HashMap<>();
-        localMap.put(AgentConfigImpl.HIGH_SECURITY, true);
-        localMap.put(AgentConfigImpl.IS_SSL, false);
-        Map<String, Object> ttMap = new HashMap<>();
-        ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "raw");
-        ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
-        localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
-        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
-
-        Assert.assertTrue(config.isHighSecurity());
-        // with high security true - ssl should be true
-        Assert.assertTrue(config.isSSL());
         // record sql should be off or obfuscated
         Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
@@ -62,7 +40,6 @@ public class HighSecurityTest {
     public void isEnableHighSecurityRecordSqlOff() throws Exception {
         Map<String, Object> localMap = new HashMap<>();
         localMap.put(AgentConfigImpl.HIGH_SECURITY, true);
-        localMap.put(AgentConfigImpl.IS_SSL, false);
         Map<String, Object> ttMap = new HashMap<>();
         ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "off");
         ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
@@ -70,8 +47,6 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
         Assert.assertTrue(config.isHighSecurity());
-        // with high security true - ssl should be true
-        Assert.assertTrue(config.isSSL());
         // record sql should be off or obfuscated
         Assert.assertEquals(SqlObfuscator.OFF_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
@@ -82,7 +57,6 @@ public class HighSecurityTest {
     public void isEnableHighSecurityOff() throws Exception {
         Map<String, Object> localMap = new HashMap<>();
         localMap.put(AgentConfigImpl.HIGH_SECURITY, false);
-        localMap.put(AgentConfigImpl.IS_SSL, false);
         Map<String, Object> ttMap = new HashMap<>();
         ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "raw");
         ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
@@ -90,7 +64,6 @@ public class HighSecurityTest {
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
         Assert.assertFalse(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
         Assert.assertEquals("raw", config.getTransactionTracerConfig().getRecordSql());
         // list to keep should be empty since high_security is disabled
         Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
@@ -100,15 +73,12 @@ public class HighSecurityTest {
     public void isEnableHighSecurityCheckFlattenProps() throws Exception {
         Map<String, Object> localMap = new HashMap<>();
         localMap.put(AgentConfigImpl.HIGH_SECURITY, Boolean.TRUE);
-        localMap.put(AgentConfigImpl.IS_SSL, Boolean.FALSE);
         Map<String, Object> ttMap = new HashMap<>();
         ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
         localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
         Assert.assertEquals(true, config.getValue(AgentConfigImpl.HIGH_SECURITY));
-        // with high security true - ssl should be true
-        Assert.assertEquals(true, config.getValue(AgentConfigImpl.IS_SSL));
         // record sql should be off or obfuscated
         Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getValue("transaction_tracer.record_sql"));
         // permitted-module should be present
@@ -119,12 +89,9 @@ public class HighSecurityTest {
     public void isEnableHighSecurityCheckFlattenPropsWithSystemProps() throws Exception {
         try {
             Map<String, String> properties = new HashMap<>();
-            String key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.IS_SSL;
-            String val = String.valueOf(false);
-            properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
+            String key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
                     + TransactionTracerConfigImpl.RECORD_SQL;
-            val = "raw";
+            String val = "raw";
             properties.put(key, val);
             key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
                     + TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM;
@@ -134,12 +101,9 @@ public class HighSecurityTest {
 
             Map<String, Object> localMap = new HashMap<>();
             localMap.put(AgentConfigImpl.HIGH_SECURITY, Boolean.TRUE);
-            localMap.put(AgentConfigImpl.IS_SSL, Boolean.FALSE);
             AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
             Assert.assertEquals(true, config.getValue(AgentConfigImpl.HIGH_SECURITY));
-            // with high security true - ssl should be true
-            Assert.assertEquals(true, config.getValue(AgentConfigImpl.IS_SSL));
             // record sql should be off or obfuscated
             Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getValue("transaction_tracer.record_sql"));
             // permitted-module should be present
@@ -162,74 +126,7 @@ public class HighSecurityTest {
             AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
             Assert.assertTrue(config.isHighSecurity());
-            Assert.assertTrue(config.isSSL());
             Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
-            // list to keep should be empty since high_security is disabled
-            Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
-        } finally {
-            Mocks.createSystemPropertyProvider(new HashMap<String, String>());
-        }
-    }
-
-    @Test
-    public void isEnableHighSecuritySslSystemProperty() throws Exception {
-        try {
-            Map<String, String> properties = new HashMap<>();
-            String key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.HIGH_SECURITY;
-            String val = String.valueOf(true);
-            properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.IS_SSL;
-            val = String.valueOf(false);
-            properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
-                    + TransactionTracerConfigImpl.RECORD_SQL;
-            val = "raw";
-            properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
-                    + TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM;
-            val = PERMITTED_MODULE;
-            properties.put(key, val);
-            Mocks.createSystemPropertyProvider(properties);
-            Map<String, Object> localMap = new HashMap<>();
-            localMap.put(AgentConfigImpl.HIGH_SECURITY, AgentConfigImpl.DEFAULT_HIGH_SECURITY);
-            AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
-
-            Assert.assertTrue(config.isHighSecurity());
-            Assert.assertTrue(config.isSSL());
-            Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
-            // permitted-module should be present
-            Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
-        } finally {
-            Mocks.createSystemPropertyProvider(new HashMap<String, String>());
-        }
-    }
-
-    @Test
-    public void isDisableHighSecuritySslSystemProperty() throws Exception {
-        try {
-            Map<String, String> properties = new HashMap<>();
-            String key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.HIGH_SECURITY;
-            String val = String.valueOf(false);
-            properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.IS_SSL;
-            val = String.valueOf(false);
-            properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
-                    + TransactionTracerConfigImpl.RECORD_SQL;
-            val = "raw";
-            properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
-                    + TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM;
-            val = PERMITTED_MODULE;
-            properties.put(key, val);
-            Mocks.createSystemPropertyProvider(properties);
-            Map<String, Object> localMap = new HashMap<>();
-            localMap.put(AgentConfigImpl.HIGH_SECURITY, true);
-            AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
-
-            Assert.assertFalse(config.isHighSecurity());
-            Assert.assertTrue(config.isSSL());
-            Assert.assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
             // list to keep should be empty since high_security is disabled
             Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
         } finally {
@@ -252,9 +149,6 @@ public class HighSecurityTest {
             String key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.HIGH_SECURITY;
             String val = String.valueOf(true);
             properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.IS_SSL;
-            val = String.valueOf(false);
-            properties.put(key, val);
             key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.TRANSACTION_TRACER + "."
                     + TransactionTracerConfigImpl.RECORD_SQL;
             val = "raw";
@@ -269,7 +163,6 @@ public class HighSecurityTest {
             AgentConfig config = AgentConfigFactory.createAgentConfig(new HashMap<String, Object>(), serverMap, null);
 
             Assert.assertTrue(config.isHighSecurity());
-            Assert.assertTrue(config.isSSL());
             // record sql should be off or obfuscated
             Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
             // permitted-module should be present
@@ -286,9 +179,6 @@ public class HighSecurityTest {
             String key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.HIGH_SECURITY;
             String val = String.valueOf(false);
             properties.put(key, val);
-            key = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.IS_SSL;
-            val = String.valueOf(false);
-            properties.put(key, val);
             Mocks.createSystemPropertyProvider(properties);
             Map<String, Object> serverMap = new HashMap<>();
             serverMap.put(AgentConfigImpl.HIGH_SECURITY, Boolean.TRUE);
@@ -300,7 +190,6 @@ public class HighSecurityTest {
             AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
 
             Assert.assertFalse(config.isHighSecurity());
-            Assert.assertTrue(config.isSSL());
             Assert.assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
             // list to keep should be empty since high_security is disabled
             Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
@@ -318,7 +207,6 @@ public class HighSecurityTest {
 
         Map<String, Object> localMap = new HashMap<>();
         localMap.put(AgentConfigImpl.HIGH_SECURITY, true);
-        localMap.put(AgentConfigImpl.IS_SSL, false);
         Map<String, Object> ttMap = new HashMap<>();
         ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "off");
         ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
@@ -328,7 +216,6 @@ public class HighSecurityTest {
 
         // off setting okay with high security
         Assert.assertTrue(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
         Assert.assertEquals(SqlObfuscator.OFF_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
         Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
@@ -344,7 +231,6 @@ public class HighSecurityTest {
 
         Map<String, Object> localMap = new HashMap<>();
         localMap.put(AgentConfigImpl.HIGH_SECURITY, true);
-        localMap.put(AgentConfigImpl.IS_SSL, false);
         Map<String, Object> ttMap = new HashMap<>();
         ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "raw");
         ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
@@ -354,7 +240,6 @@ public class HighSecurityTest {
 
         // no high security change from server
         Assert.assertTrue(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
         Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should be present
         Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
@@ -370,7 +255,6 @@ public class HighSecurityTest {
 
         Map<String, Object> localMap = new HashMap<>();
         localMap.put(AgentConfigImpl.HIGH_SECURITY, false);
-        localMap.put(AgentConfigImpl.IS_SSL, false);
         Map<String, Object> ttMap = new HashMap<>();
         ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "raw");
         ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
@@ -380,66 +264,10 @@ public class HighSecurityTest {
 
         // no high security change from server - takes local properties
         Assert.assertFalse(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
         Assert.assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // list to keep should be empty since high_security is disabled
         Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
 
-    }
-
-    @Test
-    public void localWithSslRecordServerPropFalse() throws Exception {
-        Map<String, Object> serverMap = new HashMap<>();
-        Map<String, Object> serverInnerData = new HashMap<>();
-        serverMap.put(AgentConfigFactory.AGENT_CONFIG, serverInnerData);
-        serverInnerData.put(AgentConfigImpl.HIGH_SECURITY, Boolean.FALSE);
-        serverInnerData.put(AgentConfigImpl.IS_SSL, Boolean.FALSE);
-        serverInnerData.put(AgentConfigFactory.RECORD_SQL, "raw");
-        serverInnerData.put(AgentConfigFactory.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
-
-        Map<String, Object> localMap = new HashMap<>();
-        localMap.put(AgentConfigImpl.HIGH_SECURITY, true);
-        Map<String, Object> ttMap = new HashMap<>();
-        ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE_2);
-        localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
-
-        AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
-
-        // ignores invalid server properties
-        Assert.assertTrue(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
-        Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
-        // permitted-module should NOT be present (we don't accept list to keep from server) but permitted-module-2 should be present
-        Assert.assertFalse(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE_2));
-    }
-
-    @Test
-    public void localWithSslRecordOffServerPropFalse() throws Exception {
-        Map<String, Object> serverMap = new HashMap<>();
-        Map<String, Object> serverInnerData = new HashMap<>();
-        serverMap.put(AgentConfigFactory.AGENT_CONFIG, serverInnerData);
-        serverInnerData.put(AgentConfigImpl.HIGH_SECURITY, Boolean.FALSE);
-        serverInnerData.put(AgentConfigImpl.IS_SSL, Boolean.FALSE);
-        serverInnerData.put(AgentConfigFactory.RECORD_SQL, "off");
-        serverInnerData.put(AgentConfigFactory.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
-
-        Map<String, Object> localMap = new HashMap<>();
-        localMap.put(AgentConfigImpl.HIGH_SECURITY, true);
-        Map<String, Object> ttMap = new HashMap<>();
-        localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
-        ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "obfuscated");
-        ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE_2);
-
-        AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
-
-        // picks up off setting since that is acceptable with high security
-        Assert.assertTrue(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
-        Assert.assertEquals(SqlObfuscator.OFF_SETTING, config.getTransactionTracerConfig().getRecordSql());
-        // permitted-module should NOT be present (we don't accept list from server) but permitted-module-2 should be present
-        Assert.assertFalse(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE_2));
     }
 
     @Test
@@ -448,7 +276,6 @@ public class HighSecurityTest {
         Map<String, Object> serverInnerData = new HashMap<>();
         serverMap.put(AgentConfigFactory.AGENT_CONFIG, serverInnerData);
         serverInnerData.put(AgentConfigImpl.HIGH_SECURITY, Boolean.FALSE);
-        serverInnerData.put(AgentConfigImpl.IS_SSL, null);
         serverInnerData.put(AgentConfigFactory.RECORD_SQL, null);
         serverInnerData.put(AgentConfigFactory.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
 
@@ -463,7 +290,6 @@ public class HighSecurityTest {
 
         // make sure null do not throw exceptions
         Assert.assertTrue(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
         Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // permitted-module should NOT be present (we don't accept list from server) but permitted-module-2 should be present
         Assert.assertFalse(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().contains(PERMITTED_MODULE));
@@ -471,38 +297,10 @@ public class HighSecurityTest {
     }
 
     @Test
-    public void localWithSslServerProp() throws Exception {
-        Map<String, Object> serverMap = new HashMap<>();
-        Map<String, Object> serverInnerData = new HashMap<>();
-        serverMap.put(AgentConfigFactory.AGENT_CONFIG, serverInnerData);
-        serverInnerData.put(AgentConfigImpl.HIGH_SECURITY, Boolean.FALSE);
-        serverInnerData.put(AgentConfigImpl.IS_SSL, Boolean.TRUE);
-        serverInnerData.put(AgentConfigFactory.RECORD_SQL, "raw");
-        serverInnerData.put(AgentConfigFactory.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
-
-        Map<String, Object> localMap = new HashMap<>();
-        localMap.put(AgentConfigImpl.HIGH_SECURITY, false);
-        Map<String, Object> ttMap = new HashMap<>();
-        ttMap.put(TransactionTracerConfigImpl.RECORD_SQL, "off");
-        ttMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE_2);
-        localMap.put(AgentConfigImpl.TRANSACTION_TRACER, ttMap);
-
-        AgentConfig config = AgentConfigFactory.createAgentConfig(localMap, serverMap, null);
-
-        // picks up server settings since high security mode is off
-        Assert.assertFalse(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
-        Assert.assertEquals(SqlObfuscator.RAW_SETTING, config.getTransactionTracerConfig().getRecordSql());
-        // list to keep should be empty since high_security is disabled
-        Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());
-    }
-
-    @Test
     public void localWithRootServer() throws Exception {
         Map<String, Object> serverMap = new HashMap<>();
 
         serverMap.put(AgentConfigImpl.HIGH_SECURITY, Boolean.TRUE);
-        serverMap.put(AgentConfigImpl.IS_SSL, Boolean.FALSE);
         serverMap.put(TransactionTracerConfigImpl.RECORD_SQL, "raw");
         serverMap.put(TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM, PERMITTED_MODULE);
 
@@ -513,7 +311,6 @@ public class HighSecurityTest {
 
         // picks up server settings since high security mode is off
         Assert.assertTrue(config.isHighSecurity());
-        Assert.assertTrue(config.isSSL());
         Assert.assertEquals(SqlObfuscator.OBFUSCATED_SETTING, config.getTransactionTracerConfig().getRecordSql());
         // list to keep should be empty since high_security is disabled
         Assert.assertTrue(config.getTransactionTracerConfig().getCollectSlowQueriesFromModules().isEmpty());


### PR DESCRIPTION
…ns since 4.0

### Overview
The agent sopped allowing plaintext connections in 4.0. This change removes both the local configuration and server-side configuration checks

### Related Github Issue
#50 
