### PR TITLE
update all 1st error to last error reported

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
@@ -23,7 +23,7 @@ public interface PublicApi {
      * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * @param throwable The throwable to notice and report.
      * @param params Custom parameters to include in the traced error. May be null.
@@ -42,7 +42,7 @@ public interface PublicApi {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * @param message The error message to be reported.
      * @param params Custom parameters to include in the traced error. May be null.
@@ -53,7 +53,7 @@ public interface PublicApi {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * @param message Message to report with a transaction when it finishes.
      */
@@ -63,7 +63,7 @@ public interface PublicApi {
      * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * Expected errors do not increment an application's error count or contribute towards its Apdex score.
      *
@@ -94,7 +94,7 @@ public interface PublicApi {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * Expected errors do not increment an application's error count or contribute towards its Apdex score.
      *
@@ -114,7 +114,7 @@ public interface PublicApi {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * Expected errors do not increment an application's error count or contribute towards its Apdex score.
      *

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -73,7 +73,7 @@ public final class NewRelic {
      * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * <p>
      * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
@@ -102,7 +102,7 @@ public final class NewRelic {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * <p>
      * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
@@ -121,7 +121,7 @@ public final class NewRelic {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * @param message Message to report with a transaction when it finishes.
      * @since 2.21.0
@@ -133,7 +133,7 @@ public final class NewRelic {
      * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * Expected errors do not increment an application's error count or contribute towards its Apdex score.
      *
@@ -168,7 +168,7 @@ public final class NewRelic {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * Expected errors do not increment an application's error count or contribute towards its Apdex score.
      *
@@ -190,7 +190,7 @@ public final class NewRelic {
      * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
      * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
      * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * first error will be reported.
+     * last error will be reported.
      *
      * Expected errors do not increment an application's error count or contribute towards its Apdex score.
      *


### PR DESCRIPTION


### Overview
javadoc erroneously indicated that first error in noticeError call is the one that is reported.
Last error is in fact the one reported.
### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/305

This change updates the comments so the javadoc correctly states that the last error will be reported.

