### PR TITLE
Sustainability of Scala Test Compile

### DIFF
--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -55,6 +55,6 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the functional tests
-        run: ./gradlew --console=plain --parallel functional_test:test --continue
+        run: ./gradlew --console=plain --parallel functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test --continue
 
 

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -55,6 +55,6 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the functional tests
-        run: ./gradlew --console=plain --parallel functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test --continue
+        run: ./gradlew --console=plain --parallel :functional_test:test :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test --continue
 
 

--- a/.github/workflows/instrumentation_test_java.yml
+++ b/.github/workflows/instrumentation_test_java.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  unit_test:
+  instrumentation_test_java:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/instrumentation_test_java.yml
+++ b/.github/workflows/instrumentation_test_java.yml
@@ -32,4 +32,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean instrumentation:test -PnoScala --continue
+        run: ./gradlew --console=plain --parallel clean instrumentation:test -Ptest8 -PnoScala --continue

--- a/.github/workflows/instrumentation_test_java.yml
+++ b/.github/workflows/instrumentation_test_java.yml
@@ -58,4 +58,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean instrumentation:test -Ptest8 -PnoScala --continue
+        run: ./gradlew --console=plain --parallel clean instrumentation:build -Ptest8 -PnoScala --continue

--- a/.github/workflows/instrumentation_test_java.yml
+++ b/.github/workflows/instrumentation_test_java.yml
@@ -57,5 +57,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
       # Start running the build.
-      - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean instrumentation:build -Ptest8 -PnoScala --continue
+      - name: Run the Java Instrumentation Tests
+        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoScala --continue

--- a/.github/workflows/instrumentation_test_java.yml
+++ b/.github/workflows/instrumentation_test_java.yml
@@ -1,0 +1,35 @@
+name: PR Build - Instrumentation Tests Java
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      # The first JDK set up gets to be "primary".
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 8
+      - name: save JAVA_HOME as JDK8 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk8=$JAVA_HOME" >> $GITHUB_ENV
+      # Restore the gradle cache
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          # The docs say to use hashfiles, but gradle itself is smart enough to
+          # re-download dependencies if it couldn't resolve them.
+          # Because our gradle cache is _so big_, I think a 90% cache is far
+          # better than a 0% cache.
+          key: ${{ runner.os }}-gradle
+          restore-keys: |
+            ${{ runner.os }}-gradle
+      # Start running the build.
+      - name: run the unit tests
+        run: ./gradlew --console=plain --parallel clean instrumentation:test -PnoScala --continue

--- a/.github/workflows/instrumentation_test_java.yml
+++ b/.github/workflows/instrumentation_test_java.yml
@@ -17,6 +17,20 @@ jobs:
           java-version: 8
       - name: save JAVA_HOME as JDK8 for later usage
         run: echo "ORG_GRADLE_PROJECT_jdk8=$JAVA_HOME" >> $GITHUB_ENV
+      # The second JDK is not first in the path but does reset JAVA_HOME
+      - name: Set up JDK 1.7
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 7
+      - name: save JAVA_HOME as JDK7 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk7=$JAVA_HOME" >> $GITHUB_ENV
+      # JDK 11
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - name: save JAVA_HOME as JDK11 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk11=$JAVA_HOME" >> $GITHUB_ENV
       # Restore the gradle cache
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/instrumentation_test_java.yml
+++ b/.github/workflows/instrumentation_test_java.yml
@@ -24,6 +24,18 @@ jobs:
           java-version: 7
       - name: save JAVA_HOME as JDK7 for later usage
         run: echo "ORG_GRADLE_PROJECT_jdk7=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 1.9
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 9
+      - name: save JAVA_HOME as JDK9 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk9=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 1.10
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 10
+      - name: save JAVA_HOME as JDK10 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk10=$JAVA_HOME" >> $GITHUB_ENV
       # JDK 11
       - name: Set up JDK 11
         uses: actions/setup-java@v1.4.3

--- a/.github/workflows/instrumentation_test_scala-2.10.yml
+++ b/.github/workflows/instrumentation_test_scala-2.10.yml
@@ -1,4 +1,4 @@
-name: PR Build - Instrumentation Tests Java
+name: PR Build - Instrumentation Tests Scala 2.10
 
 on:
   pull_request:
@@ -57,5 +57,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
       # Start running the build.
