### PR TITLE
catch unexpired tokens in postFire

### DIFF
--- a/instrumentation/java.completable-future-jdk8u40/src/main/java/java/util/concurrent/CompletableFuture_Instrumentation.java
+++ b/instrumentation/java.completable-future-jdk8u40/src/main/java/java/util/concurrent/CompletableFuture_Instrumentation.java
@@ -60,44 +60,51 @@ public class CompletableFuture_Instrumentation<T> {
 
     final boolean internalComplete(Object r) {
         boolean result = Weaver.callOriginal();
-        finishCompletableFuture(result);
+        finishCompletableFuture();
         return result;
     }
 
     final boolean completeNull() {
         boolean result = Weaver.callOriginal();
-        finishCompletableFuture(result);
+        finishCompletableFuture();
         return result;
     }
 
     final boolean completeValue(T t) {
         boolean result = Weaver.callOriginal();
-        finishCompletableFuture(result);
+        finishCompletableFuture();
         return result;
     }
 
     final boolean completeThrowable(Throwable x) {
         boolean result = Weaver.callOriginal();
-        finishCompletableFuture(result);
+        finishCompletableFuture();
         return result;
     }
 
     final boolean completeThrowable(Throwable x, Object r) {
         boolean result = Weaver.callOriginal();
-        finishCompletableFuture(result);
+        finishCompletableFuture();
         return result;
     }
 
     final boolean completeRelay(Object r) {
         boolean result = Weaver.callOriginal();
-        finishCompletableFuture(result);
+        finishCompletableFuture();
+        return result;
+    }
+
+    final CompletableFuture<T> postFire(CompletableFuture<?> a, int mode) {
+        CompletableFuture<T> result = Weaver.callOriginal();
+        //this requires a boolean 
+        finishCompletableFuture();
         return result;
     }
 
     /**
      * Expire any tokens that we've created and used on this CompletableFuture since it is now finished executing
      */
-    private void finishCompletableFuture(boolean result) {
+    private void finishCompletableFuture() {
         if (this.completableToken != null) {
             this.completableToken.expire();
             this.completableToken = null;

--- a/instrumentation/java.completable-future-jdk8u40/src/main/java/java/util/concurrent/CompletableFuture_Instrumentation.java
+++ b/instrumentation/java.completable-future-jdk8u40/src/main/java/java/util/concurrent/CompletableFuture_Instrumentation.java
@@ -96,7 +96,6 @@ public class CompletableFuture_Instrumentation<T> {
 
     final CompletableFuture<T> postFire(CompletableFuture<?> a, int mode) {
         CompletableFuture<T> result = Weaver.callOriginal();
-        //this requires a boolean 
         finishCompletableFuture();
         return result;
     }


### PR DESCRIPTION
In writing an integration test for the Java11 HttpClient Instrumentation PR, this bug was surfaced.

For every request made with the Java 11 HttpClient, numerous unexpired tokens were being created by the CompletableFutures instrumentation.  These tokens would timeout on their own - after a default 180 seconds.  This would prolong the time it takes to end the transaction and it can appear to a customer that these transactions never occurred, causing confusion and delay. 🚂 

There is a helpful supportability metric detailing where an unexpired token was created. Using that, I tracked down a code path to check for unexpired tokens and expire them. The image below shows a test run without this fix and with. The red box indicates the time for the fix being tested. 

<img width="978" alt="Screen Shot 2021-03-21 at 8 37 35 PM" src="https://user-images.githubusercontent.com/24482401/112015267-e5f4bf00-8ae8-11eb-8f61-e7d3e349abc9.png">

