### PR TITLE
Disable weaving package when reactive driver (Mongo 4.x+) is detected…

### DIFF
--- a/instrumentation/mongodb-3.7/src/main/java/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/instrumentation/mongodb-3.7/src/main/java/com/mongodb/reactivestreams/client/MongoClients.java
@@ -1,0 +1,14 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.newrelic.api.agent.weaver.SkipIfPresent;
+
+// This instrumentation will cause Segment timeouts if it applies to the reactive driver
+@SkipIfPresent
+public class MongoClients {}

--- a/instrumentation/mongodb-3.7/src/main/java/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/instrumentation/mongodb-3.7/src/main/java/com/mongodb/reactivestreams/client/MongoClients.java
@@ -11,4 +11,4 @@ import com.newrelic.api.agent.weaver.SkipIfPresent;
 
 // This instrumentation will cause Segment timeouts if it applies to the reactive driver
 @SkipIfPresent
-public class MongoClients {}
+final class MongoClients {}

--- a/instrumentation/mongodb-3.7/src/main/java/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/instrumentation/mongodb-3.7/src/main/java/com/mongodb/reactivestreams/client/MongoClients.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * Copyright 2021 New Relic Corporation. All rights reserved.
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */


### PR DESCRIPTION
… to avoid segment timeouts.

### Overview
Disables `mongodb-3.7` instrumentation when the reactive driver is detected. Previously [`NettyMongoClients`](https://github.com/newrelic/newrelic-java-agent/blob/main/instrumentation/mongodb-3.7/src/main/java/com/mongodb/async/client/NettyMongoClients.java) was used for this purpose, but this class was removed in MongoDB 4.x+ drivers. As such, the instrumentation becomes active again (when using MongoDB 4.x+) and we start seeing segment timeouts. Instead we can use the new [`MongoClients`](https://github.com/mongodb/mongo-java-driver/blob/master/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java) class from the reactive driver.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/198 (since it could be solved by adding instrumentation for the reactive driver)

### Checks

[ x ] Are your contributions backwards compatible with relevant frameworks and APIs?
~[ ] Does your code contain any breaking changes? Please describe.~
~[ ] Does your code introduce any new dependencies? Please describe.~

If there are any questions or this is not the right approach let me know, as right now we have to disable the MongoDB instrumentation altogether as pointed out [here](https://github.com/newrelic/newrelic-java-agent/issues/198#issuecomment-876322287).