### PR TITLE
Changed dropped events to log at FINE instead of WARN

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
@@ -165,7 +165,7 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
 
                 if (reservoir.size() < reservoir.getNumberOfTries()) {
                     int dropped = reservoir.getNumberOfTries() - reservoir.size();
-                    Agent.LOG.log(Level.WARNING, "Dropped {0} error events out of {1}.", dropped, reservoir.getNumberOfTries());
+                    Agent.LOG.log(Level.FINE, "Dropped {0} error events out of {1}.", dropped, reservoir.getNumberOfTries());
                 }
             } catch (HttpError e) {
                 if (!e.discardHarvestData()) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/InsightsServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/InsightsServiceImpl.java
@@ -302,7 +302,7 @@ public class InsightsServiceImpl extends AbstractService implements InsightsServ
 
                 if (reservoir.size() < reservoir.getNumberOfTries()) {
                     int dropped = reservoir.getNumberOfTries() - reservoir.size();
-                    Agent.LOG.log(Level.WARNING, "Dropped {0} custom events out of {1}.", dropped, reservoir.getNumberOfTries());
+                    Agent.LOG.log(Level.FINE, "Dropped {0} custom events out of {1}.", dropped, reservoir.getNumberOfTries());
                 }
             } catch (HttpError e) {
                 if (!e.discardHarvestData()) {


### PR DESCRIPTION
We already log about dropped span events at FINE, this PR does the same for error and insights/custom events instead of logging them at WARN to decrease log verbosity.

```
"Dropped {0} span events out of {1}."
"Dropped {0} error events out of {1}."
"Dropped {0} custom events out of {1}."
```