### PR TITLE
Enabling JFR's thread name normalizer

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     }
 
     shadowIntoJar("com.newrelic.agent.java:newrelic-module-util-java:2.0")
-    shadowIntoJar("com.newrelic:jfr-daemon:1.3.0")
+    shadowIntoJar("com.newrelic:jfr-daemon:1.4.0")
     shadowIntoJar 'org.ow2.asm:asm:8.0.1'
     shadowIntoJar 'org.ow2.asm:asm-tree:8.0.1'
     shadowIntoJar 'org.ow2.asm:asm-commons:8.0.1'

--- a/newrelic-agent/src/main/java/com/newrelic/agent/ThreadService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/ThreadService.java
@@ -31,6 +31,8 @@ import java.util.logging.Level;
  * The thread service tracks the IDs of agent threads.
  */
 public class ThreadService extends AbstractService implements ThreadNames {
+
+    public static final String NAME_PATTERN_CFG_KEY = "thread_sampler.name_pattern";
     private final Map<Long, Boolean> agentThreadIds;
     private final Cache<Long, String> threadIdToName = CacheBuilder.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).build();
     private volatile ThreadNameNormalizer threadNameNormalizer;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -9,10 +9,12 @@ package com.newrelic.agent.jfr;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
+import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.JfrConfig;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.jfr.ThreadNameNormalizer;
 import com.newrelic.jfr.daemon.*;
 import com.newrelic.telemetry.Attributes;
 
@@ -51,7 +53,8 @@ public class JfrService extends AbstractService {
                 commonAttrs.put(ENTITY_GUID, entityGuid);
 
                 final JFRUploader uploader = buildUploader(daemonConfig);
-                uploader.readyToSend(new EventConverter(commonAttrs));
+                String pattern = defaultAgentConfig.getValue(ThreadService.NAME_PATTERN_CFG_KEY, ThreadNameNormalizer.DEFAULT_PATTERN);
+                uploader.readyToSend(new EventConverter(commonAttrs, pattern));
                 jfrController = SetupUtils.buildJfrController(daemonConfig, uploader);
 
                 ExecutorService jfrMonitorService = Executors.newSingleThreadExecutor();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadNameNormalizer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadNameNormalizer.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfig;
 
 /**
@@ -60,7 +61,7 @@ public class ThreadNameNormalizer {
     private final ThreadNames threadNames;
 
     public ThreadNameNormalizer(AgentConfig config, ThreadNames threadNames) {
-        this(config.getValue("thread_sampler.name_pattern", DEFAULT_PATTERN), threadNames);
+        this(config.getValue(ThreadService.NAME_PATTERN_CFG_KEY, DEFAULT_PATTERN), threadNames);
     }
 
     /**

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -3,9 +3,11 @@ package com.newrelic.agent.jfr;
 import com.newrelic.agent.MockServiceManager;
 import com.newrelic.agent.RPMService;
 import com.newrelic.agent.RPMServiceManager;
+import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.JfrConfig;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.jfr.ThreadNameNormalizer;
 import com.newrelic.jfr.daemon.DaemonConfig;
 import com.newrelic.jfr.daemon.JfrRecorderException;
 import com.newrelic.test.marker.Java10IncompatibleTest;
@@ -39,6 +41,8 @@ public class JfrServiceTest {
         when(agentConfig.getMetricIngestUri()).thenReturn(DEFAULT_METRIC_INGEST_URI);
         when(agentConfig.getEventIngestUri()).thenReturn(DEFAULT_EVENT_INGEST_URI);
         when(agentConfig.getLicenseKey()).thenReturn("test_1234_license_key");
+        when(agentConfig.getValue(eq(ThreadService.NAME_PATTERN_CFG_KEY), any(String.class)))
+                .thenReturn(ThreadNameNormalizer.DEFAULT_PATTERN);
     }
 
     @Test


### PR DESCRIPTION
### Overview
The new version of jfr-core groups some metrics and event on thread name to decrease the amount of data sent to NR.

### Checks

Are your contributions backwards compatible with relevant frameworks and APIs?
Yes

Does your code contain any breaking changes? Please describe. 
No

Does your code introduce any new dependencies? Please describe.
It updates the dependency on jfr-daemon