### PR TITLE
Class annotation to trace methods by return type

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
@@ -96,6 +96,13 @@ public class InstrumentationContextManager {
             matchVisitors.put(new ServletAnnotationVisitor(), NO_OP_TRANSFORMER);
         }
 
+        if (agentConfig.getValue("instrumentation.scala_future_trace.enabled", false)) {
+          Agent.LOG.log(Level.FINEST, "scala_future_trace instrumentation is enabled");
+          matchVisitors.put(new TraceByReturnTypeMatchVisitor(), NO_OP_TRANSFORMER);
+        } else {
+          Agent.LOG.log(Level.FINEST, "scala_future_trace instrumentation is disabled because it is not explicitly enabled");
+        }
+
         Config instrumentationConfig = agentConfig.getClassTransformerConfig().getInstrumentationConfig(
                 "com.newrelic.instrumentation.ejb-3.0");
         if (instrumentationConfig.getProperty("enabled", false)) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/TraceByReturnTypeMatchVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/TraceByReturnTypeMatchVisitor.java
@@ -1,0 +1,89 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.instrumentation.context;
+
+import com.newrelic.agent.MetricNames;
+import com.newrelic.agent.bridge.TransactionNamePriority;
+import com.newrelic.agent.instrumentation.InstrumentationType;
+import com.newrelic.agent.instrumentation.tracing.TraceDetails;
+import com.newrelic.agent.instrumentation.tracing.TraceDetailsBuilder;
+import com.newrelic.api.agent.TraceByReturnType;
+import com.newrelic.weave.utils.WeaveUtils;
+import org.objectweb.asm.*;
+import org.objectweb.asm.commons.Method;
+
+import java.util.*;
+
+public class TraceByReturnTypeMatchVisitor implements ClassMatchVisitorFactory {
+
+  private static final String TRACE_BY_RETURN_TYPE_DESC = Type.getDescriptor(TraceByReturnType.class);
+  private static final String TRACE_RETURN_TYPES_NAME = "traceReturnTypes";
+
+  @Override
+  public ClassVisitor newClassMatchVisitor(ClassLoader loader, Class<?> classBeingRedefined, final ClassReader reader, ClassVisitor cv,
+                                           final InstrumentationContext context) {
+    return new ClassVisitor(WeaveUtils.ASM_API_LEVEL, cv) {
+
+      private boolean isScalaFutureTrace = false;
+      private List<String> traceReturnTypeDescriptors = new ArrayList<>();
+
+      @Override
+      public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+        AnnotationVisitor av = super.visitAnnotation(descriptor, visible);
+        if (TRACE_BY_RETURN_TYPE_DESC.equals(descriptor)) {
+          isScalaFutureTrace = true;
+          av = new AnnotationVisitor(WeaveUtils.ASM_API_LEVEL, av) {
+            @Override
+            public AnnotationVisitor visitArray(String name) {
+              AnnotationVisitor av = super.visitArray(name);
+              if(TRACE_RETURN_TYPES_NAME.equals(name)) {
+                return new AnnotationVisitor(WeaveUtils.ASM_API_LEVEL, av) {
+                  @Override
+                  public void visit(String name, Object value) {
+                    super.visit(name, value);
+                    traceReturnTypeDescriptors.add(((Type)value).getDescriptor());
+                  }
+                };
+              }
+              return av;
+            }
+          };
+        }
+        return av;
+      }
+
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+        if (isScalaFutureTrace && isTracedMethod(descriptor)) {
+          Method method = new Method(name, descriptor);
+          TraceDetails traceDetails = TraceDetailsBuilder.newBuilder()
+                                                         .setMetricName(method.getName())
+                                                         .setInstrumentationType(InstrumentationType.BuiltIn)
+                                                         .setInstrumentationSourceName(TraceByReturnType.class.getName())
+                                                         .setTransactionName(TransactionNamePriority.FRAMEWORK_LOW, false,
+                                                                             MetricNames.CUSTOM, method.getName())
+                                                         .build();
+          context.addTrace(method, traceDetails);
+        }
+        return mv;
+      }
+
+      private boolean isTracedMethod(String descriptor) {
+        boolean matchFound = false;
+        for(String returnTypeDescriptor: traceReturnTypeDescriptors) {
+          if(descriptor.endsWith(returnTypeDescriptor)) {
+            matchFound = true;
+            break;
+          }
+        }
+        return matchFound;
+      }
+    };
+  }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/classmatchers/TraceByReturnTypeMatchVisitorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/classmatchers/TraceByReturnTypeMatchVisitorTest.java
@@ -1,0 +1,158 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.instrumentation.classmatchers;
+
+import com.newrelic.agent.instrumentation.context.InstrumentationContext;
+import com.newrelic.agent.instrumentation.context.TraceByReturnTypeMatchVisitor;
+import com.newrelic.api.agent.TraceByReturnType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.*;
+
+public class TraceByReturnTypeMatchVisitorTest {
+
+  @Test
+  public void testFutureReturnType() throws IOException {
+    InstrumentationContext context = instrumentClass(JavaFutureInstrumented.class);
+    Set<Method> tracedMethods = context.getTraceInformation().getTraceAnnotations().keySet();
+    Set<String> tracedMethodNames = methodNames(tracedMethods);
+    Assert.assertTrue(allMatchTypeDescriptor(tracedMethods, Future.class));
+    Assert.assertThat(tracedMethodNames, containsInAnyOrder("returnFuture", "submitFuture", "access$000"));
+    Assert.assertThat(tracedMethodNames, not(contains("returnString", "returnInteger")));
+  }
+
+  @Test
+  public void testStringReturnType() throws IOException {
+    InstrumentationContext context = instrumentClass(StringInstrumented.class);
+    Set<Method> tracedMethods = context.getTraceInformation().getTraceAnnotations().keySet();
+    Set<String> tracedMethodNames = methodNames(tracedMethods);
+    Assert.assertTrue(allMatchTypeDescriptor(tracedMethods, String.class));
+    Assert.assertThat(tracedMethodNames, containsInAnyOrder("returnString"));
+    Assert.assertThat(tracedMethodNames, not(contains("returnInteger")));
+  }
+
+  @Test
+  public void testFutureAndStringReturnType() throws IOException {
+    InstrumentationContext context = instrumentClass(FutureAndStringInstrumented.class);
+    Set<Method> tracedMethods = context.getTraceInformation().getTraceAnnotations().keySet();
+    Set<String> tracedMethodNames = methodNames(tracedMethods);
+    Assert.assertTrue(allMatchTypeDescriptor(tracedMethods, Future.class, String.class));
+    Assert.assertThat(tracedMethodNames, containsInAnyOrder("returnString", "returnFuture"));
+    Assert.assertThat(tracedMethodNames, not(contains("returnInteger")));
+  }
+
+  private boolean allMatchTypeDescriptor(Set<Method> methods, final Class<?>... clazzes) {
+    Predicate<Method> methodDescriptorMatchesOneClass = new Predicate<Method>() {
+      @Override
+      public boolean test(final Method method) {
+        return Arrays.stream(clazzes).anyMatch(new Predicate<Class<?>>() {
+          @Override
+          public boolean test(Class<?> clazz) {
+            return method.getDescriptor().endsWith(Type.getDescriptor(clazz));
+          }
+        });
+      }
+    };
+    return methods.stream().allMatch(methodDescriptorMatchesOneClass);
+  }
+
+  private Set<String> methodNames(Set<Method> methods) {
+    return methods.stream().map(new Function<Method, String>() {
+      @Override
+      public String apply(Method method) {
+        return method.getName();
+      }
+    }).collect(Collectors.<String>toSet());
+  }
+
+  private InstrumentationContext instrumentClass(Class<?> clazz) throws IOException {
+    InstrumentationContext context = new InstrumentationContext(null, clazz, clazz.getProtectionDomain());
+    ClassReader reader = new ClassReader(clazz.getName());
+    ClassVisitor visitor = new TraceByReturnTypeMatchVisitor().newClassMatchVisitor(clazz.getClassLoader(), clazz, reader, new ClassWriter(0), context);
+    reader.accept(visitor, 0);
+    return context;
+  }
+
+  @TraceByReturnType(traceReturnTypes = Future.class)
+  class JavaFutureInstrumented {
+    private ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    //becomes static method access$000
+    public Function<Integer, Future<Integer>> futureFunction =
+      new Function<Integer, Future<Integer>>() {
+        @Override
+        public Future<Integer> apply(Integer i) {
+          return JavaFutureInstrumented.this.submitFuture(i);
+        }
+      };
+
+    public Future<Integer> returnFuture() {
+      return submitFuture(1);
+    }
+
+    private <T> Future<T> submitFuture(final T t) {
+      return executorService.submit(new Callable<T>() {
+        @Override
+        public T call() throws Exception {
+          return t;
+        }
+      });
+    }
+
+    public String returnString() {
+      return "";
+    }
+
+    public Integer returnInteger() {
+      return 0;
+    }
+  }
+
+  @TraceByReturnType(traceReturnTypes = String.class)
+  class StringInstrumented {
+
+    public String returnString() {
+      return "";
+    }
+
+    public Integer returnInteger() {
+      return 0;
+    }
+  }
+
+  @TraceByReturnType(traceReturnTypes = {Future.class, String.class})
+  class FutureAndStringInstrumented {
+
+    public String returnString() {
+      return "";
+    }
+
+    public Future<Integer> returnFuture() { return null;}
+
+    public Integer returnInteger() {
+      return 0;
+    }
+  }
+}

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/TraceByReturnType.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/TraceByReturnType.java
@@ -1,0 +1,26 @@
+package com.newrelic.api.agent;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Target;
+
+/**
+ * A class annotated with TraceByReturnType will cause the New Relic agent to annotate methods
+ * with a return type matching Classes specified in {@link TraceByReturnType#traceReturnTypes}
+ * with a @{link com.newrelic.api.agent.Trace} annotation.
+ */
+
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TraceByReturnType {
+
+  /**
+   * Specifies return types of methods that should be annotated with {@link TraceByReturnType#traceReturnTypes}
+   * Type parameters for Generic Types are ignored. e.g. List.class will match methods returning List<Integer> and
+   * List<String>
+   */
+  Class[] traceReturnTypes() default {};
+}

