### PR TITLE
Zinc compiler Scala version resolution strategy

### DIFF
--- a/functional_test/build.gradle
+++ b/functional_test/build.gradle
@@ -4,6 +4,10 @@ evaluationDependsOn(":newrelic-agent") // This is important because we need newr
 
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Premain-Class': 'com.newrelic.agent.test.agent.FunctionalAgent' }
 }

--- a/instrumentation/akka-http-2.11_2.4.5/build.gradle
+++ b/instrumentation/akka-http-2.11_2.4.5/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.12.12")
+    }
+}
+
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 

--- a/instrumentation/akka-http-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-2.13_10.1.8/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.12.12")
+    }
+}
+
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 

--- a/instrumentation/akka-http-core-0.4/build.gradle
+++ b/instrumentation/akka-http-core-0.4/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.12.12")
+    }
+}
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-0.4' }
 }

--- a/instrumentation/akka-http-core-0.7/build.gradle
+++ b/instrumentation/akka-http-core-0.7/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-0.7' }
 }

--- a/instrumentation/akka-http-core-1.0/build.gradle
+++ b/instrumentation/akka-http-core-1.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-1.0' }
 }

--- a/instrumentation/akka-http-core-10.0/build.gradle
+++ b/instrumentation/akka-http-core-10.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.0' }
 }

--- a/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
+++ b/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.0.11' }
 }

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-2.13_10.2.0' }
 }

--- a/instrumentation/anorm-2.3/build.gradle
+++ b/instrumentation/anorm-2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/anorm-2.4/build.gradle
+++ b/instrumentation/anorm-2.4/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+  resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 repositories {
   maven {
     // repo for aws-wrap

--- a/instrumentation/cats-effect-2/build.gradle
+++ b/instrumentation/cats-effect-2/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/newrelic-scala-cats-api/build.gradle
+++ b/instrumentation/newrelic-scala-cats-api/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))

--- a/instrumentation/newrelic-scala-zio-api/build.gradle
+++ b/instrumentation/newrelic-scala-zio-api/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.4/build.gradle
+++ b/instrumentation/play-2.4/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -6,6 +6,10 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 buildscript {
     dependencies {
         classpath 'com.typesafe.play:routes-compiler_2.11:2.6.0'

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -6,6 +6,10 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 buildscript {
     dependencies {
         classpath 'com.typesafe.play:routes-compiler_2.11:2.6.0'

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -6,6 +6,10 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 buildscript {
     dependencies {
         classpath 'com.typesafe.play:routes-compiler_2.11:2.7.0-M2'

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 compileJava.options.bootstrapClasspath = null
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/instrumentation/scala-2.12.0/build.gradle
+++ b/instrumentation/scala-2.12.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/scala-2.13.0/build.gradle
+++ b/instrumentation/scala-2.13.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/scala-2.9.3/build.gradle
+++ b/instrumentation/scala-2.9.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+configurations.zinc {
+  resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
 
 dependencies {
   implementation(project(":newrelic-api"))

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+configurations.zinc {
+  resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
 
 dependencies {
   implementation(project(":newrelic-api"))

--- a/instrumentation/spray-can-1.3.1/build.gradle
+++ b/instrumentation/spray-can-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spray-can-1.3.1' }
 }

--- a/instrumentation/spray-can-http-client-1.3.1/build.gradle
+++ b/instrumentation/spray-can-http-client-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+  resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
   implementation(project(":newrelic-api"))
   implementation(project(":agent-bridge"))

--- a/instrumentation/spray-client-1.3.1/build.gradle
+++ b/instrumentation/spray-client-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spray-client-1.3.1' }
 }

--- a/instrumentation/spray-http-1.3.1/build.gradle
+++ b/instrumentation/spray-http-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 

--- a/instrumentation/sttp-2.12_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.12_2.2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-2.13_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.13_2.2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-2.13_3.0.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.12.12")
+    }
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/zio/build.gradle
+++ b/instrumentation/zio/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
 dependencies {
     implementation("dev.zio:zio_2.13:1.0.9")
     implementation(project(":agent-bridge"))

--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -16,6 +16,12 @@ crossBuild {
     }
 }
 
+configurations.zinc {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.12.12")
+    }
+}
+
 java {
     withSourcesJar()
     withJavadocJar()

--- a/newrelic-scala-cats-api/build.gradle.kts
+++ b/newrelic-scala-cats-api/build.gradle.kts
@@ -16,6 +16,12 @@ crossBuild {
     }
 }
 
+configurations.zinc {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.12.12")
+    }
+}
+
 java {
     withSourcesJar()
     withJavadocJar()

--- a/newrelic-scala-zio-api/build.gradle.kts
+++ b/newrelic-scala-zio-api/build.gradle.kts
@@ -16,6 +16,12 @@ crossBuild {
     }
 }
 
+configurations.zinc {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.12.12")
+    }
+}
+
 java {
     withSourcesJar()
     withJavadocJar()

--- a/newrelic-weaver-scala/build.gradle
+++ b/newrelic-weaver-scala/build.gradle
@@ -2,6 +2,10 @@ evaluationDependsOn(":newrelic-agent") // This is important because we need newr
 
 apply plugin: 'scala'
 
+configurations.zinc {
+    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+}
+
 configurations {
     compileFirst
 }


### PR DESCRIPTION
### Overview
Set zinc compiler Scala version resolution strategy to avoid scala test compile issue with Scala version mismatch

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/390

### Testing
Ran and compiled Scala test locally consistently 

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? No
[X] Does your code introduce any new dependencies? No