### PR TITLE
Migrate Guava cache usage to Caffeine

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/ExtensionHolder.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/ExtensionHolder.java
@@ -8,6 +8,7 @@
 package com.newrelic.agent.bridge;
 
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 /**
  * A holder for Weaver extension classes.
@@ -17,7 +18,7 @@ public interface ExtensionHolder<T> {
      * Return the value associated with the instance in this ExtensionHolder. If the value is not present it will be
      * initialized (in a thread-safe manner) using valueLoader.
      */
-    public T getExtension(Object instance, Callable<T> valueLoader);
+    public T getExtension(Object instance, Supplier<T> valueLoader);
 
     /**
      * Return the value associated with the instance in this ExtensionHolder.<br/>

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -94,6 +94,8 @@ dependencies {
 
     shadowIntoJar('com.google.guava:guava:28.2-jre') 
 
+    shadowIntoJar('com.github.ben-manes.caffeine:caffeine:2.9.0')
+
     shadowIntoJar("org.yaml:snakeyaml:1.27")
 
     implementation("javax.management.j2ee:management-api:1.1-rev-1") {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionRewriter.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionRewriter.java
@@ -27,7 +27,7 @@ import java.util.jar.JarOutputStream;
 public class ExtensionRewriter {
 
     static final DependencyRemapper REMAPPER = new DependencyRemapper(ImmutableSet.of("org/objectweb/asm/",
-            "com/google/", "org/apache/commons/"));
+            "com/github/benmanes/caffeine/", "com/google/", "org/apache/commons/"));
 
     private ExtensionRewriter() {
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
@@ -22,7 +22,7 @@ import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.instrumentation.context.ContextClassTransformer;
 import com.newrelic.agent.instrumentation.context.InstrumentationContext;
 import com.newrelic.agent.instrumentation.weaver.errorhandler.LogAndReturnOriginal;
-import com.newrelic.agent.instrumentation.weaver.extension.GuavaBackedExtensionClass;
+import com.newrelic.agent.instrumentation.weaver.extension.CaffeineBackedExtensionClass;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.weave.utils.BootstrapLoader;
 import com.newrelic.weave.utils.ClassCache;
@@ -128,7 +128,7 @@ public class ClassLoaderClassTransformer implements ClassMatchVisitorFactory, Co
         // Try to use a custom Guava-based extension template to make NewField access better
         try {
             extensionTemplate = WeaveUtils.convertToClassNode(WeaveUtils.getClassBytesFromClassLoaderResource(
-                    GuavaBackedExtensionClass.class.getName(), GuavaBackedExtensionClass.class.getClassLoader()));
+                    CaffeineBackedExtensionClass.class.getName(), CaffeineBackedExtensionClass.class.getClassLoader()));
         } catch (Exception e) {
             AgentBridge.getAgent().getLogger().log(Level.WARNING, e, "Unable to initialize custom extension class "
                     + "template. Falling back to default java NewField implementation");

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
@@ -21,7 +21,7 @@ import com.newrelic.agent.instrumentation.context.ContextClassTransformer;
 import com.newrelic.agent.instrumentation.context.InstrumentationContext;
 import com.newrelic.agent.instrumentation.weaver.errorhandler.LogAndReturnOriginal;
 import com.newrelic.agent.instrumentation.weaver.extension.ExtensionHolderFactoryImpl;
-import com.newrelic.agent.instrumentation.weaver.extension.GuavaBackedExtensionClass;
+import com.newrelic.agent.instrumentation.weaver.extension.CaffeineBackedExtensionClass;
 import com.newrelic.agent.instrumentation.weaver.preprocessors.AgentPostprocessors;
 import com.newrelic.agent.instrumentation.weaver.preprocessors.AgentPreprocessors;
 import com.newrelic.agent.instrumentation.weaver.preprocessors.TracedWeaveInstrumentationTracker;
@@ -93,7 +93,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
         AgentBridge.extensionHolderFactory = new ExtensionHolderFactoryImpl();
         try {
             EXTENSION_TEMPLATE = WeaveUtils.convertToClassNode(WeaveUtils.getClassBytesFromClassLoaderResource(
-                    GuavaBackedExtensionClass.class.getName(), GuavaBackedExtensionClass.class.getClassLoader()));
+                    CaffeineBackedExtensionClass.class.getName(), CaffeineBackedExtensionClass.class.getClassLoader()));
         } catch (Exception e) {
             AgentBridge.getAgent().getLogger().log(Level.WARNING, e,
                     "Unable to initialize custom extension class template. Falling back to default java NewField implementation");

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/extension/CaffeineBackedExtensionClass.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/extension/CaffeineBackedExtensionClass.java
@@ -11,28 +11,28 @@ import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.ExtensionHolder;
 import com.newrelic.weave.weavepackage.ExtensionClassTemplate;
 
-import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 /**
  * This class provides the custom bytecode template which will form the extension class for weaved classes.
  *
- * @see ExtensionHolderFactoryImpl provides the agent's implementation using guava
+ * @see ExtensionHolderFactoryImpl provides the agent's implementation using Caffeine
  */
