### PR TITLE
remove bintray and jcenter, update dependency versions

### DIFF
--- a/instrumentation/anorm-2.0/build.gradle
+++ b/instrumentation/anorm-2.0/build.gradle
@@ -1,17 +1,11 @@
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation("org.scala-lang:scala-library:2.10.7")
-    implementation("com.typesafe.play:anorm_2.10:2.2.0")
+    implementation("com.typesafe.play:anorm_2.10:2.3.9")
 }
 
 jar {

--- a/instrumentation/anorm-2.3/build.gradle
+++ b/instrumentation/anorm-2.3/build.gradle
@@ -1,17 +1,11 @@
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation("org.scala-lang:scala-library:2.10.7")
-    implementation("com.typesafe.play:anorm_2.10:2.3.8")
+    implementation("com.typesafe.play:anorm_2.10:2.3.9")
 }
 
 jar {

--- a/instrumentation/anorm-2.4/build.gradle
+++ b/instrumentation/anorm-2.4/build.gradle
@@ -1,11 +1,5 @@
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -1,16 +1,10 @@
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
-    implementation("com.typesafe.play:play_2.10:2.3.0")
+    implementation("com.typesafe.play:play_2.10:2.3.9")
     implementation("org.scala-lang:scala-library:2.10.7")
 }
 

--- a/instrumentation/play-2.4/build.gradle
+++ b/instrumentation/play-2.4/build.gradle
@@ -1,11 +1,5 @@
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,11 +1,5 @@
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -5,18 +5,11 @@ import scala.collection.JavaConversions
 
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 buildscript {
     dependencies {
         classpath 'com.typesafe.play:routes-compiler_2.11:2.6.0'
     }
     repositories {
-        jcenter()
         mavenCentral()
     }
 }

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -5,18 +5,11 @@ import scala.collection.JavaConversions
 
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 buildscript {
     dependencies {
         classpath 'com.typesafe.play:routes-compiler_2.11:2.6.0'
     }
     repositories {
-        jcenter()
         mavenCentral()
     }
 }

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -5,18 +5,11 @@ import scala.collection.JavaConversions
 
 apply plugin: 'scala'
 
-repositories {
-    maven {
-        url 'https://dl.bintray.com/typesafe/maven-releases/'
-    }
-}
-
 buildscript {
     dependencies {
         classpath 'com.typesafe.play:routes-compiler_2.11:2.7.0-M2'
     }
     repositories {
-        jcenter()
         mavenCentral()
     }
 }


### PR DESCRIPTION
anorm and play instrumentation module dependencies do not resolve through bintray and the agent does not compile and build

This removes dl.bintray.  Also, this removes jcenter because it goes away Feb 2022. 

A few of the module's dependencies had to be updated. They are not available on jcenter or mavenCentral.