### PR TITLE
Wrong URL reporting for Spring WebClient when multiple threads make requests to different URLs in parallel

### DIFF
--- a/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
@@ -39,6 +39,9 @@ public class Util {
     }
 
     public static Mono<ClientResponse> reportAsExternal(ClientRequest request, Mono<ClientResponse> response) {
+        if(request == null) {
+            return response;
+        }
         Segment segment = (Segment) request.attribute(SEGMENT_ATTRIBUTE).orElse(null);
         if (segment == null) {
             return response;

--- a/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
@@ -8,11 +8,15 @@
 package com.nr.agent.instrumentation.spring_webclient;
 
 import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.Transaction;
 import com.newrelic.api.agent.GenericParameters;
 import com.newrelic.api.agent.HttpParameters;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.weaver.Weaver;
+import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -22,35 +26,49 @@ import java.util.logging.Level;
 public class Util {
 
     private static final String LIBRARY = "Spring-WebClient";
+    private static final String SEGMENT_ATTRIBUTE = "newrelic-segment";
     private static final URI UNKNOWN_HOST = URI.create("UnknownHost");
-    private static URI uri = null;
 
-    public static BiConsumer<? super ClientResponse, Throwable> reportAsExternal(Segment segment) {
+    public static void startExternalSegmentIfNeeded(WebClient.RequestHeadersSpec<?> request) {
+        Transaction txn = AgentBridge.getAgent().getTransaction(false);
+        if (txn != null) {
+            Segment segment = txn.startSegment("WebClient.exchange");
+            segment.addOutboundRequestHeaders(new OutboundRequestWrapper(request));
+            request.attribute(SEGMENT_ATTRIBUTE, segment);
+        }
+    }
+
+    public static Mono<ClientResponse> reportAsExternal(ClientRequest request, Mono<ClientResponse> response) {
+        Segment segment = (Segment) request.attribute(SEGMENT_ATTRIBUTE).orElse(null);
+        if (segment == null) {
+            return response;
+        }
+        URI uri = request.url();
+        return response.doAfterSuccessOrError(reportAsExternal(segment, uri));
+    }
+
+    private static BiConsumer<? super ClientResponse, Throwable> reportAsExternal(Segment segment, URI uri) {
         return new BiConsumer<ClientResponse, Throwable>() {
             @Override
             public void accept(ClientResponse clientResponse, Throwable throwable) {
                 try {
-                    if (segment != null && uri != null) {
-                        if (clientResponse != null) {
-                            segment.reportAsExternal(HttpParameters
+                    if (clientResponse != null) {
+                        segment.reportAsExternal(HttpParameters
+                                .library(LIBRARY)
+                                .uri(uri)
+                                .procedure("exchange")
+                                .inboundHeaders(new InboundResponseWrapper(clientResponse))
+                                .build());
+                    } else {
+                        if (throwable instanceof UnknownHostException) {
+                            segment.reportAsExternal(GenericParameters
                                     .library(LIBRARY)
-                                    .uri(uri)
-                                    .procedure("exchange")
-                                    .inboundHeaders(new InboundResponseWrapper(clientResponse))
+                                    .uri(UNKNOWN_HOST)
+                                    .procedure("failed")
                                     .build());
-                        } else {
-                            if (throwable instanceof UnknownHostException) {
-                                segment.reportAsExternal(GenericParameters
-                                        .library(LIBRARY)
-                                        .uri(UNKNOWN_HOST)
-                                        .procedure("failed")
-                                        .build());
-                            }
                         }
                     }
-                    if (segment != null) {
-                        segment.end();
-                    }
+                    segment.end();
                 } catch (Throwable e) {
                     AgentBridge.getAgent()
                             .getLogger()
@@ -59,17 +77,5 @@ public class Util {
                 }
             }
         };
-    }
-
-    public static void setUri(String uri) {
-        Util.uri = URI.create(uri);
-    }
-
-    public static void setUri(URI uri) {
-        Util.uri = uri;
-    }
-
-    public static URI getUri() {
-       return Util.uri;
     }
 }

--- a/instrumentation/spring-webclient-5.0/src/main/java/org/springframework/web/reactive/function/client/ExchangeFunction_Instrumentation.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/org/springframework/web/reactive/function/client/ExchangeFunction_Instrumentation.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.springframework.web.reactive.function.client;
+
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.spring_webclient.Util;
+import reactor.core.publisher.Mono;
+
+@Weave(type = MatchType.Interface, originalName = "org.springframework.web.reactive.function.client.ExchangeFunction")
+public class ExchangeFunction_Instrumentation {
+
+    public Mono<ClientResponse> exchange(ClientRequest request) {
+
+        Mono<ClientResponse> response = Weaver.callOriginal();
+
+        return Util.reportAsExternal(request, response);
+    }
+}

--- a/instrumentation/spring-webclient-5.0/src/main/java/org/springframework/web/reactive/function/client/WebClient_Instrumentation.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/org/springframework/web/reactive/function/client/WebClient_Instrumentation.java
@@ -7,18 +7,11 @@
 
 package org.springframework.web.reactive.function.client;
 
-import com.newrelic.agent.bridge.AgentBridge;
-import com.newrelic.agent.bridge.Transaction;
-import com.newrelic.api.agent.NewRelic;
-import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
-import com.nr.agent.instrumentation.spring_webclient.OutboundRequestWrapper;
 import com.nr.agent.instrumentation.spring_webclient.Util;
 import reactor.core.publisher.Mono;
-
-import java.net.URI;
 
 @Weave(type = MatchType.Interface, originalName = "org.springframework.web.reactive.function.client.WebClient")
 public class WebClient_Instrumentation {
@@ -26,52 +19,11 @@ public class WebClient_Instrumentation {
     @Weave(type = MatchType.Interface, originalName = "org.springframework.web.reactive.function.client.WebClient$RequestHeadersSpec")
     public abstract static class RequestHeadersSpec_Instrumentation<S extends RequestHeadersSpec_Instrumentation<S>> {
 
-        public abstract S header(String headerName, String... headerValues);
-
         public Mono<ClientResponse> exchange() {
 
-            Object thisTemp = this;
-            URI uri = Util.getUri();
-            Segment segment = null;
+            Util.startExternalSegmentIfNeeded((WebClient.RequestHeadersSpec<?>) this);
 
-            if (thisTemp instanceof UriSpec_Instrumentation) {
-                if (uri != null) {
-                    String scheme = uri.getScheme();
-                    if (scheme != null) {
-                        final Transaction txn = AgentBridge.getAgent().getTransaction(false);
-                        final String lowerCaseScheme = scheme.toLowerCase();
-                        if (txn != null && ("http".equals(lowerCaseScheme) || "https".equals(lowerCaseScheme))) {
-                            segment = NewRelic.getAgent().getTransaction().startSegment("WebClient.exchange");
-                            segment.addOutboundRequestHeaders(
-                                    new OutboundRequestWrapper((WebClient.RequestHeadersSpec) thisTemp));
-                        }
-                    }
-                }
-            }
-
-            Mono<ClientResponse> response = Weaver.callOriginal();
-            if (segment == null || uri == null) {
-                return response;
-            }
-            return response.doAfterSuccessOrError(Util.reportAsExternal(segment));
-        }
-    }
-
-    @Weave(type = MatchType.Interface, originalName = "org.springframework.web.reactive.function.client.WebClient$UriSpec")
-    public static class UriSpec_Instrumentation<S extends WebClient.RequestHeadersSpec<?>> {
-
-        public S uri(URI uri) {
-            Util.setUri(uri);
             return Weaver.callOriginal();
         }
-    }
-
-    @Weave(type = MatchType.Interface, originalName = "org.springframework.web.reactive.function.client.WebClient$Builder")
-    public static class Builder_Instrumentation {
-
-        public WebClient.Builder baseUrl(String baseUrl) {
-            Util.setUri(baseUrl);
-            return Weaver.callOriginal();
-        }
-    }
+   }
 }

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/ConcurrencyTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/ConcurrencyTest.java
@@ -1,0 +1,185 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.instrumentation;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Trace;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyExtractor;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.newrelic.agent.introspec.MetricsHelper.getUnscopedMetricCount;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = {"org.springframework"})
+public class ConcurrencyTest {
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testParallelWebClientCalls() throws Exception {
+        int nIterations = 1000;
+        waitAll(executor.submit(new WebClientCaller(nIterations, "http://host0.com")),
+                executor.submit(new WebClientCaller(nIterations, "http://host1.com")));
+        assertEquals(nIterations, getUnscopedMetricCount("External/host0.com/Spring-WebClient/exchange"));
+        assertEquals(nIterations, getUnscopedMetricCount("External/host1.com/Spring-WebClient/exchange"));
+    }
+
+    public void waitAll(Future<?>... futures) throws Exception {
+        for (Future<?> future : futures)
+            future.get();
+    }
+
+    public static class WebClientCaller implements Runnable {
+        final int count;
+        final String url;
+
+        public WebClientCaller(int count, String url) {
+            this.count = count;
+            this.url = url;
+        }
+
+        @Override
+        public void run() {
+            int remainingCalls = count;
+            while (remainingCalls-- > 0) {
+                makeGetRequest(URI.create(url)).block();
+            }
+        }
+
+        @Trace(dispatcher = true)
+        public Mono<ClientResponse> makeGetRequest(URI uri) {
+            WebClient webClient = WebClient.builder()
+                    .exchangeFunction(new ExchangeFunctionStub())
+                    .build();
+            return webClient.get().uri(uri).exchange();
+        }
+    }
+
+    public static class ExchangeFunctionStub implements ExchangeFunction {
+        @Override
+        public Mono<ClientResponse> exchange(ClientRequest request) {
+            return Mono.just(new ClientResponseStub());
+        }
+    }
+
+    public static class ClientResponseStub implements ClientResponse {
+
+        @Override
+        public HttpStatus statusCode() {
+            return HttpStatus.OK;
+        }
+
+        @Override
+        public Headers headers() {
+            return new Headers() {
+                @Override
+                public OptionalLong contentLength() {
+                    return OptionalLong.of(0L);
+                }
+
+                @Override
+                public Optional<MediaType> contentType() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public List<String> header(String headerName) {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public HttpHeaders asHttpHeaders() {
+                    return new HttpHeaders();
+                }
+            };
+        }
+
+        @Override
+        public MultiValueMap<String, ResponseCookie> cookies() {
+            return null;
+        }
+
+        @Override
+        public <T> T body(BodyExtractor<T, ? super ClientHttpResponse> extractor) {
+            return null;
+        }
+
+        @Override
+        public <T> Mono<T> bodyToMono(Class<? extends T> elementClass) {
+            return null;
+        }
+
+        @Override
+        public <T> Mono<T> bodyToMono(ParameterizedTypeReference<T> typeReference) {
+            return null;
+        }
+
+        @Override
+        public <T> Flux<T> bodyToFlux(Class<? extends T> elementClass) {
+            return null;
+        }
+
+        @Override
+        public <T> Flux<T> bodyToFlux(ParameterizedTypeReference<T> typeReference) {
+            return null;
+        }
+
+        @Override
+        public <T> Mono<ResponseEntity<T>> toEntity(Class<T> bodyType) {
+            return null;
+        }
+
+        @Override
+        public <T> Mono<ResponseEntity<T>> toEntity(ParameterizedTypeReference<T> typeReference) {
+            return null;
+        }
+
+        @Override
+        public <T> Mono<ResponseEntity<List<T>>> toEntityList(Class<T> elementType) {
+            return null;
+        }
+
+        @Override
+        public <T> Mono<ResponseEntity<List<T>>> toEntityList(ParameterizedTypeReference<T> typeReference) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
The behavior being fixed: When multiple threads make HTTP calls to several URLs in parallel, the stats reported to NewRelic for one call may be recorded with URL from another call.

Root cause: The logic capturing request URLs was passing the URLs to the reporting logic (segment.reportAsExternal) using a static variable. Multiple threads were able to write and read that variable in parallel. Since a thread wrote its request URL to the variable, but before it read it back, other threads were able to overwrite it.