### PR TITLE
Split scala apis to publish in separate step

### DIFF
--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -73,13 +73,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-scala-zio-api:publish
-          - name: Publish snapshot apis
-            env:
-              SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-              SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-              ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-              ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
-              ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-            run: ./gradlew :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-scala-zio-api:publish
+      - name: Publish snapshot apis
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-scala-zio-api:publish
 
 


### PR DESCRIPTION
### Overview
Currently, publishing is failing due to issues compiling the scala API projects.
This PR excludes the 3 API projects from the publish command, and then runs publish for the 3 excluded API projects as a follow on step

### Testing
Reproducing the publishing issue locally. Using the publishToMavenLocal command in place of the publish command.

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? Please describe.  No
[X] Does your code introduce any new dependencies? Please describe. No
