### PR TITLE
revert to java7 compatible embedded mongodb library for mongdb-2.12, …

### DIFF
--- a/instrumentation/mongodb-2.12/build.gradle
+++ b/instrumentation/mongodb-2.12/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:2.12.3")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-2.14/build.gradle
+++ b/instrumentation/mongodb-2.14/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:2.14.0")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-2.14/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb214Test.java
+++ b/instrumentation/mongodb-2.14/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb214Test.java
@@ -20,16 +20,15 @@ import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.Defaults;
-import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
+import de.flapdoodle.embed.mongo.config.ExtractedArtifactStoreBuilder;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.RuntimeConfig;
-import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
-import de.flapdoodle.embed.process.extract.TempNaming;
-import de.flapdoodle.embed.process.io.directories.PropertyOrPlatformTempDir;
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.extract.ITempNaming;
 import de.flapdoodle.embed.process.runtime.Network;
-import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,26 +47,21 @@ public class MongoDb214Test {
     private static final MongodStarter mongodStarter;
 
     static {
-        Command command = Command.MongoD;
-        RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(command)
-                .artifactStore(ExtractedArtifactStore.builder()
-                        .from(Defaults.extractedArtifactStoreFor(command))
-                        .temp(DirectoryAndExecutableNaming.builder()
-                                .directory(new PropertyOrPlatformTempDir())
-                                // The default configuration creates executables whose names contain random UUIDs, which
-                                // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
-                                // produces a stable executable name and only have to acknowledge the firewall dialogs once.
-                                // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
-                                // Failure to click fast enough will result in additional dialogs on subsequent test runs.
-                                // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
-                                .executableNaming(new TempNaming() {
-                                    @Override
-                                    public String nameFor(String prefix, String postfix) {
-                                        return prefix + "-Db214-" + postfix;
-                                    }
-                                })
-                                .build())
-                        .build())
+        IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaults(Command.MongoD)
+                .artifactStore(new ExtractedArtifactStoreBuilder()
+                        .defaults(Command.MongoD)
+                        // The default configuration creates executables whose names contain random UUIDs, which
+                        // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
+                        // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                        // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
+                        // Failure to click fast enough will result in additional dialogs on subsequent test runs.
+                        // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
+                        .executableNaming(new ITempNaming() {
+                            @Override
+                            public String nameFor(String prefix, String postfix) {
+                                return prefix + "-Db214-" + postfix;
+                            }
+                        }))
                 .build();
         mongodStarter = MongodStarter.getInstance(runtimeConfig);
     }
@@ -79,8 +73,7 @@ public class MongoDb214Test {
     @Before
     public void startMongo() throws Exception {
         int port = Network.getFreeServerPort();
-        @SuppressWarnings("deprecation")
-        ImmutableMongodConfig mongodConfig = ImmutableMongodConfig.builder()
+        IMongodConfig mongodConfig = new MongodConfigBuilder()
                 .version(Version.V2_6_11)
                 .net(new Net(port, Network.localhostIsIPv6()))
                 .build();

--- a/instrumentation/mongodb-3.0/build.gradle
+++ b/instrumentation/mongodb-3.0/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:3.0.0")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-3.1/build.gradle
+++ b/instrumentation/mongodb-3.1/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation("org.mongodb:mongo-java-driver:3.1.0")
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2")
 }
 
 verifyInstrumentation {

--- a/instrumentation/mongodb-3.1/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb310Test.java
+++ b/instrumentation/mongodb-3.1/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDb310Test.java
@@ -21,17 +21,15 @@ import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.Defaults;
-import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.ExtractedArtifactStoreBuilder;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.RuntimeConfig;
-import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
-import de.flapdoodle.embed.process.extract.TempNaming;
-import de.flapdoodle.embed.process.io.directories.PropertyOrPlatformTempDir;
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.extract.ITempNaming;
 import de.flapdoodle.embed.process.runtime.Network;
-import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,26 +48,21 @@ public class MongoDb310Test {
     private static final MongodStarter mongodStarter;
 
     static {
-        Command command = Command.MongoD;
-        RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(command)
-                .artifactStore(ExtractedArtifactStore.builder()
-                        .from(Defaults.extractedArtifactStoreFor(command))
-                        .temp(DirectoryAndExecutableNaming.builder()
-                                .directory(new PropertyOrPlatformTempDir())
-                                // The default configuration creates executables whose names contain random UUIDs, which
-                                // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
-                                // produces a stable executable name and only have to acknowledge the firewall dialogs once.
-                                // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
-                                // Failure to click fast enough will result in additional dialogs on subsequent test runs.
-                                // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
-                                .executableNaming(new TempNaming() {
-                                    @Override
-                                    public String nameFor(String prefix, String postfix) {
-                                        return prefix + "-Db310-" + postfix;
-                                    }
-                                })
-                                .build())
-                        .build())
+        IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaults(Command.MongoD)
+                .artifactStore(new ExtractedArtifactStoreBuilder()
+                        .defaults(Command.MongoD)
+                        // The default configuration creates executables whose names contain random UUIDs, which
+                        // prompts repetitive firewall dialog popups. Instead, we use a naming strategy that
+                        // produces a stable executable name and only have to acknowledge the firewall dialogs once.
+                        // On macOS systems, the dialogs must be acknowledged quickly in order to be registered.
+                        // Failure to click fast enough will result in additional dialogs on subsequent test runs.
+                        // This firewall dialog issue only seems to occur with versions of mongo < 3.6.0
+                        .executableNaming(new ITempNaming() {
+                            @Override
+                            public String nameFor(String prefix, String postfix) {
+                                return prefix + "-Db310-" + postfix;
+                            }
+                        }))
                 .build();
         mongodStarter = MongodStarter.getInstance(runtimeConfig);
     }
@@ -81,8 +74,7 @@ public class MongoDb310Test {
     @Before
     public void startMongo() throws Exception {
         int port = Network.getFreeServerPort();
-        @SuppressWarnings("deprecation")
-        MongodConfig mongodConfig = ImmutableMongodConfig.builder()
+        IMongodConfig mongodConfig = new MongodConfigBuilder()
                 .version(Version.V3_2_0)
                 .net(new Net(port, Network.localhostIsIPv6()))
                 .build();


### PR DESCRIPTION
# Overview
This previous [PR](https://github.com/newrelic/newrelic-java-agent/pull/111) upgraded to a later version of `de.flapdoodle.embed:de.flapdoodle.embed.mongo`, which broke Java 7 compatibility for several of the `instrumentation:mongodb-X` modules. This change reverts to the older Java 7 compatible version of the library while retaining the reduced firewall dialog functionality. 

### Related Github Issue
N/A

### Testing
I've validated that this passes Java7 compatibility using `./gradlew newrelic-java-agent:instrumentation test -Ptest7 --continue`. 

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
