### PR TITLE
JBoss Wildfly throws error on startup

### DIFF
--- a/instrumentation/jboss-jmx-7/src/main/java/org/jboss/modules/ModuleLoader_Instrumentation.java
+++ b/instrumentation/jboss-jmx-7/src/main/java/org/jboss/modules/ModuleLoader_Instrumentation.java
@@ -7,16 +7,39 @@
 
 package org.jboss.modules;
 
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.xml.namespace.QName;
+import java.util.logging.Level;
+
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
+import com.newrelic.api.agent.NewRelic;
 import com.nr.agent.instrumentation.jboss.JBossUtils;
 
 @Weave(type = MatchType.ExactClass, originalName = "org.jboss.modules.ModuleLoader")
 public class ModuleLoader_Instrumentation {
 
     static void installMBeanServer() {
-        JBossUtils.addJmx();
+
+        final ScheduledExecutorService scheduler
+                 = Executors.newSingleThreadScheduledExecutor();
+
+        Runnable task = new Runnable() {
+		public void run() {
+			JBossUtils.addJmx();
+			scheduler.shutdown();
+            NewRelic.getAgent().getLogger().log(Level.FINER, "JBoss7 JMX monitoring service has been installed");
+		}
+        };
+
+        int jmxServiceDelay = NewRelic.getAgent().getConfig().getValue("jboss7_jmxService_delay", 0);
+        scheduler.schedule(task, jmxServiceDelay, TimeUnit.SECONDS);
+        NewRelic.getAgent().getLogger().log(Level.FINER, "JBoss7 invoking JMX service with delay {0} sec", jmxServiceDelay);
         Weaver.callOriginal();
     }
 }
+


### PR DESCRIPTION
### Overview
By allowing a specific delay to be set in the yml file, using the new parameter jboss7_jmxService_delay an int that is a child of common, the number of seconds to delay monitoring of the jboss jmx service, the admin can ensure that no error is thrown in the JBoss console during startup. This change has been implemented successfully at a New Relic customer's enterprise JBoss 7 implementation.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/229

### Testing
Set log_level to finer to introduce two new log entries, for example:
2021-02-25T16:03:01,020-0500 [17938 1] com.newrelic FINE: JBoss7 invoking JMX service with delay 60 sec
2021-02-25T16:04:01,011-0500 [17938 36] com.newrelic FINE: JBoss7 JMX monitoring service has been installed

### Checks

[Y] Are your contributions backwards compatible with relevant frameworks and APIs?
[N] Does your code contain any breaking changes? Please describe. 
[N] Does your code introduce any new dependencies? Please describe.
