### PR TITLE
Add config "newrelic.config.jmx.linkingMetadataMBean"

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
@@ -174,8 +174,7 @@ class IntrospectorServiceManager extends AbstractService implements ServiceManag
         remoteInstrumentationService = new RemoteInstrumentationServiceImpl();
         sourceLanguageService = new SourceLanguageService();
         classTransformerService = new NoOpClassTransformerService();
-        boolean jmxEnabled = configService.getDefaultAgentConfig().getJmxConfig().isEnabled();
-        jmxService = new JmxService(jmxEnabled);
+        jmxService = new JmxService(configService.getDefaultAgentConfig().getJmxConfig());
         attributesService = new AttributesService();
         circuitBreakerService = new CircuitBreakerService();
         AgentConfig agentConfig = createAgentConfig(config, (Map) config.get("distributed_tracing"));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfig.java
@@ -25,4 +25,9 @@ public interface JmxConfig {
      */
     Collection<String> getDisabledJmxFrameworks();
 
+    /**
+     * Returns true if the LinkingMetadataMBean should be registered in the platform
+     * MBean server.
+     */
+    boolean registerLinkingMetadataMBean();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
@@ -14,7 +14,9 @@ import java.util.Map;
 class JmxConfigImpl extends BaseConfig implements JmxConfig {
 
     public static final String ENABLED = "enabled";
+    public static final String REGISTER_LINKING_METADATA_MBEAN = "linkingMetadataMBean";
     public static final String DISABLED_JMX_FRAMEWORKS = "disabled_jmx_frameworks";
+    public static final boolean DEFAULT_REGISTER_LINKING_METADATA_MBEAN = false;
     public static final Boolean DEFAULT_ENABLED = Boolean.TRUE;
     public static final String SYSTEM_PROPERTY_ROOT = "newrelic.config.jmx.";
 
@@ -44,4 +46,8 @@ class JmxConfigImpl extends BaseConfig implements JmxConfig {
         return disabledJmxFrameworks;
     }
 
+    @Override
+    public boolean registerLinkingMetadataMBean(){
+        return getProperty(REGISTER_LINKING_METADATA_MBEAN, DEFAULT_REGISTER_LINKING_METADATA_MBEAN);
+    }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
@@ -10,6 +10,7 @@ package com.newrelic.agent.jmx;
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.HarvestListener;
+import com.newrelic.agent.config.JmxConfig;
 import com.newrelic.agent.extension.Extension;
 import com.newrelic.agent.jmx.create.JmxGet;
 import com.newrelic.agent.jmx.create.JmxInvoke;
@@ -46,7 +47,6 @@ public class JmxService extends AbstractService implements HarvestListener {
     private static final int INVOKE_ERROR_COUNT_MAX = 5;
     private static final String J2EE_STATS_ATTRIBUTE_PROCESSOR_CLASS_NAME = "com.newrelic.agent.jmx.J2EEStatsAttributeProcessor";
 
-    private final boolean enabled;
     private final Set<JmxAttributeProcessor> jmxAttributeProcessors = new HashSet<>();
     /**
      * This is used to create JmxGet and JmxInvoke objects.
@@ -72,10 +72,11 @@ public class JmxService extends AbstractService implements HarvestListener {
      * Remove MBeanServers who class name is contained here.
      */
     private final Set<MBeanServer> toRemoveMBeanServers = new CopyOnWriteArraySet<>();
+    private final JmxConfig jmxConfig;
 
-    public JmxService(boolean enabled) {
+    public JmxService(JmxConfig jmxConfig) {
         super(JmxService.class.getSimpleName());
-        this.enabled = enabled;
+        this.jmxConfig = jmxConfig;
         jmxMetricFactory = JmxObjectFactory.createJmxFactory();
     }
 
@@ -91,7 +92,7 @@ public class JmxService extends AbstractService implements HarvestListener {
 
     @Override
     protected void doStart() {
-        if (enabled) {
+        if (jmxConfig.isEnabled()) {
             registerAgentMBeans();
             jmxMetricFactory.getStartUpJmxObjects(jmxGets, jmxInvokes);
             if (jmxGets.size() > 0) {
@@ -105,14 +106,14 @@ public class JmxService extends AbstractService implements HarvestListener {
 
     @Override
     public final boolean isEnabled() {
-        return enabled;
+        return jmxConfig.isEnabled();
     }
 
     /**
      * This method can be called by multiple threads. Be careful!!
      */
     public void addJmxFrameworkValues(final JmxFrameworkValues jmxValues) {
-        if (enabled) {
+        if (jmxConfig.isEnabled()) {
             toBeAdded.add(jmxValues);
         }
     }
@@ -417,8 +418,10 @@ public class JmxService extends AbstractService implements HarvestListener {
     }
 
     private void registerAgentMBeans() {
-        // This registers the mbean that exposes linking metadata
-        new LinkingMetadataRegistration(Agent.LOG).registerLinkingMetadata();
+        if(jmxConfig.registerLinkingMetadataMBean()){
+            // This registers the mbean that exposes linking metadata
+            new LinkingMetadataRegistration(Agent.LOG).registerLinkingMetadata();
+        }
     }
 
     /*

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -164,7 +164,7 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
 
         AgentConfig config = configService.getDefaultAgentConfig();
         JmxConfig jmxConfig = config.getJmxConfig();
-        jmxService = new JmxService(jmxConfig.isEnabled());
+        jmxService = new JmxService(jmxConfig);
 
         Logger jarCollectorLogger = Agent.LOG.getChildLogger("com.newrelic.jar_collector");
         boolean jarCollectorEnabled = configService.getDefaultAgentConfig().getJarCollectorConfig().isEnabled();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
@@ -15,6 +15,7 @@ import com.newrelic.agent.commands.CommandParser;
 import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.ConfigService;
 import com.newrelic.agent.config.ConfigServiceFactory;
+import com.newrelic.agent.config.JmxConfig;
 import com.newrelic.agent.core.CoreService;
 import com.newrelic.agent.database.DatabaseService;
 import com.newrelic.agent.environment.EnvironmentService;
@@ -140,7 +141,8 @@ public class MockServiceManager extends AbstractService implements ServiceManage
         commandParser = new CommandParser();
         remoteInstrumentationService = Mockito.mock(RemoteInstrumentationService.class);
         classTransformerService = Mockito.mock(ClassTransformerService.class);
-        jmxService = new JmxService(true);
+        JmxConfig jmxConfig = this.configService.getDefaultAgentConfig().getJmxConfig();
+        jmxService = new JmxService(jmxConfig);
         circuitBreakerService = new CircuitBreakerService();
         spanEventsService = Mockito.mock(SpanEventsService.class);
         insights = Mockito.mock(InsightsServiceImpl.class);


### PR DESCRIPTION
This fixes #62.

We introduce a new config item `newrelic.config.jmx.linkingMetadataMBean` that, when set to true, will cause the `LinkingMetadataMBean` to be registered with the platform MBean server.  This value defaults to false (not registered).

