### PR TITLE
ignore SocketExceptions when attempting to connect to cloud providers

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/CloudUtility.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/CloudUtility.java
@@ -24,6 +24,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 
@@ -31,7 +32,7 @@ public class CloudUtility {
 
     // Spec: All characters should be in the following character class: over U+007F
     private static final int MIN_CHAR_CODEPOINT = "\u007F".codePointAt(0);
-    private final Function<Integer,CloseableHttpClient> httpClientCreator;
+    private final Function<Integer, CloseableHttpClient> httpClientCreator;
 
     public CloudUtility() {
         this(new Function<Integer, CloseableHttpClient>() {
@@ -58,7 +59,8 @@ public class CloudUtility {
         return makeHttpRequest(httpPut, requestTimeoutMillis, headers);
     }
 
-    private String makeHttpRequest(HttpUriRequest request, int requestTimeoutMillis, String[] headers) throws IOException {
+    private String makeHttpRequest(HttpUriRequest request, int requestTimeoutMillis, String[] headers)
+            throws IOException {
         try (CloseableHttpClient httpclient = httpClientCreator.apply(requestTimeoutMillis)) {
             for (String header : headers) {
                 String[] parts = header.split(":");
@@ -70,7 +72,7 @@ public class CloudUtility {
             if (response.getStatusLine().getStatusCode() <= HttpStatus.SC_MULTI_STATUS) {
                 return EntityUtils.toString(response.getEntity(), "UTF-8");
             }
-        } catch (ConnectTimeoutException | UnknownHostException | SocketTimeoutException ignored) {
+        } catch (ConnectTimeoutException | UnknownHostException | SocketTimeoutException | SocketException ignored) {
             // we expect these values in situations where there is no cloud provider, or
             // we're on a different cloud provider than expected.
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/utilization/CloudUtilityTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/utilization/CloudUtilityTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 
 import static org.junit.Assert.assertEquals;
@@ -105,6 +106,19 @@ public class CloudUtilityTest {
 
         when(mockClientCreator.apply(anyInt())).thenReturn(explodingClient);
         when(explodingClient.execute(isA(HttpUriRequest.class))).thenThrow(new SocketTimeoutException("oof"));
+
+        CloudUtility testClass = new CloudUtility(mockClientCreator);
+        String result = testClass.httpGet("https://example.com/some/path", 12, "foo:bar");
+        assertNull(result);
+    }
+
+    @Test
+    public void testSocketExceptionIsHandled() throws Exception {
+        Function<Integer, CloseableHttpClient> mockClientCreator = mock(Function.class);
+        CloseableHttpClient explodingClient = mock(CloseableHttpClient.class);
+
+        when(mockClientCreator.apply(anyInt())).thenReturn(explodingClient);
+        when(explodingClient.execute(isA(HttpUriRequest.class))).thenThrow(new SocketException("oof"));
 
         CloudUtility testClass = new CloudUtility(mockClientCreator);
         String result = testClass.httpGet("https://example.com/some/path", 12, "foo:bar");


### PR DESCRIPTION
I noticed we'd log a SocketException when attempting to connect to AWS for cloud usage data