-      - name: run the java instrumentation tests
-        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoScala --continue
+      - name: run the scala 2.10 instrumentation tests
+        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.10 --continue

--- a/.github/workflows/instrumentation_test_scala-2.10.yml
+++ b/.github/workflows/instrumentation_test_scala-2.10.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  unit_test:
+  instrumentation_test_scala_2_10:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/instrumentation_test_scala-2.11.yml
+++ b/.github/workflows/instrumentation_test_scala-2.11.yml
@@ -1,4 +1,4 @@
-name: PR Build - Instrumentation Tests Java
+name: PR Build - Instrumentation Tests Scala 2.11
 
 on:
   pull_request:
@@ -57,5 +57,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
       # Start running the build.
-      - name: run the java instrumentation tests
-        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoScala --continue
+      - name: run the scala 2.11 instrumentation tests
+        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.11 --continue

--- a/.github/workflows/instrumentation_test_scala-2.11.yml
+++ b/.github/workflows/instrumentation_test_scala-2.11.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  unit_test:
+  instrumentation_test_scala_2_11:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/instrumentation_test_scala-2.12.yml
+++ b/.github/workflows/instrumentation_test_scala-2.12.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  unit_test:
+  instrumentation_test_scala_2_12:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/instrumentation_test_scala-2.12.yml
+++ b/.github/workflows/instrumentation_test_scala-2.12.yml
@@ -1,4 +1,4 @@
-name: PR Build - Instrumentation Tests Java
+name: PR Build - Instrumentation Tests Scala 2.12
 
 on:
   pull_request:
@@ -57,5 +57,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
       # Start running the build.
-      - name: run the java instrumentation tests
-        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoScala --continue
+      - name: run the scala 2.12 instrumentation tests
+        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.12 --continue

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -58,4 +58,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean instrumentation:test -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.13 --continue
+        run: ./gradlew --console=plain --parallel clean instrumentation:build -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.13 --continue

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -32,4 +32,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean instrumentation:test -PnoInstrumentation -PnoScala -Pscala-2.13 --continue
+        run: ./gradlew --console=plain --parallel clean instrumentation:test -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.13 --continue

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -58,4 +58,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean instrumentation:build -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.13 --continue
+        run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.13 --continue

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -57,5 +57,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
       # Start running the build.
-      - name: run the unit tests
+      - name: run the scala 2.13 instrumentation tests
         run: ./gradlew --console=plain --parallel clean :instrumentation:build -Ptest8 -PnoInstrumentation -PnoScala -Pscala-2.13 --continue

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  unit_test:
+  instrumentation_test_scala_2_13:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -1,0 +1,35 @@
+name: PR Build - Instrumentation Tests Scala 2.13
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      # The first JDK set up gets to be "primary".
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 8
+      - name: save JAVA_HOME as JDK8 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk8=$JAVA_HOME" >> $GITHUB_ENV
+      # Restore the gradle cache
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          # The docs say to use hashfiles, but gradle itself is smart enough to
+          # re-download dependencies if it couldn't resolve them.
+          # Because our gradle cache is _so big_, I think a 90% cache is far
+          # better than a 0% cache.
+          key: ${{ runner.os }}-gradle
+          restore-keys: |
+            ${{ runner.os }}-gradle
+      # Start running the build.
+      - name: run the unit tests
+        run: ./gradlew --console=plain --parallel clean instrumentation:test -PnoInstrumentation -PnoScala -Pscala-2.13 --continue

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -17,6 +17,20 @@ jobs:
           java-version: 8
       - name: save JAVA_HOME as JDK8 for later usage
         run: echo "ORG_GRADLE_PROJECT_jdk8=$JAVA_HOME" >> $GITHUB_ENV
