### PR TITLE
Akka http fix

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpTracedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpTracedMethod.java
@@ -95,7 +95,7 @@ public final class NoOpTracedMethod implements TracedMethod {
     }
 
     @Override
-    public boolean trackCallbackRunnable() {
+    public boolean isTrackCallbackRunnable() {
         return false;
     }
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpTracedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpTracedMethod.java
@@ -90,6 +90,16 @@ public final class NoOpTracedMethod implements TracedMethod {
     }
 
     @Override
+    public void setTrackCallbackRunnable(boolean shouldTrack) {
+
+    }
+
+    @Override
+    public boolean trackCallbackRunnable() {
+        return false;
+    }
+
+    @Override
     public void addOutboundRequestHeaders(OutboundHeaders outboundHeaders) {
     }
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
@@ -80,7 +80,7 @@ public interface TracedMethod extends com.newrelic.api.agent.TracedMethod {
      */
     public void setTrackCallbackRunnable(boolean shouldTrack);
 
-    public boolean trackCallbackRunnable();
+    public boolean isTrackCallbackRunnable();
 
     /**
      * Do not use. Use

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
@@ -75,6 +75,14 @@ public interface TracedMethod extends com.newrelic.api.agent.TracedMethod {
     public boolean trackChildThreads();
 
     /**
+     * Tell the tracer to track child CallbackRunnable jobs which are submitted under its method call.
+     * This only applies to the Akka-Http instrumentation at the moment.
+     */
+    public void setTrackCallbackRunnable(boolean shouldTrack);
+
+    public boolean trackCallbackRunnable();
+
+    /**
      * Do not use. Use
      * {@link com.newrelic.api.agent.TracedMethod#addOutboundRequestHeaders(OutboundHeaders)} instead.
      *

--- a/functional_test/src/test/java/com/newrelic/agent/bridge/MockTracer.java
+++ b/functional_test/src/test/java/com/newrelic/agent/bridge/MockTracer.java
@@ -111,7 +111,7 @@ public class MockTracer implements ExitTracer {
     }
 
     @Override
-    public boolean trackCallbackRunnable() {
+    public boolean isTrackCallbackRunnable() {
         return false;
     }
 

--- a/functional_test/src/test/java/com/newrelic/agent/bridge/MockTracer.java
+++ b/functional_test/src/test/java/com/newrelic/agent/bridge/MockTracer.java
@@ -106,6 +106,16 @@ public class MockTracer implements ExitTracer {
     }
 
     @Override
+    public void setTrackCallbackRunnable(boolean shouldTrack) {
+
+    }
+
+    @Override
+    public boolean trackCallbackRunnable() {
+        return false;
+    }
+
+    @Override
     public void addOutboundRequestHeaders(OutboundHeaders outboundHeaders) {
     }
 

--- a/instrumentation/akka-http-2.4.5/src/main/scala/akka/http/scaladsl/server/AkkaHttpContextFunction.scala
+++ b/instrumentation/akka-http-2.4.5/src/main/scala/akka/http/scaladsl/server/AkkaHttpContextFunction.scala
@@ -42,7 +42,8 @@ class ContextWrapper(original: Function1[RequestContext, Future[RouteResult]]) e
     try {
       val tracedMethod = AgentBridge.getAgent.getTracedMethod
       tracedMethod.setMetricName("AkkaHttp")
-
+      // Akka-http 10.1.5 uses CallbackRunnable and we lose transaction context between Directives
+      AgentBridge.getAgent.getTracedMethod.setTrackCallbackRunnable(true);
       val token = AgentBridge.getAgent.getTransaction(false).getToken
       PathMatcherUtils.setHttpRequest(ctx.request)
       // We use this method to wire up our RequestContext wrapper and start our transaction

--- a/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
+++ b/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
@@ -34,7 +34,9 @@ public class CallbackRunnable_Instrumentation<T> {
 
     public CallbackRunnable_Instrumentation(final ExecutionContext executor, final Function1 onComplete) {
         Transaction transaction = AgentBridge.getAgent().getTransaction(false);
-        if (AgentBridge.activeToken.get() == null && transaction != null) {
+        if (AgentBridge.activeToken.get() == null &&
+                transaction != null &&
+                AgentBridge.getAgent().getTracedMethod().trackCallbackRunnable()) {
             token = transaction.getToken();
         }
     }

--- a/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
+++ b/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
@@ -38,7 +38,7 @@ public class CallbackRunnable_Instrumentation<T> {
         if (AgentBridge.activeToken.get() == null &&
                 transaction != null &&
                 NewRelic.getAgent().getConfig().getValue("scala.callbackrunnable.enabled", false) &&
-                AgentBridge.getAgent().getTracedMethod().trackCallbackRunnable()) {
+                AgentBridge.getAgent().getTracedMethod().isTrackCallbackRunnable()) {
             token = transaction.getToken();
         }
     }

--- a/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
+++ b/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
@@ -10,12 +10,15 @@ package scala.concurrent.impl;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.Transaction;
 import com.newrelic.api.agent.Segment;
+import com.newrelic.api.agent.Token;
 import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.agent.instrumentation.scala.ScalaUtils;
 import com.nr.agent.instrumentation.scala.WrappedTry;
 import scala.Function1;
+import scala.concurrent.ExecutionContext;
 import scala.util.Try;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -25,15 +28,23 @@ import static com.nr.agent.instrumentation.scala.ScalaUtils.scalaFuturesAsSegmen
 @Weave(originalName = "scala.concurrent.impl.CallbackRunnable")
 public class CallbackRunnable_Instrumentation<T> {
     private final Function1<Try<?>, Object> onComplete = Weaver.callOriginal();
-
     private Try<T> value = Weaver.callOriginal();
+    @NewField
+    private Token token;
+
+    public CallbackRunnable_Instrumentation(final ExecutionContext executor, final Function1 onComplete) {
+        Transaction transaction = AgentBridge.getAgent().getTransaction(false);
+        if (AgentBridge.activeToken.get() == null && transaction != null) {
+            token = transaction.getToken();
+        }
+    }
 
     /**
      * Override the setter for "value" so we can replace it with our wrapped version
      */
+
     public void value_$eq(Try<T> original) {
         Weaver.callOriginal();
-
         AgentBridge.TokenAndRefCount tokenAndRefCount = AgentBridge.activeToken.get();
         if (tokenAndRefCount == null) {
             Transaction tx = AgentBridge.getAgent().getTransaction(false);
@@ -48,15 +59,17 @@ public class CallbackRunnable_Instrumentation<T> {
         }
     }
 
-    @Trace(excludeFromTransactionTrace = true)
+    @Trace(async = true, excludeFromTransactionTrace = true)
     public void run() {
         Segment segment = null;
         WrappedTry wrapped = null;
         boolean remove = false;
-
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
         if (value instanceof WrappedTry) {
             wrapped = (WrappedTry) value;
-
             // If we are here and there is no activeToken in progress we are the first one so we set this boolean in
             // order to correctly remove the "activeToken" from the thread local after the original run() method executes
             remove = AgentBridge.activeToken.get() == null;
@@ -65,7 +78,8 @@ public class CallbackRunnable_Instrumentation<T> {
                 Transaction tx = AgentBridge.getAgent().getTransaction(false);
                 if (tx != null) {
                     segment = tx.startSegment("Scala", "Callback");
-                    segment.setMetricName("Scala", "Callback", ScalaUtils.nameScalaFunction(onComplete.getClass().getName()));
+                    segment.setMetricName("Scala", "Callback",
+                            ScalaUtils.nameScalaFunction(onComplete.getClass().getName()));
                 }
             }
             value = wrapped.original;

--- a/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
+++ b/instrumentation/scala-2.12.0/src/main/java/scala/concurrent/impl/CallbackRunnable_Instrumentation.java
@@ -9,6 +9,7 @@ package scala.concurrent.impl;
 
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Token;
 import com.newrelic.api.agent.Trace;
@@ -36,6 +37,7 @@ public class CallbackRunnable_Instrumentation<T> {
         Transaction transaction = AgentBridge.getAgent().getTransaction(false);
         if (AgentBridge.activeToken.get() == null &&
                 transaction != null &&
+                NewRelic.getAgent().getConfig().getValue("scala.callbackrunnable.enabled", false) &&
                 AgentBridge.getAgent().getTracedMethod().trackCallbackRunnable()) {
             token = transaction.getToken();
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
@@ -128,7 +128,7 @@ public class FlyweightTraceMethodVisitor extends AdviceAdapter {
         addUnsupportedMethod(map, new Method("setTrackChildThreads", "(Z)V"));
         addUnsupportedMethod(map, new Method("trackChildThreads", "()Z"));
         addUnsupportedMethod(map, new Method("setTrackCallbackRunnable", "(Z)V"));
-        addUnsupportedMethod(map, new Method("trackCallbackRunnable", "()Z"));
+        addUnsupportedMethod(map, new Method("isTrackCallbackRunnable", "()Z"));
         addUnsupportedMethod(map, new Method("reportAsDatastore",
                 "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"));
         addUnsupportedMethod(map, new Method("addOutboundRequestHeaders",

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
@@ -127,6 +127,8 @@ public class FlyweightTraceMethodVisitor extends AdviceAdapter {
         addUnsupportedMethod(map, new Method("setCustomMetricPrefix", "(Ljava/lang/String;)V"));
         addUnsupportedMethod(map, new Method("setTrackChildThreads", "(Z)V"));
         addUnsupportedMethod(map, new Method("trackChildThreads", "()Z"));
+        addUnsupportedMethod(map, new Method("setTrackCallbackRunnable", "(Z)V"));
+        addUnsupportedMethod(map, new Method("trackCallbackRunnable", "()Z"));
         addUnsupportedMethod(map, new Method("reportAsDatastore",
                 "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"));
         addUnsupportedMethod(map, new Method("addOutboundRequestHeaders",

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
@@ -50,6 +50,7 @@ public abstract class AbstractTracer implements Tracer {
     private String customPrefix = "Custom";
     // doesn't need to be thread safe since this flag affects the decision to registerAsync
     private Boolean trackChildThreads = null;
+    private Boolean trackCallBackRunnable = false;
     private AtomicReference<TracedException> tracerError = new AtomicReference<>(TracedException.NO_EXCEPTION);
 
     private final long startTimeInMillis;
@@ -229,6 +230,16 @@ public abstract class AbstractTracer implements Tracer {
             }
         }
         return this.trackChildThreads;
+    }
+
+    @Override
+    public void setTrackCallbackRunnable(boolean shouldTrack) {
+        this.trackCallBackRunnable = shouldTrack;
+    }
+
+    @Override
+    public boolean trackCallbackRunnable() {
+        return trackCallBackRunnable;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
@@ -238,16 +238,16 @@ public abstract class AbstractTracer implements Tracer {
     }
 
     @Override
-    public boolean trackCallbackRunnable() {
-        if (!this.trackCallBackRunnable) {
-            TracedMethod parent = this.getParentTracedMethod();
-            if (null == parent) {
-                return false;
-            } else {
-                return parent.trackCallbackRunnable();
-            }
+    public boolean isTrackCallbackRunnable() {
+        return this.trackCallBackRunnable || this.isParentTrackCallbackRunnable();
+    }
+
+    private boolean isParentTrackCallbackRunnable() {
+        TracedMethod parent = this.getParentTracedMethod();
+        if (null == parent) {
+            return false;
         }
-        return trackCallBackRunnable;
+        return parent.isTrackCallbackRunnable();
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
@@ -239,6 +239,14 @@ public abstract class AbstractTracer implements Tracer {
 
     @Override
     public boolean trackCallbackRunnable() {
+        if (!this.trackCallBackRunnable) {
+            TracedMethod parent = this.getParentTracedMethod();
+            if (null == parent) {
+                return false;
+            } else {
+                return parent.trackCallbackRunnable();
+            }
+        }
         return trackCallBackRunnable;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/NoOpTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/NoOpTracer.java
@@ -241,6 +241,16 @@ public final class NoOpTracer implements Tracer {
     }
 
     @Override
+    public void setTrackCallbackRunnable(boolean shouldTrack) {
+
+    }
+
+    @Override
+    public boolean trackCallbackRunnable() {
+        return false;
+    }
+
+    @Override
     public void addOutboundRequestHeaders(OutboundHeaders outboundHeaders) {
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/NoOpTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/NoOpTracer.java
@@ -246,7 +246,7 @@ public final class NoOpTracer implements Tracer {
     }
 
     @Override
-    public boolean trackCallbackRunnable() {
+    public boolean isTrackCallbackRunnable() {
         return false;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/UltraLightTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/UltraLightTracer.java
@@ -227,6 +227,16 @@ public class UltraLightTracer implements Tracer {
     }
 
     @Override
+    public void setTrackCallbackRunnable(boolean shouldTrack) {
+
+    }
+
+    @Override
+    public boolean trackCallbackRunnable() {
+        return false;
+    }
+
+    @Override
     public String getTransactionSegmentUri() {
         return null;
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/UltraLightTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/UltraLightTracer.java
@@ -232,7 +232,7 @@ public class UltraLightTracer implements Tracer {
     }
 
     @Override
-    public boolean trackCallbackRunnable() {
+    public boolean isTrackCallbackRunnable() {
         return false;
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
@@ -381,6 +381,15 @@ public class NoOpTrackingSqlTracer implements SqlTracer {
         return false;
     }
 
+    @Override
+    public void setTrackCallbackRunnable(boolean shouldTrack) {
+
+    }
+
+    @Override
+    public boolean trackCallbackRunnable() {
+        return false;
+    }
 
     @Override
     public void addOutboundRequestHeaders(OutboundHeaders outboundHeaders) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
@@ -387,7 +387,7 @@ public class NoOpTrackingSqlTracer implements SqlTracer {
     }
 
     @Override
-    public boolean trackCallbackRunnable() {
+    public boolean isTrackCallbackRunnable() {
         return false;
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/AbstractTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/AbstractTracerTest.java
@@ -81,7 +81,7 @@ public class AbstractTracerTest {
     @Test
     public void testTrackCallbackRunnableDefault() {
         AbstractTracer tracer = createTxnAndTracer();
-        assertFalse(tracer.trackCallbackRunnable());
+        assertFalse(tracer.isTrackCallbackRunnable());
         tracer.finish(Opcodes.RETURN, null);
     }
 
@@ -89,7 +89,7 @@ public class AbstractTracerTest {
     public void testTrackCallbackRunnableTrue() {
         AbstractTracer tracer = createTxnAndTracer();
         tracer.setTrackCallbackRunnable(true);
-        assertTrue(tracer.trackCallbackRunnable());
+        assertTrue(tracer.isTrackCallbackRunnable());
         tracer.finish(Opcodes.RETURN, null);
     }
 
@@ -97,7 +97,7 @@ public class AbstractTracerTest {
     public void testTrackCallbackRunnableFalse() {
         AbstractTracer tracer = createTxnAndTracer();
         tracer.setTrackCallbackRunnable(false);
-        assertFalse(tracer.trackCallbackRunnable());
+        assertFalse(tracer.isTrackCallbackRunnable());
         tracer.finish(Opcodes.RETURN, null);
     }
 
@@ -105,14 +105,14 @@ public class AbstractTracerTest {
     public void testEnabledTrackCallbackRunnableParent() {
         AbstractTracer tracer = createTxnAndTracer();
         tracer.setTrackCallbackRunnable(true);
-        assertTrue(tracer.trackCallbackRunnable());
+        assertTrue(tracer.isTrackCallbackRunnable());
 
         Transaction tx = Transaction.getTransaction();
         ClassMethodSignature sig = new ClassMethodSignature(getClass().getName(), "dude", "()V");
         DefaultTracer kid = new DefaultTracer(tx, sig, this);
         tx.getTransactionActivity().tracerStarted(kid);
 
-        assertTrue(kid.trackCallbackRunnable());
+        assertTrue(kid.isTrackCallbackRunnable());
 
         kid.finish(Opcodes.RETURN, null);
         tracer.finish(Opcodes.RETURN, null);
@@ -122,14 +122,14 @@ public class AbstractTracerTest {
     public void testDisabledTrackCallbackRunnableParent() {
         AbstractTracer tracer = createTxnAndTracer();
         tracer.setTrackCallbackRunnable(false);
-        assertFalse(tracer.trackCallbackRunnable());
+        assertFalse(tracer.isTrackCallbackRunnable());
 
         Transaction tx = Transaction.getTransaction();
         ClassMethodSignature sig = new ClassMethodSignature(getClass().getName(), "dude", "()V");
         DefaultTracer kid = new DefaultTracer(tx, sig, this);
         tx.getTransactionActivity().tracerStarted(kid);
 
-        assertFalse(kid.trackCallbackRunnable());
+        assertFalse(kid.isTrackCallbackRunnable());
 
         kid.finish(Opcodes.RETURN, null);
         tracer.finish(Opcodes.RETURN, null);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/AbstractTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/AbstractTracerTest.java
@@ -79,6 +79,46 @@ public class AbstractTracerTest {
     }
 
     @Test
+    public void testTrackCallbackRunnableDefault() {
+        AbstractTracer tracer = createTxnAndTracer();
+        assertFalse(tracer.trackCallbackRunnable());
+        tracer.finish(Opcodes.RETURN, null);
+    }
+
+    @Test
+    public void testTrackCallbackRunnableTrue() {
+        AbstractTracer tracer = createTxnAndTracer();
+        tracer.setTrackCallbackRunnable(true);
+        assertTrue(tracer.trackCallbackRunnable());
+        tracer.finish(Opcodes.RETURN, null);
+    }
+
+    @Test
+    public void testTrackCallbackRunnableFalse() {
+        AbstractTracer tracer = createTxnAndTracer();
+        tracer.setTrackCallbackRunnable(false);
+        assertFalse(tracer.trackCallbackRunnable());
+        tracer.finish(Opcodes.RETURN, null);
+    }
+
+    @Test
+    public void testTrackCallbackRunnableParent() {
+        AbstractTracer tracer = createTxnAndTracer();
+        tracer.setTrackCallbackRunnable(true);
+        assertTrue(tracer.trackCallbackRunnable());
+
+        Transaction tx = Transaction.getTransaction();
+        ClassMethodSignature sig = new ClassMethodSignature(getClass().getName(), "dude", "()V");
+        DefaultTracer kid = new DefaultTracer(tx, sig, this);
+        tx.getTransactionActivity().tracerStarted(kid);
+
+        assertFalse(kid.trackCallbackRunnable());
+
+        kid.finish(Opcodes.RETURN, null);
+        tracer.finish(Opcodes.RETURN, null);
+    }
+
+    @Test
     public void testGetParentTracerWithSpan() throws Exception {
         AbstractTracer childTracer = createTxnAndTracer(true, false);
         Tracer parentTracer = childTracer.getParentTracer();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/AbstractTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/AbstractTracerTest.java
@@ -102,10 +102,27 @@ public class AbstractTracerTest {
     }
 
     @Test
-    public void testTrackCallbackRunnableParent() {
+    public void testEnabledTrackCallbackRunnableParent() {
         AbstractTracer tracer = createTxnAndTracer();
         tracer.setTrackCallbackRunnable(true);
         assertTrue(tracer.trackCallbackRunnable());
+
+        Transaction tx = Transaction.getTransaction();
+        ClassMethodSignature sig = new ClassMethodSignature(getClass().getName(), "dude", "()V");
+        DefaultTracer kid = new DefaultTracer(tx, sig, this);
+        tx.getTransactionActivity().tracerStarted(kid);
+
+        assertTrue(kid.trackCallbackRunnable());
+
+        kid.finish(Opcodes.RETURN, null);
+        tracer.finish(Opcodes.RETURN, null);
+    }
+
+    @Test
+    public void testDisabledTrackCallbackRunnableParent() {
+        AbstractTracer tracer = createTxnAndTracer();
+        tracer.setTrackCallbackRunnable(false);
+        assertFalse(tracer.trackCallbackRunnable());
 
         Transaction tx = Transaction.getTransaction();
         ClassMethodSignature sig = new ClassMethodSignature(getClass().getName(), "dude", "()V");


### PR DESCRIPTION
Transaction context can get lost between Directives because of Akka-Https use CallbackRunnables. This change attempts to propagate that context by weaving the CallbackRunnable constructor to create a token and link it on the run() method.

Due to performance concerns, I added a trackCallbackRunnable api to the Tracer, so that we only create/link the token when coming directly from AkkaHttp. We may consider putting this behind a config and/or traversing the tracer stack and not just checking the current tracer.

Thoughts?