### PR TITLE
Automatically set the metric/event ingest URIs based on region parsed…

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
@@ -91,6 +91,122 @@ public class AgentConfigImplTest {
     }
 
     @Test
+    public void defaultMetricIngestUri() throws Exception {
+        Map<String, Object> localMap = new HashMap<>();
+
+        // regular pre-protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "0123456789abcdef0123456789abcdef01234567");
+        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.DEFAULT_METRIC_INGEST_URI, config.getMetricIngestUri());
+
+        // improper padding
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "xEU016789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.DEFAULT_METRIC_INGEST_URI, config.getMetricIngestUri());
+
+        // no padding
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "EU0076789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.DEFAULT_METRIC_INGEST_URI, config.getMetricIngestUri());
+    }
+
+    @Test
+    public void regionAwareMetricIngestUri() throws Exception {
+        Map<String, Object> localMap = new HashMap<>();
+
+        // proper 4 character protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "eu01xX6789abcdef0123456789abcdef01234567");
+        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.EU_METRIC_INGEST_URI, config.getMetricIngestUri());
+
+        // proper 5 character protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "euV09x6789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.EU_METRIC_INGEST_URI, config.getMetricIngestUri());
+
+        // proper 4 character protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "eu03XX6789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.EU_METRIC_INGEST_URI, config.getMetricIngestUri());
+    }
+
+    @Test
+    public void setMetricIngestUri() {
+        Map<String, Object> localMap = new HashMap<>();
+        String stagingMetricIngestUri = "https://staging-metric-api.newrelic.com/metric/v1";
+
+        // if host is set explicitly, never parse the license key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "0123456789abcdef0123456789abcdef01234567");
+        localMap.put(AgentConfigImpl.METRIC_INGEST_URI, stagingMetricIngestUri);
+        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(stagingMetricIngestUri, config.getMetricIngestUri());
+
+        // if host is set explicitly, never parse the license key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "eu01xx6789abcdef0123456789abcdef01234567");
+        localMap.put(AgentConfigImpl.METRIC_INGEST_URI, stagingMetricIngestUri);
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(stagingMetricIngestUri, config.getMetricIngestUri());
+    }
+
+    @Test
+    public void defaultEventIngestUri() throws Exception {
+        Map<String, Object> localMap = new HashMap<>();
+
+        // regular pre-protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "0123456789abcdef0123456789abcdef01234567");
+        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.DEFAULT_EVENT_INGEST_URI, config.getEventIngestUri());
+
+        // improper padding
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "xEU016789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.DEFAULT_EVENT_INGEST_URI, config.getEventIngestUri());
+
+        // no padding
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "EU0076789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.DEFAULT_EVENT_INGEST_URI, config.getEventIngestUri());
+    }
+
+    @Test
+    public void regionAwareEventIngestUri() throws Exception {
+        Map<String, Object> localMap = new HashMap<>();
+
+        // proper 4 character protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "eu01xX6789abcdef0123456789abcdef01234567");
+        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.EU_EVENT_INGEST_URI, config.getEventIngestUri());
+
+        // proper 5 character protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "euV09x6789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.EU_EVENT_INGEST_URI, config.getEventIngestUri());
+
+        // proper 4 character protocol 15 key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "eu03XX6789abcdef0123456789abcdef01234567");
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(AgentConfigImpl.EU_EVENT_INGEST_URI, config.getEventIngestUri());
+    }
+
+    @Test
+    public void setEventIngestUri() {
+        Map<String, Object> localMap = new HashMap<>();
+        String stagingEventIngestUri = "https://staging-insights-collector.newrelic.com/v1/accounts/events";
+
+        // if host is set explicitly, never parse the license key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "0123456789abcdef0123456789abcdef01234567");
+        localMap.put(AgentConfigImpl.EVENT_INGEST_URI, stagingEventIngestUri);
+        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(stagingEventIngestUri, config.getEventIngestUri());
+
+        // if host is set explicitly, never parse the license key
+        localMap.put(AgentConfigImpl.LICENSE_KEY, "eu01xx6789abcdef0123456789abcdef01234567");
+        localMap.put(AgentConfigImpl.EVENT_INGEST_URI, stagingEventIngestUri);
+        config = AgentConfigImpl.createAgentConfig(localMap);
+        assertEquals(stagingEventIngestUri, config.getEventIngestUri());
+    }
+
+    @Test
     public void extensionReloadAsDottedInYaml() {
         AgentConfig hasDefaultReloadModified = AgentConfigImpl.createAgentConfig(Collections.<String, Object>emptyMap());
         boolean defaultReloadModified = hasDefaultReloadModified.getExtensionsConfig().shouldReloadModified();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -46,7 +46,7 @@ public class JfrServiceTest {
         JfrService jfrService = new JfrService(jfrConfig, agentConfig);
         DaemonConfig daemonConfig = jfrService.buildDaemonConfig();
 
-        assertTrue(daemonConfig.isUseLicenseKey());
+        assertTrue(daemonConfig.isUseLicenseKey()); // TODO refactor this to daemonConfig.useLicenseKey() when updating from jfr-daemon 1.2.0
         assertEquals("test_1234_license_key", daemonConfig.getApiKey());
         assertEquals("test_app_name", daemonConfig.getMonitoredAppName());
         assertEquals(DEFAULT_METRIC_INGEST_URI, daemonConfig.getMetricsUri().toString());


### PR DESCRIPTION
… from license key

This PR automatically sets the metric & event ingest URIs for US & EU Prod based on parsing the region from the license key. Since there is nothing in the license to tell the difference between staging and prod it will always be necessary to explicitly set the staging endpoints using the agent config `metric_ingest_uri` and `event_ingest_uri` properties as follows, just like it is when setting the staging collector `host`:

```
common:

  host: staging-collector.newrelic.com
  api_host: staging.newrelic.com

  metric_ingest_uri: https://staging-metric-api.newrelic.com/metric/v1
  event_ingest_uri: https://staging-insights-collector.newrelic.com/v1/accounts/events
```

I also verified that JFR events & metrics successfully reported to US & EU Prod and Staging and that the Realtime Profiling nerdlet and flamegraph chart displayed in each environment.

---

Explicitly configured to use staging:

```
2021-05-27T10:21:05,072-0700 [41460 52] com.newrelic INFO: Using configured collector host: staging-collector.newrelic.com
2021-05-27T10:21:05,072-0700 [41460 52] com.newrelic INFO: Using configured metric ingest URI: https://staging-metric-api.newrelic.com/metric/v1
2021-05-27T10:21:05,072-0700 [41460 52] com.newrelic INFO: Using configured event ingest URI: https://staging-insights-collector.newrelic.com/v1/accounts/events
```


Region aware config based on parsing license key only.

US Prod (default)
```
2021-05-27T10:29:39,689-0700 [41671 52] com.newrelic INFO: Using default collector host: collector.newrelic.com
2021-05-27T10:29:39,689-0700 [41671 52] com.newrelic INFO: Using default metric ingest URI: https://metric-api.newrelic.com/metric/v1
2021-05-27T10:29:39,689-0700 [41671 52] com.newrelic INFO: Using default event ingest URI: https://insights-collector.newrelic.com/v1/accounts/events
```

EU Prod
```
2021-05-27T11:00:46,057-0700 [43591 52] com.newrelic INFO: Using region aware collector host: collector.eu01.nr-data.net
2021-05-27T11:00:46,057-0700 [43591 52] com.newrelic INFO: Using region aware metric ingest URI: https://metric-api.eu.newrelic.com/metric/v1
2021-05-27T11:00:46,057-0700 [43591 52] com.newrelic INFO: Using region aware event ingest URI: https://insights-collector.eu01.nr-data.net/v1/accounts/events
```