### PR TITLE
Exclude spring-ws-core 3.1.0 from being verified against spring-ws-2.0 instrumentation

### DIFF
--- a/instrumentation/spring-ws-2.0/build.gradle
+++ b/instrumentation/spring-ws-2.0/build.gradle
@@ -16,6 +16,8 @@ verifyInstrumentation {
   passesOnly('org.springframework.ws:spring-ws-core:[1.5.7,)'){
     compile("org.apache.ws.commons.axiom:axiom-api:1.2.14")
   }
+  // version 3.1.0 fails but then 3.1.1 passes again
+  exclude('org.springframework.ws:spring-ws-core:3.1.0')
 }
 
 test {


### PR DESCRIPTION
Instrumentation verifier [failed](https://javaagent-build.pdx.vm.datanerd.us/job/JavaAgent_Verify_Instrumentation/1953/consoleText) for the spring-ws-2.0 instrumentation on `org.springframework.ws:spring-ws-core:3.1.0` but then passes again for `org.springframework.ws:spring-ws-core:3.1.1`.

Hopefully it was a one off thing for that version but we'll want to keep an eye on it.

Failure was:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':instrumentation:spring-ws-2.0:verifyPass_org.springframework.ws_spring-ws-core_3.1.0'.
> A failure occurred while executing com.newrelic.agent.instrumentation.verify.VerifyWorkAction
   > Verification FAILED. Instrumentation module spring-ws-2.0-1.0.jar SHOULD HAVE applied to org.springframework.ws:spring-ws-core:3.1.0 and did not. You may need to adjust the range "org.springframework.ws:spring-ws-core:[1.5.7,)".
     Verifier output:
     Creating user classloader with custom classpath:
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework.ws/spring-ws-core/3.1.0/757d1825b382327dd4ac2ce8512abb6b4eac1ec9/spring-ws-core-3.1.0.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.apache.ws.commons.axiom/axiom-api/1.2.14/5b11407fb3c02556e7c86a0922f8f8105afb3e4d/axiom-api-1.2.14.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework.ws/spring-xml/3.1.0/a94be0bcbb73eacbe1db9a654023e2da87d60650/spring-xml-3.1.0.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-webmvc/5.3.7/8437c7a572177a34607abdaef2f6b8088488f5c0/spring-webmvc-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-context/5.3.7/330b3957efdcdebe3550b8e2c5d45a4c25496626/spring-context-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-aop/5.3.7/b86edd2455f8c4399068c999beb9ea2a9e7f2047/spring-aop-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-oxm/5.3.7/d4dc78b85456ca6e6f070d426d302828c930445e/spring-oxm-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-web/5.3.7/49e6a8f45e77f14ef16f82c0413254ef493b785f/spring-web-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-beans/5.3.7/8b1eacd7aaa12f7d173a2f0836d28bd0c1b098fe/spring-beans-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-expression/5.3.7/13351fce0a604957cd6a41478ebb54a953a0245e/spring-expression-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-core/5.3.7/4aad1b62bd347a806fe693c9d67b376a3ad8151c/spring-core-5.3.7.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.apache.geronimo.specs/geronimo-activation_1.1_spec/1.1/f15af1b53fba7f23ce5e9de4fb57a88585aa9eee/geronimo-activation_1.1_spec-1.1.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.apache.geronimo.specs/geronimo-javamail_1.4_spec/1.7.1/43ad4090b1a07a11c82ac40c01fc4e2fbad20013/geronimo-javamail_1.4_spec-1.7.1.jar
     	/home/jenkins/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/jaxen/jaxen/1.1.4/8c06a96cf9150ded75c28b7087ed821a93270c41/jaxen-1.1.4.jar
     	/home/jenkins/.m2/repository/org/apache/geronimo/specs/geronimo-stax-api_1.0_spec/1.0.1/geronimo-stax-api_1.0_spec-1.0.1.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.apache.james/apache-mime4j-core/0.7.2/a81264fe0265ebe8fd1d8128aad06dc320de6eef/apache-mime4j-core-0.7.2.jar
     	/home/jenkins/.gradle/caches/modules-2/files-2.1/org.springframework/spring-jcl/5.3.7/ccd8bde38bad689737295fa220e1c70680676d72/spring-jcl-5.3.7.jar
     ReferenceViolation{type=MISSING_ORIGINAL_BYTECODE, weaveClass=org/springframework/ws/server/MessageDispatcher, originalClass=org/springframework/ws/context/MessageContext, violationMessage=Could not find resource}
     ReferenceViolation{type=MISSING_ORIGINAL_BYTECODE, weaveClass=com/nr/instrumentation/springws20/SpringWSUtils, originalClass=org/springframework/ws/soap/SoapVersion, violationMessage=Could not find resource}
     ReferenceViolation{type=MISSING_ORIGINAL_BYTECODE, weaveClass=com/nr/instrumentation/springws20/SpringWSUtils, originalClass=org/springframework/ws/soap/saaj/SaajSoapMessage, violationMessage=Could not find resource}
     ReferenceViolation{type=MISSING_ORIGINAL_BYTECODE, weaveClass=org/springframework/ws/server/MessageDispatcher, originalClass=org/springframework/ws/WebServiceMessage, violationMessage=Could not find resource}
     ReferenceViolation{type=MISSING_ORIGINAL_BYTECODE, weaveClass=com/nr/instrumentation/springws20/SpringWSUtils, originalClass=org/springframework/ws/soap/SoapMessage, violationMessage=Could not find resource}
     WeaveViolation{type=MISSING_ORIGINAL_BYTECODE, clazz=org/springframework/ws/soap/axiom/AxiomSoapMessage}
     WeaveViolation{type=MISSING_ORIGINAL_BYTECODE, clazz=org/springframework/ws/server/MessageDispatcher}
```

