### PR TITLE
Prevent CompileTestScala from running under noInstrumentation

### DIFF
--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -6,6 +6,10 @@ subprojects {
     // pull in shared instrumentation build logic
     apply from: "$rootProject.projectDir/gradle/script/instrumentation.gradle"
 
+    tasks.withType(ScalaCompile).each { task ->
+        task.enabled = !project.hasProperty('noInstrumentation')
+    }
+
     tasks.withType(Test).each { task ->
         task.enabled = !project.hasProperty('noInstrumentation')
     }


### PR DESCRIPTION
### Overview
Prevents compileTestScala from running when noInstrumentation profile is on.

### Checks

Are your contributions backwards compatible with relevant frameworks and APIs?
Yes

Does your code contain any breaking changes? Please describe. 
No

Does your code introduce any new dependencies? Please describe.
No