### PR TITLE
fix infinite tracing race condition regarding span observer

### DIFF
--- a/infinite-tracing/src/main/java/com/newrelic/ResponseObserver.java
+++ b/infinite-tracing/src/main/java/com/newrelic/ResponseObserver.java
@@ -111,7 +111,7 @@ class ResponseObserver implements StreamObserver<V1.RecordStatus> {
     public void onCompleted() {
         logger.log(Level.FINE, "Completing gRPC response observer.");
         aggregator.incrementCounter("Supportability/InfiniteTracing/Response/Completed");
-        channelManager.cancelSpanObserver();
+        channelManager.recreateSpanObserver();
     }
 
 }

--- a/infinite-tracing/src/test/java/com/newrelic/ResponseObserverTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/ResponseObserverTest.java
@@ -129,7 +129,7 @@ class ResponseObserverTest {
         target.onCompleted();
 
         verify(aggregator).incrementCounter("Supportability/InfiniteTracing/Response/Completed");
-        verify(channelManager).cancelSpanObserver();
+        verify(channelManager).recreateSpanObserver();
     }
 
 }


### PR DESCRIPTION
Fix a race condition in infinite tracing involving `SpanEventSender` and `ResponseObserver`:
- SpanEventSender obtains an observer via `ChannelManager#getSpanObserver()`
- SpanEventSender does some work, and eventually writes a Span to the observer
- However, the observer has already been cancelled by  ResponseObserver#onCompleted, which cancels the observer

The fix is to have ResponseObserver not directly cancel the observer, but instead mark it as needing recreation, where its recreated the next time SpanEventSender gets an observer from the channel manager. In doing so, SpanEventSender shouldn't be able to write to a cancelled observer, since any cancelling and recreation of observers happens in a blocking fashion during its call to ChannelManager#getSpanObserver(), and never in a separate thread.