### PR TITLE
Fix issue causing multiple instrumentation modules to apply

### DIFF
--- a/instrumentation/akka-http-core-10.0.11/build.gradle
+++ b/instrumentation/akka-http-core-10.0.11/build.gradle
@@ -15,10 +15,10 @@ dependencies {
 verifyInstrumentation {
     fails('com.typesafe.akka:akka-http-core-experimental_2.11:[1.0,10.0.11)')
     fails('com.typesafe.akka:akka-http-core-experimental_2.10:[1.0,10.0.11)')
-    passesOnly('com.typesafe.akka:akka-http-core_2.11:[10.0.11,)') {
+    passesOnly('com.typesafe.akka:akka-http-core_2.11:[10.0.11,10.2.0-M1)') {
         compile("com.typesafe.akka:akka-stream_2.11:2.5.11")
     }
-    passesOnly('com.typesafe.akka:akka-http-core_2.12:[10.0.11,10.2.0-RC1)') {
+    passesOnly('com.typesafe.akka:akka-http-core_2.12:[10.0.11,10.2.0-M1)') {
         compile("com.typesafe.akka:akka-stream_2.12:2.5.11")
     }
 }

--- a/instrumentation/akka-http-core-10.0.11/src/main/scala/akka/http/DefaultParsingErrorHandler.scala
+++ b/instrumentation/akka-http-core-10.0.11/src/main/scala/akka/http/DefaultParsingErrorHandler.scala
@@ -1,8 +1,8 @@
-package akka.http.impl.engine
+package akka.http
 
 import com.newrelic.api.agent.weaver.SkipIfPresent
 
 @SkipIfPresent
-class HttpConnectionTimeoutException {
+class DefaultParsingErrorHandler {
 
 }

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -13,10 +13,16 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passesOnly('com.typesafe.akka:akka-http-core_2.11:[10.2.0-RC1,)') {
+    passes('com.typesafe.akka:akka-http-core_2.11:[10.2.0-M1,)') {
         compile("com.typesafe.akka:akka-stream_2.11:2.5.11")
     }
-    passesOnly('com.typesafe.akka:akka-http-core_2.12:[10.2.0-RC1,)') {
+    fails('com.typesafe.akka:akka-http-core_2.11:[,10.2.0-M1)') {
+        compile("com.typesafe.akka:akka-stream_2.11:2.5.11")
+    }
+    passes('com.typesafe.akka:akka-http-core_2.12:[10.2.0-M1,)') {
+        compile("com.typesafe.akka:akka-stream_2.12:2.5.11")
+    }
+    fails('com.typesafe.akka:akka-http-core_2.12:[,10.2.0-M1)') {
         compile("com.typesafe.akka:akka-stream_2.12:2.5.11")
     }
 }

--- a/instrumentation/akka-http-core-10.2.0/src/main/scala/akka/http/DefaultParsingErrorHandler.scala
+++ b/instrumentation/akka-http-core-10.2.0/src/main/scala/akka/http/DefaultParsingErrorHandler.scala
@@ -1,0 +1,8 @@
+package akka.http
+
+import com.newrelic.api.agent.weaver.Weave
+
+@Weave
+class DefaultParsingErrorHandler {
+
+}


### PR DESCRIPTION
 `Play2Test.test_play_27` and `SnapTest.test_snap_270` AITs were failing due to both the `akka-http-core-10.0.11` and `akka-http-core-10.2.0` instrumentation modules applying and causing doubled metric counts:

`Expected {'name': 'Akka/RequestHandler', 'count': 1} `

Actual count was 2 due to the doubling.

Tests now pass:

```
(agent-integration-tests) jkeller in ~/code/agent-integration-tests on branch main > TEST_APP_OVERRIDE='play2.version=2.7.0' ./bin/runtest.sh tests/java/functionality/framework/play/play2.py Play2Test.test_play_27
runtest.sh: firing up...
runtest.sh: all tests to run tests/java/functionality/framework/play/play2.py Play2Test.test_play_27
AIT validate: start.
AIT validate: success.
runtest.sh: Python interpreter: /Users/jkeller/code/agent-integration-tests/bin/python
runtest.sh: running test tests/java/functionality/framework/play/play2.py with args Play2Test.test_play_27
test_play_27 (__main__.Play2Test) ... 2020-11-09 17:07:28,159 - INFO: run: tests/java/functionality/framework/play/play2.py:test_play_27, tmpdir: /tmp/tmpzz2pmsci
2020-11-09 17:07:28,166 - INFO: ............... collector [10]
2020-11-09 17:07:28,166 - INFO: ................. java_agent [master]
2020-11-09 17:07:28,167 - INFO: ................... java [8]
2020-11-09 17:07:28,167 - INFO: ..................... play2 [2.7.0]
/Users/jkeller/code/agent-integration-tests/lib/python3.8/site-packages/requests/models.py:170: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  if isinstance(hook, collections.Callable):
2020-11-09 17:08:57,908 - INFO: Starting new HTTP connection (1): localhost
ok

----------------------------------------------------------------------
Ran 1 test in 134.611s

OK
runtest.sh: test run OK
```

```
(agent-integration-tests) jkeller in ~/code/agent-integration-tests on branch main >  ./bin/runtest.sh tests/java/functionality/framework/snap/snap.py SnapTest.test_snap_270
runtest.sh: firing up...
runtest.sh: all tests to run tests/java/functionality/framework/snap/snap.py SnapTest.test_snap_270
AIT validate: start.
AIT validate: success.
runtest.sh: Python interpreter: /Users/jkeller/code/agent-integration-tests/bin/python
runtest.sh: running test tests/java/functionality/framework/snap/snap.py with args SnapTest.test_snap_270
test_snap_270 (__main__.SnapTest) ... 2020-11-09 17:11:48,564 - INFO: run: tests/java/functionality/framework/snap/snap.py:test_snap_270, tmpdir: /tmp/tmpfqrp0_ab
2020-11-09 17:11:48,569 - INFO: ............... collector [10]
2020-11-09 17:11:48,569 - INFO: ................. java_agent [master]
2020-11-09 17:11:48,569 - INFO: ................... java [8]
2020-11-09 17:11:48,570 - INFO: ..................... play2 [2.7.0]
2020-11-09 17:14:05,296 - INFO: ..................... play2 [2.7.0-netty]
ok

----------------------------------------------------------------------
Ran 1 test in 247.558s

OK
runtest.sh: test run OK
```