### PR TITLE
fix span error builder

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorSpanEventService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorSpanEventService.java
@@ -50,11 +50,11 @@ public class IntrospectorSpanEventService extends SpanEventsServiceImpl {
     private static TracerToSpanEvent buildTracerToSpanEvent(AgentConfig agentConfig, EnvironmentService environmentService,
             TransactionDataToDistributedTraceIntrinsics transactionDataToDistributedTraceIntrinsics) {
         Map<String, SpanErrorBuilder> map = new HashMap<>();
-        map.put(agentConfig.getApplicationName(), new SpanErrorBuilder(
+        SpanErrorBuilder spanErrorBuilder = new SpanErrorBuilder(
                 new ErrorAnalyzerImpl(agentConfig.getErrorCollectorConfig()),
-                new ErrorMessageReplacer(agentConfig.getStripExceptionConfig())
-        ));
-        return new TracerToSpanEvent(map, environmentService, transactionDataToDistributedTraceIntrinsics);
+                new ErrorMessageReplacer(agentConfig.getStripExceptionConfig()));
+        map.put(agentConfig.getApplicationName(), spanErrorBuilder);
+        return new TracerToSpanEvent(map, environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
@@ -53,25 +53,28 @@ public class TracerToSpanEvent {
     private final Supplier<Long> timestampSupplier;
     private final EnvironmentService environmentService;
     private final TransactionDataToDistributedTraceIntrinsics transactionDataToDistributedTraceIntrinsics;
+    private final SpanErrorBuilder defaultSpanErrorBuilder;
 
     public TracerToSpanEvent(Map<String, SpanErrorBuilder> errorBuilderForApp, EnvironmentService environmentService,
-            TransactionDataToDistributedTraceIntrinsics transactionDataToDistributedTraceIntrinsics) {
+            TransactionDataToDistributedTraceIntrinsics transactionDataToDistributedTraceIntrinsics, SpanErrorBuilder defaultSpanErrorBuilder) {
         this(
                 errorBuilderForApp,
                 AttributeFilters.SPAN_EVENTS_ATTRIBUTE_FILTER,
                 SpanEventFactory.DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER,
                 environmentService,
-                transactionDataToDistributedTraceIntrinsics);
+                transactionDataToDistributedTraceIntrinsics,
+                defaultSpanErrorBuilder);
     }
 
     TracerToSpanEvent(Map<String, SpanErrorBuilder> errorBuilderForApp, AttributeFilter filter, Supplier<Long> timestampSupplier,
             EnvironmentService environmentService,
-            TransactionDataToDistributedTraceIntrinsics transactionDataToDistributedTraceIntrinsics) {
+            TransactionDataToDistributedTraceIntrinsics transactionDataToDistributedTraceIntrinsics, SpanErrorBuilder defaultSpanErrorBuilder) {
         this.errorBuilderForApp = errorBuilderForApp;
         this.filter = filter;
         this.timestampSupplier = timestampSupplier;
         this.environmentService = environmentService;
         this.transactionDataToDistributedTraceIntrinsics = transactionDataToDistributedTraceIntrinsics;
+        this.defaultSpanErrorBuilder = defaultSpanErrorBuilder;
     }
 
     public SpanEvent createSpanEvent(Tracer tracer, TransactionData transactionData, TransactionStats transactionStats, boolean isRoot,
@@ -121,6 +124,8 @@ public class TracerToSpanEvent {
 
     private SpanEventFactory maybeSetError(Tracer tracer, TransactionData transactionData, boolean isRoot, SpanEventFactory builder) {
         SpanErrorBuilder spanErrorBuilder = errorBuilderForApp.get(transactionData.getApplicationName());
+        spanErrorBuilder = spanErrorBuilder == null ? defaultSpanErrorBuilder: spanErrorBuilder;
+
         if (spanErrorBuilder.areErrorsEnabled()) {
             final SpanError spanError = spanErrorBuilder.buildSpanError(
                     tracer,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
@@ -124,7 +124,7 @@ public class TracerToSpanEvent {
 
     private SpanEventFactory maybeSetError(Tracer tracer, TransactionData transactionData, boolean isRoot, SpanEventFactory builder) {
         SpanErrorBuilder spanErrorBuilder = errorBuilderForApp.get(transactionData.getApplicationName());
-        spanErrorBuilder = spanErrorBuilder == null ? defaultSpanErrorBuilder: spanErrorBuilder;
+        spanErrorBuilder = spanErrorBuilder == null ? defaultSpanErrorBuilder : spanErrorBuilder;
 
         if (spanErrorBuilder.areErrorsEnabled()) {
             final SpanError spanError = spanErrorBuilder.buildSpanError(

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventsServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventsServiceTest.java
@@ -82,17 +82,18 @@ public class SpanEventsServiceTest {
             }
         };
 
-        Map<String, SpanErrorBuilder> map = new HashMap<>();
-        map.put(agentConfig.getApplicationName(), new SpanErrorBuilder(
+        SpanErrorBuilder defaultSpanErrorBuilder = new SpanErrorBuilder(
                 new ErrorAnalyzerImpl(agentConfig.getErrorCollectorConfig()),
-                new ErrorMessageReplacer(agentConfig.getStripExceptionConfig())
-        ));
+                new ErrorMessageReplacer(agentConfig.getStripExceptionConfig()));
+
+        Map<String, SpanErrorBuilder> map = new HashMap<>();
+        map.put(agentConfig.getApplicationName(), defaultSpanErrorBuilder);
 
         EnvironmentService environmentService = mock(EnvironmentService.class, RETURNS_DEEP_STUBS);
         TransactionDataToDistributedTraceIntrinsics transactionDataToDistributedTraceIntrinsics = mock(TransactionDataToDistributedTraceIntrinsics.class);
         when(transactionDataToDistributedTraceIntrinsics.buildDistributedTracingIntrinsics(any(TransactionData.class), anyBoolean()))
                 .thenReturn(Collections.<String, Object>emptyMap());
-        TracerToSpanEvent tracerToSpanEvent = new TracerToSpanEvent(map, environmentService, transactionDataToDistributedTraceIntrinsics);
+        TracerToSpanEvent tracerToSpanEvent = new TracerToSpanEvent(map, environmentService, transactionDataToDistributedTraceIntrinsics, defaultSpanErrorBuilder);
         SpanEventsServiceImpl spanEventsService = SpanEventsServiceImpl.builder()
                 .agentConfig(agentConfig)
                 .reservoirManager(reservoirManager)

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/TracerToSpanEventTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/TracerToSpanEventTest.java
@@ -155,7 +155,7 @@ public class TracerToSpanEventTest {
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
@@ -176,7 +176,7 @@ public class TracerToSpanEventTest {
         when(spanProxy.getInitiatingW3CTraceState()).thenReturn(traceState);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -201,7 +201,7 @@ public class TracerToSpanEventTest {
         when(tracer.getParentTracer()).thenReturn(parentTracer);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -224,7 +224,7 @@ public class TracerToSpanEventTest {
         when(txnData.getInboundDistributedTracePayload()).thenReturn(dtPayload);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -247,7 +247,7 @@ public class TracerToSpanEventTest {
         when(w3cPayload.getParentId()).thenReturn(parentGuid);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -272,7 +272,7 @@ public class TracerToSpanEventTest {
         when(tracer.getParentTracer()).thenReturn(parentTracer);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, true);
@@ -321,7 +321,7 @@ public class TracerToSpanEventTest {
         when(txnStats.getUnscopedStats().getOrCreateResponseTimeStats(QUEUE_TIME).getTotal()).thenReturn(queueDuration);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -350,7 +350,7 @@ public class TracerToSpanEventTest {
         when(txnData.getAgentAttributes()).thenReturn(transactionAgentAttributes);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -381,7 +381,7 @@ public class TracerToSpanEventTest {
         when(txnData.getPrefixedAttributes()).thenReturn(prefixedAttributes);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -401,7 +401,7 @@ public class TracerToSpanEventTest {
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -423,7 +423,7 @@ public class TracerToSpanEventTest {
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -446,7 +446,7 @@ public class TracerToSpanEventTest {
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, isRoot, false);
@@ -469,7 +469,7 @@ public class TracerToSpanEventTest {
         when(txnData.getIntrinsicAttributes()).thenReturn(intrinsicAttributes);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
@@ -504,7 +504,7 @@ public class TracerToSpanEventTest {
         when(txnData.getAgentAttributes()).thenReturn(transactionAgentAttributes);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
@@ -521,7 +521,33 @@ public class TracerToSpanEventTest {
         when(spanErrorBuilder.areErrorsEnabled()).thenReturn(false);
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
+
+        // execution
+        SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
+
+        // assertions
+        assertEquals(expectedSpanEvent, spanEvent);
+    }
+
+    @Test
+    public void testAutoAppNaming() {
+        // setup
+        String newAppName = "new app name";
+        when(txnData.getApplicationName()).thenReturn(newAppName);
+        SpanEvent expectedSpanEvent = SpanEvent.builder()
+                .appName(newAppName)
+                .priority(priority)
+                .putAllAgentAttributes(expectedAgentAttributes)
+                .putAllIntrinsics(expectedIntrinsicAttributes)
+                .putAllUserAttributes(expectedUserAttributes)
+                .decider(true)
+                .timestamp(timestamp)
+                .build();
+        when(spanErrorBuilder.areErrorsEnabled()).thenReturn(true);
+
+        TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
@@ -538,7 +564,7 @@ public class TracerToSpanEventTest {
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
@@ -557,7 +583,7 @@ public class TracerToSpanEventTest {
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
@@ -582,7 +608,7 @@ public class TracerToSpanEventTest {
         }
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);
@@ -613,7 +639,7 @@ public class TracerToSpanEventTest {
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
         TracerToSpanEvent testClass = new TracerToSpanEvent(errorBuilderMap, new AttributeFilter.PassEverythingAttributeFilter(), timestampProvider,
-                environmentService, transactionDataToDistributedTraceIntrinsics);
+                environmentService, transactionDataToDistributedTraceIntrinsics, spanErrorBuilder);
 
         // execution
         SpanEvent spanEvent = testClass.createSpanEvent(tracer, txnData, txnStats, true, false);


### PR DESCRIPTION
Context: When we process tracers to convert them to span events, we grab an error handler based off of the app name from the transaction. Since we register error handlers on startup and it’s based on the app name from the config, the transaction app name might not match the yaml app name (when auto app naming is enabled), which results in returning null for the error handler. The agent then tries to operate with it, causing an NPE and preventing the span event from reporting .

The stacktrace for this NPE looks like: 

```
2020-11-19T14:19:25,742-0600 [1886 428] com.newrelic FINER: An error occurred creating span event for tracer: com.newrelic.agent.tracers.OtherRootTracer@2f2fe363 in tx: /custom/transaction 124ms
java.lang.NullPointerException: null
        at com.newrelic.agent.service.analytics.TracerToSpanEvent.maybeSetError(TracerToSpanEvent.java:124) ~[newrelic.jar:6.1.0]
        at com.newrelic.agent.service.analytics.TracerToSpanEvent.createSpanEvent(TracerToSpanEvent.java:96) ~[newrelic.jar:6.1.0]
        at com.newrelic.agent.service.analytics.SpanEventsServiceImpl.createAndStoreSpanEvent(SpanEventsServiceImpl.java:107) ~[newrelic.jar:6.1.0]
        at com.newrelic.agent.service.analytics.SpanEventsServiceImpl.storeSafely(SpanEventsServiceImpl.java:86) [newrelic.jar:6.1.0]
        at com.newrelic.agent.service.analytics.SpanEventsServiceImpl.dispatcherTransactionFinished(SpanEventsServiceImpl.java:78) [newrelic.jar:6.1.0]
        at com.newrelic.agent.TransactionService.doProcessTransaction(TransactionService.java:160) [newrelic.jar:6.1.0]
        at com.newrelic.agent.TransactionService.transactionFinished(TransactionService.java:116) [newrelic.jar:6.1.0]
        at com.newrelic.agent.Transaction.finishTransaction(Transaction.java:1122) [newrelic.jar:6.1.0]
        at com.newrelic.agent.Transaction.checkFinishTransaction(Transaction.java:2421) [newrelic.jar:6.1.0]
        at com.newrelic.agent.Transaction.checkFinishTransaction(Transaction.java:2407) [newrelic.jar:6.1.0]
        at com.newrelic.agent.Transaction.activityFinished(Transaction.java:2506) [newrelic.jar:6.1.0]
        at com.newrelic.agent.TransactionActivity.finished(TransactionActivity.java:423) [newrelic.jar:6.1.0]
        at com.newrelic.agent.TransactionActivity.tracerFinished(TransactionActivity.java:374) [newrelic.jar:6.1.0]
        at com.newrelic.agent.tracers.DefaultTracer.performFinishWork(DefaultTracer.java:275) [newrelic.jar:6.1.0]
        at com.newrelic.agent.tracers.DefaultTracer.finish(DefaultTracer.java:222) [newrelic.jar:6.1.0]
```

The fix is to use the default error handler in the case where we can't find the app-name-specific error handler.
