### PR TITLE
upgrade to latest version of embedded mongo, assign embedded mongo ex…

### DIFF
--- a/instrumentation/mongodb-2.12/build.gradle
+++ b/instrumentation/mongodb-2.12/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:2.12.3")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-2.12/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb212Test.java
+++ b/instrumentation/mongodb-2.12/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb212Test.java
@@ -7,59 +7,89 @@
 
 package com.nr.agent.instrumentation.mongodb;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.Collection;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
 import com.newrelic.agent.introspec.DatastoreHelper;
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.api.agent.Trace;
-import com.newrelic.agent.introspec.InstrumentationTestConfig;
-
+import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.config.RuntimeConfig;
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.extract.TempNaming;
+import de.flapdoodle.embed.process.io.directories.PropertyOrPlatformTempDir;
 import de.flapdoodle.embed.process.runtime.Network;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = "com.mongodb")
 public class MongoDb212Test {
 
     private static final String MONGODB_PRODUCT = DatastoreVendor.MongoDB.toString();
-    private static final MongodStarter mongodStarter = MongodStarter.getDefaultInstance();
+    private static final MongodStarter mongodStarter;
+
+    static {
+        Command command = Command.MongoD;
+        RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(command)
+                .artifactStore(ExtractedArtifactStore.builder()
+                        .from(Defaults.extractedArtifactStoreFor(command))
+                        .temp(DirectoryAndExecutableNaming.builder()
+                                .directory(new PropertyOrPlatformTempDir())
+                                // The default configuration creates executables whose names contain random UUIDs, which
+                                // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
+                                // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                                // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
+                                .executableNaming(new TempNaming() {
+                                    @Override
+                                    public String nameFor(String prefix, String postfix) {
+                                        return prefix + "-Db212-" + postfix;
+                                    }
+                                })
+                                .build())
+                        .build())
+                .build();
+        mongodStarter = MongodStarter.getInstance(runtimeConfig);
+    }
+
     private MongodExecutable mongodExecutable;
     private MongodProcess mongodProcess;
     private MongoClient mongoClient;
 
     @Before
     public void startMongo() throws Exception {
-        final int port = InstrumentationTestRunner.getIntrospector().getRandomPort();
-        IMongodConfig mongodConfig = new MongodConfigBuilder().version(Version.V2_6_11).net(new Net(port,
-                Network.localhostIsIPv6())).build();
+        int port = Network.getFreeServerPort();
+        @SuppressWarnings("deprecation")
+        ImmutableMongodConfig mongodConfig = ImmutableMongodConfig.builder()
+                .version(Version.V2_6_11)
+                .net(new Net(port, Network.localhostIsIPv6()))
+                .build();
+
         mongodExecutable = mongodStarter.prepare(mongodConfig);
         mongodProcess = mongodExecutable.start();
         mongoClient = new MongoClient("localhost", port);
     }
 
     @After
-    public void stopMongo() throws Exception {
+    public void stopMongo() {
         if (mongoClient != null) {
             mongoClient.close();
         }

--- a/instrumentation/mongodb-2.12/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb212Test.java
+++ b/instrumentation/mongodb-2.12/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb212Test.java
@@ -57,6 +57,8 @@ public class MongoDb212Test {
                                 // The default configuration creates executables whose names contain random UUIDs, which
                                 // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
                                 // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                                // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
+                                // Failure to click fast enough will result in additional dialogs on subsequent test runs.
                                 // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
                                 .executableNaming(new TempNaming() {
                                     @Override

--- a/instrumentation/mongodb-2.14/build.gradle
+++ b/instrumentation/mongodb-2.14/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:2.14.0")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-2.14/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb214Test.java
+++ b/instrumentation/mongodb-2.14/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb214Test.java
@@ -57,6 +57,8 @@ public class MongoDb214Test {
                                 // The default configuration creates executables whose names contain random UUIDs, which
                                 // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
                                 // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                                // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
+                                // Failure to click fast enough will result in additional dialogs on subsequent test runs.
                                 // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
                                 .executableNaming(new TempNaming() {
                                     @Override

--- a/instrumentation/mongodb-2.14/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb214Test.java
+++ b/instrumentation/mongodb-2.14/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb214Test.java
@@ -7,59 +7,89 @@
 
 package com.nr.agent.instrumentation.mongodb;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.Collection;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
 import com.newrelic.agent.introspec.DatastoreHelper;
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.api.agent.Trace;
-import com.newrelic.agent.introspec.InstrumentationTestConfig;
-
+import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.config.RuntimeConfig;
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.extract.TempNaming;
+import de.flapdoodle.embed.process.io.directories.PropertyOrPlatformTempDir;
 import de.flapdoodle.embed.process.runtime.Network;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = "com.mongodb")
 public class MongoDb214Test {
 
     private static final String MONGODB_PRODUCT = DatastoreVendor.MongoDB.toString();
-    private static final MongodStarter mongodStarter = MongodStarter.getDefaultInstance();
+    private static final MongodStarter mongodStarter;
+
+    static {
+        Command command = Command.MongoD;
+        RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(command)
+                .artifactStore(ExtractedArtifactStore.builder()
+                        .from(Defaults.extractedArtifactStoreFor(command))
+                        .temp(DirectoryAndExecutableNaming.builder()
+                                .directory(new PropertyOrPlatformTempDir())
+                                // The default configuration creates executables whose names contain random UUIDs, which
+                                // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
+                                // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                                // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
+                                .executableNaming(new TempNaming() {
+                                    @Override
+                                    public String nameFor(String prefix, String postfix) {
+                                        return prefix + "-Db214-" + postfix;
+                                    }
+                                })
+                                .build())
+                        .build())
+                .build();
+        mongodStarter = MongodStarter.getInstance(runtimeConfig);
+    }
+
     private MongodExecutable mongodExecutable;
     private MongodProcess mongodProcess;
     private MongoClient mongoClient;
 
     @Before
     public void startMongo() throws Exception {
-        final int port = InstrumentationTestRunner.getIntrospector().getRandomPort();
-        IMongodConfig mongodConfig = new MongodConfigBuilder().version(Version.V2_6_11).net(new Net(port,
-                Network.localhostIsIPv6())).build();
+        int port = Network.getFreeServerPort();
+        @SuppressWarnings("deprecation")
+        ImmutableMongodConfig mongodConfig = ImmutableMongodConfig.builder()
+                .version(Version.V2_6_11)
+                .net(new Net(port, Network.localhostIsIPv6()))
+                .build();
+
         mongodExecutable = mongodStarter.prepare(mongodConfig);
         mongodProcess = mongodExecutable.start();
         mongoClient = new MongoClient("localhost", port);
     }
 
     @After
-    public void stopMongo() throws Exception {
+    public void stopMongo() {
         if (mongoClient != null) {
             mongoClient.close();
         }

--- a/instrumentation/mongodb-3.0/build.gradle
+++ b/instrumentation/mongodb-3.0/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:3.0.0")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-3.0/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb300Test.java
+++ b/instrumentation/mongodb-3.0/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb300Test.java
@@ -60,6 +60,8 @@ public class MongoDb300Test {
                                 // The default configuration creates executables whose names contain random UUIDs, which
                                 // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
                                 // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                                // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
+                                // Failure to click fast enough will result in additional dialogs on subsequent test runs.
                                 // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
                                 .executableNaming(new TempNaming() {
                                     @Override

--- a/instrumentation/mongodb-3.0/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb300Test.java
+++ b/instrumentation/mongodb-3.0/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb300Test.java
@@ -9,11 +9,17 @@ package com.nr.agent.instrumentation.mongodb;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import de.flapdoodle.embed.mongo.Command;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
+import de.flapdoodle.embed.process.config.RuntimeConfig;
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.extract.TempNaming;
+import de.flapdoodle.embed.process.io.directories.PropertyOrPlatformTempDir;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,8 +39,6 @@ import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
@@ -44,23 +48,51 @@ import de.flapdoodle.embed.process.runtime.Network;
 public class MongoDb300Test {
 
     private static final String MONGODB_PRODUCT = DatastoreVendor.MongoDB.toString();
-    private static final MongodStarter mongodStarter = MongodStarter.getDefaultInstance();
+    private static final MongodStarter mongodStarter;
+
+    static {
+        Command command = Command.MongoD;
+        RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(command)
+                .artifactStore(ExtractedArtifactStore.builder()
+                        .from(Defaults.extractedArtifactStoreFor(command))
+                        .temp(DirectoryAndExecutableNaming.builder()
+                                .directory(new PropertyOrPlatformTempDir())
+                                // The default configuration creates executables whose names contain random UUIDs, which
+                                // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
+                                // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                                // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
+                                .executableNaming(new TempNaming() {
+                                    @Override
+                                    public String nameFor(String prefix, String postfix) {
+                                        return prefix + "-Db300-" + postfix;
+                                    }
+                                })
+                                .build())
+                        .build())
+                .build();
+        mongodStarter = MongodStarter.getInstance(runtimeConfig);
+    }
+
     private MongodExecutable mongodExecutable;
     private MongodProcess mongodProcess;
     private MongoClient mongoClient;
 
     @Before
     public void startMongo() throws Exception {
-        final int port = InstrumentationTestRunner.getIntrospector().getRandomPort();
-        IMongodConfig mongodConfig = new MongodConfigBuilder().version(Version.V3_0_8).net(new Net(port,
-                Network.localhostIsIPv6())).build();
+        int port = Network.getFreeServerPort();
+        @SuppressWarnings("deprecation")
+        ImmutableMongodConfig mongodConfig = ImmutableMongodConfig.builder()
+                .version(Version.V3_0_8)
+                .net(new Net(port, Network.localhostIsIPv6()))
+                .build();
+
         mongodExecutable = mongodStarter.prepare(mongodConfig);
         mongodProcess = mongodExecutable.start();
         mongoClient = new MongoClient("localhost", port);
     }
 
     @After
-    public void stopMongo() throws Exception {
+    public void stopMongo() {
         if (mongoClient != null) {
             mongoClient.close();
         }

--- a/instrumentation/mongodb-3.1/build.gradle
+++ b/instrumentation/mongodb-3.1/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:3.1.0")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-3.1/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb310Test.java
+++ b/instrumentation/mongodb-3.1/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb310Test.java
@@ -59,6 +59,8 @@ public class MongoDb310Test {
                                 // The default configuration creates executables whose names contain random UUIDs, which
                                 // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
                                 // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                                // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
+                                // Failure to click fast enough will result in additional dialogs on subsequent test runs.
                                 // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
                                 .executableNaming(new TempNaming() {
                                     @Override

--- a/instrumentation/mongodb-3.7/build.gradle
+++ b/instrumentation/mongodb-3.7/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:3.7.0")
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:2.2.0")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-3.7/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb370Test.java
+++ b/instrumentation/mongodb-3.7/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb370Test.java
@@ -21,8 +21,8 @@ import com.newrelic.test.marker.Java7IncompatibleTest;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
@@ -47,20 +47,22 @@ public class MongoDb370Test {
     private MongodExecutable mongodExecutable;
     private MongodProcess mongodProcess;
     private MongoClient mongoClient;
-    private int port;
 
     @Before
     public void startMongo() throws Exception {
-        port = InstrumentationTestRunner.getIntrospector().getRandomPort();
-        IMongodConfig mongodConfig = new MongodConfigBuilder().version(Version.V3_6_5).net(new Net(port,
-                Network.localhostIsIPv6())).build();
+        int port = Network.getFreeServerPort();
+        MongodConfig mongodConfig = ImmutableMongodConfig.builder()
+                .version(Version.V3_6_5)
+                .net(new Net(port, Network.localhostIsIPv6()))
+                .build();
+
         mongodExecutable = mongodStarter.prepare(mongodConfig);
         mongodProcess = mongodExecutable.start();
         mongoClient = MongoClients.create(new ConnectionString("mongodb://localhost:" + port));
     }
 
     @After
-    public void stopMongo() throws Exception {
+    public void stopMongo() {
         if (mongoClient != null) {
             mongoClient.close();
         }


### PR DESCRIPTION
### Overview
The mongo instrumentation module tests use the `de.flapdoodle.embed.mongo` library to spin up and test again embedded mongo db instances. Connecting to older versions of embedded mongo (< 3.6.0) produces pesky firewall dialogs. The executables are assigned names with UUIDs in them so you're constantly re-prompted to acknowledge the same connections. 

This PR updates the configuration to assign stable names to the embedded mongo executables. This allows developers to acknowledge the firewall dialogs once and only once.

### Related Github Issue
None applicable. 

### Testing
The code changed is test code. I've verified that the changes produce the intended results and reduce the burden of testing the mongo instrumentation modules. 

### Checks
[x] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
