### PR TITLE
change dropped span log level to fine

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/CollectorSpanEventReservoirManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/CollectorSpanEventReservoirManager.java
@@ -73,7 +73,7 @@ public class CollectorSpanEventReservoirManager implements ReservoirManager<Span
             eventSender.sendEvents(appName, config.getMaxSamplesStored(), toSend.getNumberOfTries(), Collections.unmodifiableList(toSend.asList()));
             if (toSend.size() < toSend.getNumberOfTries()) {
                 int dropped = toSend.getNumberOfTries() - toSend.size();
-                logger.log(Level.WARNING, "Dropped {0} span events out of {1}.", dropped, toSend.getNumberOfTries());
+                logger.log(Level.FINE, "Dropped {0} span events out of {1}.", dropped, toSend.getNumberOfTries());
             }
             return new HarvestResult(toSend.getNumberOfTries(), toSend.size());
         } catch (HttpError e) {


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
Changed logging on `CollectorSpanEventReservoirManager` for dropped spans from warn to fine
### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/176
### Testing
existing tests. 

### Checks

[ yes] Are your contributions backwards compatible with relevant frameworks and APIs?
[ no] Does your code contain any breaking changes? Please describe. 
[ no] Does your code introduce any new dependencies? Please describe.
