### PR TITLE
Create supportability metrics for JfrService

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -458,6 +458,10 @@ public class MetricNames {
     public static final String ERRORS_BY_PARENT_UNKNOWN = "ErrorsByCaller/Unknown/Unknown/Unknown/{0}/all";
     public static final String TRANSPORT_DURATION_BY_PARENT = "TransportDuration/" + PARENT_DATA;
 
+    // JFR Service
+    public static final String SUPPORTABILITY_JFR_SERVICE_STARTED_SUCCESS = "Supportability/JfrService/Started/Success";
+    public static final String SUPPORTABILITY_JFR_SERVICE_STARTED_FAIL = "Supportability/JfrService/Started/Fail";
+
     /**
      * Utility method for adding supportability metrics to APIs
      *

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -9,11 +9,13 @@ package com.newrelic.agent.jfr;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
+import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.JfrConfig;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.jfr.ThreadNameNormalizer;
 import com.newrelic.jfr.daemon.*;
 import com.newrelic.telemetry.Attributes;
@@ -41,9 +43,10 @@ public class JfrService extends AbstractService {
 
     @Override
     protected void doStart() {
-
         if (coreApisExist() && isEnabled()) {
             Agent.LOG.log(Level.INFO, "Attaching New Relic JFR Monitor");
+
+            NewRelic.getAgent().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_JFR_SERVICE_STARTED_SUCCESS);
 
             try {
                 final DaemonConfig daemonConfig = buildDaemonConfig();
@@ -70,6 +73,8 @@ public class JfrService extends AbstractService {
             } catch (Throwable t) {
                 Agent.LOG.log(Level.INFO, "Unable to attach JFR Monitor", t);
             }
+        } else {
+            NewRelic.getAgent().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_JFR_SERVICE_STARTED_FAIL);
         }
     }
 


### PR DESCRIPTION
Generates a `Supportability/JfrService/Started/Success` metric if the JfrService starts (enabled & core APIs exist).

Generates a `Supportability/JfrService/Started/Fail` metric if the JfrService fails to start.