-public class GuavaBackedExtensionClass extends ExtensionClassTemplate implements Callable<GuavaBackedExtensionClass> {
-    private static final ExtensionHolder<GuavaBackedExtensionClass> AGENT_EXTENSION_HOLDER = AgentBridge.extensionHolderFactory.build();
-    private static final Callable<GuavaBackedExtensionClass> AGENT_VALUE_LOADER = new GuavaBackedExtensionClass();
+public class CaffeineBackedExtensionClass extends ExtensionClassTemplate implements Supplier<CaffeineBackedExtensionClass> {
+    private static final ExtensionHolder<CaffeineBackedExtensionClass> AGENT_EXTENSION_HOLDER = AgentBridge.extensionHolderFactory.build();
+    private static final Supplier<CaffeineBackedExtensionClass> AGENT_VALUE_LOADER = new CaffeineBackedExtensionClass();
 
-    public static GuavaBackedExtensionClass getAndRemoveExtension(Object instance) {
+    public static CaffeineBackedExtensionClass getAndRemoveExtension(Object instance) {
         return AGENT_EXTENSION_HOLDER.getAndRemoveExtension(instance);
     }
 
-    public static GuavaBackedExtensionClass getExtension(Object instance) {
+    public static CaffeineBackedExtensionClass getExtension(Object instance) {
         try {
             return AGENT_EXTENSION_HOLDER.getExtension(instance, AGENT_VALUE_LOADER);
         } catch (Throwable t) {
             // This should never happen. But if it does the agent has already logged the appropriate messages.
             // We need to return something non-null here since untrapped code could be invoking this method.
-            return new GuavaBackedExtensionClass();
+            return new CaffeineBackedExtensionClass();
         }
     }
 
@@ -41,7 +41,7 @@ public class GuavaBackedExtensionClass extends ExtensionClassTemplate implements
      * So we implement the valueLoader here instead of in a nested class.
      */
     @Override
-    public GuavaBackedExtensionClass call() {
-        return new GuavaBackedExtensionClass();
+    public CaffeineBackedExtensionClass get() {
+        return new CaffeineBackedExtensionClass();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/sql/BoundedConcurrentCache.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/sql/BoundedConcurrentCache.java
@@ -7,8 +7,8 @@
 
 package com.newrelic.agent.sql;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -41,8 +41,8 @@ public class BoundedConcurrentCache<K, V extends Comparable<V> & CacheValue<K>> 
     public BoundedConcurrentCache(int size, Comparator<V> comparator) {
         this.maxCapacity = size;
         this.priorityQueue = new PriorityBlockingQueue<>(size, comparator);
-        this.cache = CacheBuilder.newBuilder()
-                .concurrencyLevel(16)
+        this.cache = Caffeine.newBuilder()
+                .initialCapacity(16)
                 .build();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transaction/TransactionCache.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transaction/TransactionCache.java
@@ -7,8 +7,8 @@
 
 package com.newrelic.agent.transaction;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.newrelic.agent.tracers.MetricNameFormatWithHost;
 
 import java.net.URL;
@@ -29,7 +29,7 @@ public class TransactionCache {
 
     private Cache<Object, MetricNameFormatWithHost> getInputStreamCache() {
         if (inputStreamCache == null) {
-            inputStreamCache = CacheBuilder.newBuilder().weakKeys().build();
+            inputStreamCache = Caffeine.newBuilder().weakKeys().build();
         }
         return inputStreamCache;
     }
@@ -44,7 +44,7 @@ public class TransactionCache {
 
     private Cache<Object, URL> getUrlCache() {
         if (urlCache == null) {
-            urlCache = CacheBuilder.newBuilder().weakKeys().build();
+            urlCache = Caffeine.newBuilder().weakKeys().build();
         }
         return urlCache;
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
@@ -9,15 +9,15 @@ package com.newrelic.agent.util;
 
 import java.util.Map;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.newrelic.agent.bridge.CollectionFactory;
 
 public class AgentCollectionFactory implements CollectionFactory {
 
     @Override
     public <K, V> Map<K, V> createConcurrentWeakKeyedMap() {
-        Cache<K, V> cache = CacheBuilder.newBuilder().concurrencyLevel(32).weakKeys().build();
+        Cache<K, V> cache = Caffeine.newBuilder().initialCapacity(32).weakKeys().build();
         return cache.asMap();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/bootstrap/EmbeddedJarFilesImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/bootstrap/EmbeddedJarFilesImpl.java
@@ -13,11 +13,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.concurrent.ExecutionException;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 
 public class EmbeddedJarFilesImpl implements EmbeddedJarFiles {
 
@@ -29,7 +28,7 @@ public class EmbeddedJarFilesImpl implements EmbeddedJarFiles {
     /**
      * A map of jar names to the temp files containing those jars.
      */
-    private final LoadingCache<String, File> embeddedAgentJarFiles = CacheBuilder.newBuilder().build(
+    private final LoadingCache<String, File> embeddedAgentJarFiles = Caffeine.newBuilder().build(
             new CacheLoader<String, File>() {
 
                 @Override
@@ -66,17 +65,7 @@ public class EmbeddedJarFilesImpl implements EmbeddedJarFiles {
 
     @Override
     public File getJarFileInAgent(String jarNameWithoutExtension) throws IOException {
-        try {
-            return embeddedAgentJarFiles.get(jarNameWithoutExtension);
-        } catch (ExecutionException e) {
-            try {
-                throw e.getCause();
-            } catch (IOException ex) {
-                throw ex;
-            } catch (Throwable ex) {
-                throw new RuntimeException(ex);
-            }
-        }
+        return embeddedAgentJarFiles.get(jarNameWithoutExtension);
     }
 
     @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/extension/DependencyRemapperTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/extension/DependencyRemapperTest.java
@@ -7,8 +7,9 @@
 
 package com.newrelic.agent.extension;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.google.common.collect.ImmutableSet;
 import com.newrelic.agent.util.asm.BenignClassReadException;
 import com.newrelic.agent.util.asm.Utils;
 import org.junit.Assert;
@@ -42,8 +43,11 @@ public class DependencyRemapperTest {
                 "com/newrelic/agent/deps/org/objectweb/asm/ClassVisitor", remapper.getRemappings().get(
                         "org/objectweb/asm/ClassVisitor"));
         Assert.assertEquals(remapper.getRemappings().toString(),
-                "com/newrelic/agent/deps/com/google/common/cache/CacheBuilder", remapper.getRemappings().get(
-                        "com/google/common/cache/CacheBuilder"));
+                "com/newrelic/agent/deps/com/github/benmanes/caffeine/cache/Caffeine", remapper.getRemappings().get(
+                        "com/github/benmanes/caffeine/cache/Caffeine"));
+        Assert.assertEquals(remapper.getRemappings().toString(),
+                "com/newrelic/agent/deps/com/google/common/collect/ImmutableSet", remapper.getRemappings().get(
+                        "com/google/common/collect/ImmutableSet"));
     }
 
     @Test
@@ -51,7 +55,15 @@ public class DependencyRemapperTest {
 
         DependencyRemapper remapper = ExtensionRewriter.REMAPPER;
         Assert.assertEquals(remapper.getRemappings().toString(),
-                "com/newrelic/agent/deps/com/google/common/cache/CacheLoader",
+                "com/newrelic/agent/deps/com/google/common/collect/ImmutableSet",
+                remapper.mapType(Type.getInternalName(ImmutableSet.class)));
+    }
+
+    @Test
+    public void caffeine() {
+        DependencyRemapper remapper = ExtensionRewriter.REMAPPER;
+        Assert.assertEquals(remapper.getRemappings().toString(),
+                "com/newrelic/agent/deps/com/github/benmanes/caffeine/cache/CacheLoader",
                 remapper.mapType(Type.getInternalName(CacheLoader.class)));
     }
 
@@ -72,8 +84,10 @@ public class DependencyRemapperTest {
 
         @Override
         public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-            // make sure we pick up this google reference
-            CacheBuilder<Object, Object> newBuilder = CacheBuilder.newBuilder();
+            // Make sure we pick up this Caffeine reference.
+            Caffeine<Object, Object> newBuilder = Caffeine.newBuilder();
+            // Make sure we pick up this Guava reference.
+            ImmutableSet<Object> set = ImmutableSet.of();
             return super.visitMethod(access, name, desc, signature, exceptions);
         }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/extension/JarExtensionTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/extension/JarExtensionTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.objectweb.asm.Type;
 
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import com.newrelic.agent.bridge.Agent;
 import com.newrelic.agent.bridge.AgentBridge;
@@ -69,8 +69,8 @@ public class JarExtensionTest {
         public static void premain(String agentArgs, Instrumentation inst) {
             AgentBridge.getAgent().getLogger().log(Level.INFO, "My cool extension started! {0}", inst);
 
-            // reference a google class so the jar gets rewritten
-            CacheBuilder<?, ?> builder = CacheBuilder.newBuilder();
+            // Reference a Caffeine class so the jar gets rewritten.
+            Caffeine<?, ?> builder = Caffeine.newBuilder();
         }
     }
 }

--- a/newrelic-weaver/build.gradle
+++ b/newrelic-weaver/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation("com.google.guava:guava:28.2-android") {
         transitive = false
     }
+    implementation("com.github.ben-manes.caffeine:caffeine:2.9.0")
 
     // used to invoke agentmain
     testImplementation(files(jdk7 + "/lib/tools.jar"))

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageManagerTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageManagerTest.java
@@ -83,7 +83,7 @@ public class WeavePackageManagerTest {
                 wpm.validPackages.getIfPresent(Thread.currentThread().getContextClassLoader()).values()) {
             WeaveTestUtils.expectViolations(res);
         }
-        Assert.assertEquals(1, wpm.validPackages.size());
+        Assert.assertEquals(1, wpm.validPackages.asMap().size());
         Assert.assertEquals(2, wpm.validPackages.getIfPresent(Thread.currentThread().getContextClassLoader()).size());
 
         Assert.assertNotNull(compositeBytes);
@@ -124,8 +124,8 @@ public class WeavePackageManagerTest {
                 WeaveTestUtils.getClassBytes(targetClassName));
         Assert.assertTrue(bsPackage.hasMatcher(targetInternalName, superNames, interfaceNames,
                 Collections.<String>emptySet(), Collections.<String>emptySet(), null));
-        Assert.assertEquals(0, wpm.invalidPackages.size());
-        Assert.assertEquals(1, wpm.validPackages.size());
+        Assert.assertEquals(0, wpm.invalidPackages.asMap().size());
+        Assert.assertEquals(1, wpm.validPackages.asMap().size());
         Assert.assertNotNull(wpm.validPackages.getIfPresent(BootstrapLoader.PLACEHOLDER));
         Assert.assertNotNull(wpm.validPackages.getIfPresent(BootstrapLoader.PLACEHOLDER).get(bsPackage));
 
@@ -147,7 +147,7 @@ public class WeavePackageManagerTest {
         byte[] compositeBytes = WeaveTestUtils.getClassBytes(className);
         Assert.assertNotNull(compositeBytes);
         compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes);
-        Assert.assertEquals(1, wpm.validPackages.size());
+        Assert.assertEquals(1, wpm.validPackages.asMap().size());
         Assert.assertEquals(1, wpm.validPackages.getIfPresent(originalClassLoader).size());
 
         Assert.assertNotNull(compositeBytes);
@@ -169,7 +169,7 @@ public class WeavePackageManagerTest {
             wpm.weave(cl, "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
                     WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"));
         }
-        Assert.assertTrue(wpm.validPackages.size() <= WeavePackageManager.MAX_VALID_PACKAGE_CACHE);
+        Assert.assertTrue(wpm.validPackages.asMap().size() <= WeavePackageManager.MAX_VALID_PACKAGE_CACHE);
 
         // 3) load the original class and a new class with the original classloader and verify they load + weave
 
@@ -187,7 +187,7 @@ public class WeavePackageManagerTest {
         byte[] newCompositeBytes = WeaveTestUtils.getClassBytes(newClassName);
         Assert.assertNotNull(newCompositeBytes);
         newCompositeBytes = wpm.weave(originalClassLoader, newInternalName, newCompositeBytes);
-        Assert.assertTrue(wpm.validPackages.size() <= WeavePackageManager.MAX_VALID_PACKAGE_CACHE);
+        Assert.assertTrue(wpm.validPackages.asMap().size() <= WeavePackageManager.MAX_VALID_PACKAGE_CACHE);
         Assert.assertEquals(1, wpm.validPackages.getIfPresent(originalClassLoader).size());
 
         Assert.assertNotNull(newCompositeBytes);
@@ -218,7 +218,7 @@ public class WeavePackageManagerTest {
         byte[] compositeBytes = WeaveTestUtils.getClassBytes(className);
         Assert.assertNotNull(compositeBytes);
         compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes);
-        Assert.assertEquals(1, wpm.invalidPackages.size());
+        Assert.assertEquals(1, wpm.invalidPackages.asMap().size());
         Assert.assertEquals(1, wpm.invalidPackages.getIfPresent(originalClassLoader).size());
 
         Assert.assertNull(compositeBytes);
@@ -239,7 +239,8 @@ public class WeavePackageManagerTest {
             wpm.weave(cl, "com/newrelic/weave/weavepackage/WeavePackageManagerTest$NewNoMatchClass",
                     WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.WeavePackageManagerTest$NewNoMatchClass"));
         }
-        Assert.assertTrue(WeavePackageManager.MAX_INVALID_PACKAGE_CACHE >= wpm.invalidPackages.size());
+        wpm.invalidPackages.cleanUp();
+        Assert.assertTrue(WeavePackageManager.MAX_INVALID_PACKAGE_CACHE >= wpm.invalidPackages.asMap().size());
 
         // 3) load with the original classloader again and verify that class loads but doesn't weave (pushes to invalid)
         compositeBytes = WeaveTestUtils.getClassBytes(className);
@@ -269,7 +270,7 @@ public class WeavePackageManagerTest {
             wpm.weave(cl, "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
                     WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"));
         }
-        Assert.assertEquals(numClassLoaders, wpm.validPackages.size());
+        Assert.assertEquals(numClassLoaders, wpm.validPackages.asMap().size());
 
         for (int i = 0; i < 5; ++i) {
             System.gc();
@@ -278,7 +279,7 @@ public class WeavePackageManagerTest {
             wpm.weave(cl, "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
                     WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"));
         }
-        Assert.assertTrue(wpm.validPackages.size() >= numClassLoaders);
+        Assert.assertTrue(wpm.validPackages.asMap().size() >= numClassLoaders);
 
         classloaders.clear();
         for (int i = 0; i < 10; ++i) {
@@ -291,7 +292,7 @@ public class WeavePackageManagerTest {
             wpm.validPackages.invalidate(cl);
         }
 
-        Assert.assertTrue(wpm.validPackages.size() < numClassLoaders);
+        Assert.assertTrue(wpm.validPackages.asMap().size() < numClassLoaders);
     }
 
     /**


### PR DESCRIPTION
For details, see #258. This is a draft PR to assess what is involved.

:exclamation: Note the base branch; these changes are built on top of #276 because Caffeine requires Java 8.

I'll add some comments with additional context/questions.
