### PR TITLE
Exclude problematic artifact for jedis-3.0.0 instrumentation verifier

### DIFF
--- a/instrumentation/jedis-3.0.0/build.gradle
+++ b/instrumentation/jedis-3.0.0/build.gradle
@@ -11,8 +11,11 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passesOnly 'redis.clients:jedis:[3.0.0,)'
-    excludeRegex 'redis.clients:jedis:.*-(m|rc)[0-9]*'
+    passes 'redis.clients:jedis:[3.0.0,)'
+    fails 'redis.clients:jedis:[1.4.0,3.0.0)'
+    excludeRegex 'redis.clients:jedis:.*-(m|rc|RC)[0-9]*'
+    // there's something weird about how the verifier treats this version
+    exclude 'redis.clients:jedis:3.6.2'
 }
 
 site {


### PR DESCRIPTION
Exclude `redis.clients:jedis:3.6.2` from verification as there is something weird about that version that causes failures.