### PR TITLE
Update to gradle 6.9.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://docs.gradle.org/6.9.1/release-notes.html#backports

```
Limited support for Java 16
This release does not support running Gradle with JDK 16, but you can use Java toolchains to request Java 16 and compile your project.
```

https://docs.gradle.org/6.8.3/release-notes.html#composite-builds-improvements

```
Composite builds improvements
```

https://docs.gradle.org/6.8.3/release-notes.html#java-toolchain-improvements

```
Java toolchain improvements
```