### PR TITLE
Disable netty-reactor instrumentation modules from running in Java 7

### DIFF
--- a/instrumentation/netty-reactor-0.7.0/build.gradle
+++ b/instrumentation/netty-reactor-0.7.0/build.gradle
@@ -29,3 +29,9 @@ site {
     title 'Netty Reactor'
     type 'Appserver'
 }
+
+test {
+    onlyIf {
+        !project.hasProperty('test7')
+    }
+}

--- a/instrumentation/netty-reactor-0.8.0/build.gradle
+++ b/instrumentation/netty-reactor-0.8.0/build.gradle
@@ -25,3 +25,9 @@ site {
     title 'Netty Reactor'
     type 'Appserver'
 }
+
+test {
+    onlyIf {
+        !project.hasProperty('test7')
+    }
+}

--- a/instrumentation/netty-reactor-0.9.0/build.gradle
+++ b/instrumentation/netty-reactor-0.9.0/build.gradle
@@ -25,3 +25,9 @@ site {
     title 'Netty Reactor'
     type 'Appserver'
 }
+
+test {
+    onlyIf {
+        !project.hasProperty('test7')
+    }
+}


### PR DESCRIPTION
### Overview
This commit disables the netty-reactor instrumentation tests from running in Java 7.
All the supported netty-reactor versions require Java 8+, which causes problems when running with Java 7.

### Checks

Are your contributions backwards compatible with relevant frameworks and APIs?
Yes.

Does your code contain any breaking changes? Please describe. 
No.

Does your code introduce any new dependencies? Please describe.
No.