+      # The second JDK is not first in the path but does reset JAVA_HOME
+      - name: Set up JDK 1.7
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 7
+      - name: save JAVA_HOME as JDK7 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk7=$JAVA_HOME" >> $GITHUB_ENV
+      # JDK 11
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - name: save JAVA_HOME as JDK11 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk11=$JAVA_HOME" >> $GITHUB_ENV
       # Restore the gradle cache
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/instrumentation_test_scala-2.13.yml
+++ b/.github/workflows/instrumentation_test_scala-2.13.yml
@@ -24,6 +24,18 @@ jobs:
           java-version: 7
       - name: save JAVA_HOME as JDK7 for later usage
         run: echo "ORG_GRADLE_PROJECT_jdk7=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 1.9
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 9
+      - name: save JAVA_HOME as JDK9 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk9=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 1.10
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 10
+      - name: save JAVA_HOME as JDK10 for later usage
+        run: echo "ORG_GRADLE_PROJECT_jdk10=$JAVA_HOME" >> $GITHUB_ENV
       # JDK 11
       - name: Set up JDK 11
         uses: actions/setup-java@v1.4.3

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,4 +55,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean test -x instrumentation functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 --continue
+        run: ./gradlew --console=plain --parallel clean test -x instrumentation:test functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 --continue

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,4 +55,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean test -x functional_test:test -PnoInstrumentation --continue
+        run: ./gradlew --console=plain --parallel clean test -x functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -PnoInstrumentation --continue

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,4 +55,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean test -x functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 -PnoInstrumentation --continue
+        run: ./gradlew --console=plain --parallel clean test -x instrumentation functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 --continue

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,4 +55,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean test -x functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 -PnoInstrumentation --continue
+        run: ./gradlew --console=plain --parallel clean test -x :functional_test:test :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test -Ptest8 -PnoInstrumentation --continue

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,4 +55,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean test -x :functional_test:test :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test -Ptest8 -PnoInstrumentation --continue
+        run: ./gradlew --console=plain --parallel clean test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-scala-zio-api:test -Ptest8 -PnoInstrumentation --continue

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,4 +55,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean test -x functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -PnoInstrumentation --continue
+        run: ./gradlew --console=plain --parallel clean test -x functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 -PnoInstrumentation --continue

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -55,4 +55,4 @@ jobs:
             ${{ runner.os }}-gradle
       # Start running the build.
       - name: run the unit tests
-        run: ./gradlew --console=plain --parallel clean test -x instrumentation:test functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 --continue
+        run: ./gradlew --console=plain --parallel clean test -x functional_test:test newrelic-scala-api:test newrelic-scala-cats-api:test newrelic-scala-zio-api:test -Ptest8 -PnoInstrumentation --continue

--- a/instrumentation/akka-http-2.11_2.4.5/build.gradle
+++ b/instrumentation/akka-http-2.11_2.4.5/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/akka-http-2.11_2.4.5/build.gradle
+++ b/instrumentation/akka-http-2.11_2.4.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
+
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 

--- a/instrumentation/akka-http-2.11_2.4.5/build.gradle
+++ b/instrumentation/akka-http-2.11_2.4.5/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/akka-http-2.11_2.4.5/build.gradle
+++ b/instrumentation/akka-http-2.11_2.4.5/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/akka-http-2.11_2.4.5/build.gradle
+++ b/instrumentation/akka-http-2.11_2.4.5/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
+
 
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []

--- a/instrumentation/akka-http-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-2.13_10.1.8/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/akka-http-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-2.13_10.1.8/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/akka-http-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-2.13_10.1.8/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/akka-http-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-2.13_10.1.8/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 

--- a/instrumentation/akka-http-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-2.13_10.1.8/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []

--- a/instrumentation/akka-http-core-0.4/build.gradle
+++ b/instrumentation/akka-http-core-0.4/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-0.4' }
 }

--- a/instrumentation/akka-http-core-0.4/build.gradle
+++ b/instrumentation/akka-http-core-0.4/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/akka-http-core-0.4/build.gradle
+++ b/instrumentation/akka-http-core-0.4/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-0.4/build.gradle
+++ b/instrumentation/akka-http-core-0.4/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-0.4/build.gradle
+++ b/instrumentation/akka-http-core-0.4/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-0.4' }

--- a/instrumentation/akka-http-core-0.7/build.gradle
+++ b/instrumentation/akka-http-core-0.7/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/akka-http-core-0.7/build.gradle
+++ b/instrumentation/akka-http-core-0.7/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-0.7/build.gradle
+++ b/instrumentation/akka-http-core-0.7/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-0.7/build.gradle
+++ b/instrumentation/akka-http-core-0.7/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-0.7' }
 }

--- a/instrumentation/akka-http-core-0.7/build.gradle
+++ b/instrumentation/akka-http-core-0.7/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-0.7' }

