### PR TITLE
Move linking mbean to jmxservice

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
@@ -7,13 +7,23 @@
 
 package com.newrelic.agent.introspec.internal;
 
-import com.newrelic.agent.*;
+import com.newrelic.agent.ExpirationService;
+import com.newrelic.agent.HarvestService;
+import com.newrelic.agent.RPMServiceManager;
+import com.newrelic.agent.ThreadService;
+import com.newrelic.agent.TracerService;
+import com.newrelic.agent.TransactionService;
 import com.newrelic.agent.attributes.AttributesService;
 import com.newrelic.agent.browser.BrowserService;
 import com.newrelic.agent.cache.CacheService;
 import com.newrelic.agent.circuitbreaker.CircuitBreakerService;
 import com.newrelic.agent.commands.CommandParser;
-import com.newrelic.agent.config.*;
+import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.AgentConfigFactory;
+import com.newrelic.agent.config.AgentConfigImpl;
+import com.newrelic.agent.config.ConfigService;
+import com.newrelic.agent.config.ConfigServiceFactory;
+import com.newrelic.agent.config.DistributedTracingConfig;
 import com.newrelic.agent.core.CoreService;
 import com.newrelic.agent.database.DatabaseService;
 import com.newrelic.agent.environment.EnvironmentService;
@@ -37,7 +47,13 @@ import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.Service;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.service.ServiceManager;
-import com.newrelic.agent.service.analytics.*;
+import com.newrelic.agent.service.analytics.CollectorSpanEventReservoirManager;
+import com.newrelic.agent.service.analytics.CollectorSpanEventSender;
+import com.newrelic.agent.service.analytics.InsightsService;
+import com.newrelic.agent.service.analytics.SpanEventCreationDecider;
+import com.newrelic.agent.service.analytics.SpanEventsService;
+import com.newrelic.agent.service.analytics.TransactionDataToDistributedTraceIntrinsics;
+import com.newrelic.agent.service.analytics.TransactionEventsService;
 import com.newrelic.agent.service.async.AsyncTransactionService;
 import com.newrelic.agent.service.module.JarCollectorService;
 import com.newrelic.agent.sql.SqlTraceService;
