### PR TITLE
Fix okhttp dependency clash

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -170,7 +170,8 @@ task relocatedShadowJar(type: ShadowJar) {
             "org.apache.log4j", "org.apache.log", "org.apache.avalon",
             "org.checkerframework", "org.dom4j", "org.zeromq", "org.apache.kafka",
             "com.lmax", "com.conversantmedia", "org.jctools",
-            "com.fasterxml", "org.osgi", "org.codehaus", "org.fusesource", "kotlin", "org.jetbrains"
+            "com.fasterxml", "org.osgi", "org.codehaus", "org.fusesource", "kotlin", "org.jetbrains",
+            "okhttp3", "org.bouncycastle", "org.conscrypt", "org.openjsse"
     ].each {
         relocate(it, "com.newrelic.agent.deps.$it")
     }


### PR DESCRIPTION
### Overview
On the 7.0.0 release, an indirect dependency to okhttp (4.8) was introduced to the agent.
This dependency was not shadowed, so it shared the same namespace of any customers' dependencies to older versions of okhttp, which caused errors on their end.

This commit instructs the shadower to change those classes so they are in a different namespace (package).
As an added bonus, this will also prevent the weaver to change these classes.

### Related Github Issue
Resolves https://github.com/newrelic/newrelic-java-agent/issues/324

### Testing
This change cannot be tested in this project, as it requires different versions of the same dependency to be loaded at the same time.

### Checks

[Y] Are your contributions backwards compatible with relevant frameworks and APIs?
[N] Does your code contain any breaking changes? Please describe. 
[N] Does your code introduce any new dependencies? Please describe.
