### PR TITLE
Reproducible build

### DIFF
--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -10,6 +10,11 @@ subprojects {
         task.enabled = !project.hasProperty('noInstrumentation')
     }
 
+    tasks.withType(AbstractArchiveTask) {
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
+    }
+
     jar {
         manifest {
             attributes 'Implementation-Vendor': 'New Relic', 'Implementation-Version': project.version


### PR DESCRIPTION
The weaver [loads & caches each instrumentation module](https://github.com/newrelic/newrelic-java-agent/blob/main/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/CachedWeavePackage.java#L162-L189) by locating the instrumentation module jar and reading in the bytes for the all of the classes contained in the module.

However it appears that the weaver depends on the classes being read in from the JarInputStream in a specific and predictable order, meaning that the instrumentation module jar files need to be generated in a deterministic manner. 

This PR modifies the build task for the instrumentation modules so that the resulting jar file always adds files in a reproducible order.

---

One notable example is the `jax-rs-1.0` instrumentation, which could fail with a `WeaveViolation` if the classes weren't read in from the jar (`newrelic.jar!/instrumentation/jax-rs-1.0-1.0.jar`) in the correct order.

The changes in this PR resulted in the `jax-rs-1.0-1.0.jar` being consistent between local builds and those published via the github build pipeline and in a manner that resolves the `WeaveViolation`

---

Helpful reference: https://dzone.com/articles/reproducible-builds-in-java