### PR TITLE
Fix test failures on Java 11+ and Scala 2.13

### DIFF
--- a/instrumentation/akka-2.2/src/test/java/com/nr/instrumentation/akka22/test/AkkaTest.java
+++ b/instrumentation/akka-2.2/src/test/java/com/nr/instrumentation/akka22/test/AkkaTest.java
@@ -12,6 +12,12 @@ import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TracedMetricData;
+import com.newrelic.test.marker.Java11IncompatibleTest;
+import com.newrelic.test.marker.Java12IncompatibleTest;
+import com.newrelic.test.marker.Java13IncompatibleTest;
+import com.newrelic.test.marker.Java14IncompatibleTest;
+import com.newrelic.test.marker.Java15IncompatibleTest;
+import com.newrelic.test.marker.Java16IncompatibleTest;
 import com.newrelic.test.marker.Java7IncompatibleTest;
 import com.nr.instrumentation.akka22.test.actors.broadcasting.ActorA;
 import com.nr.instrumentation.akka22.test.actors.broadcasting.ActorB;
@@ -30,7 +36,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-@Category({ Java7IncompatibleTest.class })
+// Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
+@Category({ Java11IncompatibleTest.class, Java12IncompatibleTest.class, Java13IncompatibleTest.class, Java14IncompatibleTest.class,
+        Java15IncompatibleTest.class, Java16IncompatibleTest.class })
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = { "akka.actor", "akka.dispatch", "akka.pattern", "akka.routing" })
 public class AkkaTest {

--- a/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
+++ b/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
@@ -15,9 +15,16 @@ import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TransactionEvent;
 import com.newrelic.agent.util.Obfuscator;
+import com.newrelic.test.marker.Java11IncompatibleTest;
+import com.newrelic.test.marker.Java12IncompatibleTest;
+import com.newrelic.test.marker.Java13IncompatibleTest;
+import com.newrelic.test.marker.Java14IncompatibleTest;
+import com.newrelic.test.marker.Java15IncompatibleTest;
+import com.newrelic.test.marker.Java16IncompatibleTest;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.UnsupportedEncodingException;
@@ -27,6 +34,9 @@ import java.util.UUID;
 import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
+// Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
+@Category({ Java11IncompatibleTest.class, Java12IncompatibleTest.class, Java13IncompatibleTest.class, Java14IncompatibleTest.class,
+        Java15IncompatibleTest.class, Java16IncompatibleTest.class })
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = { "akka", "scala", "com.agent", "com.nr" })
 public class AkkaHttpRoutesTest {

--- a/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaResponseWrapperTest.java
+++ b/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaResponseWrapperTest.java
@@ -11,8 +11,15 @@ import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TransactionEvent;
+import com.newrelic.test.marker.Java11IncompatibleTest;
+import com.newrelic.test.marker.Java12IncompatibleTest;
+import com.newrelic.test.marker.Java13IncompatibleTest;
+import com.newrelic.test.marker.Java14IncompatibleTest;
+import com.newrelic.test.marker.Java15IncompatibleTest;
+import com.newrelic.test.marker.Java16IncompatibleTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
@@ -24,6 +31,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+// Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
+@Category({ Java11IncompatibleTest.class, Java12IncompatibleTest.class, Java13IncompatibleTest.class, Java14IncompatibleTest.class,
+        Java15IncompatibleTest.class, Java16IncompatibleTest.class })
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = {"akka", "scala"})
 public class AkkaResponseWrapperTest {

--- a/instrumentation/spray-can-http-client-1.3.1/src/test/scala/com/nr/agent/instrumentation/spray/can/SprayCanClientTest.scala
+++ b/instrumentation/spray-can-http-client-1.3.1/src/test/scala/com/nr/agent/instrumentation/spray/can/SprayCanClientTest.scala
@@ -7,39 +7,30 @@
 
 package com.nr.agent.instrumentation.spray.can
 
+import akka.actor._
+import akka.io.IO
+import akka.pattern.ask
+import akka.util.Timeout
 import com.newrelic.agent.bridge.AgentBridge
-import com.newrelic.agent.introspec.HttpTestServer
-import com.newrelic.agent.introspec.CatHelper
-import com.newrelic.agent.introspec.ExternalRequest
-import com.newrelic.agent.introspec.InstrumentationTestConfig
-import com.newrelic.agent.introspec.InstrumentationTestRunner
-import com.newrelic.agent.introspec.Introspector;
-import com.newrelic.agent.introspec.MetricsHelper;
-import com.newrelic.agent.introspec.TransactionEvent;
-import com.newrelic.agent.introspec.internal.HttpServerLocator;
-import com.newrelic.api.agent.Trace;
+import com.newrelic.agent.introspec._
+import com.newrelic.agent.introspec.internal.HttpServerLocator
+import com.newrelic.api.agent.Trace
+import com.newrelic.test.marker._
+import org.junit._
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import spray.can.Http
+import spray.http.HttpMethods._
+import spray.http._
 
 import java.net.URI
-import java.util.Collection;
-import org.junit.{After, Assert}
-import org.junit.AfterClass
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
-import spray.can.Http.HostConnectorInfo
-
+import java.util.Collection
 import scala.concurrent._
 import scala.concurrent.duration._
 
-import akka.io.IO
-import akka.util.Timeout
-import akka.pattern.ask
-import akka.actor._
-import spray.can.Http
-import spray.http._
-import HttpMethods._
-
+//// Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
+@Category(Array(classOf[Java11IncompatibleTest], classOf[Java12IncompatibleTest], classOf[Java13IncompatibleTest], classOf[Java14IncompatibleTest],
+  classOf[Java15IncompatibleTest], classOf[Java16IncompatibleTest]))
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("spray.", "akka.", "scala.", "com.nr.agent.instrumentation."))
 class SprayCanClientTest extends ConnectionLevelApiDemo {
@@ -76,8 +67,8 @@ class SprayCanClientTest extends ConnectionLevelApiDemo {
   }
 
   /**
-    * Return the first transaction name that matches the regex .*ClientTest.*
-    */
+   * Return the first transaction name that matches the regex .*ClientTest.*
+   */
   private def getCanClientTx(introspector: Introspector): String = {
     var clientTx: String = null;
     val it: java.util.Iterator[String] = introspector.getTransactionNames().iterator()

--- a/instrumentation/spray-client-1.3.1/src/test/scala/com/nr/agent/instrumentation/sprayclient/SprayClientCatTest.scala
+++ b/instrumentation/spray-client-1.3.1/src/test/scala/com/nr/agent/instrumentation/sprayclient/SprayClientCatTest.scala
@@ -7,33 +7,36 @@
 
 package com.nr.agent.instrumentation.sprayclient
 
-import com.newrelic.agent.introspec.HttpTestServer;
-import com.newrelic.agent.introspec.CatHelper;
-import com.newrelic.agent.introspec.ExternalRequest;
+import com.newrelic.agent.introspec.HttpTestServer
+import com.newrelic.agent.introspec.CatHelper
+import com.newrelic.agent.introspec.ExternalRequest
 import com.newrelic.agent.introspec.InstrumentationTestConfig
 import com.newrelic.agent.introspec.InstrumentationTestRunner
-import com.newrelic.agent.introspec.Introspector;
-import com.newrelic.agent.introspec.MetricsHelper;
-import com.newrelic.agent.introspec.TransactionEvent;
-import com.newrelic.agent.introspec.internal.HttpServerLocator;
-import com.newrelic.api.agent.Trace;
+import com.newrelic.agent.introspec.Introspector
+import com.newrelic.agent.introspec.MetricsHelper
+import com.newrelic.agent.introspec.TransactionEvent
+import com.newrelic.agent.introspec.internal.HttpServerLocator
+import com.newrelic.api.agent.Trace
+import com.newrelic.test.marker.{Java11IncompatibleTest, Java12IncompatibleTest, Java13IncompatibleTest, Java14IncompatibleTest, Java15IncompatibleTest, Java16IncompatibleTest}
 
 import java.net.URI
-import java.util.Collection;
-
+import java.util.Collection
 import org.junit.Assert
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import org.junit.runner.RunWith;
-
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
 import spray.http._
 import spray.client.pipelining._
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
+//// Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
+@Category(Array(classOf[Java11IncompatibleTest], classOf[Java12IncompatibleTest], classOf[Java13IncompatibleTest], classOf[Java14IncompatibleTest],
+classOf[Java15IncompatibleTest], classOf[Java16IncompatibleTest]))
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("spray."))
 class SprayClientCatTest {

--- a/instrumentation/spray-client-1.3.1/src/test/scala/com/nr/agent/instrumentation/sprayclient/SprayClientTest.scala
+++ b/instrumentation/spray-client-1.3.1/src/test/scala/com/nr/agent/instrumentation/sprayclient/SprayClientTest.scala
@@ -7,33 +7,36 @@
 
 package com.nr.agent.instrumentation.sprayclient
 
-import com.newrelic.agent.introspec.HttpTestServer;
-import com.newrelic.agent.introspec.CatHelper;
-import com.newrelic.agent.introspec.ExternalRequest;
+import com.newrelic.agent.introspec.HttpTestServer
+import com.newrelic.agent.introspec.CatHelper
+import com.newrelic.agent.introspec.ExternalRequest
 import com.newrelic.agent.introspec.InstrumentationTestConfig
 import com.newrelic.agent.introspec.InstrumentationTestRunner
-import com.newrelic.agent.introspec.Introspector;
-import com.newrelic.agent.introspec.MetricsHelper;
-import com.newrelic.agent.introspec.TransactionEvent;
-import com.newrelic.agent.introspec.internal.HttpServerLocator;
-import com.newrelic.api.agent.Trace;
+import com.newrelic.agent.introspec.Introspector
+import com.newrelic.agent.introspec.MetricsHelper
+import com.newrelic.agent.introspec.TransactionEvent
+import com.newrelic.agent.introspec.internal.HttpServerLocator
+import com.newrelic.api.agent.Trace
 
 import java.net.URI
-import java.util.Collection;
-
+import java.util.Collection
 import org.junit.Assert
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import org.junit.runner.RunWith;
-
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
 import spray.http._
 import spray.client.pipelining._
+import com.newrelic.test.marker.{Java11IncompatibleTest, Java12IncompatibleTest, Java13IncompatibleTest, Java14IncompatibleTest, Java15IncompatibleTest, Java16IncompatibleTest}
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
+//// Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
+@Category(Array(classOf[Java11IncompatibleTest], classOf[Java12IncompatibleTest], classOf[Java13IncompatibleTest], classOf[Java14IncompatibleTest],
+classOf[Java15IncompatibleTest], classOf[Java16IncompatibleTest]))
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("spray."))
 class SprayClientTest {

--- a/instrumentation/spray-http-1.3.1/src/test/java/com/nr/spray/SprayHttpRoutesTest.java
+++ b/instrumentation/spray-http-1.3.1/src/test/java/com/nr/spray/SprayHttpRoutesTest.java
@@ -15,9 +15,16 @@ import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TracedMetricData;
 import com.newrelic.agent.util.Obfuscator;
+import com.newrelic.test.marker.Java11IncompatibleTest;
+import com.newrelic.test.marker.Java12IncompatibleTest;
+import com.newrelic.test.marker.Java13IncompatibleTest;
+import com.newrelic.test.marker.Java14IncompatibleTest;
+import com.newrelic.test.marker.Java15IncompatibleTest;
+import com.newrelic.test.marker.Java16IncompatibleTest;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.UnsupportedEncodingException;
@@ -29,6 +36,9 @@ import java.util.regex.Pattern;
 import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
+// Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
+@Category({ Java11IncompatibleTest.class, Java12IncompatibleTest.class, Java13IncompatibleTest.class, Java14IncompatibleTest.class,
+        Java15IncompatibleTest.class, Java16IncompatibleTest.class })
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = {"spray", "akka", "scala"})
 public class SprayHttpRoutesTest {


### PR DESCRIPTION
We’re seeing failures with some of our Scala related instrumentation tests (e.g. `com.nr.instrumentation.akka22.test.AkkaTest`) that appear to be happening only on Java 11+, which I think are likely due to this bug with Scala 2.13: https://github.com/scala/bug/issues/12340

We’re seeing the same failure:

```
java.lang.IllegalAccessError: Update to static final field akka.pattern.package$.MODULE$ attempted from a different method (<init>) than the initializer method <clinit> 
```

This can be repro’d locally against main by running the following:

```
./gradlew -Ptest11 :instrumentation:akka-2.2:test --tests "com.nr.instrumentation.akka22.test.AkkaTest" --stacktrace
```

This PR prevents those tests from running on Java 11+