### PR TITLE
mark test as incompatible with java 11+

### DIFF
--- a/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
+++ b/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
@@ -12,16 +12,12 @@ import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationT
 import com.nr.weave.weavepackage.language.scala.testclasses._
 import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
-import com.newrelic.test.marker.Java11IncompatibleTest
-import com.newrelic.test.marker.Java12IncompatibleTest
-import com.newrelic.test.marker.Java13IncompatibleTest
-import com.newrelic.test.marker.Java14IncompatibleTest
-import com.newrelic.test.marker.Java15IncompatibleTest
+import com.newrelic.test.marker.{Java11IncompatibleTest, Java12IncompatibleTest, Java13IncompatibleTest, Java14IncompatibleTest, Java15IncompatibleTest, Java16IncompatibleTest}
 
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("com.nr.weave.weavepackage.language.scala.weaveclasses."))
 @Category(Array(classOf[Java11IncompatibleTest],classOf[Java12IncompatibleTest],classOf[Java13IncompatibleTest]
-  ,classOf[Java14IncompatibleTest],classOf[Java15IncompatibleTest]))
+  ,classOf[Java14IncompatibleTest],classOf[Java15IncompatibleTest],classOf[Java16IncompatibleTest]))
 class ScalaAdapterTest {
 
   @Test

--- a/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
+++ b/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
@@ -7,13 +7,21 @@
 
 package com.nr.weave.weavepackage.language.scala;
 
+import org.junit.experimental.categories.Category
 import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner}
 import com.nr.weave.weavepackage.language.scala.testclasses._
 import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
+import com.newrelic.test.marker.Java11IncompatibleTest
+import com.newrelic.test.marker.Java12IncompatibleTest
+import com.newrelic.test.marker.Java13IncompatibleTest
+import com.newrelic.test.marker.Java14IncompatibleTest
+import com.newrelic.test.marker.Java15IncompatibleTest
 
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("com.nr.weave.weavepackage.language.scala.weaveclasses."))
+@Category(Array(classOf[Java11IncompatibleTest],classOf[Java12IncompatibleTest],classOf[Java13IncompatibleTest]
+  ,classOf[Java14IncompatibleTest],classOf[Java15IncompatibleTest]))
 class ScalaAdapterTest {
 
   @Test

--- a/test-annotations/src/main/java/com/newrelic/test/marker/Java16IncompatibleTest.java
+++ b/test-annotations/src/main/java/com/newrelic/test/marker/Java16IncompatibleTest.java
@@ -1,0 +1,4 @@
+package com.newrelic.test.marker;
+
+public interface Java16IncompatibleTest {
+}


### PR DESCRIPTION
Additional work will need to be done for the ScalaAdapterTest to be compatible with Java11+ . That work is being tracked #438 