### PR TITLE
update to the latest protobufs for infinite tracing

### DIFF
--- a/infinite-tracing/build.gradle.kts
+++ b/infinite-tracing/build.gradle.kts
@@ -12,7 +12,7 @@ java {
 }
 
 dependencies {
-    implementation("com.newrelic.agent.java:infinite-tracing-protobuf:3.1")
+    implementation("com.newrelic.agent.java:infinite-tracing-protobuf:3.2")
     implementation("com.google.guava:guava:28.2-android")
     implementation(project(":agent-model"))
     implementation(project(":agent-interfaces"))


### PR DESCRIPTION
This works around an earlier grpc vuln.