--- a/newrelic-weaver-scala/build.gradle
+++ b/newrelic-weaver-scala/build.gradle
@@ -9,18 +9,16 @@ configurations {
 dependencies {
     compileFirst project(path: ":newrelic-agent", configuration: "finalArtifact")
     implementation("org.scala-lang:scala-library:2.11.1")
-
     testImplementation("org.ow2.asm:asm:8.0.1")
     testImplementation("org.ow2.asm:asm-util:8.0.1")
     testImplementation("org.ow2.asm:asm-tree:8.0.1")
+    testImplementation("org.ow2.asm:asm-commons:8.0.1")
     testImplementation("com.google.guava:guava:28.2-android") {
         transitive = false
     }
-
     testImplementation(project(":newrelic-weaver-api"))
     testImplementation(project(":newrelic-weaver-scala-api"))
     testImplementation(project(":instrumentation-test"))
-
     // import test utils from newrelic-weaver project
     testImplementation(project(path: ':newrelic-weaver', configuration: 'testClasses'))
 }

--- a/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/TraceByReturnTypeVisitorTest.scala
+++ b/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/TraceByReturnTypeVisitorTest.scala
@@ -1,0 +1,110 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.weave.weavepackage.language.scala
+
+import java.util.concurrent.Executors
+import java.util.{Set => JSet}
+
+import com.newrelic.api.agent.{TraceByReturnType, Trace}
+import org.junit.{Assert, Test}
+import com.newrelic.agent.instrumentation.context.{InstrumentationContext, TraceByReturnTypeMatchVisitor}
+import org.hamcrest.Matchers.{contains, containsInAnyOrder, not}
+import com.newrelic.agent.deps.org.objectweb.asm.{ClassReader, ClassWriter, Type}
+import com.newrelic.agent.deps.org.objectweb.asm.commons.Method
+import collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class TraceByReturnTypeVisitorTest {
+  @Test
+  def testFutureReturnType(): Unit = {
+
+    val context = instrumentClass(classOf[FutureAnnotatedClass])
+    val traceInformation = context.getTraceInformation
+    val tracedMethods: JSet[Method] = traceInformation.getTraceAnnotations.keySet()
+    val tracedMethodNames: JSet[String] = methodNames(tracedMethods)
+
+    Assert.assertTrue("all traced methods should return Future",
+      allMatchTypeDescriptor(tracedMethods, classOf[Future[_]])
+    )
+    Assert.assertThat(tracedMethodNames,
+      containsInAnyOrder("twoFuture",
+        "oneFuture")
+    )
+    Assert.assertThat(tracedMethodNames, not(contains("returnString", "returnsInt", "oneOption")))
+  }
+
+  @Test
+  def testFutureAndOptionReturnType(): Unit = {
+
+    val context = instrumentClass(classOf[OptionAndFutureAnnotatedClass])
+    val traceInformation = context.getTraceInformation
+    val tracedMethods: JSet[Method] = traceInformation.getTraceAnnotations.keySet()
+    val tracedMethodNames: JSet[String] = methodNames(tracedMethods)
+
+    Assert.assertTrue("all traced methods should return Future or Option",
+      allMatchTypeDescriptor(tracedMethods, classOf[Future[_]], classOf[Option[_]])
+    )
+    Assert.assertThat(tracedMethodNames,
+      containsInAnyOrder("twoFuture",
+        "oneFuture",
+        "oneOption")
+    )
+    Assert.assertThat(tracedMethodNames, not(contains("returnString", "returnsInt")))
+  }
+
+  private def methodNames(traceMethods: JSet[Method]): JSet[String] =
+    traceMethods.asScala.map(_.getName).asJava
+
+  private def allMatchTypeDescriptor(methods: JSet[Method], clazzes: Class[_]*): Boolean = {
+    val methodDescriptorMatchesOneClass: Method => Boolean =
+      method => clazzes.toList.exists(clazz => method.getDescriptor.endsWith(Type.getDescriptor(clazz)))
+    methods.asScala.forall(methodDescriptorMatchesOneClass)
+  }
+
+  private def instrumentClass(clazz: Class[_]) = {
+    val context = new InstrumentationContext(null, clazz, clazz.getProtectionDomain)
+    val reader = new ClassReader(clazz.getName)
+    val target = new TraceByReturnTypeMatchVisitor()
+    val visitor = target.newClassMatchVisitor(clazz.getClassLoader, clazz, reader, new ClassWriter(0), context)
+    reader.accept(visitor, 0)
+    context
+  }
+
+  @TraceByReturnType(traceReturnTypes = Array(classOf[Future[_]], classOf[Option[_]]))
+  class OptionAndFutureAnnotatedClass {
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+
+    def returnInt: Int = 1
+
+    def returnString: String = "String"
+
+    def oneFuture(i: Int): Future[Int] = Future.successful(i)
+
+    def twoFuture(i: Int): Future[Int] = Future.successful(i).map(_ + 2)
+
+    def oneOption(i: Int): Option[Int] = Option(i)
+  }
+
+  @TraceByReturnType(traceReturnTypes = Array(classOf[Future[_]]))
+  class FutureAnnotatedClass {
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+
+    def returnInt: Int = 1
+
+    def returnString: String = "String"
+
+    def oneFuture(i: Int): Future[Int] = Future.successful(i)
+
+    def twoFuture(i: Int): Future[Int] = oneFuture(i).map(_ + 2)
+
+    def oneOption(i: Int): Option[Int] = Option(i)
+  }
+
+}
+


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
New class annotation TraceByReturnType. Marking a class with the TraceByReturnType annotation will instruct the New Relic agent to automatically annotate methods with return type matching any class specified in `TraceByReturnType#traceReturnTypes`

### Testing
Added unit tests to cover TraceByReturnType usage scenarios with Java and Scala.
Deploy updated agent locally and reviewed traces in New Relic One.

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
[x] Does your code contain any breaking changes? Please describe. 
[x] Does your code introduce any new dependencies? Please describe.
