### PR TITLE
JFR on-by-default

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
@@ -14,7 +14,7 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
 
     public static final String SYSTEM_PROPERTY_ROOT = "newrelic.config.jfr.";
     public static final String ENABLED = "enabled";
-    public static final Boolean ENABLED_DEFAULT = Boolean.FALSE;
+    public static final Boolean ENABLED_DEFAULT = Boolean.TRUE;
     public static final String AUDIT_LOGGING = "audit_logging";
     public static final Boolean AUDIT_LOGGING_DEFAULT = Boolean.FALSE;
     public static final Boolean USE_LICENSE_KEY_DEFAULT = Boolean.TRUE;

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -279,9 +279,9 @@ common: &default_settings
   # Requires a JVM that provides the JFR library.
   jfr:
 
-    # Set to true to enable Real-time profiling with JFR.
-    # Default is false.
-    enabled: false
+    # Set to false to disable Real-time profiling with JFR.
+    # Default is true.
+    enabled: true
 
     # Set to true to enable audit logging which will display all JFR metrics and events in each harvest batch.
     # Audit logging is extremely verbose and should only be used for troubleshooting purposes.


### PR DESCRIPTION
### Overview
Changing JFR to be on by default and updating `newrelic.yml`.

### Related Github Issue
#329 

### Checks

Are your contributions backwards compatible with relevant frameworks and APIs?
Yes

Does your code contain any breaking changes? Please describe. 
No

Does your code introduce any new dependencies? Please describe.
No