### PR TITLE
add weave to get uri placeholder value

### DIFF
--- a/instrumentation/spring-4.3.0/build.gradle
+++ b/instrumentation/spring-4.3.0/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation("org.springframework:spring-context:4.3.0.RELEASE")
     implementation("org.springframework:spring-web:4.3.0.RELEASE")
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.31")
+    compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 }
 
 jar {

--- a/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringControllerUtility.java
+++ b/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringControllerUtility.java
@@ -79,9 +79,11 @@ public class SpringControllerUtility {
         if (rootPath == null && methodPath == null) {
             AgentBridge.getAgent().getLogger().log(Level.FINE, "No path was specified for SpringController {0}", matchedAnnotationClass.getName());
         } else {
-            String fullPath = SpringControllerUtility.getPath(rootPath, methodPath, httpMethod);
-            transaction.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController",
-                    fullPath);
+            if(!SpringPlaceholderConfig.springPlaceholderValue){
+                String fullPath = SpringControllerUtility.getPath(rootPath, methodPath, httpMethod);
+                transaction.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController",
+                        fullPath);
+            }
         }
     }
 

--- a/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringControllerUtility.java
+++ b/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringControllerUtility.java
@@ -79,6 +79,7 @@ public class SpringControllerUtility {
         if (rootPath == null && methodPath == null) {
             AgentBridge.getAgent().getLogger().log(Level.FINE, "No path was specified for SpringController {0}", matchedAnnotationClass.getName());
         } else {
+
             if(!SpringPlaceholderConfig.springPlaceholderValue){
                 String fullPath = SpringControllerUtility.getPath(rootPath, methodPath, httpMethod);
                 transaction.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController",

--- a/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringPlaceholderConfig.java
+++ b/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringPlaceholderConfig.java
@@ -1,0 +1,13 @@
+package com.nr.agent.instrumentation;
+
+import com.newrelic.api.agent.NewRelic;
+
+public class SpringPlaceholderConfig {
+
+    public static final boolean springPlaceholderValue = NewRelic.getAgent().getConfig()
+            .getValue("spring.placeholder_value.enabled", false);
+
+    private SpringPlaceholderConfig() {
+    }
+
+}

--- a/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringPlaceholderConfig.java
+++ b/instrumentation/spring-4.3.0/src/main/java/com/nr/agent/instrumentation/SpringPlaceholderConfig.java
@@ -5,7 +5,7 @@ import com.newrelic.api.agent.NewRelic;
 public class SpringPlaceholderConfig {
 
     public static final boolean springPlaceholderValue = NewRelic.getAgent().getConfig()
-            .getValue("spring.placeholder_value.enabled", false);
+            .getValue("spring.placeholder_value.enabled", true);
 
     private SpringPlaceholderConfig() {
     }

--- a/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -1,0 +1,30 @@
+package org.springframework.web.util;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.TransactionNamePriority;
+import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.SpringControllerUtility;
+import com.nr.agent.instrumentation.SpringPlaceholderConfig;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Weave
+public class UrlPathHelper {
+
+    public UrlPathHelper(){}
+
+    public String getLookupPathForRequest(HttpServletRequest request) {
+        String result = Weaver.callOriginal();
+        Transaction tx = AgentBridge.getAgent().getTransaction(false);
+
+        if(SpringPlaceholderConfig.springPlaceholderValue && result != null && tx != null){
+            tx.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController",
+                    result);
+
+        }
+
+        return result;
+    }
+}

--- a/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -1,6 +1,6 @@
 package org.springframework.web.util;
 
-import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Transaction;
 import com.newrelic.api.agent.TransactionNamePriority;
 import com.newrelic.api.agent.weaver.Weave;
@@ -16,7 +16,7 @@ public class UrlPathHelper {
 
     public String getLookupPathForRequest(HttpServletRequest request) {
         String result = Weaver.callOriginal();
-        Transaction tx = AgentBridge.getAgent().getTransaction(false);
+        Transaction tx = NewRelic.getAgent().getTransaction();
 
         if(SpringPlaceholderConfig.springPlaceholderValue && result != null && tx != null){
             String methodName = (request.getMethod() != null) ? " ("+request.getMethod()+")" : "";

--- a/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -20,9 +20,7 @@ public class UrlPathHelper {
         Transaction tx = AgentBridge.getAgent().getTransaction(false);
 
         if(SpringPlaceholderConfig.springPlaceholderValue && result != null && tx != null){
-            tx.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController",
-                    result);
-
+            tx.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController", result);
         }
 
         return result;

--- a/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -6,6 +6,7 @@ import com.newrelic.api.agent.TransactionNamePriority;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.agent.instrumentation.SpringPlaceholderConfig;
+
 import javax.servlet.http.HttpServletRequest;
 
 @Weave
@@ -18,7 +19,9 @@ public class UrlPathHelper {
         Transaction tx = AgentBridge.getAgent().getTransaction(false);
 
         if(SpringPlaceholderConfig.springPlaceholderValue && result != null && tx != null){
-            tx.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController", result);
+            String methodName = (request.getMethod() != null) ? " ("+request.getMethod()+")" : "";
+            tx.setTransactionName(TransactionNamePriority.FRAMEWORK_HIGH, true, "SpringController",
+                    result + methodName);
         }
 
         return result;

--- a/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/instrumentation/spring-4.3.0/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -1,13 +1,11 @@
 package org.springframework.web.util;
 
 import com.newrelic.agent.bridge.AgentBridge;
-import com.newrelic.agent.bridge.TransactionNamePriority;
 import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.TransactionNamePriority;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
-import com.nr.agent.instrumentation.SpringControllerUtility;
 import com.nr.agent.instrumentation.SpringPlaceholderConfig;
-
 import javax.servlet.http.HttpServletRequest;
 
 @Weave

--- a/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/App.java
+++ b/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/App.java
@@ -7,9 +7,9 @@
 
 package com.nr.agent.instrumentation;
 
-import java.util.Collections;
-
 import com.newrelic.api.agent.Trace;
+
+import java.util.Collections;
 
 public class App {
 
@@ -82,4 +82,10 @@ public class App {
     public static String delete() {
         return new VerbTests().deleteMapping();
     }
+
+    @Trace(dispatcher = true)
+    public static String placeholder(){
+        return new PlaceHolderPath().path();
+    }
+
 }

--- a/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/PlaceHolderPath.java
+++ b/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/PlaceHolderPath.java
@@ -1,0 +1,14 @@
+package com.nr.agent.instrumentation;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class PlaceHolderPath {
+
+    @RequestMapping("/${request.mapping}")
+    public String path(){
+        return "path";
+    }
+
+}

--- a/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/SpringControllerTests.java
+++ b/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/SpringControllerTests.java
@@ -7,17 +7,16 @@
 
 package com.nr.agent.instrumentation;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TracedMetricData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = { "com.nr.agent.instrumentation" })
@@ -91,6 +90,15 @@ public class SpringControllerTests {
         String expectedTransactionName = "OtherTransaction/SpringController/path/value (GET)";
         Map<String, TracedMetricData> metrics = introspector.getMetricsForTransaction(expectedTransactionName);
         assertEquals(1, metrics.get("Java/com.nr.agent.instrumentation.PathAndValueTest/pathAndValue").getCallCount());
+    }
+    @Test
+    public void testPlaceHolderPath() {
+        assertEquals("path", App.placeholder());
+
+        Introspector introspector = InstrumentationTestRunner.getIntrospector();
+        String expectedTransactionName = "OtherTransaction/SpringController/placeHolder (GET)";
+        Map<String, TracedMetricData> metrics = introspector.getMetricsForTransaction(expectedTransactionName);
+        assertEquals(1, metrics.get("Java/com.nr.agent.instrumentation.PlaceHolderPath/placeHolder").getCallCount());
     }
 
     @Test

--- a/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/application.properties
+++ b/instrumentation/spring-4.3.0/src/test/java/com/nr/agent/instrumentation/application.properties
@@ -1,0 +1,1 @@
+requestmapping.path=placeHolder

--- a/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
@@ -27,6 +27,7 @@ import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.agent.tracers.servlet.ExternalTimeTracker;
 import com.newrelic.agent.transaction.TransactionNamer;
 import com.newrelic.agent.transaction.WebTransactionNamer;
+import com.newrelic.agent.util.Strings;
 import com.newrelic.api.agent.ExtendedRequest;
 import com.newrelic.api.agent.Request;
 import com.newrelic.api.agent.Response;
@@ -37,7 +38,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
-public class  WebRequestDispatcher extends DefaultDispatcher implements WebResponse {
+public class WebRequestDispatcher extends DefaultDispatcher implements WebResponse {
 
     private static final String UNKNOWN_URI = "/Unknown";
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
@@ -27,7 +27,6 @@ import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.agent.tracers.servlet.ExternalTimeTracker;
 import com.newrelic.agent.transaction.TransactionNamer;
 import com.newrelic.agent.transaction.WebTransactionNamer;
-import com.newrelic.agent.util.Strings;
 import com.newrelic.api.agent.ExtendedRequest;
 import com.newrelic.api.agent.Request;
 import com.newrelic.api.agent.Response;
@@ -38,7 +37,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
-public class WebRequestDispatcher extends DefaultDispatcher implements WebResponse {
+public class  WebRequestDispatcher extends DefaultDispatcher implements WebResponse {
 
     private static final String UNKNOWN_URI = "/Unknown";
 


### PR DESCRIPTION
### Overview
Describe the changes present in the pull request
Weave spring UrlPathHelper to set the Transaction Name to the actual path for a request when a path placeholder is used on `RequestMapping` 
e.g. `RequestMapping(path= "/${...}")`
https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#mvc

To use the placeholder value instead of the String value `"/${...}")' a configuration option is required.
Requires configuration to change from previous behavior.  Default will not change previous behavior.

Adds optional configuration to use property file defined URI.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/126

### Testing
ran existing instrumentation and functional tests
Validated fix with local Spring App

### Checks

[* ] Are your contributions backwards compatible with relevant frameworks and APIs?
Currently only changes spring-4.3.0
[* ] Does your code introduce any new dependencies? Please describe.
Yes.
`compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'`

<img width="669" alt="transactionName" src="https://user-images.githubusercontent.com/7401258/101720707-2315d380-3a5b-11eb-96c8-c11ef6268178.png">
