### PR TITLE
Update and fix OpenTelemetry URLs

### DIFF
--- a/instrumentation/netty-reactor-0.7.0/NOTICE.txt
+++ b/instrumentation/netty-reactor-0.7.0/NOTICE.txt
@@ -14,4 +14,4 @@ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
 or implied. See the License for the specific language governing permissions and limitations under
 the License.
 
-  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/LICENSE
+  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/LICENSE

--- a/instrumentation/netty-reactor-0.7.0/src/main/java/com/nr/instrumentation/TokenLinkingSubscriber.java
+++ b/instrumentation/netty-reactor-0.7.0/src/main/java/com/nr/instrumentation/TokenLinkingSubscriber.java
@@ -17,7 +17,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 // Based on OpenTelemetry code
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/instrumentation-core/reactor-3.1/src/main/java/io/opentelemetry/instrumentation/reactor/TracingSubscriber.java
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingSubscriber.java
 public class TokenLinkingSubscriber<T> implements CoreSubscriber<T> {
     private final Token token;
     private final Subscriber<? super T> subscriber;

--- a/instrumentation/netty-reactor-0.8.0/NOTICE.txt
+++ b/instrumentation/netty-reactor-0.8.0/NOTICE.txt
@@ -14,4 +14,4 @@ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
 or implied. See the License for the specific language governing permissions and limitations under
 the License.
 
-  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/LICENSE
+  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/LICENSE

--- a/instrumentation/netty-reactor-0.8.0/src/main/java/com/nr/instrumentation/reactor/netty/TokenLinkingSubscriber.java
+++ b/instrumentation/netty-reactor-0.8.0/src/main/java/com/nr/instrumentation/reactor/netty/TokenLinkingSubscriber.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 // Based on OpenTelemetry code
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/instrumentation-core/reactor-3.1/src/main/java/io/opentelemetry/instrumentation/reactor/TracingSubscriber.java
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingSubscriber.java
 public class TokenLinkingSubscriber<T> implements CoreSubscriber<T> {
     private final Token token;
     private final Subscriber<? super T> subscriber;

--- a/instrumentation/netty-reactor-0.9.0/NOTICE.txt
+++ b/instrumentation/netty-reactor-0.9.0/NOTICE.txt
@@ -14,4 +14,4 @@ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
 or implied. See the License for the specific language governing permissions and limitations under
 the License.
 
-  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/LICENSE
+  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/LICENSE

--- a/instrumentation/netty-reactor-0.9.0/src/main/java/com/nr/instrumentation/reactor/netty/TokenLinkingSubscriber.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/com/nr/instrumentation/reactor/netty/TokenLinkingSubscriber.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 // Based on OpenTelemetry code
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/instrumentation-core/reactor-3.1/src/main/java/io/opentelemetry/instrumentation/reactor/TracingSubscriber.java
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingSubscriber.java
 public class TokenLinkingSubscriber<T> implements CoreSubscriber<T> {
     private final Token token;
     private final Subscriber<? super T> subscriber;

--- a/instrumentation/spring-webflux-5.0.0/NOTICE.txt
+++ b/instrumentation/spring-webflux-5.0.0/NOTICE.txt
@@ -14,4 +14,4 @@ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
 or implied. See the License for the specific language governing permissions and limitations under
 the License.
 
-  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/LICENSE
+  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/LICENSE

--- a/instrumentation/spring-webflux-5.0.0/src/main/java/org/springframework/web/reactive/DispatchHandler_Instrumentation.java
+++ b/instrumentation/spring-webflux-5.0.0/src/main/java/org/springframework/web/reactive/DispatchHandler_Instrumentation.java
@@ -10,7 +10,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 // Based on OpenteTemetry instrumentation
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerAdvice.java
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerAdvice.java
 @Weave(type =MatchType.ExactClass, originalName = "org.springframework.web.reactive.DispatcherHandler")
 public class DispatchHandler_Instrumentation {
     @Trace

--- a/instrumentation/spring-webflux-5.1.0/NOTICE.txt
+++ b/instrumentation/spring-webflux-5.1.0/NOTICE.txt
@@ -14,4 +14,4 @@ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
 or implied. See the License for the specific language governing permissions and limitations under
 the License.
 
-  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/LICENSE
+  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/LICENSE

--- a/instrumentation/spring-webflux-5.1.0/src/main/java/org/springframework/web/reactive/DispatchHandler_Instrumentation.java
+++ b/instrumentation/spring-webflux-5.1.0/src/main/java/org/springframework/web/reactive/DispatchHandler_Instrumentation.java
@@ -10,7 +10,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 // Based on OpenTelemetry instrumentation
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerAdvice.java
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerAdvice.java
 @Weave(type =MatchType.ExactClass, originalName = "org.springframework.web.reactive.DispatcherHandler")
 public class DispatchHandler_Instrumentation {
     @Trace

--- a/instrumentation/spring-webflux-5.3.0/NOTICE.txt
+++ b/instrumentation/spring-webflux-5.3.0/NOTICE.txt
@@ -14,4 +14,4 @@ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
 or implied. See the License for the specific language governing permissions and limitations under
 the License.
 
-  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/LICENSE
+  * Homepage: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/LICENSE

--- a/instrumentation/spring-webflux-5.3.0/src/main/java/org/springframework/web/reactive/DispatchHandler_Instrumentation.java
+++ b/instrumentation/spring-webflux-5.3.0/src/main/java/org/springframework/web/reactive/DispatchHandler_Instrumentation.java
@@ -10,7 +10,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 // Based on OpenTelemetry instrumentation
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerAdvice.java
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerAdvice.java
 @Weave(type =MatchType.ExactClass, originalName = "org.springframework.web.reactive.DispatcherHandler")
 public class DispatchHandler_Instrumentation {
     @Trace


### PR DESCRIPTION
The OpenTelemetry default branch name was updated. Additionally, `TracingSubscriber.java` was moved to another location.