### PR TITLE
add instrumentation to PeriodicWorkerTask and InstantPeriodicWorkerTa…

### DIFF
--- a/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask_Instrumentation.java
@@ -1,0 +1,21 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package reactor.core.scheduler;
+
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(originalName = "reactor.core.scheduler.InstantPeriodicWorkerTask")
+final class InstantPeriodicWorkerTask_Instrumentation {
+
+    @Trace(async = true, excludeFromTransactionTrace = true)
+    public Void call() {
+        return Weaver.callOriginal();
+    }
+}

--- a/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/core/scheduler/PeriodicWorkerTask_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/core/scheduler/PeriodicWorkerTask_Instrumentation.java
@@ -1,0 +1,21 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package reactor.core.scheduler;
+
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(originalName = "reactor.core.scheduler.PeriodicWorkerTask")
+final class PeriodicWorkerTask_Instrumentation {
+
+    @Trace(async = true, excludeFromTransactionTrace = true)
+    public Void call() {
+        return Weaver.callOriginal();
+    }
+}

--- a/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/scheduler/InstantPeriodicWorkerTask_Instrumentation.java
@@ -1,0 +1,21 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package reactor.core.scheduler;
+
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(originalName = "reactor.core.scheduler.InstantPeriodicWorkerTask")
+final class InstantPeriodicWorkerTask_Instrumentation {
+
+    @Trace(async = true, excludeFromTransactionTrace = true)
+    public Void call() {
+        return Weaver.callOriginal();
+    }
+}

--- a/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/scheduler/PeriodicWorkerTask_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/scheduler/PeriodicWorkerTask_Instrumentation.java
@@ -1,0 +1,21 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package reactor.core.scheduler;
+
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(originalName = "reactor.core.scheduler.PeriodicWorkerTask")
+final class PeriodicWorkerTask_Instrumentation {
+
+    @Trace(async = true, excludeFromTransactionTrace = true)
+    public Void call() {
+        return Weaver.callOriginal();
+    }
+}


### PR DESCRIPTION
Fix issue preventing activity from Flux.interval() from being linked to the transaction.

In an spring webflux set, this allows the following code to properly link the external activity:
```
@GetMapping("/reactiveFluxInterval")
Flux<String> handleReactiveWithFluxInterval() {
    return Flux.interval(Duration.ZERO, Duration.ofSeconds(1))
        .flatMap((Function<Long, Publisher<String>>) aLong -> WEB_CLIENT.get().retrieve().bodyToMono(String.class));
}
```