### PR TITLE
Refactor to use SafeConstructor for SnakeYAML

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigHelper.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigHelper.java
@@ -12,8 +12,7 @@ import com.newrelic.agent.errors.ExceptionHandlerSignature;
 import com.newrelic.agent.instrumentation.methodmatchers.InvalidMethodDescriptor;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
-import org.yaml.snakeyaml.constructor.Construct;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
@@ -88,11 +87,11 @@ public class AgentConfigHelper {
     }
 
     private static Yaml createYaml() {
-        Constructor constructor = new ExtensionConstructor();
+        SafeConstructor constructor = new ExtensionConstructor();
         return new Yaml(constructor);
     }
 
-    private static class ExtensionConstructor extends Constructor {
+    private static class ExtensionConstructor extends SafeConstructor {
         public ExtensionConstructor() {
             yamlConstructors.put(new Tag("!exception_handler"), new AbstractConstruct() {
                 @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/PointCutConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/PointCutConfig.java
@@ -15,7 +15,7 @@ import com.newrelic.agent.instrumentation.custom.ExtensionClassAndMethodMatcher;
 import com.newrelic.agent.instrumentation.yaml.InstrumentationConstructor;
 import com.newrelic.agent.instrumentation.yaml.PointCutFactory;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -98,7 +98,7 @@ public class PointCutConfig {
     }
 
     private void initYaml() {
-        Constructor constructor = new InstrumentationConstructor();
+        SafeConstructor constructor = new InstrumentationConstructor();
         yaml = new Yaml(constructor);
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionParsers.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionParsers.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 import com.newrelic.agent.extension.dom.ExtensionDomParser;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Tag;
 
 public class ExtensionParsers {
@@ -25,7 +25,7 @@ public class ExtensionParsers {
     private final ExtensionParser xmlParser;
 
     public ExtensionParsers(final List<ConfigurationConstruct> constructs) {
-        Constructor constructor = new Constructor() {
+        SafeConstructor constructor = new SafeConstructor() {
             {
                 for (ConfigurationConstruct construct : constructs) {
                     this.yamlConstructors.put(new Tag(construct.getName()), construct);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/yaml/InstrumentationConstructor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/yaml/InstrumentationConstructor.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
@@ -28,7 +28,7 @@ import com.newrelic.agent.instrumentation.methodmatchers.OrMethodMatcher;
 import com.newrelic.agent.instrumentation.yaml.PointCutFactory.ClassMethodNameFormatDescriptor;
 import org.yaml.snakeyaml.nodes.Tag;
 
-public class InstrumentationConstructor extends Constructor {
+public class InstrumentationConstructor extends SafeConstructor {
     public final Collection<ConfigurationConstruct> constructs;
 
     public InstrumentationConstructor() {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/PointCutConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/PointCutConfigTest.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -251,7 +251,7 @@ public class PointCutConfigTest {
 
     @Test
     public void yaml() {
-        Constructor constructor = new InstrumentationConstructor();
+        SafeConstructor constructor = new InstrumentationConstructor();
         Yaml yaml = new Yaml(constructor);
 
         Object config = yaml.load("--- !interface_matcher 'org/apache/solr/request/SolrRequestHandler'");

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/yaml/InstrumentationConstructorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/yaml/InstrumentationConstructorTest.java
@@ -23,13 +23,14 @@ import com.newrelic.agent.instrumentation.classmatchers.OrClassMatcher;
 import com.newrelic.agent.instrumentation.methodmatchers.ExactMethodMatcher;
 import com.newrelic.agent.instrumentation.methodmatchers.MethodMatcher;
 import com.newrelic.agent.instrumentation.methodmatchers.OrMethodMatcher;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 public class InstrumentationConstructorTest {
     private Yaml yaml;
 
     @Before
     public void setup() {
-        InstrumentationConstructor constructor = new InstrumentationConstructor();
+        SafeConstructor constructor = new InstrumentationConstructor();
         yaml = new Yaml(constructor);
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxYmlParserTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxYmlParserTest.java
@@ -24,6 +24,7 @@ import org.yaml.snakeyaml.Yaml;
 import com.newrelic.agent.config.BaseConfig;
 import com.newrelic.agent.config.Config;
 import com.newrelic.agent.jmx.JmxType;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * Tests the utility methods found in JmxYmlUtils.
@@ -181,7 +182,7 @@ public class JmxYmlParserTest {
     }
 
     protected static BaseConfig readYml(File file) throws Exception {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
         try (Reader reader = new FileReader(file)) {
             Map output = (Map) yaml.load(reader);
             return new BaseConfig(output);


### PR DESCRIPTION
Switches everything over to use [SafeConstructor](https://www.javadoc.io/doc/org.yaml/snakeyaml/1.27/org/yaml/snakeyaml/constructor/SafeConstructor.html) (Construct standard Java classes) instead of [Constructor](https://www.javadoc.io/doc/org.yaml/snakeyaml/1.27/org/yaml/snakeyaml/constructor/Constructor.html) (Construct a custom Java instance).

AIT: https://javaagent-build.pdx.vm.datanerd.us/view/All/job/JavaAgent_PR_AIT/55/