### PR TITLE
Infinite tracing failed precondition

### DIFF
--- a/infinite-tracing/src/main/java/com/newrelic/BackoffPolicy.java
+++ b/infinite-tracing/src/main/java/com/newrelic/BackoffPolicy.java
@@ -4,5 +4,6 @@ import io.grpc.Status;
 
 public interface BackoffPolicy {
     boolean shouldReconnect(Status status);
+    int duration();
     void backoff();
 }

--- a/infinite-tracing/src/main/java/com/newrelic/ChannelSupplier.java
+++ b/infinite-tracing/src/main/java/com/newrelic/ChannelSupplier.java
@@ -17,7 +17,7 @@ public class ChannelSupplier implements Supplier<ManagedChannel> {
     private final ChannelFactory channelFactory;
     private volatile ManagedChannel channel;
 
-    public ChannelSupplier(ChannelFactory channelFactory, ConnectionStatus connectionStatus, Logger logger) {
+    public ChannelSupplier(ConnectionStatus connectionStatus, Logger logger, ChannelFactory channelFactory) {
         this.connectionStatus = connectionStatus;
         this.logger = logger;
         this.channelFactory = channelFactory;

--- a/infinite-tracing/src/main/java/com/newrelic/ConnectBackoffPolicy.java
+++ b/infinite-tracing/src/main/java/com/newrelic/ConnectBackoffPolicy.java
@@ -1,0 +1,48 @@
+package com.newrelic;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Status;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConnectBackoffPolicy implements BackoffPolicy {
+
+    @VisibleForTesting
+    final int[] BACKOFF_INTERVAL_IN_SEC = new int[] { 0, 15, 15, 30, 60, 120, 300 };
+    private final int MAX_BACKOFF_DELAY = 300;
+    private final AtomicInteger backoffIndex = new AtomicInteger(0);
+
+    @Override
+    public boolean shouldReconnect(Status status) {
+        // See: https://source.datanerd.us/agents/agent-specs/blob/master/Infinite-Tracing.md#unimplemented
+        if (status != null) {
+            return status.getCode() != Status.Code.UNIMPLEMENTED;
+        }
+        return true;
+    }
+
+    @Override
+    public int duration() {
+        return BACKOFF_INTERVAL_IN_SEC [backoffIndex.get()];
+    }
+
+    @Override
+    public void backoff() {
+        try {
+            // See: https://source.datanerd.us/agents/agent-specs/blob/master/Infinite-Tracing.md#failed_precondition
+            TimeUnit.SECONDS.sleep(nextBackoffDuration());
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void reset() {
+        backoffIndex.set(0);
+    }
+
+    int nextBackoffDuration() {
+        return BACKOFF_INTERVAL_IN_SEC [backoffIndex.get()] != MAX_BACKOFF_DELAY ?
+                BACKOFF_INTERVAL_IN_SEC [backoffIndex.getAndIncrement()] : MAX_BACKOFF_DELAY;
+    }
+}

--- a/infinite-tracing/src/main/java/com/newrelic/DefaultBackoffPolicy.java
+++ b/infinite-tracing/src/main/java/com/newrelic/DefaultBackoffPolicy.java
@@ -6,17 +6,27 @@ import java.util.concurrent.TimeUnit;
 
 public class DefaultBackoffPolicy implements BackoffPolicy {
 
+    private final int DEFAULT_BACKOFF_DELAY = 15;
+
     @Override
     public boolean shouldReconnect(Status status) {
         // See: https://source.datanerd.us/agents/agent-specs/blob/master/Infinite-Tracing.md#unimplemented
-        return status != Status.UNIMPLEMENTED;
+        if (status != null) {
+            return status.getCode() != Status.Code.UNIMPLEMENTED;
+        }
+        return true;
+    }
+
+    @Override
+    public int duration() {
+        return DEFAULT_BACKOFF_DELAY;
     }
 
     @Override
     public void backoff() {
         try {
             // See: https://source.datanerd.us/agents/agent-specs/blob/master/Infinite-Tracing.md#other-errors-1
-            TimeUnit.SECONDS.sleep(15);
+            TimeUnit.SECONDS.sleep(DEFAULT_BACKOFF_DELAY);
         } catch (InterruptedException ignored) {
             Thread.currentThread().interrupt();
         }

--- a/infinite-tracing/src/main/java/com/newrelic/ResponseObserver.java
+++ b/infinite-tracing/src/main/java/com/newrelic/ResponseObserver.java
@@ -17,7 +17,7 @@ public class ResponseObserver implements StreamObserver<V1.RecordStatus> {
     private final AtomicBoolean shouldRecreateCall;
 
     public ResponseObserver(MetricAggregator metricAggregator, Logger logger, DisconnectionHandler disconnectionHandler,
-            AtomicBoolean shouldRecreateCall) {
+                            AtomicBoolean shouldRecreateCall) {
         this.metricAggregator = metricAggregator;
         this.logger = logger;
         this.disconnectionHandler = disconnectionHandler;
@@ -64,6 +64,7 @@ public class ResponseObserver implements StreamObserver<V1.RecordStatus> {
         logger.log(Level.FINE, "Completing gRPC call.");
         shouldRecreateCall.set(true);
         metricAggregator.incrementCounter("Supportability/InfiniteTracing/Response/Completed");
+        disconnectionHandler.resetConnectBackoffPolicy();
     }
 
     /**

--- a/infinite-tracing/src/main/java/com/newrelic/SpanDelivery.java
+++ b/infinite-tracing/src/main/java/com/newrelic/SpanDelivery.java
@@ -20,7 +20,7 @@ class SpanDelivery implements Runnable {
     private final Supplier<ClientCallStreamObserver<V1.Span>> streamObserverSupplier;
 
     public SpanDelivery(SpanConverter<V1.Span> spanConverter, MetricAggregator metricAggregator, Logger logger, BlockingQueue<SpanEvent> queue,
-            Supplier<ClientCallStreamObserver<V1.Span>> streamObserverSupplier) {
+                        Supplier<ClientCallStreamObserver<V1.Span>> streamObserverSupplier) {
         this.spanConverter = spanConverter;
         this.metricAggregator = metricAggregator;
         this.logger = logger;

--- a/infinite-tracing/src/main/java/com/newrelic/StreamObserverFactory.java
+++ b/infinite-tracing/src/main/java/com/newrelic/StreamObserverFactory.java
@@ -1,5 +1,6 @@
 package com.newrelic;
 
+import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.MetricAggregator;
 import com.newrelic.trace.v1.IngestServiceGrpc;
 import com.newrelic.trace.v1.V1;
@@ -7,13 +8,17 @@ import io.grpc.ManagedChannel;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
+import java.util.logging.Level;
+
 public class StreamObserverFactory {
+    private final Logger logger;
     private final MetricAggregator aggregator;
     private final StreamObserver<V1.RecordStatus> responseObserver;
 
-    public StreamObserverFactory(
-            MetricAggregator aggregator,
-            StreamObserver<V1.RecordStatus> responseObserver) {
+    public StreamObserverFactory(Logger logger,
+                                 MetricAggregator aggregator,
+                                 StreamObserver<V1.RecordStatus> responseObserver) {
+        this.logger = logger;
         this.aggregator = aggregator;
         this.responseObserver = responseObserver;
     }
@@ -23,6 +28,7 @@ public class StreamObserverFactory {
         ClientCallStreamObserver<V1.Span> streamObserver = (ClientCallStreamObserver<V1.Span>) ingestServiceFutureStub.recordSpan(responseObserver);
 
         aggregator.incrementCounter("Supportability/InfiniteTracing/Connect");
+        logger.log(Level.FINE, "Connected to Trace Observer.");
         return streamObserver;
     }
 

--- a/infinite-tracing/src/test/java/com/newrelic/ChannelSupplierTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/ChannelSupplierTest.java
@@ -26,6 +26,8 @@ class ChannelSupplierTest {
     public ManagedChannel mockChannel;
     @Mock
     public ConnectionStatus connectionStatus;
+    @Mock
+    public ConnectBackoffPolicy connectBackoffPolicy;
 
     @Test
     public void shouldCallFactoryIfNotAlreadyExisting() throws InterruptedException {
@@ -73,7 +75,7 @@ class ChannelSupplierTest {
     public ChannelSupplier prepTargetForFirstCall() throws InterruptedException {
         when(channelFactory.createChannel()).thenReturn(mockChannel);
         when(connectionStatus.blockOnConnection()).thenReturn(ConnectionStatus.BlockResult.MUST_ATTEMPT_CONNECTION);
-        return new ChannelSupplier(channelFactory, connectionStatus, mock(Logger.class));
+        return new ChannelSupplier(connectionStatus, mock(Logger.class), channelFactory);
     }
 
 }

--- a/infinite-tracing/src/test/java/com/newrelic/ConnectBackoffPolicyTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/ConnectBackoffPolicyTest.java
@@ -1,0 +1,17 @@
+package com.newrelic;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConnectBackoffPolicyTest {
+
+    @Test
+    public void shouldReturnCorrectBackoffInterval() {
+        ConnectBackoffPolicy connectBackoffPolicy = new ConnectBackoffPolicy();
+
+        for(int backoffDuration : connectBackoffPolicy.BACKOFF_INTERVAL_IN_SEC) {
+            assertEquals(connectBackoffPolicy.nextBackoffDuration(), backoffDuration);
+        }
+    }
+
+}

--- a/infinite-tracing/src/test/java/com/newrelic/DisconnectionHandlerTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/DisconnectionHandlerTest.java
@@ -7,54 +7,64 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class DisconnectionHandlerTest {
-    @Test
-    public void shouldNotBackOffIfCannotSetStatus() {
-        DisconnectionHandler target = new DisconnectionHandler(connectionStatus, backoffPolicy, mock(Logger.class));
-        when(connectionStatus.shouldReconnect()).thenReturn(false);
-        target.handle(null);
-    }
-
-    @Test
-    public void shutdownIfShouldShutdown() {
-        DisconnectionHandler target = new DisconnectionHandler(connectionStatus, backoffPolicy, mock(Logger.class));
-        when(connectionStatus.shouldReconnect()).thenReturn(true);
-        when(backoffPolicy.shouldReconnect(Status.ABORTED)).thenReturn(false);
-        target.handle(Status.ABORTED);
-        verify(connectionStatus).shutDownForever();
-    }
-
-    @Test
-    public void shouldBackOff() {
-        DisconnectionHandler target = new DisconnectionHandler(connectionStatus, backoffPolicy, mock(Logger.class));
-        when(connectionStatus.shouldReconnect()).thenReturn(true);
-        when(backoffPolicy.shouldReconnect(Status.ABORTED)).thenReturn(true);
-        target.handle(Status.ABORTED);
-        verify(backoffPolicy).shouldReconnect(Status.ABORTED);
-        verify(connectionStatus).reattemptConnection();
-    }
-
-    @Test
-    public void shouldShutdownForeverOnUnimplemented() {
-        DisconnectionHandler target = new DisconnectionHandler(connectionStatus, backoffPolicy, mock(Logger.class));
-        when(connectionStatus.shouldReconnect()).thenReturn(true);
-        when(backoffPolicy.shouldReconnect(Status.UNIMPLEMENTED)).thenReturn(false);
-        target.handle(Status.UNIMPLEMENTED);
-        verify(connectionStatus).shutDownForever();
-    }
 
     @Mock
     public ConnectionStatus connectionStatus;
 
     @Mock
-    public BackoffPolicy backoffPolicy;
+    public BackoffPolicy defaultBackoffPolicy;
+
+    @Mock
+    public ConnectBackoffPolicy connectBackoffPolicy;
+
+    public DisconnectionHandler target;
 
     @BeforeEach
     public void beforeEach() {
         MockitoAnnotations.initMocks(this);
+        target = new DisconnectionHandler(connectionStatus, defaultBackoffPolicy, connectBackoffPolicy, mock(Logger.class));;
+    }
+
+    @Test
+    public void shouldNotBackOffIfCannotSetStatus() {
+        when(defaultBackoffPolicy.shouldReconnect(null)).thenReturn(true);
+        when(connectionStatus.shouldReconnect()).thenReturn(false);
+
+        target.handle(null);
+
+        verify(defaultBackoffPolicy, times(0)).backoff();
+    }
+
+    @Test
+    public void shouldBackOff() {
+        when(defaultBackoffPolicy.shouldReconnect(Status.ABORTED)).thenReturn(true);
+        when(connectionStatus.shouldReconnect()).thenReturn(true);
+
+        target.handle(Status.ABORTED);
+
+        verify(defaultBackoffPolicy).backoff();
+        verify(connectionStatus).reattemptConnection();
+    }
+
+    @Test
+    public void shouldShutdownForeverOnUnimplemented() {
+        when(defaultBackoffPolicy.shouldReconnect(Status.UNIMPLEMENTED)).thenReturn(false);
+
+        target.handle(Status.UNIMPLEMENTED);
+
+        verify(connectionStatus).shutDownForever();
+    }
+
+    @Test
+    public void shouldConnectWithConnectBackoffPolicyForFailedPrecondition() {
+        when(defaultBackoffPolicy.shouldReconnect(Status.UNIMPLEMENTED)).thenReturn(true);
+
+        target.handle(Status.FAILED_PRECONDITION);
+
+        verify(connectBackoffPolicy).backoff();
+        verify(connectionStatus, times(1)).reattemptConnection();
     }
 }

--- a/infinite-tracing/src/test/java/com/newrelic/SpanDeliveryTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/SpanDeliveryTest.java
@@ -46,6 +46,8 @@ class SpanDeliveryTest {
     public Logger logger;
     @Mock
     public Supplier<ClientCallStreamObserver<V1.Span>> streamObserverSupplier;
+    @Mock
+    public ConnectBackoffPolicy connectBackoffPolicy;
 
     @SuppressWarnings("unchecked")
     public ClientCallStreamObserver<V1.Span> mockStreamObserver() {


### PR DESCRIPTION
### Overview

When the agent receives a `Failed_Precondition` gRPC response code from Infinite Tracing, the agent will disconnect to the Trace Observer by closing the existing channel fully and clear the stream observer. The agent will then immediately try to reconnect to the Trace Observer. The reason we are doing this is here #157 

General code context:

The [entry point for building](https://github.com/newrelic/newrelic-java-agent/blob/6d3dceb8143c639331eb3ecb40fc2cbdab8720c1/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java#L227) Infinite Tracing from the agent side.
When [agent successfully connects](https://github.com/newrelic/newrelic-java-agent/blob/6d3dceb8143c639331eb3ecb40fc2cbdab8720c1/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java#L278-L282), that's when  Infinite Tracing [actually starts.](https://github.com/newrelic/newrelic-java-agent/blob/6d3dceb8143c639331eb3ecb40fc2cbdab8720c1/newrelic-agent/src/main/java/com/newrelic/agent/service/UpdateInfiniteTracingAfterConnect.java#L28-L34)

Once it starts, `LoopForever` gets looping and regularly checks `ConnectionStatus` to determine if a channel and stream observer needs to be built. It does this by going through a couple of layers to `ChannelSupplier`

After a channel and stream observer are connected, one way they are disconnected is due to receiving certain status codes. The status codes are received in `ResponseObserver` and the `DisconnectionHandler` is the bulk of the logic to change connection status. 

### Related Github Issue
#160  and #164

