### PR TITLE
#63 Exclude Java 6 dependency from verification

### DIFF
--- a/instrumentation/jdbc-postgresql-9.4.1208/build.gradle
+++ b/instrumentation/jdbc-postgresql-9.4.1208/build.gradle
@@ -54,6 +54,7 @@ jar {
 
 verifyInstrumentation {
     passesOnly 'org.postgresql:postgresql:[9.4.1208,)'
+    excludeRegex 'org.postgresql:postgresql:.*.jre6'
 }
 
 site {


### PR DESCRIPTION
Addresses #63 < See this for failure details

Verification failed locally before the change in this PR and passes with the change:

```
~/code/newrelic-java-agent/instrumentation/jdbc-postgresql-9.4.1208 on branch fix-verifier-jdbc-postgres-9-4-1208 > ../../gradlew verifyInstrumentation --info

Resolving: org.postgresql:postgresql:9.4.1208
Resolving: org.postgresql:postgresql:9.4.1208.jre6
Resolving: org.postgresql:postgresql:9.4.1208.jre7
Resolving: org.postgresql:postgresql:9.4.1209
Resolving: org.postgresql:postgresql:9.4.1209.jre6
Resolving: org.postgresql:postgresql:9.4.1209.jre7
Resolving: org.postgresql:postgresql:9.4.1210
Resolving: org.postgresql:postgresql:9.4.1210.jre6
Resolving: org.postgresql:postgresql:9.4.1210.jre7
Resolving: org.postgresql:postgresql:9.4.1211
Resolving: org.postgresql:postgresql:9.4.1211.jre6
Resolving: org.postgresql:postgresql:9.4.1211.jre7
Resolving: org.postgresql:postgresql:9.4.1212
Resolving: org.postgresql:postgresql:9.4.1212.jre6
Resolving: org.postgresql:postgresql:9.4.1212.jre7
Resolving: org.postgresql:postgresql:42.0.0
Resolving: org.postgresql:postgresql:42.0.0.jre6
Resolving: org.postgresql:postgresql:42.0.0.jre7
Resolving: org.postgresql:postgresql:42.1.0
Resolving: org.postgresql:postgresql:42.1.0.jre7
Resolving: org.postgresql:postgresql:42.1.1
Resolving: org.postgresql:postgresql:42.1.1.jre6
Resolving: org.postgresql:postgresql:42.1.1.jre7
Resolving: org.postgresql:postgresql:42.1.2
Resolving: org.postgresql:postgresql:42.1.2.jre6
Resolving: org.postgresql:postgresql:42.1.2.jre7
Resolving: org.postgresql:postgresql:42.1.3
Resolving: org.postgresql:postgresql:42.1.3.jre6
Resolving: org.postgresql:postgresql:42.1.3.jre7
Resolving: org.postgresql:postgresql:42.1.4
Resolving: org.postgresql:postgresql:42.1.4.jre6
Resolving: org.postgresql:postgresql:42.1.4.jre7
Resolving: org.postgresql:postgresql:42.2.0
Resolving: org.postgresql:postgresql:42.2.0.jre6
Resolving: org.postgresql:postgresql:42.2.0.jre7
Resolving: org.postgresql:postgresql:42.2.1
Resolving: org.postgresql:postgresql:42.2.1.jre6
Resolving: org.postgresql:postgresql:42.2.1.jre7
Resolving: org.postgresql:postgresql:42.2.2
Resolving: org.postgresql:postgresql:42.2.2.jre6
Resolving: org.postgresql:postgresql:42.2.2.jre7
Resolving: org.postgresql:postgresql:42.2.3
Resolving: org.postgresql:postgresql:42.2.3.jre6
Resolving: org.postgresql:postgresql:42.2.3.jre7
Resolving: org.postgresql:postgresql:42.2.4
Resolving: org.postgresql:postgresql:42.2.4.jre6
Resolving: org.postgresql:postgresql:42.2.4.jre7
Resolving: org.postgresql:postgresql:42.2.5
Resolving: org.postgresql:postgresql:42.2.5.jre6
Resolving: org.postgresql:postgresql:42.2.5.jre7
Resolving: org.postgresql:postgresql:42.2.6
Resolving: org.postgresql:postgresql:42.2.6.jre6
Resolving: org.postgresql:postgresql:42.2.6.jre7
Resolving: org.postgresql:postgresql:42.2.7
Resolving: org.postgresql:postgresql:42.2.7.jre6
Resolving: org.postgresql:postgresql:42.2.7.jre7
Resolving: org.postgresql:postgresql:42.2.8
Resolving: org.postgresql:postgresql:42.2.8.jre6
Resolving: org.postgresql:postgresql:42.2.8.jre7
Resolving: org.postgresql:postgresql:42.2.9
Resolving: org.postgresql:postgresql:42.2.9.jre6
Resolving: org.postgresql:postgresql:42.2.9.jre7
Resolving: org.postgresql:postgresql:42.2.10
Resolving: org.postgresql:postgresql:42.2.10.jre6
Resolving: org.postgresql:postgresql:42.2.10.jre7
Resolving: org.postgresql:postgresql:42.2.11
Resolving: org.postgresql:postgresql:42.2.11.jre6
Resolving: org.postgresql:postgresql:42.2.11.jre7
Resolving: org.postgresql:postgresql:42.2.12
Resolving: org.postgresql:postgresql:42.2.12.jre6
Resolving: org.postgresql:postgresql:42.2.12.jre7
Resolving: org.postgresql:postgresql:42.2.13
Resolving: org.postgresql:postgresql:42.2.13.jre6
Resolving: org.postgresql:postgresql:42.2.13.jre7
Resolving: org.postgresql:postgresql:42.2.14
Resolving: org.postgresql:postgresql:42.2.14.jre6
Resolving: org.postgresql:postgresql:42.2.14.jre7
Resolving: org.postgresql:postgresql:42.2.15
Resolving: org.postgresql:postgresql:42.2.15.jre6
Resolving: org.postgresql:postgresql:42.2.15.jre7
Resolving: org.postgresql:postgresql:42.2.16
Resolving: org.postgresql:postgresql:42.2.16.jre6
Resolving: org.postgresql:postgresql:42.2.16.jre7
Resolving: org.postgresql:postgresql:9.2-1002-jdbc4
Resolving: org.postgresql:postgresql:9.2-1003-jdbc3
Resolving: org.postgresql:postgresql:9.2-1003-jdbc4
Resolving: org.postgresql:postgresql:9.2-1004-jdbc3
Resolving: org.postgresql:postgresql:9.2-1004-jdbc4
Resolving: org.postgresql:postgresql:9.2-1004-jdbc41
Resolving: org.postgresql:postgresql:9.3-1100-jdbc3
Resolving: org.postgresql:postgresql:9.3-1100-jdbc4
Resolving: org.postgresql:postgresql:9.3-1100-jdbc41
Resolving: org.postgresql:postgresql:9.3-1101-jdbc3
Resolving: org.postgresql:postgresql:9.3-1101-jdbc4
Resolving: org.postgresql:postgresql:9.3-1101-jdbc41
Resolving: org.postgresql:postgresql:9.3-1102-jdbc3
Resolving: org.postgresql:postgresql:9.3-1102-jdbc4
Resolving: org.postgresql:postgresql:9.3-1102-jdbc41
Resolving: org.postgresql:postgresql:9.3-1103-jdbc3
Resolving: org.postgresql:postgresql:9.3-1103-jdbc4
Resolving: org.postgresql:postgresql:9.3-1103-jdbc41
Resolving: org.postgresql:postgresql:9.3-1104-jdbc4
Resolving: org.postgresql:postgresql:9.3-1104-jdbc41
Resolving: org.postgresql:postgresql:9.4-1200-jdbc4
Resolving: org.postgresql:postgresql:9.4-1200-jdbc41
Resolving: org.postgresql:postgresql:9.4-1201-jdbc4
Resolving: org.postgresql:postgresql:9.4-1201-jdbc41
Resolving: org.postgresql:postgresql:9.4-1202-jdbc4
Resolving: org.postgresql:postgresql:9.4-1202-jdbc41
Resolving: org.postgresql:postgresql:9.4-1202-jdbc42
Resolving: org.postgresql:postgresql:9.4-1203-jdbc4
Resolving: org.postgresql:postgresql:9.4-1203-jdbc41
Resolving: org.postgresql:postgresql:9.4-1203-jdbc42
Resolving: org.postgresql:postgresql:9.4-1204-jdbc4
Resolving: org.postgresql:postgresql:9.4-1204-jdbc41
Resolving: org.postgresql:postgresql:9.4-1204-jdbc42
Resolving: org.postgresql:postgresql:9.4-1205-jdbc4
Resolving: org.postgresql:postgresql:9.4-1205-jdbc41
Resolving: org.postgresql:postgresql:9.4-1205-jdbc42
Resolving: org.postgresql:postgresql:9.4-1206-jdbc4
Resolving: org.postgresql:postgresql:9.4-1206-jdbc41
Resolving: org.postgresql:postgresql:9.4-1206-jdbc42
Resolving: org.postgresql:postgresql:9.4.1207
Resolving: org.postgresql:postgresql:9.4.1207.jre6
Resolving: org.postgresql:postgresql:9.4.1207.jre7
Resolving: org.postgresql:postgresql:9.4.1208.jre6
Resolving: org.postgresql:postgresql:9.4.1209.jre6
Resolving: org.postgresql:postgresql:9.4.1210.jre6
Resolving: org.postgresql:postgresql:9.4.1211.jre6
Resolving: org.postgresql:postgresql:9.4.1212.jre6
Resolving: org.postgresql:postgresql:42.0.0.jre6
Resolving: org.postgresql:postgresql:42.1.1.jre6
Resolving: org.postgresql:postgresql:42.1.2.jre6
Resolving: org.postgresql:postgresql:42.1.3.jre6
Resolving: org.postgresql:postgresql:42.1.4.jre6
Resolving: org.postgresql:postgresql:42.2.0.jre6
Resolving: org.postgresql:postgresql:42.2.1.jre6
Resolving: org.postgresql:postgresql:42.2.2.jre6
Resolving: org.postgresql:postgresql:42.2.3.jre6
Resolving: org.postgresql:postgresql:42.2.4.jre6
Resolving: org.postgresql:postgresql:42.2.5.jre6
Resolving: org.postgresql:postgresql:42.2.6.jre6
Resolving: org.postgresql:postgresql:42.2.7.jre6
Resolving: org.postgresql:postgresql:42.2.8.jre6
Resolving: org.postgresql:postgresql:42.2.9.jre6
Resolving: org.postgresql:postgresql:42.2.10.jre6
Resolving: org.postgresql:postgresql:42.2.11.jre6
Resolving: org.postgresql:postgresql:42.2.12.jre6
Resolving: org.postgresql:postgresql:42.2.13.jre6
Resolving: org.postgresql:postgresql:42.2.14.jre6
Resolving: org.postgresql:postgresql:42.2.15.jre6
Resolving: org.postgresql:postgresql:42.2.16.jre6

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyInstrumentation UP-TO-DATE
Skipping task ':instrumentation:jdbc-postgresql-9.4.1208:verifyInstrumentation' as it has no actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyInstrumentation (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.0 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212 (Thread[Execution worker for ':' Thread 3,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211.jre7 (Thread[Execution worker for ':',5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211 (Thread[Daemon worker Thread 7,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210.jre7 (Thread[Execution worker for ':' Thread 2,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210 (Thread[Execution worker for ':' Thread 10,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209.jre7 (Thread[Execution worker for ':' Thread 4,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209 (Thread[Execution worker for ':' Thread 9,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208.jre7 (Thread[Execution worker for ':' Thread 5,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208 (Thread[Execution worker for ':' Thread 8,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9.jre7 (Thread[Execution worker for ':' Thread 6,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.319 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8.jre7 (Thread[Execution worker for ':' Thread 8,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.323 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.328 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7.jre7 (Thread[Daemon worker Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.327 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7 (Thread[Execution worker for ':' Thread 10,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.332 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6.jre7 (Thread[Execution worker for ':' Thread 3,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1209.jre7 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.328 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6 (Thread[Execution worker for ':' Thread 4,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9.jre7 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.326 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5.jre7 (Thread[Execution worker for ':' Thread 6,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1208.jre7 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.329 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5 (Thread[Execution worker for ':' Thread 5,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1212.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.353 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1210.jre7 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.352 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4 (Thread[Execution worker for ':' Thread 2,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_9.4.1211.jre7 (Thread[Execution worker for ':',5,main]) completed. Took 0.355 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3.jre7 (Thread[Execution worker for ':',5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.9 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.353 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.351 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2.jre7 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.368 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2 (Thread[Execution worker for ':' Thread 5,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.352 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16.jre7 (Thread[Execution worker for ':' Thread 2,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.8.jre7 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.38 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16 (Thread[Execution worker for ':' Thread 8,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.354 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15.jre7 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.4.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.37 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.393 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14.jre7 (Thread[Execution worker for ':' Thread 4,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.6.jre7 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.638 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14 (Thread[Execution worker for ':' Thread 3,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.5.jre7 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.634 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13.jre7 (Thread[Execution worker for ':' Thread 6,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.3.jre7 (Thread[Execution worker for ':',5,main]) completed. Took 0.618 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13 (Thread[Execution worker for ':',5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7.jre7 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.644 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12.jre7 (Thread[Daemon worker Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.7 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.648 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12 (Thread[Execution worker for ':' Thread 10,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2.jre7 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.548 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11.jre7 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.2 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.563 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11 (Thread[Execution worker for ':' Thread 5,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.55 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.567 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10 (Thread[Execution worker for ':' Thread 8,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.15.jre7 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.561 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1.jre7 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.16.jre7 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.573 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1 (Thread[Execution worker for ':' Thread 2,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14.jre7 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.317 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12.jre7 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.31 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0.jre7 (Thread[Execution worker for ':' Thread 4,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0 (Thread[Daemon worker Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.12 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.324 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4.jre7 (Thread[Execution worker for ':' Thread 10,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.14 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.334 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4 (Thread[Execution worker for ':' Thread 3,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13 (Thread[Execution worker for ':',5,main]) completed. Took 0.334 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3.jre7 (Thread[Execution worker for ':',5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.13.jre7 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.351 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3 (Thread[Execution worker for ':' Thread 6,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11.jre7 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.318 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2.jre7 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.351 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2 (Thread[Execution worker for ':' Thread 8,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.10.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.365 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.367 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1 (Thread[Execution worker for ':' Thread 2,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.11 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.38 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0.jre7 (Thread[Execution worker for ':' Thread 5,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.369 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0 (Thread[Daemon worker Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.1.jre7 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.375 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0.jre7 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.2.0.jre7 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.386 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0 (Thread[Execution worker for ':' Thread 4,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3.jre7 (Thread[Execution worker for ':',5,main]) completed. Took 0.366 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_classpath (Thread[Execution worker for ':',5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4.jre7 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.386 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207.jre7 (Thread[Execution worker for ':' Thread 10,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.3 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.371 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207 (Thread[Execution worker for ':' Thread 6,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.4 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.443 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc42 (Thread[Execution worker for ':' Thread 3,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2.jre7 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.358 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc41 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.2 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.337 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc4 (Thread[Execution worker for ':' Thread 8,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1.jre7 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.339 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc42 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0.jre7 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.328 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc41 (Thread[Execution worker for ':' Thread 5,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0.jre7 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.325 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc4 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.1 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.344 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc42 (Thread[Execution worker for ':' Thread 2,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.1.0 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.345 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc41 (Thread[Daemon worker Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_org.postgresql_postgresql_42.0.0 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.344 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc4 (Thread[Execution worker for ':' Thread 4,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207.jre7
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207.jre7' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207.jre7' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207.jre7 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.337 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc42 (Thread[Execution worker for ':' Thread 10,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyPass_classpath
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_classpath' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyPass_classpath' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyPass_classpath (Thread[Execution worker for ':',5,main]) completed. Took 0.361 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc41 (Thread[Execution worker for ':',5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4.1207 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.361 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc4 (Thread[Execution worker for ':' Thread 6,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc42
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc42' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc42' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc42 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.335 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc42 (Thread[Execution worker for ':' Thread 3,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc41 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.452 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc41 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1206-jdbc4 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.475 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc4 (Thread[Execution worker for ':' Thread 8,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc41 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.441 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc41 (Thread[Daemon worker Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc42
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc42' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc42' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc42 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.482 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc4 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc4 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.477 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc41 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc4 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.45 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc4 (Thread[Execution worker for ':' Thread 4,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1205-jdbc41 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.489 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc41 (Thread[Execution worker for ':' Thread 5,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc42
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc42' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc42' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc42 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.441 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc4 (Thread[Execution worker for ':' Thread 10,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc42
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc42' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc42' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1204-jdbc42 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.48 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc41 (Thread[Execution worker for ':' Thread 2,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc41 (Thread[Execution worker for ':',5,main]) completed. Took 0.443 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc4 (Thread[Execution worker for ':',5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1203-jdbc4 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.439 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc3 (Thread[Execution worker for ':' Thread 6,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc42
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc42' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc42' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc42 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.435 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc41 (Thread[Execution worker for ':' Thread 3,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc41 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.367 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc4 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc41 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.414 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc3 (Thread[Daemon worker Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1201-jdbc4 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.409 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc41 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc41 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.412 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc4 (Thread[Execution worker for ':' Thread 7,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1200-jdbc4 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.411 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc3 (Thread[Execution worker for ':' Thread 4,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc4 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.411 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc41 (Thread[Execution worker for ':' Thread 10,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1104-jdbc41 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.417 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc4 (Thread[Execution worker for ':' Thread 5,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc3 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.392 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc4 (Thread[Execution worker for ':',5,main]) completed. Took 0.406 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc3 (Thread[Execution worker for ':' Thread 6,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc41 (Thread[Execution worker for ':',5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1103-jdbc41 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.415 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.4-1202-jdbc4 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.448 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc4 (Thread[Execution worker for ':' Thread 2,5,main]) started.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc3 (Thread[Execution worker for ':' Thread 8,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc41 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.404 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc4 (Thread[Execution worker for ':' Thread 3,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc4 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.35 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc3 (Thread[Execution worker for ':' Thread 9,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc41 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.331 secs.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1002-jdbc4 (Thread[Execution worker for ':' Thread 11,5,main]) started.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc4 (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 0.372 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc41 (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 0.372 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc4 (Thread[Execution worker for ':' Thread 5,5,main]) completed. Took 0.372 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc3 (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 0.381 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1101-jdbc3 (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 0.407 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc4 (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.401 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1100-jdbc3 (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 0.408 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.3-1102-jdbc3 (Thread[Daemon worker Thread 7,5,main]) completed. Took 0.453 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc41
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc41' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc41' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1004-jdbc41 (Thread[Execution worker for ':',5,main]) completed. Took 0.449 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc4 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.414 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc3
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc3' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc3' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1003-jdbc3 (Thread[Execution worker for ':' Thread 9,5,main]) completed. Took 0.303 secs.

> Task :instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1002-jdbc4
Caching disabled for task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1002-jdbc4' because:
  Build cache is disabled
Task ':instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1002-jdbc4' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:instrumentation:jdbc-postgresql-9.4.1208:verifyFail_org.postgresql_postgresql_9.2-1002-jdbc4 (Thread[Execution worker for ':' Thread 11,5,main]) completed. Took 0.303 secs.

BUILD SUCCESSFUL in 7s
128 actionable tasks: 112 executed, 16 up-to-date
```