### PR TITLE
Reintroduce use_private_ssl config to prevent adding ssl certs by def…

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
@@ -13,7 +13,16 @@ import com.newrelic.agent.transaction.TransactionNamingScheme;
 import com.newrelic.agent.transport.DataSenderImpl;
 
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
@@ -113,6 +122,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     public static final double DEFAULT_APDEX_T = 1.0; // 1 second
     public static final String DEFAULT_API_HOST = "rpm.newrelic.com";
     public static final String DEFAULT_CA_BUNDLE_PATH = null;
+    public static final boolean DEFAULT_USE_PRIVATE_SSL = false;
     public static final String DEFAULT_COMPRESSED_CONTENT_ENCODING = DataSenderImpl.GZIP_ENCODING;
     public static final boolean DEFAULT_CPU_SAMPLING_ENABLED = true;
     public static final boolean DEFAULT_ENABLED = true;
@@ -171,6 +181,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     private final boolean autoAppNamingEnabled;
     private final boolean autoTransactionNamingEnabled;
     private final String caBundlePath;
+    private final boolean usePrivateSSL;
     private final String compressedContentEncoding;
     private final boolean cpuSamplingEnabled;
     private final boolean customInstrumentationEditorAllowed;
@@ -288,7 +299,8 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
         startupTimingEnabled = getProperty(STARTUP_TIMING, DEFAULT_STARTUP_TIMING);
         sendJvmProps = getProperty(SEND_JVM_PROPS, true);
         litemode = getProperty(LITE_MODE, false);
-        caBundlePath = initSSLConfig();
+        caBundlePath = initCaBundlePathConfig();
+        usePrivateSSL = initUsePrivateSSLConfig();
         trimStats = getProperty(TRIM_STATS, DEFAULT_TRIM_STATS);
         platformInformationEnabled = getProperty(PLATFORM_INFORMATION_ENABLED, DEFAULT_PLATFORM_INFORMATION_ENABLED);
         ibmWorkaroundEnabled = getProperty(IBM_WORKAROUND, DEFAULT_IBM_WORKAROUND);
@@ -350,17 +362,12 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
         }
     }
 
+    private String initCaBundlePathConfig() {
+        return getProperty(CA_BUNDLE_PATH, DEFAULT_CA_BUNDLE_PATH);
+    }
 
-    private String initSSLConfig() {
-        String caBundlePath = getProperty(CA_BUNDLE_PATH, DEFAULT_CA_BUNDLE_PATH);
-        if (getProperty(USE_PRIVATE_SSL) != null) {
-            if (caBundlePath != null) {
-                Agent.LOG.log(Level.INFO, "use_private_ssl configuration setting has been removed.");
-            } else {
-                Agent.LOG.log(Level.SEVERE, "use_private_ssl configuration setting has been removed. Please use ca_bundle_path instead.");
-            }
-        }
-        return caBundlePath;
+    private boolean initUsePrivateSSLConfig() {
+        return getProperty(USE_PRIVATE_SSL, DEFAULT_USE_PRIVATE_SSL);
     }
 
     /**
@@ -1096,6 +1103,11 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     @Override
     public String getCaBundlePath() {
         return caBundlePath;
+    }
+
+    @Override
+    public boolean getUsePrivateSSL() {
+        return usePrivateSSL;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/DataSenderConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/DataSenderConfig.java
@@ -31,6 +31,8 @@ public interface DataSenderConfig {
 
     String getCaBundlePath();
 
+    boolean getUsePrivateSSL();
+
     /**
      * If simple compression is enabled we will prevent data within a payload from being compressed. However,
      * the payload itself may still be compressed before being sent to the collector.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
@@ -64,7 +64,7 @@ public class DataSenderFactory {
         }
 
         private ApacheHttpClientWrapper buildApacheHttpClientWrapper(DataSenderConfig config, Logger logger) {
-            SSLContext sslContext = ApacheSSLManager.createSSLContext(config.getCaBundlePath());
+            SSLContext sslContext = ApacheSSLManager.createSSLContext(config);
 
             ApacheProxyManager proxyManager = new ApacheProxyManager(
                     config.getProxyHost(),

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheSSLManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheSSLManager.java
@@ -9,6 +9,7 @@ package com.newrelic.agent.transport.apache;
 
 import com.google.common.collect.ImmutableList;
 import com.newrelic.agent.Agent;
+import com.newrelic.agent.config.DataSenderConfig;
 import org.apache.http.ssl.SSLContextBuilder;
 
 import javax.net.ssl.SSLContext;
@@ -36,12 +37,16 @@ public class ApacheSSLManager {
     private static final Collection<String> NEW_RELIC_CERTS = ImmutableList.of("newrelic-com.pem",
             "eu-newrelic-com.pem", "eu01-nr-data-net.pem");
 
-    public static SSLContext createSSLContext(String caBundlePath) {
+    public static SSLContext createSSLContext(DataSenderConfig config) {
         SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
         try {
-            if (caBundlePath != null) {
-                sslContextBuilder.loadTrustMaterial(getKeyStore(caBundlePath), null);
-            } else {
+            if (config.getCaBundlePath() != null) {
+                if (config.getUsePrivateSSL()) {
+                   Agent.LOG.log(Level.FINE, "Ignoring use_private_ssl config." +
+                           " SSL certicates provided by ca_bundle_path.");
+                }
+                sslContextBuilder.loadTrustMaterial(getKeyStore(config.getCaBundlePath()), null);
+            } else if (config.getUsePrivateSSL()){
                 addNewRelicCertToTrustStore(sslContextBuilder);
             }
             return sslContextBuilder.build();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheSSLManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheSSLManager.java
@@ -43,7 +43,7 @@ public class ApacheSSLManager {
             if (config.getCaBundlePath() != null) {
                 if (config.getUsePrivateSSL()) {
                    Agent.LOG.log(Level.FINE, "Ignoring use_private_ssl config." +
-                           " SSL certicates provided by ca_bundle_path.");
+                           " Using SSL certificates provided by ca_bundle_path.");
                 }
                 sslContextBuilder.loadTrustMaterial(getKeyStore(config.getCaBundlePath()), null);
             } else if (config.getUsePrivateSSL()){
@@ -94,7 +94,7 @@ public class ApacheSSLManager {
         cal.add(Calendar.MONTH, +3);
         if (cal.getTime().compareTo(expiry) > 0) {
             Agent.LOG.log(Level.WARNING, "New Relic ssl certificate expire on {0}.\n" +
-                    "Applications using a custom Trustore may need to update the agent " +
+                    "Applications using a custom Truststore may need to update the agent " +
                     "or provide a valid certificate using the ca_bundle_path config", expiry);
         }
     }
@@ -104,7 +104,7 @@ public class ApacheSSLManager {
             cert.checkValidity();
         } catch (CertificateExpiredException | CertificateNotYetValidException e) {
             Agent.LOG.log(Level.WARNING, "New Relic ssl certificate has expired.\n" +
-                    "Applications using a custom Trustore may need to update the agent " +
+                    "Applications using a custom Truststore may need to update the agent " +
                     "or provide a valid certificate using the ca_bundle_path config", e);
             return false;
         }


### PR DESCRIPTION
We removed `use_private_ssl`  in 6.0 as part of the OSS effort. Unfortunately this required users to always provide their own certs. The change to add newrelic certs to the Truststore by default, has caused various SSL errors. use_private_ssl is now required to load the bundled certificates