--- a/instrumentation/akka-http-core-1.0/build.gradle
+++ b/instrumentation/akka-http-core-1.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-1.0' }
 }

--- a/instrumentation/akka-http-core-1.0/build.gradle
+++ b/instrumentation/akka-http-core-1.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/akka-http-core-1.0/build.gradle
+++ b/instrumentation/akka-http-core-1.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-1.0/build.gradle
+++ b/instrumentation/akka-http-core-1.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-1.0/build.gradle
+++ b/instrumentation/akka-http-core-1.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-1.0' }

--- a/instrumentation/akka-http-core-10.0/build.gradle
+++ b/instrumentation/akka-http-core-10.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.0' }

--- a/instrumentation/akka-http-core-10.0/build.gradle
+++ b/instrumentation/akka-http-core-10.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/akka-http-core-10.0/build.gradle
+++ b/instrumentation/akka-http-core-10.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.0' }
 }

--- a/instrumentation/akka-http-core-10.0/build.gradle
+++ b/instrumentation/akka-http-core-10.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-10.0/build.gradle
+++ b/instrumentation/akka-http-core-10.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is
 // normally able to resolve the correct version of scala for zinc (even if that version is different than

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is
 // normally able to resolve the correct version of scala for zinc (even if that version is different than
 // the version of scala required for the module), it certain circumstances the zinc scala version

--- a/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
+++ b/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
+++ b/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
+++ b/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
+++ b/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.0.11' }
 }

