### PR TITLE
Generalize the DOCKER_NATIVE_DRIVER_W_SYSTEMD regex to account for ot…

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DockerData.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DockerData.java
@@ -13,7 +13,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.io.IOException;
 import java.io.Reader;
 import java.text.MessageFormat;
 import java.util.logging.Level;
@@ -35,7 +34,7 @@ public class DockerData {
 
     private static final Pattern DOCKER_NATIVE_DRIVER_WOUT_SYSTEMD = Pattern.compile("^/.*/([0-9a-f]+)$");
     private static final Pattern DOCKER_GENERIC_DRIVER = Pattern.compile("^/([0-9a-f]+)$");
-    private static final Pattern DOCKER_NATIVE_DRIVER_W_SYSTEMD = Pattern.compile("^/.*/docker-([0-9a-f]+)\\.scope$");
+    private static final Pattern DOCKER_NATIVE_DRIVER_W_SYSTEMD = Pattern.compile("^/.*/\\w+-([0-9a-f]+)\\.scope$");
 
     public String getDockerContainerId(boolean isLinux) {
         if (isLinux) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/utilization/DockerDataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/utilization/DockerDataTest.java
@@ -78,6 +78,11 @@ public class DockerDataTest {
         line = "2:cpu:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod917d7891_0d63_11ea_873f_005056993b36.slice/docker-92b21022a0cecd0212c5097aa63ed8248ed832902dbdbb654e6df95e05573646.scope";
         Assert.assertTrue(dockerData.checkLineAndGetResult(line, sb));
         Assert.assertEquals("92b21022a0cecd0212c5097aa63ed8248ed832902dbdbb654e6df95e05573646", sb.toString());
+
+        sb = new StringBuilder();
+        line = "1:cpu:/system.slice/crio-67f98c9e6188f9c1818672a15dbe46237b6ee7e77f834d40d41c5fb3c2f84a2f.scope";
+        Assert.assertTrue(dockerData.checkLineAndGetResult(line, sb));
+        Assert.assertEquals("67f98c9e6188f9c1818672a15dbe46237b6ee7e77f834d40d41c5fb3c2f84a2f", sb.toString());
     }
 
     @Test


### PR DESCRIPTION
There can be more than one runtime. K8s with crio for example looks like this:
1:name=systemd:/system.slice/crio-67f98c9e6188f9c1818672a15dbe46237b6ee7e77f834d40d41c5fb3c2f84a2f.scope