### PR TITLE
Fix ThreadStateSamplerTest flicker

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/threads/ThreadStateSamplerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/threads/ThreadStateSamplerTest.java
@@ -54,8 +54,9 @@ public class ThreadStateSamplerTest {
                 cpuCalculationTimeSeconds >= totalTimeSeconds);
         assertTrue("UserTime: " + userTimeSeconds + ", SystemTime: " + systemTimeSeconds,
                 userTimeSeconds > systemTimeSeconds);
+        // This test is prone to flickering due to high load scenarios and rounding errors, hence the modifier added to totalTimeSeconds
         assertTrue("TotalTime: " + totalTimeSeconds + ", SystemTime: " + systemTimeSeconds + ", UserTime: " + userTimeSeconds,
-                totalTimeSeconds + 0.2 >= systemTimeSeconds + userTimeSeconds); // account for rounding error
+                totalTimeSeconds + 4.0 >= systemTimeSeconds + userTimeSeconds); // account for rounding error
 
         // Since we can't guarantee the exact total time, it should be
         // between 1 and 5 (since we had a busywork loop for ~5000ms)


### PR DESCRIPTION
Hmm `ThreadStateSamplerTest` seems to flicker pretty badly. The test passes locally but seems to fail consistently when run on PRs. I’ve seen numerous failures on a PR that doesn’t even touch agent functionality.

```
com.newrelic.agent.threads.ThreadStateSamplerTest > testCpuTimeMetrics FAILED
    java.lang.AssertionError at ThreadStateSamplerTest.java:57
```

The assertion looks to be:

```
        assertTrue("TotalTime: " + totalTimeSeconds + ", SystemTime: " + systemTimeSeconds + ", UserTime: " + userTimeSeconds,
                totalTimeSeconds + 0.2 >= systemTimeSeconds + userTimeSeconds); // account for rounding error
```