### PR TITLE
Add suppressed exceptions to ThrowableError.stackTrace

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ThrowableError.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ThrowableError.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ThrowableError extends TracedError {
 
@@ -112,6 +113,14 @@ public class ThrowableError extends TracedError {
                     stackTrace.add(" caused by " + t.getClass().getName() + ": " + errorMessageReplacer.getMessage(t));
                 }
                 stackTrace.addAll(StackTraces.stackTracesToStrings(t.getStackTrace()));
+                for (Throwable suppressed : t.getSuppressed()) {
+                    stackTrace.add("\tSuppressed: " + suppressed.getClass().getName() + ": " + errorMessageReplacer.getMessage(suppressed));
+                    stackTrace.addAll(
+                            StackTraces.stackTracesToStrings(suppressed.getStackTrace())
+                                .stream().map(line -> "\t\t" + line)
+                                .collect(Collectors.toCollection(ArrayList::new))
+                    );
+                }
                 t = t.equals(t.getCause()) ? null : t.getCause();
                 inner = true;
             }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/errors/TracedErrorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/errors/TracedErrorTest.java
@@ -383,8 +383,7 @@ public class TracedErrorTest {
     }
 
     private String findNextCausedBy(Iterator<String> it) {
-        final String contains = "caused by";
-        return findNextContaining(it, contains);
+        return findNextContaining(it, "caused by");
     }
 
     private String findNextContaining(Iterator<String> it, String contains) {


### PR DESCRIPTION
### Overview
Adds suppressed exceptions (`Throwable.getSuppressed()`) to stack traces extracted from Throwables

### Related Github Issue
This resolves #399 

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ Yes ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ No ] Does your code contain any breaking changes? Please describe. 
[ No ] Does your code introduce any new dependencies? Please describe.
