### PR TITLE
Fix of reactor lambda subscribers instrumentation

### DIFF
--- a/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/publisher/LambdaMonoSubscriber_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/publisher/LambdaMonoSubscriber_Instrumentation.java
@@ -37,8 +37,17 @@ abstract class LambdaMonoSubscriber_Instrumentation {
         if (token != null) {
             token.expire();
             this.nrContext = null;
-
         }
+        Weaver.callOriginal();
+    }
+
+    public final void onError(Throwable t) {
+        Token token = this.currentContext().getOrDefault("newrelic-token", null);
+        if (token != null) {
+            token.expire();
+            this.nrContext = null;
+        }
+        Weaver.callOriginal();
     }
 
     public Context currentContext() {

--- a/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/publisher/LambdaSubscriber_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/core/publisher/LambdaSubscriber_Instrumentation.java
@@ -35,8 +35,17 @@ abstract class LambdaSubscriber_Instrumentation {
         if (token != null) {
             token.expire();
             this.nrContext = null;
-
         }
+        Weaver.callOriginal();
+    }
+
+    public final void onError(Throwable t) {
+        Token token = this.currentContext().getOrDefault("newrelic-token", null);
+        if (token != null) {
+            token.expire();
+            this.nrContext = null;
+        }
+        Weaver.callOriginal();
     }
 
     public Context currentContext() {


### PR DESCRIPTION
Fix of lambda subscribers instrumentation to call original instrumented methods and expire token in case of errors