### PR TITLE
Make sure NettyDispatcher gets initialized

### DIFF
--- a/instrumentation/netty-4.0.8/src/main/java/io/netty/bootstrap/NettyDispatcher.java
+++ b/instrumentation/netty-4.0.8/src/main/java/io/netty/bootstrap/NettyDispatcher.java
@@ -16,6 +16,7 @@ import com.newrelic.api.agent.TracedMethod;
 import io.netty.channel.ChannelHandlerContext_Instrumentation;
 import io.netty.handler.codec.http.HttpRequest;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 /**
@@ -26,12 +27,14 @@ import java.util.logging.Level;
 public class NettyDispatcher {
 
     private static volatile NettyDispatcher instance = null;
+    public static volatile AtomicBoolean instrumented = new AtomicBoolean(false);
 
     public static NettyDispatcher get() {
         if (null == instance) {
             synchronized (NettyDispatcher.class) {
                 if (null == instance) {
                     instance = new NettyDispatcher();
+                    instrumented.set(true);
                 }
             }
         }

--- a/instrumentation/netty-4.0.8/src/main/java/io/netty/bootstrap/NettyDispatcher.java
+++ b/instrumentation/netty-4.0.8/src/main/java/io/netty/bootstrap/NettyDispatcher.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 public class NettyDispatcher {
 
     private static volatile NettyDispatcher instance = null;
-    public static volatile AtomicBoolean instrumented = new AtomicBoolean(false);
+    public static final AtomicBoolean instrumented = new AtomicBoolean(false);
 
     public static NettyDispatcher get() {
         if (null == instance) {

--- a/instrumentation/netty-4.0.8/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/instrumentation/netty-4.0.8/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -24,6 +24,12 @@ public class HttpObjectDecoder {
         Weaver.callOriginal();
         for (Object msg : out) {
             if (msg instanceof HttpRequest && ctx.pipeline().token == null) {
+                // NettyDispatcher class is usually initialized in AbstractBootstrap; however,
+                // that code is not always invoked when using recent Netty versions (4.1.54)
+                // so we check here and initialize if we haven't yet.
+                if (!NettyDispatcher.instrumented.get()) {
+                    NettyDispatcher.get();
+                }
                 NettyDispatcher.channelRead(ctx, msg);
             }
         }


### PR DESCRIPTION
When testing the spring-webflux-5.3.1 changes, @jack-berg and I found that the initial Transaction created by Netty-4.0.8 instrumentation was never getting created. The issue is that AbstractServerBootstrap isn't always used, consequently never triggering the (re)instrumentation of NettyDispatcher::channelRead , which is the Transaction start poing