### PR TITLE
Work around occasional ClassCircularityError 

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/InitProblemClasses.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/InitProblemClasses.java
@@ -73,6 +73,15 @@ public class InitProblemClasses {
             } catch (Throwable e) {
                 // This might happen on non-sun JVMs
             }
+
+            // This works around a ClassCircularityError with the doubly nested inner of ReentrantReadWriteLock.
+            try {
+                String holdCounterClassName = "java.util.concurrent.locks.ReentrantReadWriteLock$Sync$HoldCounter";
+                Class.forName(holdCounterClassName);
+                Agent.LOG.log(Level.FINE, "Worked around loading class " + holdCounterClassName);
+            } catch (ClassNotFoundException e) {
+                Agent.LOG.log(Level.WARNING, "Error working around class loading issue:", e);
+            }
         } catch (Throwable e) {
             Agent.LOG.log(Level.FINE, e, "Exception while performing initial loading");
         }


### PR DESCRIPTION
We sometimes infrequently see a `ClassCircularityError` when weaving, and it shows up when loading `java.util.concurrent.locks.ReentrantReadWriteLock$Sync$HoldCounter`.

This adds to existing work-arounds by forcing an early, deterministic classload for this class.