--- a/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
+++ b/instrumentation/akka-http-core-2.11_10.0.11/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.0.11' }

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is
 // normally able to resolve the correct version of scala for zinc (even if that version is different than
 // the version of scala required for the module), it certain circumstances the zinc scala version

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is
 // normally able to resolve the correct version of scala for zinc (even if that version is different than

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-2.13_10.2.0' }

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-2.13_10.2.0' }
 }

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.2.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/anorm-2.3/build.gradle
+++ b/instrumentation/anorm-2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/anorm-2.3/build.gradle
+++ b/instrumentation/anorm-2.3/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.10")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/anorm-2.3/build.gradle
+++ b/instrumentation/anorm-2.3/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/anorm-2.3/build.gradle
+++ b/instrumentation/anorm-2.3/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.10")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/anorm-2.3/build.gradle
+++ b/instrumentation/anorm-2.3/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/anorm-2.4/build.gradle
+++ b/instrumentation/anorm-2.4/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/anorm-2.4/build.gradle
+++ b/instrumentation/anorm-2.4/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.10")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/anorm-2.4/build.gradle
+++ b/instrumentation/anorm-2.4/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/anorm-2.4/build.gradle
+++ b/instrumentation/anorm-2.4/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.10")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/anorm-2.4/build.gradle
+++ b/instrumentation/anorm-2.4/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+  task -> {
+    if(project.hasProperty("noScala")) {
+      task.enabled = false
+    }
+    if(project.hasProperty("scala-2.10")) {
+      task.enabled = true
+    }
+  }
 }
 
 repositories {

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> {
-    if(project.hasProperty("noScala")) {
-      task.enabled = false
-    }
-    if(project.hasProperty("scala-2.10")) {
-      task.enabled = true
-    }
-  }
+  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 repositories {

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 repositories {
   maven {

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+  task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 repositories {
   maven {
     // repo for aws-wrap

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 repositories {

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -6,7 +6,7 @@ subprojects {
     // pull in shared instrumentation build logic
     apply from: "$rootProject.projectDir/gradle/script/instrumentation.gradle"
 
-    tasks.each { task ->
+    tasks.all { task ->
         task.enabled = !project.hasProperty('noInstrumentation')
     }
 

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -32,3 +32,10 @@ task test {
         it.tasks.getByName 'test'
     }
 }
+
+def isScalaProjectEnabled(Project project, String scalaVersion) {
+    return project.hasProperty(scalaVersion) ? project.tasks.all { task -> task.enabled = true }  // Enable tasks if project property matching scala version is passed
+            : project.hasProperty("noScala") ? project.tasks.all { task -> task.enabled = false } // Disable tasks if  project property noScala is passed
+            : project.hasProperty('noInstrumentation') ? project.tasks.all { task -> task.enabled = false } // Disable tasks if project property noInstrumentation is passed
+            : project.tasks.all { task -> task.enabled = task.enabled }  // Default to task enabled flag
+}

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -6,7 +6,7 @@ subprojects {
     // pull in shared instrumentation build logic
     apply from: "$rootProject.projectDir/gradle/script/instrumentation.gradle"
 
-    tasks.withType(Test).each { task ->
+    tasks.all { task ->
         task.enabled = !project.hasProperty('noInstrumentation')
     }
 

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -6,7 +6,7 @@ subprojects {
     // pull in shared instrumentation build logic
     apply from: "$rootProject.projectDir/gradle/script/instrumentation.gradle"
 
-    tasks.all { task ->
+    tasks.each { task ->
         task.enabled = !project.hasProperty('noInstrumentation')
     }
 

--- a/instrumentation/cats-effect-2/build.gradle
+++ b/instrumentation/cats-effect-2/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/cats-effect-2/build.gradle
+++ b/instrumentation/cats-effect-2/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/cats-effect-2/build.gradle
+++ b/instrumentation/cats-effect-2/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/cats-effect-2/build.gradle
+++ b/instrumentation/cats-effect-2/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/cats-effect-2/build.gradle
+++ b/instrumentation/cats-effect-2/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.12_0.22/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.21/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
+++ b/instrumentation/http4s-blaze-client-2.13_0.22/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/newrelic-scala-cats-api/build.gradle
+++ b/instrumentation/newrelic-scala-cats-api/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/newrelic-scala-cats-api/build.gradle
+++ b/instrumentation/newrelic-scala-cats-api/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/newrelic-scala-cats-api/build.gradle
+++ b/instrumentation/newrelic-scala-cats-api/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))

--- a/instrumentation/newrelic-scala-cats-api/build.gradle
+++ b/instrumentation/newrelic-scala-cats-api/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/newrelic-scala-cats-api/build.gradle
+++ b/instrumentation/newrelic-scala-cats-api/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/newrelic-scala-zio-api/build.gradle
+++ b/instrumentation/newrelic-scala-zio-api/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/newrelic-scala-zio-api/build.gradle
+++ b/instrumentation/newrelic-scala-zio-api/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/newrelic-scala-zio-api/build.gradle
+++ b/instrumentation/newrelic-scala-zio-api/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))

--- a/instrumentation/newrelic-scala-zio-api/build.gradle
+++ b/instrumentation/newrelic-scala-zio-api/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/newrelic-scala-zio-api/build.gradle
+++ b/instrumentation/newrelic-scala-zio-api/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.10")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.10")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/play-2.4/build.gradle
+++ b/instrumentation/play-2.4/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.4/build.gradle
+++ b/instrumentation/play-2.4/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.10")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/play-2.4/build.gradle
+++ b/instrumentation/play-2.4/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.4/build.gradle
+++ b/instrumentation/play-2.4/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.10")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/play-2.4/build.gradle
+++ b/instrumentation/play-2.4/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
     task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -6,7 +6,14 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 buildscript {

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -4,7 +4,10 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
 
 buildscript {
     dependencies {

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -6,14 +6,7 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 buildscript {

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -4,6 +4,7 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
     task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 buildscript {

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -6,9 +6,7 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 buildscript {
     dependencies {

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -6,7 +6,14 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 buildscript {

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -4,7 +4,10 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
 
 buildscript {
     dependencies {

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -6,14 +6,7 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 buildscript {

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -4,6 +4,7 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
     task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 buildscript {

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -6,9 +6,7 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 buildscript {
     dependencies {

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -6,7 +6,14 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 buildscript {

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -4,7 +4,10 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
 
 buildscript {
     dependencies {

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -6,14 +6,7 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 buildscript {

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -4,6 +4,7 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
     task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 buildscript {

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -6,9 +6,7 @@ import scala.collection.JavaConversions
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 buildscript {
     dependencies {

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
     task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
 
 compileJava.options.bootstrapClasspath = null
 

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 compileJava.options.bootstrapClasspath = null

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 compileJava.options.bootstrapClasspath = null
 

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 compileJava.options.bootstrapClasspath = null

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 compileJava.options.bootstrapClasspath = null

--- a/instrumentation/scala-2.12.0/build.gradle
+++ b/instrumentation/scala-2.12.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/scala-2.12.0/build.gradle
+++ b/instrumentation/scala-2.12.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/scala-2.12.0/build.gradle
+++ b/instrumentation/scala-2.12.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/scala-2.12.0/build.gradle
+++ b/instrumentation/scala-2.12.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/scala-2.12.0/build.gradle
+++ b/instrumentation/scala-2.12.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/scala-2.13.0/build.gradle
+++ b/instrumentation/scala-2.13.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/scala-2.13.0/build.gradle
+++ b/instrumentation/scala-2.13.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/scala-2.13.0/build.gradle
+++ b/instrumentation/scala-2.13.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/scala-2.13.0/build.gradle
+++ b/instrumentation/scala-2.13.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/scala-2.13.0/build.gradle
+++ b/instrumentation/scala-2.13.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/scala-2.9.3/build.gradle
+++ b/instrumentation/scala-2.9.3/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/scala-2.9.3/build.gradle
+++ b/instrumentation/scala-2.9.3/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/scala-2.9.3/build.gradle
+++ b/instrumentation/scala-2.9.3/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/scala-2.9.3/build.gradle
+++ b/instrumentation/scala-2.9.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/scala-2.9.3/build.gradle
+++ b/instrumentation/scala-2.9.3/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
     task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.11")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.11")
 
 dependencies {
   implementation(project(":newrelic-api"))

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.11")
+}
 
 dependencies {
   implementation(project(":newrelic-api"))

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.11")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.11") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
     task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
 project.tasks.all {
-  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+project.tasks.all {
+  task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
 
 dependencies {
   implementation(project(":newrelic-api"))

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 project.tasks.all {
   task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> {
-    if(project.hasProperty("noScala")) {
-      task.enabled = false
-    }
-    if(project.hasProperty("scala-2.10")) {
-      task.enabled = true
-    }
-  }
+  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'scala'
 scala.zincVersion = "1.2.5"
 
-project.tasks.all {
-  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 dependencies {
   implementation(project(":newrelic-api"))

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+  task -> {
+    if(project.hasProperty("noScala")) {
+      task.enabled = false
+    }
+    if(project.hasProperty("scala-2.10")) {
+      task.enabled = true
+    }
+  }
 }
 
 dependencies {

--- a/instrumentation/spray-can-1.3.1/build.gradle
+++ b/instrumentation/spray-can-1.3.1/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.10")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/spray-can-1.3.1/build.gradle
+++ b/instrumentation/spray-can-1.3.1/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spray-can-1.3.1' }

--- a/instrumentation/spray-can-1.3.1/build.gradle
+++ b/instrumentation/spray-can-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spray-can-1.3.1' }
 }

--- a/instrumentation/spray-can-1.3.1/build.gradle
+++ b/instrumentation/spray-can-1.3.1/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.10")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/spray-can-1.3.1/build.gradle
+++ b/instrumentation/spray-can-1.3.1/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/spray-can-http-client-1.3.1/build.gradle
+++ b/instrumentation/spray-can-http-client-1.3.1/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> {
-    if(project.hasProperty("noScala")) {
-      task.enabled = false
-    }
-    if(project.hasProperty("scala-2.10")) {
-      task.enabled = true
-    }
-  }
+  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/spray-can-http-client-1.3.1/build.gradle
+++ b/instrumentation/spray-can-http-client-1.3.1/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/spray-can-http-client-1.3.1/build.gradle
+++ b/instrumentation/spray-can-http-client-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+  task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 dependencies {
   implementation(project(":newrelic-api"))
   implementation(project(":agent-bridge"))

--- a/instrumentation/spray-can-http-client-1.3.1/build.gradle
+++ b/instrumentation/spray-can-http-client-1.3.1/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-  task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 dependencies {
   implementation(project(":newrelic-api"))

--- a/instrumentation/spray-can-http-client-1.3.1/build.gradle
+++ b/instrumentation/spray-can-http-client-1.3.1/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-  task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+  task -> {
+    if(project.hasProperty("noScala")) {
+      task.enabled = false
+    }
+    if(project.hasProperty("scala-2.10")) {
+      task.enabled = true
+    }
+  }
 }
 
 dependencies {

--- a/instrumentation/spray-client-1.3.1/build.gradle
+++ b/instrumentation/spray-client-1.3.1/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.10")) {
+            task.enabled = true
+        }
+    }
 }
 
 jar {

--- a/instrumentation/spray-client-1.3.1/build.gradle
+++ b/instrumentation/spray-client-1.3.1/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spray-client-1.3.1' }

--- a/instrumentation/spray-client-1.3.1/build.gradle
+++ b/instrumentation/spray-client-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spray-client-1.3.1' }
 }

--- a/instrumentation/spray-client-1.3.1/build.gradle
+++ b/instrumentation/spray-client-1.3.1/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.10")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/spray-client-1.3.1/build.gradle
+++ b/instrumentation/spray-client-1.3.1/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 jar {

--- a/instrumentation/spray-http-1.3.1/build.gradle
+++ b/instrumentation/spray-http-1.3.1/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+}
+
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 

--- a/instrumentation/spray-http-1.3.1/build.gradle
+++ b/instrumentation/spray-http-1.3.1/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.10")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.10")) {
+            task.enabled = true
+        }
+    }
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/spray-http-1.3.1/build.gradle
+++ b/instrumentation/spray-http-1.3.1/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.10")
 
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []

--- a/instrumentation/spray-http-1.3.1/build.gradle
+++ b/instrumentation/spray-http-1.3.1/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.10")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/spray-http-1.3.1/build.gradle
+++ b/instrumentation/spray-http-1.3.1/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.10") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 sourceSets.test.scala.srcDir "src/test/java"

--- a/instrumentation/sttp-2.12_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.12_2.2.3/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-2.12_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.12_2.2.3/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-2.12_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.12_2.2.3/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-2.12_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.12_2.2.3/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-2.12_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.12_2.2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-2.13_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.13_2.2.3/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-2.13_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.13_2.2.3/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-2.13_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.13_2.2.3/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-2.13_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.13_2.2.3/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-2.13_2.2.3/build.gradle
+++ b/instrumentation/sttp-2.13_2.2.3/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-2.13_3.0.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-2.13_3.0.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-2.13_3.0.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-2.13_3.0.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-2.13_3.0.0/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
+
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.12_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-akka-2.13_2.1.5/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
+++ b/instrumentation/sttp-akka-2.13_3.0.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.12")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.12") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.12")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.12")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.12_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.12")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_2.1.5/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
+++ b/instrumentation/sttp-http4s-2.13_3.3.0/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {

--- a/instrumentation/zio/build.gradle
+++ b/instrumentation/zio/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/zio/build.gradle
+++ b/instrumentation/zio/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'scala'
 
-project.tasks.all {
-    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : project.hasProperty('noInstrumentation') ? false : task.enabled
-}
+isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
     implementation("dev.zio:zio_2.13:1.0.9")

--- a/instrumentation/zio/build.gradle
+++ b/instrumentation/zio/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> {
-        if(project.hasProperty("noScala")) {
-            task.enabled = false
-        }
-        if(project.hasProperty("scala-2.13")) {
-            task.enabled = true
-        }
-    }
+    task -> task.enabled = project.hasProperty("scala-2.13") ? true : project.hasProperty("noScala") ? false : task.enabled
 }
 
 dependencies {

--- a/instrumentation/zio/build.gradle
+++ b/instrumentation/zio/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'scala'
 
+project.tasks.all {
+    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+}
+
 dependencies {
     implementation("dev.zio:zio_2.13:1.0.9")
     implementation(project(":agent-bridge"))

--- a/instrumentation/zio/build.gradle
+++ b/instrumentation/zio/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'scala'
 
 project.tasks.all {
-    task -> task.enabled = !project.hasProperty('noScala') || project.hasProperty("scala-2.13")
+    task -> {
+        if(project.hasProperty("noScala")) {
+            task.enabled = false
+        }
+        if(project.hasProperty("scala-2.13")) {
+            task.enabled = true
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### Overview
Address the sustainability of Scala Test Compile. The Scala Test compile is currently unreliable. The interplay between different Scala versions and the Zinc compiler running on GitHub Actions is causing Zinc compile issues during the instrumentation test compilation. This pull request splits the instrumentation test compilation into multiple GitHub Action Workflows separated by Scala version to minimise interplay between different Scala versions during instrumentation test compilation.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/390

### Testing
GitHub Actions changes tested using draft pull requests and review logs on GitHub.

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? isScalaProjectEnabled function fallbacks to original behaviour. 
[X] Does your code contain any breaking changes? Please describe. No code, build changes
[X] Does your code introduce any new dependencies? Please describe. No new dependencies
