### PR TITLE
Add verfier range for akka on scala 2.12

### DIFF
--- a/instrumentation/akka-2.2/build.gradle
+++ b/instrumentation/akka-2.2/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 verifyInstrumentation {
     passes 'com.typesafe.akka:akka-actor_2.10:[2.2.0-RC1,)'
     passes 'com.typesafe.akka:akka-actor_2.11:[2.3.2,)'
+    passes 'com.typesafe.akka:akka-actor_2.12:[2.4.10,)'
     exclude 'com.typesafe.akka:akka-actor_2.11:2.4-M1'
 }
 


### PR DESCRIPTION
We currently don't verify akka instrumentation on scala 2.12. This changes that.

Looks like this correctly verifies akka against scala 2.12

```
> Task :instrumentation:akka-2.2:verifyInstrumentation
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.4
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.6
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.7
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-RC2
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.2
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.9
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.8
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-RC1
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.3
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.1
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M8
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.5
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.9
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.7
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M6
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M1
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M5
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M7
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M4
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M3
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.6
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.8
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.6.0-M2
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.5
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.31
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.4
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.30
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.28
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.29
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.3
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.27
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.23
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.26
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.24
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.25
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.21
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.22
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.20
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.14
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.2
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.19
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.17
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.16
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.13
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.18
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.15
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.12
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.11
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.10
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.1
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.0-RC2
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.0-RC1
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5-M2
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5-M1
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.5.0
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.20
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.18
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.17
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.19
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.16
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.14
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.13
> Task :instrumentation:akka-2.2:verifyPass_com.typesafe.akka_akka-actor_2.12_2.4.12
```