### PR TITLE
Cap ojdbc8 support range to fix verifier

### DIFF
--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/build.gradle
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/build.gradle
@@ -9,7 +9,8 @@ jar {
 }
 
 verifyInstrumentation {
-    passes("com.oracle.database.jdbc:ojdbc8:[0,)")
+    passes("com.oracle.database.jdbc:ojdbc10:[0,)")
+    passes("com.oracle.database.jdbc:ojdbc8:[0,21.1.0.0)")
     fails("com.oracle.database.jdbc:ojdbc6:[0,)")
     fails("com.oracle.database.jdbc:ojdbc5:[0,)")
 }


### PR DESCRIPTION
It looks like the instrumentation verifier failed on our `jdbc-ojdbc7-12.1.0.2` instrumentation module. This appears to be due to a breaking change in [version 21.1.0.0 of ojdbc8](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8/21.1.0.0).

This PR caps the `ojdbc8` support at the breaking version and also adds `ojdbc10` to the verifier for this instrumentation.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':instrumentation:jdbc-ojdbc7-12.1.0.2:verifyPass_com.oracle.database.jdbc_ojdbc8_21.1.0.0'.
> A failure occurred while executing com.newrelic.agent.instrumentation.verify.VerifyWorkAction
   > Verification FAILED. Instrumentation module jdbc-ojdbc7-12.1.0.2-1.0.jar SHOULD HAVE applied to com.oracle.database.jdbc:ojdbc8:21.1.0.0 and did not. You may need to adjust the range "com.oracle.database.jdbc:ojdbc8:[0,)".
     Verifier output:
     Creating user classloader with custom classpath:
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/com.oracle.database.jdbc/ojdbc8/21.1.0.0/50044485aea10afd7defeee8109c5195b4d3cae2/ojdbc8-21.1.0.0.jar
     WeaveViolation{type=METHOD_BASE_CONCRETE_WEAVE, clazz=oracle/jdbc/pool/OracleDataSource, method=getConnection(Ljava/lang/String;Ljava/lang/String;)Ljava/sql/Connection;}
```

Also filed an issue to update the instrumentation: https://github.com/newrelic/newrelic-java-agent/issues/194