### PR TITLE
Correctly verify against Scala 2.13 instead of 2.12

### DIFF
--- a/instrumentation/sttp-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-2.13_3.0.0/build.gradle
@@ -14,7 +14,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'com.softwaremill.sttp.client3:core_2.12:[3.0.0,)'
+    passes 'com.softwaremill.sttp.client3:core_2.13:[3.0.0,)'
     passes 'com.softwaremill.sttp.client3:core_3:[3.0.0,)'
     excludeRegex ".*(RC|M)[0-9]*"
 }


### PR DESCRIPTION
This instrumentation module was supposed to be verifying against Scala 2.13 instead of 2.12. All versions pass now.