@@ -48,7 +64,11 @@ import com.newrelic.agent.tracing.DistributedTraceService;
 import com.newrelic.agent.tracing.DistributedTraceServiceImpl;
 import com.newrelic.agent.utilization.UtilizationService;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 class IntrospectorServiceManager extends AbstractService implements ServiceManager {
 
@@ -154,7 +174,8 @@ class IntrospectorServiceManager extends AbstractService implements ServiceManag
         remoteInstrumentationService = new RemoteInstrumentationServiceImpl();
         sourceLanguageService = new SourceLanguageService();
         classTransformerService = new NoOpClassTransformerService();
-        jmxService = new JmxService();
+        boolean jmxEnabled = configService.getDefaultAgentConfig().getJmxConfig().isEnabled();
+        jmxService = new JmxService(jmxEnabled);
         attributesService = new AttributesService();
         circuitBreakerService = new CircuitBreakerService();
         AgentConfig agentConfig = createAgentConfig(config, (Map) config.get("distributed_tracing"));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -16,7 +16,6 @@ import com.newrelic.agent.config.JarResource;
 import com.newrelic.agent.config.JavaVersionUtils;
 import com.newrelic.agent.core.CoreService;
 import com.newrelic.agent.core.CoreServiceImpl;
-import com.newrelic.agent.jmx.LinkingMetadataRegistration;
 import com.newrelic.agent.logging.AgentLogManager;
 import com.newrelic.agent.logging.IAgentLogger;
 import com.newrelic.agent.service.ServiceFactory;
@@ -167,8 +166,6 @@ public final class Agent {
 
             logAnyFilesFoundInEndorsedDirs();
 
-            registerAgentMBeans();
-
             if (serviceManager.getConfigService().getDefaultAgentConfig().isStartupTimingEnabled()) {
                 recordPremainTime(serviceManager.getStatsService(), startTime);
             }
@@ -199,11 +196,6 @@ public final class Agent {
             t.printStackTrace();
             System.exit(1);
         }
-    }
-
-    private static void registerAgentMBeans() {
-        // This registers the mbean that exposes linking metadata
-        new LinkingMetadataRegistration(LOG).registerLinkingMetadata();
     }
 
     private static boolean tryToInitializeServiceManager(Instrumentation inst) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
@@ -10,8 +10,6 @@ package com.newrelic.agent.jmx;
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.HarvestListener;
-import com.newrelic.agent.config.AgentConfig;
-import com.newrelic.agent.config.JmxConfig;
 import com.newrelic.agent.extension.Extension;
 import com.newrelic.agent.jmx.create.JmxGet;
 import com.newrelic.agent.jmx.create.JmxInvoke;
@@ -20,7 +18,6 @@ import com.newrelic.agent.jmx.metrics.JmxFrameworkValues;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.stats.StatsEngine;
-
 
 import javax.management.Attribute;
 import javax.management.AttributeNotFoundException;
@@ -76,11 +73,9 @@ public class JmxService extends AbstractService implements HarvestListener {
      */
     private final Set<MBeanServer> toRemoveMBeanServers = new CopyOnWriteArraySet<>();
 
-    public JmxService() {
+    public JmxService(boolean enabled) {
         super(JmxService.class.getSimpleName());
-        AgentConfig config = ServiceFactory.getConfigService().getDefaultAgentConfig();
-        JmxConfig jmxConfig = config.getJmxConfig();
-        enabled = jmxConfig.isEnabled();
+        this.enabled = enabled;
         jmxMetricFactory = JmxObjectFactory.createJmxFactory();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
@@ -92,6 +92,7 @@ public class JmxService extends AbstractService implements HarvestListener {
     @Override
     protected void doStart() {
         if (enabled) {
+            registerAgentMBeans();
             jmxMetricFactory.getStartUpJmxObjects(jmxGets, jmxInvokes);
             if (jmxGets.size() > 0) {
                 ServiceFactory.getHarvestService().addHarvestListener(this);
@@ -413,6 +414,11 @@ public class JmxService extends AbstractService implements HarvestListener {
         for (Extension newExtension : extensions) {
             jmxMetricFactory.addExtension(newExtension, jmxGets);
         }
+    }
+
+    private void registerAgentMBeans() {
+        // This registers the mbean that exposes linking metadata
+        new LinkingMetadataRegistration(Agent.LOG).registerLinkingMetadata();
     }
 
     /*

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
@@ -25,7 +25,7 @@ public class LinkingMetadataRegistration {
             Object bean = new LinkingMetadata();
             server.registerMBean(bean, name);
             logger.log(Level.INFO, "JMX LinkingMetadata bean registered");
-        } catch (Exception e) {
+        } catch (Exception | NoClassDefFoundError e) {
             logger.log(Level.INFO, "Error registering JMX LinkingMetadata MBean", e);
         }
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -27,7 +27,9 @@ import com.newrelic.agent.browser.BrowserServiceImpl;
 import com.newrelic.agent.cache.CacheService;
 import com.newrelic.agent.circuitbreaker.CircuitBreakerService;
 import com.newrelic.agent.commands.CommandParser;
+import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.ConfigService;
+import com.newrelic.agent.config.JmxConfig;
 import com.newrelic.agent.core.CoreService;
 import com.newrelic.agent.database.DatabaseService;
 import com.newrelic.agent.deadlock.DeadlockDetectorService;
@@ -159,7 +161,10 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
         threadService = new ThreadService();
         circuitBreakerService = new CircuitBreakerService();
         classTransformerService = new ClassTransformerServiceImpl(coreService.getInstrumentation());
-        jmxService = new JmxService();
+
+        AgentConfig config = configService.getDefaultAgentConfig();
+        JmxConfig jmxConfig = config.getJmxConfig();
+        jmxService = new JmxService(jmxConfig.isEnabled());
 
         Logger jarCollectorLogger = Agent.LOG.getChildLogger("com.newrelic.jar_collector");
         boolean jarCollectorEnabled = configService.getDefaultAgentConfig().getJarCollectorConfig().isEnabled();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
@@ -124,8 +124,6 @@ public class MockServiceManager extends AbstractService implements ServiceManage
         Mockito.when(statsService.getMetricAggregator()).thenReturn(metricAggregator);
         harvestService = Mockito.mock(HarvestService.class);
         sqlTraceService = Mockito.mock(SqlTraceService.class);
-        // browserService;
-        // cacheService;
         dbService = new DatabaseService();
         extensionService = new ExtensionService(configService, ExtensionsLoadedListener.NOOP);
         jarCollectorService = Mockito.mock(JarCollectorService.class);
@@ -142,7 +140,7 @@ public class MockServiceManager extends AbstractService implements ServiceManage
         commandParser = new CommandParser();
         remoteInstrumentationService = Mockito.mock(RemoteInstrumentationService.class);
         classTransformerService = Mockito.mock(ClassTransformerService.class);
-        jmxService = new JmxService();
+        jmxService = new JmxService(true);
         circuitBreakerService = new CircuitBreakerService();
         spanEventsService = Mockito.mock(SpanEventsService.class);
         insights = Mockito.mock(InsightsServiceImpl.class);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/LinkingMetadataRegistrationTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/LinkingMetadataRegistrationTest.java
@@ -1,6 +1,7 @@
 package com.newrelic.agent.jmx;
 
 import com.newrelic.api.agent.Logger;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.management.MBeanServer;
@@ -16,11 +17,19 @@ import static org.mockito.Mockito.when;
 
 public class LinkingMetadataRegistrationTest {
 
+    ObjectName name;
+    Logger logger;
+    MBeanServer fakeServer;
+
+    @Before
+    public void setup() throws Exception {
+        name = new ObjectName(MBEAN_NAME);
+        logger = mock(Logger.class);
+        fakeServer = mock(MBeanServer.class);
+    }
+
     @Test
     public void testRegisterHappyPath() throws Exception {
-        ObjectName name = new ObjectName(MBEAN_NAME);
-        Logger logger = mock(Logger.class);
-        final MBeanServer fakeServer = mock(MBeanServer.class);
 
         LinkingMetadataRegistration testClass = new LinkingMetadataRegistration(logger) {
             @Override
@@ -35,11 +44,27 @@ public class LinkingMetadataRegistrationTest {
 
     @Test
     public void testExceptionsAreHandled() throws Exception {
-        ObjectName name = new ObjectName(MBEAN_NAME);
         RuntimeException exception = new RuntimeException("Bad beans exception");
 
-        Logger logger = mock(Logger.class);
-        final MBeanServer fakeServer = mock(MBeanServer.class);
+        when(fakeServer.registerMBean(isA(LinkingMetadataMBean.class), eq(name))).thenThrow(exception);
+
+        LinkingMetadataRegistration testClass = new LinkingMetadataRegistration(logger) {
+            @Override
+            protected MBeanServer getMbeanServer() {
+                return fakeServer;
+            }
+        };
+
+        testClass.registerLinkingMetadata();
+        //success
+        verify(logger).log(eq(Level.INFO), eq("JMX LinkingMetadata started, registering MBean: com.newrelic.jfr:type=LinkingMetadata"));
+        verify(logger).log(eq(Level.INFO), eq("Error registering JMX LinkingMetadata MBean"), eq(exception));
+    }
+
+    @Test
+    public void testNoClassDefErrorAlsoHandled() throws Exception {
+        NoClassDefFoundError exception = new NoClassDefFoundError("I am broken.");
+
         when(fakeServer.registerMBean(isA(LinkingMetadataMBean.class), eq(name))).thenThrow(exception);
 
         LinkingMetadataRegistration testClass = new LinkingMetadataRegistration(logger) {


### PR DESCRIPTION
This resolves #61 

This moves the registration of the linking metadata mbean into the jmxservice.

I picked up a little bit of campsite cleanup around the `ServiceFactory` usage in the `JMXService` as well.