### PR TITLE
Cap http4s-blaze-client instrumentation range

### DIFF
--- a/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
@@ -24,7 +24,7 @@ jar {
     }
 }
 verifyInstrumentation {
-    passes 'org.http4s:http4s-blaze-client_2.12:[0.22.0,1.0)'
+    passes 'org.http4s:http4s-blaze-client_2.12:[0.22.0,0.23.0)'
     excludeRegex '.*(RC|M)[0-9]*'
     excludeRegex '.*0.22\\-[0-9].*'
 }

--- a/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
@@ -24,7 +24,7 @@ jar {
     }
 }
 verifyInstrumentation {
-    passes 'org.http4s:http4s-blaze-client_2.13:[0.22.0,1.0)'
+    passes 'org.http4s:http4s-blaze-client_2.13:[0.22.0,0.23.0)'
     excludeRegex '.*(RC|M)[0-9]*'
     excludeRegex '.*0.22\\-[0-9].*'
 }


### PR DESCRIPTION
Cap `http4s-blaze-client-2.12_0.22` and `http4s-blaze-client-2.13_0.22` instrumentation supported versions to prevent verifier failures.

Full context here: https://github.com/newrelic/newrelic-java-agent/issues/429

