### PR TITLE
Add LinkingMetadataMBean supportability metric

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -47,5 +47,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel test -x functional_test:test -PnoInstrumentation --continue
-
+        run: ./gradlew --console=plain --parallel clean test -x functional_test:test -PnoInstrumentation --continue

--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -442,6 +442,9 @@ public class MetricNames {
     // Deprecated features
     public static final String SUPPORTABILITY_DEPRECATED_CONFIG_JAR_COLLECTOR = "Supportability/Deprecated/Config/JarCollector";
 
+    // JMX
+    public static final String LINKING_METADATA_MBEAN = "Supportability/LinkingMetadataMBean/Enabled";
+
     // parent.type/parent.account/parent.appId/transport
     public static final String PARENT_DATA = "{0}/{1}/{2}/{3}/{4}";
     public static final String PARENT_DATA_ALL = "all";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
@@ -418,7 +418,7 @@ public class JmxService extends AbstractService implements HarvestListener {
     }
 
     private void registerAgentMBeans() {
-        if(jmxConfig.registerLinkingMetadataMBean()){
+        if (jmxConfig.registerLinkingMetadataMBean()) {
             // This registers the mbean that exposes linking metadata
             new LinkingMetadataRegistration(Agent.LOG).registerLinkingMetadata();
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
@@ -1,12 +1,16 @@
 package com.newrelic.agent.jmx;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.newrelic.agent.MetricNames;
+import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.api.agent.Logger;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.util.logging.Level;
+
+import static com.newrelic.agent.stats.StatsWorks.getRecordMetricWork;
 
 public class LinkingMetadataRegistration {
 
@@ -25,6 +29,7 @@ public class LinkingMetadataRegistration {
             Object bean = new LinkingMetadata();
             server.registerMBean(bean, name);
             logger.log(Level.INFO, "JMX LinkingMetadata bean registered");
+            ServiceFactory.getStatsService().doStatsWork(getRecordMetricWork(MetricNames.LINKING_METADATA_MBEAN, 1));
         } catch (Exception | NoClassDefFoundError e) {
             logger.log(Level.INFO, "Error registering JMX LinkingMetadata MBean", e);
         }


### PR DESCRIPTION
Adds a `Supportability/LinkingMetadataMBean/Enabled` metric when the agent is configured as follows:

```
  jmx:
    enabled: true
    linkingMetadataMBean: true
```

This will help us to partially track JFR (aka RTP) usage but only when using the agent.

<img width="1049" alt="supportability" src="https://user-images.githubusercontent.com/3496648/102256571-67243080-3ec0-11eb-81d5-b8870e344225.png">
