### PR TITLE
Prevent multiple versions of akka-http-core instrumentation from applying.

### DIFF
--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -21,7 +21,6 @@ dependencies {
 }
 
 verifyInstrumentation {
-    fails('com.typesafe.akka:akka-http-core-experimental_2.13:[1.0,10.1.8)')
     passesOnly('com.typesafe.akka:akka-http-core_2.13:[10.1.8,10.2.0-RC1)') {
         compile("com.typesafe.akka:akka-stream_2.13:2.5.23")
     }

--- a/instrumentation/akka-http-core-2.13_10.1.8/src/main/scala/akka/http/scaladsl/HttpInstrumentation.java
+++ b/instrumentation/akka-http-core-2.13_10.1.8/src/main/scala/akka/http/scaladsl/HttpInstrumentation.java
@@ -36,7 +36,7 @@ public class HttpInstrumentation {
         public ServerBinding() {
             AgentBridge.getAgent().getLogger().log(Level.FINE, "Setting akka-http port to: {0,number,#}", localAddress().getPort());
             AgentBridge.publicApi.setAppServerPort(localAddress().getPort());
-            AgentBridge.publicApi.setServerInfo("Akka HTTP", ManifestUtils.getVersionFromManifest(getClass(), "akka-http-core", "10.0.11"));
+            AgentBridge.publicApi.setServerInfo("Akka HTTP", ManifestUtils.getVersionFromManifest(getClass(), "akka-http-core", "10.1.8"));
 
             AgentBridge.instrumentation.retransformUninstrumentedClass(SyncRequestHandler.class);
             AgentBridge.instrumentation.retransformUninstrumentedClass(AsyncRequestHandler.class);

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passesOnly('com.typesafe.akka:akka-http-core_2.13:[10.2.0-RC1,)') {
+    passesOnly('com.typesafe.akka:akka-http-core_2.13:[10.2.0-RC2,)') {
         compile("com.typesafe.akka:akka-stream_2.13:2.5.23")
     }
     fails('com.typesafe.akka:akka-http-core_2.12:[10.2.0-RC1,)') {

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -11,7 +11,6 @@ dependencies {
 }
 
 verifyInstrumentation {
-    fails('com.typesafe.akka:akka-http-core-experimental_2.13:[1.0,10.1.8)')
     passesOnly('com.typesafe.akka:akka-http-core_2.13:[10.2.0-RC1,)') {
         compile("com.typesafe.akka:akka-stream_2.13:2.5.23")
     }

--- a/instrumentation/akka-http-core-2.13_10.2.0/src/main/scala/akka/http/scaladsl/HttpExtInstrumentation.java
+++ b/instrumentation/akka-http-core-2.13_10.2.0/src/main/scala/akka/http/scaladsl/HttpExtInstrumentation.java
@@ -25,6 +25,13 @@ import scala.concurrent.Future;
 @Weave(type = MatchType.ExactClass, originalName = "akka.http.scaladsl.HttpExt")
 public class HttpExtInstrumentation {
 
+    // This method only exists to ensure that this weave module doesn't match for versions of akka-http-core-2.13 prior to 10.2.0.
+    // That said, as of 10.2.0 bind, bindAndHandle, bindAndHandleSync, and bindAndHandleAsync were all deprecated in favor of newServerAt:
+    //   @deprecated("Use Http.newServerAt(...)...connectionSource() to create a source that can be materialized to a binding.", since = "10.2.0")
+    public ServerBuilder newServerAt(String interfaceString, int port) {
+        return Weaver.callOriginal();
+    }
+
     public Future<HttpInstrumentation.ServerBinding> bindAndHandleAsync(
             Function1<HttpRequest, Future<HttpResponse>> handler,
             String interfaceString, int port,

--- a/instrumentation/akka-http-core-2.13_10.2.0/src/main/scala/akka/http/scaladsl/HttpInstrumentation.java
+++ b/instrumentation/akka-http-core-2.13_10.2.0/src/main/scala/akka/http/scaladsl/HttpInstrumentation.java
@@ -36,7 +36,7 @@ public class HttpInstrumentation {
         public ServerBinding() {
             AgentBridge.getAgent().getLogger().log(Level.FINE, "Setting akka-http port to: {0,number,#}", localAddress().getPort());
             AgentBridge.publicApi.setAppServerPort(localAddress().getPort());
-            AgentBridge.publicApi.setServerInfo("Akka HTTP", ManifestUtils.getVersionFromManifest(getClass(), "akka-http-core", "10.0.11"));
+            AgentBridge.publicApi.setServerInfo("Akka HTTP", ManifestUtils.getVersionFromManifest(getClass(), "akka-http-core", "10.2.0"));
 
             AgentBridge.instrumentation.retransformUninstrumentedClass(SyncRequestHandler.class);
             AgentBridge.instrumentation.retransformUninstrumentedClass(AsyncRequestHandler.class);


### PR DESCRIPTION
When running a Play 2.8.5/Scala 2.13 app I noticed that multiple versions of the `akka-http-core` instrumentation were being applied:

```
com.newrelic.instrumentation.jdbc-socket - validated classloader BootstrapPlaceholder
com.newrelic.instrumentation.scala-2.13.0 - validated classloader sun.misc.Launcher$AppClassLoader@18b4aac2
com.newrelic.instrumentation.akka-2.2 - validated classloader sun.misc.Launcher$AppClassLoader@18b4aac2
com.newrelic.instrumentation.play-2.7 - validated classloader sun.misc.Launcher$AppClassLoader@18b4aac2
com.newrelic.instrumentation.akka-http-core-2.13_10.1.8 - validated classloader sun.misc.Launcher$AppClassLoader@18b4aac2
com.newrelic.instrumentation.akka-http-core-2.13_10.2.0 - validated classloader sun.misc.Launcher$AppClassLoader@18b4aac2
com.newrelic.instrumentation.play-shaded-async-http-client-1.0.0 - validated classloader sun.misc.Launcher$AppClassLoader@18b4aac2
com.newrelic.instrumentation.java.completable-future-jdk8u40 - validated classloader BootstrapPlaceholder
```

And that classes were being instrumented by both:

```
Supportability/WeaveInstrumentation/WeaveClass/com.newrelic.instrumentation.akka-http-core-2.13_10.1.8/akka/http/scaladsl/Http$ServerBinding
Supportability/WeaveInstrumentation/WeaveClass/com.newrelic.instrumentation.akka-http-core-2.13_10.1.8/akka/http/scaladsl/HttpExt
Supportability/WeaveInstrumentation/WeaveClass/com.newrelic.instrumentation.akka-http-core-2.13_10.2.0/akka/http/scaladsl/Http$ServerBinding
Supportability/WeaveInstrumentation/WeaveClass/com.newrelic.instrumentation.akka-http-core-2.13_10.2.0/akka/http/scaladsl/HttpExt
```

The app that I tested with was using `akka-http-core_2.13-10.1.12.jar` so I would expect only the `akka-http-core-2.13_10.1.8` instrumentation to have applied.

After the changes in this PR only `akka-http-core-2.13_10.1.8` instrumentation is applied, as expected:

```
2021-02-04T10:48:34,855-0800 [41431 33] com.newrelic FINE: com.newrelic.instrumentation.java.completable-future-jdk8u40 - validated classloader BootstrapPlaceholder
2021-02-04T10:48:35,080-0800 [41431 35] com.newrelic FINE: com.newrelic.instrumentation.jdbc-socket - validated classloader BootstrapPlaceholder
2021-02-04T10:48:37,627-0800 [41431 1] com.newrelic FINE: com.newrelic.instrumentation.scala-2.13.0 - validated classloader jdk.internal.loader.ClassLoaders$AppClassLoader@2c13da15
2021-02-04T10:48:37,847-0800 [41431 1] com.newrelic FINE: com.newrelic.instrumentation.akka-2.2 - validated classloader jdk.internal.loader.ClassLoaders$AppClassLoader@2c13da15
2021-02-04T10:48:39,758-0800 [41431 1] com.newrelic FINE: com.newrelic.instrumentation.play-2.7 - validated classloader jdk.internal.loader.ClassLoaders$AppClassLoader@2c13da15
2021-02-04T10:48:40,096-0800 [41431 1] com.newrelic FINE: com.newrelic.instrumentation.akka-http-core-2.13_10.1.8 - validated classloader jdk.internal.loader.ClassLoaders$AppClassLoader@2c13da15
2021-02-04T10:48:48,573-0800 [41431 48] com.newrelic FINE: com.newrelic.instrumentation.play-shaded-async-http-client-1.0.0 - validated classloader jdk.internal.loader.ClassLoaders$AppClassLoader@2c13da15
```
