### PR TITLE
Update http Response code attribute names

### DIFF
--- a/functional_test/src/test/java/test/newrelic/test/agent/HttpCommonsTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/HttpCommonsTest.java
@@ -90,12 +90,15 @@ public class HttpCommonsTest {
 
         Set<String> metrics = AgentHelper.getMetrics();
         assertTrue(metrics.toString(), metrics.contains("External/localhost/CommonsHttp"));
+        assertTrue(metrics.toString(), metrics.contains("External/localhost/CommonsHttp/execute"));
         assertTrue(metrics.toString(), metrics.contains("External/localhost/all"));
         assertTrue(metrics.toString(), metrics.contains("External/all"));
         assertTrue(metrics.toString(), metrics.contains("External/allOther"));
 
         Map<String, Integer> metricCounts = getMetricCounts(
                 MetricName.create("External/localhost/CommonsHttp",
+                        "OtherTransaction/Custom/test.newrelic.test.agent.HttpCommonsTest/httpMethodImpl"),
+                MetricName.create("External/localhost/CommonsHttp/execute",
                         "OtherTransaction/Custom/test.newrelic.test.agent.HttpCommonsTest/httpMethodImpl"),
                 MetricName.create("External/localhost/all"),
                 MetricName.create("External/all"),
@@ -105,9 +108,10 @@ public class HttpCommonsTest {
         assertEquals(3, (int) metricCounts.get("External/all"));
         assertEquals(3, (int) metricCounts.get("External/allOther"));
 
-        // This is 6 because the loop executes 3 times and each loop calls
+        // This is 3 because the loop executes 3 times and each loop calls
         // execute() and releaseConnection(), both of which are instrumented
-        assertEquals(6, (int) metricCounts.get("External/localhost/CommonsHttp"));
+        assertEquals(3, (int) metricCounts.get("External/localhost/CommonsHttp")); // releaseConnection
+        assertEquals(3, (int) metricCounts.get("External/localhost/CommonsHttp/execute"));
     }
 
     @Trace(dispatcher = true)

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/ExternalRequest.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/ExternalRequest.java
@@ -17,6 +17,10 @@ public interface ExternalRequest {
 
     String getLibrary();
 
+    Integer getStatusCode();
+
+    String getStatusText();
+
     String getOperation();
 
     String getTransactionGuild();

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/SpanEvent.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/SpanEvent.java
@@ -28,5 +28,9 @@ public interface SpanEvent {
 
     String getTransactionId();
 
+    Integer getStatusCode();
+
+    String getStatusText();
+
     Map<String, Object> getAgentAttributes();
 }

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/ExternalRequestImpl.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/ExternalRequestImpl.java
@@ -23,12 +23,12 @@ class ExternalRequestImpl extends RequestImpl implements ExternalRequest {
     private static Pattern EXTERNAL_TX_METRIC = Pattern.compile("ExternalTransaction/([^/]+)/(.+)");
     private static Pattern EXTERNAL_TX_SEGMENT = Pattern.compile("ExternalTransaction/([^/]+)/(.+)");
 
-    private String library;
-    private String operation;
-    private Integer statusCode;
-    private String statusText;
-    private String segmentName;
-    private String catTransactionGuid;
+    private final String library;
+    private final String operation;
+    private final Integer statusCode;
+    private final String statusText;
+    private final String segmentName;
+    private final String catTransactionGuid;
 
     private ExternalRequestImpl(String originalMetric, String segmentName, String host, String lib, String operation, Integer statusCode, String statusText,
             String catTransactionGuid) {

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/ExternalRequestImpl.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/ExternalRequestImpl.java
@@ -12,6 +12,8 @@ import java.util.regex.Pattern;
 
 import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.tracers.Tracer;
+import com.newrelic.api.agent.ExternalParameters;
+import com.newrelic.api.agent.HttpParameters;
 
 class ExternalRequestImpl extends RequestImpl implements ExternalRequest {
 
@@ -23,15 +25,19 @@ class ExternalRequestImpl extends RequestImpl implements ExternalRequest {
 
     private String library;
     private String operation;
+    private Integer statusCode;
+    private String statusText;
     private String segmentName;
     private String catTransactionGuid;
 
-    private ExternalRequestImpl(String originalMetric, String segmentName, String host, String lib, String operation,
+    private ExternalRequestImpl(String originalMetric, String segmentName, String host, String lib, String operation, Integer statusCode, String statusText,
             String catTransactionGuid) {
         super(originalMetric, host);
         this.library = lib;
         this.segmentName = segmentName;
         this.operation = operation;
+        this.statusCode = statusCode;
+        this.statusText = statusText;
         this.catTransactionGuid = catTransactionGuid;
     }
 
@@ -41,6 +47,15 @@ class ExternalRequestImpl extends RequestImpl implements ExternalRequest {
         String metricName = transactionSegment.getMetricName();
         Matcher segMatcher = EXTERNAL_SEGMENT.matcher(transactionSegmentName);
         Matcher metricMatcher = EXTERNAL_METRIC.matcher(metricName);
+
+        Integer statusCode = null;
+        String statusText = null;
+        if (transactionSegment.getExternalParameters() instanceof HttpParameters) {
+            HttpParameters httpParams = (HttpParameters) transactionSegment.getExternalParameters();
+            statusCode = httpParams.getStatusCode();
+            statusText = httpParams.getStatusText();
+        }
+
         if (segMatcher.matches() && (segMatcher.groupCount() == 2 || segMatcher.groupCount() == 4)
                 && metricMatcher.matches() && metricMatcher.groupCount() == 2) {
             String host = segMatcher.group(1);
@@ -49,7 +64,7 @@ class ExternalRequestImpl extends RequestImpl implements ExternalRequest {
             if (segMatcher.groupCount() == 4) {
                 op = segMatcher.group(4);
             }
-            return new ExternalRequestImpl(metricName, transactionSegmentName, host, lib, op,
+            return new ExternalRequestImpl(metricName, transactionSegmentName, host, lib, op, statusCode, statusText,
                     (String) transactionSegment.getAgentAttribute("transaction_guid"));
         } else {
             segMatcher = EXTERNAL_TX_METRIC.matcher(transactionSegmentName);
@@ -59,7 +74,7 @@ class ExternalRequestImpl extends RequestImpl implements ExternalRequest {
                 String host = segMatcher.group(1);
                 String lib = null;
                 String op = null;
-                return new ExternalRequestImpl(metricName, transactionSegmentName, host, lib, op,
+                return new ExternalRequestImpl(metricName, transactionSegmentName, host, lib, op, statusCode, statusText,
                         (String) transactionSegment.getAgentAttribute("transaction_guid"));
             }
         }
@@ -81,6 +96,16 @@ class ExternalRequestImpl extends RequestImpl implements ExternalRequest {
     @Override
     public String getLibrary() {
         return library;
+    }
+
+    @Override
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String getStatusText() {
+        return statusText;
     }
 
     @Override

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/SpanEventImpl.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/SpanEventImpl.java
@@ -65,6 +65,17 @@ public class SpanEventImpl implements SpanEvent {
     }
 
     @Override
+    public Integer getStatusCode() {
+        return (Integer) spanEvent.getAgentAttributes().get("http.statusCode");
+    }
+
+    @Override
+    public String getStatusText() {
+        return (String) spanEvent.getAgentAttributes().get("http.statusText");
+    }
+
+
+    @Override
     public Map<String, Object> getAgentAttributes() {
         return spanEvent.getAgentAttributes();
     }

--- a/instrumentation/async-http-client-2.0.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/async-http-client-2.0.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -45,6 +45,8 @@ public class NRAsyncHandler<T> {
     public URI uri;
     @NewField
     private InboundWrapper inboundHeaders;
+    @NewField
+    private HttpResponseStatus responseStatus;
 
     public AsyncHandler.State onStatusReceived(HttpResponseStatus responseStatus) throws Exception {
         AsyncHandler.State userState = Weaver.callOriginal();
@@ -52,6 +54,7 @@ public class NRAsyncHandler<T> {
             userAbortedOnStatusReceived.set(true);
             return AsyncHandler.State.CONTINUE;
         }
+        this.responseStatus = responseStatus;
         return userState;
     }
 
@@ -93,6 +96,7 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
+                    .status(getStatusCode(), getStatusText())
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
@@ -101,5 +105,19 @@ public class NRAsyncHandler<T> {
         }
 
         return Weaver.callOriginal();
+    }
+
+    private Integer getStatusCode() {
+        if (responseStatus != null) {
+            return responseStatus.getStatusCode();
+        }
+        return null;
+    }
+
+    private String getStatusText() {
+        if (responseStatus != null) {
+            return responseStatus.getStatusText();
+        }
+        return null;
     }
 }

--- a/instrumentation/async-http-client-2.0.0/src/test/java/com/nr/agent/instrumentation/asynchttpclient/AsyncHttpClient2_0_0Tests.java
+++ b/instrumentation/async-http-client-2.0.0/src/test/java/com/nr/agent/instrumentation/asynchttpclient/AsyncHttpClient2_0_0Tests.java
@@ -96,6 +96,8 @@ public class AsyncHttpClient2_0_0Tests {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(endpoint.getHost(), externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
 
     }
 
@@ -153,6 +155,8 @@ public class AsyncHttpClient2_0_0Tests {
         assertEquals(host, externalRequest.getHostname());
         assertEquals("AsyncHttpClient", externalRequest.getLibrary());
         assertEquals("onCompleted", externalRequest.getOperation());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test

--- a/instrumentation/async-http-client-2.1.0/src/main/java/org/asynchttpclient/AsyncHandler_Instrumentation.java
+++ b/instrumentation/async-http-client-2.1.0/src/main/java/org/asynchttpclient/AsyncHandler_Instrumentation.java
@@ -43,6 +43,8 @@ public class AsyncHandler_Instrumentation<T> {
     public URI uri;
     @NewField
     private InboundWrapper inboundHeaders;
+    @NewField
+    private HttpResponseStatus responseStatus;
 
     public AsyncHandler.State onStatusReceived(HttpResponseStatus responseStatus) {
         AsyncHandler.State userState = Weaver.callOriginal();
@@ -53,6 +55,7 @@ public class AsyncHandler_Instrumentation<T> {
             userAbortedOnStatusReceived.set(true);
             return AsyncHandler.State.CONTINUE;
         }
+        this.responseStatus = responseStatus;
         return userState;
     }
 
@@ -94,6 +97,7 @@ public class AsyncHandler_Instrumentation<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
+                    .status(getStatusCode(), getStatusText())
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
@@ -104,5 +108,19 @@ public class AsyncHandler_Instrumentation<T> {
         }
 
         return Weaver.callOriginal();
+    }
+
+    private Integer getStatusCode() {
+        if (responseStatus != null) {
+            return responseStatus.getStatusCode();
+        }
+        return null;
+    }
+
+    private String getStatusText() {
+        if (responseStatus != null) {
+            return responseStatus.getStatusText();
+        }
+        return null;
     }
 }

--- a/instrumentation/async-http-client-2.1.0/src/test/java/com/nr/agent/instrumentation/asynchttpclient/AsyncHttpClient2_1_0Tests.java
+++ b/instrumentation/async-http-client-2.1.0/src/test/java/com/nr/agent/instrumentation/asynchttpclient/AsyncHttpClient2_1_0Tests.java
@@ -115,6 +115,8 @@ public class AsyncHttpClient2_1_0Tests {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test
@@ -170,6 +172,8 @@ public class AsyncHttpClient2_1_0Tests {
         assertEquals(host, externalRequest.getHostname());
         assertEquals("AsyncHttpClient", externalRequest.getLibrary());
         assertEquals("onCompleted", externalRequest.getOperation());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test

--- a/instrumentation/aws-java-sdk-s3-1.2.13/src/main/java/com/amazonaws/services/s3/AmazonS3_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-s3-1.2.13/src/main/java/com/amazonaws/services/s3/AmazonS3_Instrumentation.java
@@ -12,6 +12,7 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.*;
 import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
@@ -28,64 +29,146 @@ public class AmazonS3_Instrumentation {
 
     @Trace
     public Bucket createBucket(CreateBucketRequest createBucketRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "createBucket");
-        return Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            Bucket bucket = Weaver.callOriginal();
+            statusCode = 200;
+            return bucket;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + createBucketRequest.getBucketName();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "createBucket");
+        }
+
     }
 
     @Trace
     public void deleteBucket(DeleteBucketRequest deleteBucketRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "deleteBucket");
-        Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            Weaver.callOriginal();
+            statusCode = 200;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + deleteBucketRequest.getBucketName();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "deleteBucket");
+        }
     }
 
     @Trace
     public List<Bucket> listBuckets(ListBucketsRequest listBucketsRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "listBuckets");
-        return Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            List<Bucket> buckets = Weaver.callOriginal();
+            statusCode = 200;
+            return buckets;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://amazon/";
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "listBuckets");
+        }
     }
 
     @Trace
     public String getBucketLocation(GetBucketLocationRequest getBucketLocationRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "getBucketLocation");
-        return Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            String bucketLocation = Weaver.callOriginal();
+            statusCode = 200;
+            return bucketLocation;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + getBucketLocationRequest.getBucketName();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "getBucketLocation");
+        }
     }
 
     @Trace
     public S3Object getObject(GetObjectRequest getObjectRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "getObject");
-        return Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            S3Object s3Object = Weaver.callOriginal();
+            statusCode = 200;
+            return s3Object;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + getObjectRequest.getBucketName() + "/" + getObjectRequest.getKey();
+            System.out.println("URI:"  + uri);
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "getObject");
+        }
     }
 
     @Trace
     public ObjectListing listObjects(ListObjectsRequest listObjectsRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "listObjects");
-        return Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            ObjectListing objectListing = Weaver.callOriginal();
+            statusCode = 200;
+            return objectListing;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + listObjectsRequest.getBucketName();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "listObjects");
+        }
     }
 
     @Trace
     public PutObjectResult putObject(PutObjectRequest putObjectRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "putObject");
-        return Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            PutObjectResult putObjectResult = Weaver.callOriginal();
+            statusCode = 200;
+            return putObjectResult;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + putObjectRequest.getBucketName() + "/" + putObjectRequest.getKey();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "putObject");
+        }
     }
 
     @Trace
     public void deleteObject(DeleteObjectRequest deleteObjectRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "deleteObject");
-        Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            Weaver.callOriginal();
+            statusCode = 200;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + deleteObjectRequest.getBucketName() + "/" + deleteObjectRequest.getKey();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "deleteObject");
+        }
     }
 
     @Trace
     public DeleteObjectsResult deleteObjects(DeleteObjectsRequest deleteObjectsRequest) {
-        S3MetricUtil.metrics(AgentBridge.getAgent().getTransaction(), AgentBridge.getAgent().getTracedMethod(),
-                "deleteObjects");
-        return Weaver.callOriginal();
+        Integer statusCode = null;
+        try {
+            DeleteObjectsResult deleteObjectsResult = Weaver.callOriginal();
+            statusCode = 200;
+            return deleteObjectsResult;
+        } catch (AmazonServiceException exception) {
+            statusCode = exception.getStatusCode();
+            throw exception;
+        } finally {
+            String uri = "s3://" + deleteObjectsRequest.getBucketName();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "deleteObjects");
+        }
+
     }
 }

--- a/instrumentation/aws-java-sdk-s3-1.2.13/src/test/java/com/agent/instrumentation/awsjavasdks3/package-info.java
+++ b/instrumentation/aws-java-sdk-s3-1.2.13/src/test/java/com/agent/instrumentation/awsjavasdks3/package-info.java
@@ -1,0 +1,16 @@
+/*
+ *
+ *  * Copyright 2021 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/**
+ * About testing this aws-java-sdk-s3-1.2.13:
+ * <ul>
+ *     <li>It is not possible to use an embedded s3mock because it brings conflicting AWS libraries.</li>
+ *     <li>Even if an external s3mock is used, it returns human readable (indented) XML and this version of the S3 sdk only understands single line XML.</li>
+ * </ul>
+ * So to run this test you must use a real S3 bucket.
+ */
+package com.agent.instrumentation.awsjavasdks3;

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3MetricUtil.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3MetricUtil.java
@@ -23,9 +23,21 @@ public abstract class S3MetricUtil {
 
     private static final String SERVICE = "S3";
 
-    public static void reportExternalMetrics(Segment segment, String uri, String operationName) {
+    public static void reportExternalMetrics(Segment segment, String uri, S3Response s3Response, String operationName) {
         try {
-            HttpParameters httpParameters = HttpParameters.library(SERVICE).uri(new URI(uri)).procedure(operationName).noInboundHeaders().build();
+
+            Integer statusCode = null;
+            String statusText = null;
+            if (s3Response != null) {
+                statusCode = s3Response.sdkHttpResponse().statusCode();
+                statusText = s3Response.sdkHttpResponse().statusText().orElse(null);
+            }
+            HttpParameters httpParameters = HttpParameters.library(SERVICE)
+                    .uri(new URI(uri))
+                    .procedure(operationName)
+                    .noInboundHeaders()
+                    .status(statusCode, statusText)
+                    .build();
             segment.reportAsExternal(httpParameters);
         } catch (URISyntaxException e) {
             AgentBridge.instrumentation.noticeInstrumentationError(e, Weaver.getImplementationTitle());
@@ -44,11 +56,17 @@ public abstract class S3MetricUtil {
 
     public static void reportExternalMetrics(TracedMethod tracedMethod, String uri, S3Response s3Response, String operationName) {
         try {
+            Integer statusCode = null;
+            String statusText = null;
+            if (s3Response != null) {
+                statusCode = s3Response.sdkHttpResponse().statusCode();
+                statusText = s3Response.sdkHttpResponse().statusText().orElse(null);
+            }
             HttpParameters httpParameters = HttpParameters.library(SERVICE)
                     .uri(new URI(uri))
                     .procedure(operationName)
                     .noInboundHeaders()
-                    .status(s3Response.sdkHttpResponse().statusCode(), s3Response.sdkHttpResponse().statusText().orElse(null))
+                    .status(statusCode, statusText)
                     .build();
             tracedMethod.reportAsExternal(httpParameters);
         } catch (URISyntaxException e) {

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3MetricUtil.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3MetricUtil.java
@@ -13,6 +13,8 @@ import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.TracedMethod;
 import com.newrelic.api.agent.weaver.Weaver;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Response;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -38,5 +40,19 @@ public abstract class S3MetricUtil {
             AgentBridge.instrumentation.noticeInstrumentationError(e, Weaver.getImplementationTitle());
         }
 
+    }
+
+    public static void reportExternalMetrics(TracedMethod tracedMethod, String uri, S3Response s3Response, String operationName) {
+        try {
+            HttpParameters httpParameters = HttpParameters.library(SERVICE)
+                    .uri(new URI(uri))
+                    .procedure(operationName)
+                    .noInboundHeaders()
+                    .status(s3Response.sdkHttpResponse().statusCode(), s3Response.sdkHttpResponse().statusText().orElse(null))
+                    .build();
+            tracedMethod.reportAsExternal(httpParameters);
+        } catch (URISyntaxException e) {
+            AgentBridge.instrumentation.noticeInstrumentationError(e, Weaver.getImplementationTitle());
+        }
     }
 }

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3MetricUtil.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3MetricUtil.java
@@ -55,4 +55,18 @@ public abstract class S3MetricUtil {
             AgentBridge.instrumentation.noticeInstrumentationError(e, Weaver.getImplementationTitle());
         }
     }
+
+    public static void reportExternalMetrics(TracedMethod tracedMethod, String uri, Integer statusCode, String operationName) {
+        try {
+            HttpParameters httpParameters = HttpParameters.library(SERVICE)
+                    .uri(new URI(uri))
+                    .procedure(operationName)
+                    .noInboundHeaders()
+                    .status(statusCode, null)
+                    .build();
+            tracedMethod.reportAsExternal(httpParameters);
+        } catch (URISyntaxException e) {
+            AgentBridge.instrumentation.noticeInstrumentationError(e, Weaver.getImplementationTitle());
+        }
+    }
 }

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3AsyncClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3AsyncClient_Instrumentation.java
@@ -14,6 +14,7 @@ import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
+import java.util.Optional;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
@@ -160,9 +161,9 @@ public class S3AsyncClient_Instrumentation {
         }
 
         @Override
-        public void accept(T t, U u) {
+        public void accept(T s3Response, U u) {
             try {
-                S3MetricUtil.reportExternalMetrics(segment, uri, operationName);
+                S3MetricUtil.reportExternalMetrics(segment, uri, s3Response, operationName);
                 segment.end();
             } catch (Throwable t1) {
                 AgentBridge.instrumentation.noticeInstrumentationError(t1, Weaver.getImplementationTitle());

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3AsyncClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3AsyncClient_Instrumentation.java
@@ -27,7 +27,6 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
@@ -45,51 +44,46 @@ public class S3AsyncClient_Instrumentation {
     public CompletableFuture<CreateBucketResponse> createBucket(CreateBucketRequest createBucketRequest) {
         String uri = "s3://" + createBucketRequest.bucket();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "createBucket");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "createBucket");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<CreateBucketResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "createBucket"));
     }
 
     public CompletableFuture<DeleteBucketResponse> deleteBucket(DeleteBucketRequest deleteBucketRequest) {
         String uri = "s3://" + deleteBucketRequest.bucket();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "deleteBucket");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "deleteBucket");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<DeleteBucketResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "deleteBucket"));
     }
 
     public CompletableFuture<ListBucketsResponse> listBuckets(ListBucketsRequest listBucketsRequest) {
         String uri = "s3://amazon/";
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "listBuckets");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "listBuckets");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<ListBucketsResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "listBuckets"));
     }
 
     public CompletableFuture<GetBucketLocationResponse> getBucketLocation(GetBucketLocationRequest getBucketLocationRequest) {
         String uri = "s3://" + getBucketLocationRequest.bucket();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "getBucketLocation");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "getBucketLocation");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<GetBucketLocationResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "getBucketLocation"));
     }
 
     public <ReturnT> CompletableFuture<ReturnT> getObject(GetObjectRequest getObjectRequest, AsyncResponseTransformer asyncResponseTransformer) {
         String uri = "s3://" + getObjectRequest.bucket() + "/" + getObjectRequest.key();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "getObject");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "getObject");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<ReturnT> result = Weaver.callOriginal();
@@ -100,45 +94,41 @@ public class S3AsyncClient_Instrumentation {
     public CompletableFuture<ListObjectsResponse> listObjects(ListObjectsRequest listObjectsRequest) {
         String uri = "s3://" + listObjectsRequest.bucket();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "listObjects");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "listObjects");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<ListObjectsResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "listObjects"));
     }
 
     public CompletableFuture<PutObjectResponse> putObject(PutObjectRequest putObjectRequest, AsyncRequestBody asyncRequestBody) {
         String uri = "s3://" + putObjectRequest.bucket() + "/" + putObjectRequest.key();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "putObject");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "putObject");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<PutObjectResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "putObject"));
     }
 
     public CompletableFuture<DeleteObjectResponse> deleteObject(DeleteObjectRequest deleteObjectRequest) {
         String uri = "s3://" + deleteObjectRequest.bucket() + "/" + deleteObjectRequest.key();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "deleteObject");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "deleteObject");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<DeleteObjectResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "deleteObject"));
     }
 
     public CompletableFuture<DeleteObjectsResponse> deleteObjects(DeleteObjectsRequest deleteObjectsRequest) {
         String uri = "s3://" + deleteObjectsRequest.bucket();
         Segment segment = NewRelic.getAgent().getTransaction().startSegment("S3", "deleteObjects");
-        S3MetricUtil.reportExternalMetrics(segment, uri, "deleteObjects");
         AgentBridge.getAgent().getTracedMethod().setTrackChildThreads(false);
 
         CompletableFuture<DeleteObjectsResponse> result = Weaver.callOriginal();
 
-        return result.whenComplete(new ResultWrapper<>(segment));
+        return result.whenComplete(new S3ResponseResultWrapper<>(segment, uri, "deleteObjects"));
     }
 
     private class ResultWrapper<T, U> implements BiConsumer<T, U> {
@@ -151,6 +141,28 @@ public class S3AsyncClient_Instrumentation {
         @Override
         public void accept(T t, U u) {
             try {
+                segment.end();
+            } catch (Throwable t1) {
+                AgentBridge.instrumentation.noticeInstrumentationError(t1, Weaver.getImplementationTitle());
+            }
+        }
+    }
+
+    private class S3ResponseResultWrapper<T extends S3Response, U> implements BiConsumer<T, U> {
+        private Segment segment;
+        private String uri;
+        private String operationName;
+
+        public S3ResponseResultWrapper(Segment segment, String uri, String operationName) {
+            this.segment = segment;
+            this.uri = uri;
+            this.operationName = operationName;
+        }
+
+        @Override
+        public void accept(T t, U u) {
+            try {
+                S3MetricUtil.reportExternalMetrics(segment, uri, operationName);
                 segment.end();
             } catch (Throwable t1) {
                 AgentBridge.instrumentation.noticeInstrumentationError(t1, Weaver.getImplementationTitle());

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3Client_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3Client_Instrumentation.java
@@ -95,9 +95,8 @@ public class S3Client_Instrumentation {
     /*
      * This method does not return an S3Response like all the others, so the instrumentation is drastically different.
      * If the method returns properly, it is assumed as a 200 status.
-     * Exceptional cases either use the status on the exception or assume a specific value.
-     * The original method may throw a SdkClientException, which may happen before the request is made, thus no status code.
-     * statusCode is an Integer to account for this last case.
+     * When AwsServiceException is thrown, the status code is retrieved from the exception.
+     * Other exceptions may be thrown, but they indicate something happened before the HTTP request, so there would be no status to record.
      */
     @Trace
     public <T> T getObject(GetObjectRequest getObjectRequest, ResponseTransformer responseTransformer) {
@@ -107,9 +106,6 @@ public class S3Client_Instrumentation {
             T t = Weaver.callOriginal();
             statusCode = 200;
             return t;
-        } catch (NoSuchKeyException noSuchKeyException) {
-            statusCode = 404;
-            throw noSuchKeyException;
         } catch (AwsServiceException awsServiceException) {
             statusCode = awsServiceException.statusCode();
             throw awsServiceException;

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3Client_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/software/amazon/awssdk/services/s3/S3Client_Instrumentation.java
@@ -40,29 +40,53 @@ public class S3Client_Instrumentation {
     @Trace
     public CreateBucketResponse createBucket(CreateBucketRequest createBucketRequest) {
         String uri = "s3://" + createBucketRequest.bucket();
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "createBucket");
-        return Weaver.callOriginal();
+        try {
+            CreateBucketResponse createBucketResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, createBucketResponse, "createBucket");
+            return createBucketResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "createBucket");
+            throw e;
+        }
     }
 
     @Trace
     public DeleteBucketResponse deleteBucket(DeleteBucketRequest deleteBucketRequest) {
         String uri = "s3://" + deleteBucketRequest.bucket();
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "deleteBucket");
-        return Weaver.callOriginal();
+        try {
+            DeleteBucketResponse deleteBucketResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, deleteBucketResponse, "deleteBucket");
+            return deleteBucketResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "deleteBucket");
+            throw e;
+        }
     }
 
     @Trace
     public ListBucketsResponse listBuckets(ListBucketsRequest listBucketsRequest) {
         String uri = "s3://amazon/";
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "listBuckets");
-        return Weaver.callOriginal();
+        try {
+            ListBucketsResponse listBucketsResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, listBucketsResponse, "listBuckets");
+            return listBucketsResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "listBuckets");
+            throw e;
+        }
     }
 
     @Trace
     public GetBucketLocationResponse getBucketLocation(GetBucketLocationRequest getBucketLocationRequest) {
         String uri = "s3://" + getBucketLocationRequest.bucket();
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "getBucketLocation");
-        return Weaver.callOriginal();
+        try {
+            GetBucketLocationResponse getBucketLocationResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, getBucketLocationResponse, "getBucketLocation");
+            return getBucketLocationResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "getBucketLocation");
+            throw e;
+        }
     }
 
     @Trace
@@ -75,29 +99,53 @@ public class S3Client_Instrumentation {
     @Trace
     public ListObjectsResponse listObjects(ListObjectsRequest listObjectsRequest) {
         String uri = "s3://" + listObjectsRequest.bucket();
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "listObjects");
-        return Weaver.callOriginal();
+        try {
+            ListObjectsResponse listObjectsResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, listObjectsResponse, "listObjects");
+            return listObjectsResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "listObjects");
+            throw e;
+        }
     }
 
     @Trace
     public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody RequestBody) {
         String uri = "s3://" + putObjectRequest.bucket() + "/" + putObjectRequest.key();
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "putObject");
-        return Weaver.callOriginal();
+        try {
+            PutObjectResponse putObjectResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, putObjectResponse, "putObject");
+            return putObjectResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "putObject");
+            throw e;
+        }
     }
 
     @Trace
     public DeleteObjectResponse deleteObject(DeleteObjectRequest deleteObjectRequest) {
         String uri = "s3://" + deleteObjectRequest.bucket() + "/" + deleteObjectRequest.key();
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "deleteObject");
-        return Weaver.callOriginal();
+        try {
+            DeleteObjectResponse deleteObjectResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, deleteObjectResponse, "deleteObject");
+            return deleteObjectResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "deleteObject");
+            throw e;
+        }
     }
 
     @Trace
     public DeleteObjectsResponse deleteObjects(DeleteObjectsRequest deleteObjectsRequest) {
         String uri = "s3://" + deleteObjectsRequest.bucket();
-        S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "deleteObjects");
-        return Weaver.callOriginal();
+        try {
+            DeleteObjectsResponse deleteObjectsResponse = Weaver.callOriginal();
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, deleteObjectsResponse, "deleteObjects");
+            return deleteObjectsResponse;
+        } catch (Exception e) {
+            S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, "deleteObjects");
+            throw e;
+        }
     }
 }
 

--- a/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/AmazonS3AsyncApiTest.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/AmazonS3AsyncApiTest.java
@@ -86,14 +86,14 @@ public class AmazonS3AsyncApiTest {
     @Test
     public void testCreateBucket() {
         createBucket();
-        assertMetrics("createBucket");
+        assertMetrics("createBucket", 200);
     }
 
     @Test
     public void testListBuckets() {
         createBucketNoTxn();
         listBuckets();
-        assertMetrics("listBuckets");
+        assertMetrics("listBuckets", 200);
     }
 
 // This test passes but it consistently takes 30s to complete
@@ -103,35 +103,35 @@ public class AmazonS3AsyncApiTest {
 //        createBucketNoTxn();
 //        putObjectNoTxn();
 //        getObject();
-//        assertMetrics("getObject");
+//        assertMetrics("getObject", null);
 //    }
 
     @Test
     public void testListObjects() {
         createBucketNoTxn();
         listObjects();
-        assertMetrics("listObjects");
+        assertMetrics("listObjects", 200);
     }
 
     @Test
     public void testPutObject() {
         createBucketNoTxn();
         putObject();
-        assertMetrics("putObject");
+        assertMetrics("putObject", 200);
     }
 
     @Test
     public void testDeleteBucket() {
         createBucketNoTxn();
         deleteBucket();
-        assertMetrics("deleteBucket");
+        assertMetrics("deleteBucket", 204);
     }
 
     @Test
     public void testGetBucketLocation() {
         createBucketNoTxn();
         getBucketLocation();
-        assertMetrics("getBucketLocation");
+        assertMetrics("getBucketLocation", 200);
     }
 
 // This test passes but it consistently takes 60s to complete
@@ -141,7 +141,7 @@ public class AmazonS3AsyncApiTest {
 //        createBucketNoTxn();
 //        putObjectNoTxn();
 //        deleteObject();
-//        assertMetrics("deleteObject");
+//        assertMetrics("deleteObject", 204);
 //    }
 
 // This test passes but it consistently takes 30s to complete
@@ -151,7 +151,7 @@ public class AmazonS3AsyncApiTest {
 //        createBucketNoTxn();
 //        putObjectNoTxn();
 //        deleteObjects();
-//        assertMetrics("deleteObjects");
+//        assertMetrics("deleteObjects", 200);
 //    }
 
     @Trace(dispatcher = true)

--- a/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/AmazonS3SyncApiTest.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/AmazonS3SyncApiTest.java
@@ -12,6 +12,7 @@ import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.api.agent.Trace;
 import io.findify.s3mock.S3Mock;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
@@ -111,7 +113,19 @@ public class AmazonS3SyncApiTest {
         createBucketNoTxn();
         putObjectNoTxn();
         getObject();
-        assertMetrics("getObject", null);
+        assertMetrics("getObject", 200);
+    }
+
+    @Test
+    public void testGetObjectNonexistent() {
+        createBucketNoTxn();
+        try {
+            getObject();
+            Assert.fail("Exception was expected.");
+        } catch (NoSuchKeyException exception) {
+            // this exception was expected, let the assertions begin
+        }
+        assertMetrics("getObject", 404);
     }
 
     @Test

--- a/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/AmazonS3SyncApiTest.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/AmazonS3SyncApiTest.java
@@ -19,8 +19,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
@@ -86,26 +84,26 @@ public class AmazonS3SyncApiTest {
     @Test
     public void testCreateBucket() {
         createBucket();
-        assertMetrics("createBucket");
+        assertMetrics("createBucket", 200);
     }
 
     @Test
     public void testDeleteBucket() {
         createBucketNoTxn();
         deleteBucket();
-        assertMetrics("deleteBucket");
+        assertMetrics("deleteBucket", 204);
     }
 
     @Test
     public void testListBuckets() {
         listBuckets();
-        assertMetrics("listBuckets");
+        assertMetrics("listBuckets", 200);
     }
 
     @Test
     public void testGetBucketLocation() {
         getBucketLocation();
-        assertMetrics("getBucketLocation");
+        assertMetrics("getBucketLocation", 200);
     }
 
     @Test
@@ -113,21 +111,21 @@ public class AmazonS3SyncApiTest {
         createBucketNoTxn();
         putObjectNoTxn();
         getObject();
-        assertMetrics("getObject");
+        assertMetrics("getObject", null);
     }
 
     @Test
     public void testListObjects() {
         createBucketNoTxn();
         listObjects();
-        assertMetrics("listObjects");
+        assertMetrics("listObjects", 200);
     }
 
     @Test
     public void testPutObject() {
         createBucketNoTxn();
         putObject();
-        assertMetrics("putObject");
+        assertMetrics("putObject", 200);
     }
 
     @Test
@@ -135,7 +133,7 @@ public class AmazonS3SyncApiTest {
         createBucketNoTxn();
         putObjectNoTxn();
         deleteObject();
-        assertMetrics("deleteObject");
+        assertMetrics("deleteObject", 204);
     }
 
     @Test
@@ -143,7 +141,7 @@ public class AmazonS3SyncApiTest {
         createBucketNoTxn();
         putObjectNoTxn();
         deleteObjects();
-        assertMetrics("deleteObjects");
+        assertMetrics("deleteObjects", 200);
     }
 
     @Trace(dispatcher = true)

--- a/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/S3MetricAssertions.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/S3MetricAssertions.java
@@ -86,7 +86,10 @@ class S3MetricAssertions {
         assertEquals(expectedStatusCode, externalRequest.getStatusCode());
 
         String expectedStatusText = statusCodeText.get(expectedStatusCode);
-        assertEquals(expectedStatusText, externalRequest.getStatusText());
+
+        if (!"getObject".equals(operation)) {
+            assertEquals(expectedStatusText, externalRequest.getStatusText());
+        }
     }
 
 }

--- a/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/S3MetricAssertions.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/test/java/com/agent/instrumentation/awsjavasdks3/S3MetricAssertions.java
@@ -7,19 +7,29 @@
 
 package com.agent.instrumentation.awsjavasdks3;
 
+import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.MetricsHelper;
 import com.newrelic.agent.introspec.TransactionEvent;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 class S3MetricAssertions {
 
-    static void assertMetrics(String operation) {
+    private static Map<Integer, String> statusCodeText;
+    static {
+        statusCodeText = new HashMap<>();
+        statusCodeText.put(200, "OK");
+        statusCodeText.put(204, "No Content");
+    }
+
+    static void assertMetrics(String operation, Integer expectedStatusCode) {
         Introspector introspector = InstrumentationTestRunner.getIntrospector();
         assertEquals(1, introspector.getFinishedTransactionCount(2000));
 
@@ -68,6 +78,15 @@ class S3MetricAssertions {
             assertEquals(1, transactionEvent.getExternalCallCount());
             assertTrue(transactionEvent.getExternalDurationInSec() > 0);
         }
+
+        Collection<ExternalRequest> externalRequests = introspector.getExternalRequests(txName);
+        assertEquals(1, externalRequests.size());
+
+        ExternalRequest externalRequest = externalRequests.iterator().next();
+        assertEquals(expectedStatusCode, externalRequest.getStatusCode());
+
+        String expectedStatusText = statusCodeText.get(expectedStatusCode);
+        assertEquals(expectedStatusText, externalRequest.getStatusText());
     }
 
 }

--- a/instrumentation/grpc-1.22.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
+++ b/instrumentation/grpc-1.22.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
@@ -108,6 +108,7 @@ public class ClientCall_Instrumentation<ReqT, RespT> {
                             .uri(uri)
                             .procedure(methodDescriptor.getFullMethodName())
                             .inboundHeaders(wrapper)
+                            .status(status.getCode().value(), status.getDescription())
                             .build();
                     if (segment != null) {
                         segment.reportAsExternal(params);

--- a/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -38,7 +38,11 @@ public abstract class ServerStream_Instrumentation {
         }
 
         if (status != null) {
-            NewRelic.addCustomParameter("response.status", status.getCode().value());
+            int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
+            NewRelic.addCustomParameter("http.statusCode", statusCode);
+            NewRelic.addCustomParameter("http.statusText", status.getDescription());
+
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -69,7 +69,10 @@ public abstract class ServerStream_Instrumentation {
         }
 
         if (status != null) {
-            NewRelic.addCustomParameter("response.status", status.getCode().value());
+            int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
+            NewRelic.addCustomParameter("http.statusCode", statusCode);
+            NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
@@ -7,6 +7,7 @@
 
 import app.TestServer;
 import com.newrelic.agent.introspec.CatHelper;
+import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TraceSegment;
@@ -18,6 +19,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 class ValidationHelper {
@@ -52,6 +54,12 @@ class ValidationHelper {
         }
         assertTrue("Unable to find client side External/ segment", foundSegment);
 
+        Collection<ExternalRequest> externalRequests = introspector.getExternalRequests(clientTxName);
+        assertEquals(1, externalRequests.size());
+        ExternalRequest externalRequest = externalRequests.iterator().next();
+        assertEquals(Integer.valueOf(0), externalRequest.getStatusCode());
+        assertNull(externalRequest.getStatusText());
+
         // Server side
         Collection<TransactionTrace> serverTransactionTrace = introspector.getTransactionTracesForTransaction(serverTxName);
         assertEquals(1, serverTransactionTrace.size());
@@ -61,6 +69,8 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
+        assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)

--- a/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
@@ -87,6 +87,7 @@ class ValidationHelper {
         }
 
         assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
+        assertEquals(0, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 
@@ -127,6 +128,7 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(status, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -135,6 +137,7 @@ class ValidationHelper {
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
         assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
+        assertEquals(status, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 

--- a/instrumentation/grpc-1.30.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
+++ b/instrumentation/grpc-1.30.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
@@ -108,6 +108,7 @@ public class ClientCall_Instrumentation<ReqT, RespT> {
                             .uri(uri)
                             .procedure(methodDescriptor.getFullMethodName())
                             .inboundHeaders(wrapper)
+                            .status(status.getCode().value(), status.getDescription())
                             .build();
                     if (segment != null) {
                         segment.reportAsExternal(params);

--- a/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -38,7 +38,11 @@ public abstract class ServerStream_Instrumentation {
         }
 
         if (status != null) {
-            NewRelic.addCustomParameter("response.status", status.getCode().value());
+            int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
+            NewRelic.addCustomParameter("http.statusCode", statusCode);
+            NewRelic.addCustomParameter("http.statusText", status.getDescription());
+
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -69,7 +69,10 @@ public abstract class ServerStream_Instrumentation {
         }
 
         if (status != null) {
-            NewRelic.addCustomParameter("response.status", status.getCode().value());
+            int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
+            NewRelic.addCustomParameter("http.statusCode", statusCode);
+            NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
@@ -7,6 +7,7 @@
 
 import app.TestServer;
 import com.newrelic.agent.introspec.CatHelper;
+import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TraceSegment;
@@ -18,6 +19,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 class ValidationHelper {
@@ -52,6 +54,12 @@ class ValidationHelper {
         }
         assertTrue("Unable to find client side External/ segment", foundSegment);
 
+        Collection<ExternalRequest> externalRequests = introspector.getExternalRequests(clientTxName);
+        assertEquals(1, externalRequests.size());
+        ExternalRequest externalRequest = externalRequests.iterator().next();
+        assertEquals(Integer.valueOf(0), externalRequest.getStatusCode());
+        assertNull(externalRequest.getStatusText());
+
         // Server side
         Collection<TransactionTrace> serverTransactionTrace = introspector.getTransactionTracesForTransaction(serverTxName);
         assertEquals(1, serverTransactionTrace.size());
@@ -61,6 +69,8 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
+        assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)

--- a/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
@@ -87,6 +87,7 @@ class ValidationHelper {
         }
 
         assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
+        assertEquals(0, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 
@@ -127,6 +128,7 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(status, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -135,6 +137,7 @@ class ValidationHelper {
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
         assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
+        assertEquals(status, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 

--- a/instrumentation/grpc-1.4.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
+++ b/instrumentation/grpc-1.4.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
@@ -108,6 +108,7 @@ public class ClientCall_Instrumentation<ReqT, RespT> {
                             .uri(uri)
                             .procedure(methodDescriptor.getFullMethodName())
                             .inboundHeaders(wrapper)
+                            .status(status.getCode().value(), status.getDescription())
                             .build();
                     if (segment != null) {
                         segment.reportAsExternal(params);

--- a/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -38,7 +38,10 @@ public abstract class ServerStream_Instrumentation {
         }
 
         if (status != null) {
-            NewRelic.addCustomParameter("response.status", status.getCode().value());
+            int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
+            NewRelic.addCustomParameter("http.statusCode", statusCode);
+            NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -68,7 +68,10 @@ public abstract class ServerStream_Instrumentation {
         }
 
         if (status != null) {
-            NewRelic.addCustomParameter("response.status", status.getCode().value());
+            int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
+            NewRelic.addCustomParameter("http.statusCode", statusCode);
+            NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
@@ -7,6 +7,7 @@
 
 import app.TestServer;
 import com.newrelic.agent.introspec.CatHelper;
+import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TraceSegment;
@@ -18,6 +19,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 class ValidationHelper {
@@ -52,6 +54,12 @@ class ValidationHelper {
         }
         assertTrue("Unable to find client side External/ segment", foundSegment);
 
+        Collection<ExternalRequest> externalRequests = introspector.getExternalRequests(clientTxName);
+        assertEquals(1, externalRequests.size());
+        ExternalRequest externalRequest = externalRequests.iterator().next();
+        assertEquals(Integer.valueOf(0), externalRequest.getStatusCode());
+        assertNull(externalRequest.getStatusText());
+
         // Server side
         Collection<TransactionTrace> serverTransactionTrace = introspector.getTransactionTracesForTransaction(serverTxName);
         assertEquals(1, serverTransactionTrace.size());
@@ -61,6 +69,8 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
+        assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)

--- a/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
@@ -6,6 +6,7 @@
  */
 
 import app.TestServer;
+import com.newrelic.agent.attributes.AttributeNames;
 import com.newrelic.agent.introspec.CatHelper;
 import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
@@ -87,6 +88,7 @@ class ValidationHelper {
         }
 
         assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
+        assertEquals(0, serverTxEvent.getAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 
@@ -127,6 +129,7 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(status, rootSegment.getTracerAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -135,6 +138,7 @@ class ValidationHelper {
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
         assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
+        assertEquals(status, serverTxEvent.getAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 

--- a/instrumentation/http-async-client-4/src/main/java/org/apache/http/nio/protocol/HttpAsyncResponseConsumer_Instrumentation.java
+++ b/instrumentation/http-async-client-4/src/main/java/org/apache/http/nio/protocol/HttpAsyncResponseConsumer_Instrumentation.java
@@ -35,12 +35,15 @@ public class HttpAsyncResponseConsumer_Instrumentation<T> {
     public URI uri;
     @NewField
     private InboundWrapper inboundHeaders;
+    @NewField
+    private HttpResponse httpResponse;
 
     /**
      * Invoked when a HTTP response message is received.
      */
     public void responseReceived(HttpResponse response) throws IOException, HttpException {
         inboundHeaders = new InboundWrapper(response);
+        httpResponse = response;
         Weaver.callOriginal();
     }
 
@@ -54,6 +57,7 @@ public class HttpAsyncResponseConsumer_Instrumentation<T> {
                     .uri(uri)
                     .procedure("responseCompleted")
                     .inboundHeaders(inboundHeaders)
+                    .status(getStatusCode(), getReasonMessage())
                     .build());
             segment.end();
         }
@@ -83,5 +87,20 @@ public class HttpAsyncResponseConsumer_Instrumentation<T> {
             inboundHeaders = null;
         }
         Weaver.callOriginal();
+    }
+
+    private Integer getStatusCode() {
+        if (httpResponse != null && httpResponse.getStatusLine() != null)
+        {
+            return httpResponse.getStatusLine().getStatusCode();
+        }
+        return null;
+    }
+
+    private String getReasonMessage() {
+        if (httpResponse != null && httpResponse.getStatusLine() != null) {
+            return httpResponse.getStatusLine().getReasonPhrase();
+        }
+        return null;
     }
 }

--- a/instrumentation/http-async-client-4/src/main/java/org/apache/http/nio/protocol/HttpAsyncResponseConsumer_Instrumentation.java
+++ b/instrumentation/http-async-client-4/src/main/java/org/apache/http/nio/protocol/HttpAsyncResponseConsumer_Instrumentation.java
@@ -90,8 +90,7 @@ public class HttpAsyncResponseConsumer_Instrumentation<T> {
     }
 
     private Integer getStatusCode() {
-        if (httpResponse != null && httpResponse.getStatusLine() != null)
-        {
+        if (httpResponse != null && httpResponse.getStatusLine() != null) {
             return httpResponse.getStatusLine().getStatusCode();
         }
         return null;

--- a/instrumentation/http-async-client-4/src/test/java/com/nr/agent/instrumentation/httpasyncclient4/HttpAsyncClient4Test.java
+++ b/instrumentation/http-async-client-4/src/test/java/com/nr/agent/instrumentation/httpasyncclient4/HttpAsyncClient4Test.java
@@ -116,6 +116,8 @@ public class HttpAsyncClient4Test {
         Assert.assertEquals(host, externalRequest.getHostname());
         Assert.assertEquals("HttpAsyncClient", externalRequest.getLibrary());
         Assert.assertEquals("responseCompleted", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test
@@ -184,6 +186,8 @@ public class HttpAsyncClient4Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK", externalRequest.getStatusText());
     }
 
     /**

--- a/instrumentation/httpclient-3.0/src/test/java/com/nr/agent/instrumentation/httpclient/HttpClient3Test.java
+++ b/instrumentation/httpclient-3.0/src/test/java/com/nr/agent/instrumentation/httpclient/HttpClient3Test.java
@@ -96,8 +96,8 @@ public class HttpClient3Test {
         Assert.assertEquals(2, introspector.getFinishedTransactionCount());
 
         String txOne = "OtherTransaction/Custom/com.nr.agent.instrumentation.httpclient.HttpClient3Test/httpClientExternal";
-        Assert.assertEquals(1, MetricsHelper.getScopedMetricCount(txOne, "External/localhost/CommonsHttp"));
-        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("External/localhost/CommonsHttp"));
+        Assert.assertEquals(1, MetricsHelper.getScopedMetricCount(txOne, "External/localhost/CommonsHttp/execute"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("External/localhost/CommonsHttp/execute"));
 
         // external rollups
         Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("External/localhost/all"));
@@ -117,6 +117,8 @@ public class HttpClient3Test {
         Assert.assertEquals("localhost", externalRequest.getHostname());
         Assert.assertEquals("CommonsHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test
@@ -133,10 +135,10 @@ public class HttpClient3Test {
         Assert.assertEquals(6, introspector.getFinishedTransactionCount());
 
         // host rollups
-        Assert.assertEquals(2, MetricsHelper.getUnscopedMetricCount("External/localhost/CommonsHttp"));
+        Assert.assertEquals(2, MetricsHelper.getUnscopedMetricCount("External/localhost/CommonsHttp/execute"));
         Assert.assertEquals(2, MetricsHelper.getUnscopedMetricCount("External/localhost/all"));
 
-        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("External/127.0.0.1/CommonsHttp"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("External/127.0.0.1/CommonsHttp/execute"));
         Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("External/127.0.0.1/all"));
 
         // external rollups
@@ -188,6 +190,8 @@ public class HttpClient3Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     /**
@@ -223,8 +227,10 @@ public class HttpClient3Test {
                 "OtherTransaction/Custom/com.nr.agent.instrumentation.httpclient.HttpClient3Test/execute1");
         Assert.assertTrue(metrics.containsKey("External/" + endpoint.getHost() + "/CommonsHttp"));
         metrics.get("External/" + endpoint.getHost() + "/CommonsHttp");
-        // This is 2 because execute3() calls execute() and releaseConnection(), both are instrumented
-        Assert.assertEquals(2, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
+
+        // execute1() calls execute() and releaseConnection(), both are instrumented
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp/execute").getCallCount());
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
     }
 
     @Trace(dispatcher = true)
@@ -249,8 +255,9 @@ public class HttpClient3Test {
                 "OtherTransaction/Custom/com.nr.agent.instrumentation.httpclient.HttpClient3Test/execute2");
         Assert.assertTrue(metrics.containsKey("External/" + endpoint.getHost() + "/CommonsHttp"));
         metrics.get("External/" + endpoint.getHost() + "/CommonsHttp");
-        // This is 2 because execute2() calls execute() and releaseConnection(), both are instrumented
-        Assert.assertEquals(2, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
+        // execute2() calls execute() and releaseConnection(), both are instrumented
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp/execute").getCallCount());
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
     }
 
     @Trace(dispatcher = true)
@@ -276,8 +283,9 @@ public class HttpClient3Test {
                 "OtherTransaction/Custom/com.nr.agent.instrumentation.httpclient.HttpClient3Test/execute3");
         Assert.assertTrue(metrics.containsKey("External/" + endpoint.getHost() + "/CommonsHttp"));
         metrics.get("External/" + endpoint.getHost() + "/CommonsHttp");
-        // This is 2 because execute3() calls execute() and releaseConnection(), both are instrumented
-        Assert.assertEquals(2, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
+        // execute3() calls execute() and releaseConnection(), both are instrumented
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp/execute").getCallCount());
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
     }
 
     @Trace(dispatcher = true)
@@ -304,9 +312,10 @@ public class HttpClient3Test {
 
         Assert.assertTrue(metrics.containsKey("External/" + endpoint.getHost() + "/CommonsHttp"));
         metrics.get("External/" + endpoint.getHost() + "/CommonsHttp");
-        // This is 3 because execute4() calls execute(), getResponseBody()
-        // and releaseConnection(). All 3 methods are instrumented
-        Assert.assertEquals(3, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
+        // execute4() calls execute(), getResponseBody() and releaseConnection(). All 3 methods are instrumented
+        // execute() has a metric of its own, the others are aggregated in the general metric
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp/execute").getCallCount());
+        Assert.assertEquals(2, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
     }
 
     @Trace(dispatcher = true)
@@ -331,8 +340,9 @@ public class HttpClient3Test {
                 "OtherTransaction/Custom/com.nr.agent.instrumentation.httpclient.HttpClient3Test/execute5");
         Assert.assertTrue(metrics.containsKey("External/" + endpoint.getHost() + "/CommonsHttp"));
         metrics.get("External/" + endpoint.getHost() + "/CommonsHttp");
-        // This is 2 because execute5() calls execute() and releaseConnection(), both are instrumented
-        Assert.assertEquals(2, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
+        // execute5() calls execute() and releaseConnection(), both are instrumented
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp/execute").getCallCount());
+        Assert.assertEquals(1, metrics.get("External/" + endpoint.getHost() + "/CommonsHttp").getCallCount());
     }
 
     @Trace(dispatcher = true)

--- a/instrumentation/httpclient-3.1/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
+++ b/instrumentation/httpclient-3.1/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
@@ -74,6 +74,7 @@ public abstract class HttpMethodBase implements HttpMethod {
                         .uri(netURI)
                         .procedure("execute")
                         .inboundHeaders(inboundHeaders)
+                        .status(responseCode, this.getStatusText())
                         .build());
             } catch (Throwable e) {
                 AgentBridge.getAgent().getLogger().log(Level.FINER, e,

--- a/instrumentation/httpclient-3.1/src/test/java/com/nr/agent/instrumentation/httpclient/HttpClient31Test.java
+++ b/instrumentation/httpclient-3.1/src/test/java/com/nr/agent/instrumentation/httpclient/HttpClient31Test.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.MetricsHelper;
+import com.newrelic.agent.introspec.TracedMetricData;
 import com.newrelic.agent.introspec.TransactionEvent;
 import com.newrelic.agent.introspec.internal.HttpServerLocator;
 import com.newrelic.agent.introspec.internal.HttpServerRule;
@@ -36,6 +37,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -112,6 +114,8 @@ public class HttpClient31Test {
         Assert.assertEquals("localhost", externalRequest.getHostname());
         Assert.assertEquals("CommonsHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test
@@ -203,6 +207,8 @@ public class HttpClient31Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
 }

--- a/instrumentation/httpclient-4.0/src/main/java/org/apache/http/client/HttpClient.java
+++ b/instrumentation/httpclient-4.0/src/main/java/org/apache/http/client/HttpClient.java
@@ -63,6 +63,7 @@ public abstract class HttpClient {
                 .uri(requestURI)
                 .procedure(PROCEDURE)
                 .inboundHeaders(inboundCatWrapper)
+                .status(response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase())
                 .build());
     }
 
@@ -219,6 +220,7 @@ public abstract class HttpClient {
                     .uri(requestURI)
                     .procedure(PROCEDURE)
                     .inboundHeaders(inboundCatWrapper)
+                    .status(response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase())
                     .build());
         }
     }

--- a/instrumentation/httpclient-4.0/src/test/java/com/nr/agent/instrumentation/httpclient/HttpClientSpanTests.java
+++ b/instrumentation/httpclient-4.0/src/test/java/com/nr/agent/instrumentation/httpclient/HttpClientSpanTests.java
@@ -57,6 +57,8 @@ public class HttpClientSpanTests {
         assertEquals(endpoint.toString(), externalSpanEvent.getHttpUrl());
         assertEquals("CommonsHttp", externalSpanEvent.getHttpComponent());
         assertEquals("execute", externalSpanEvent.getHttpMethod());
+        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
+        assertEquals("OK", externalSpanEvent.getStatusText());
     }
 
     /**

--- a/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -48,6 +48,8 @@ public class NRAsyncHandler<T> {
     public URI uri;
     @NewField
     private InboundWrapper inboundHeaders;
+    @NewField
+    private HttpResponseStatus responseStatus;
 
     public AsyncHandler.STATE onStatusReceived(HttpResponseStatus responseStatus) {
         AsyncHandler.STATE userState = Weaver.callOriginal();
@@ -58,6 +60,7 @@ public class NRAsyncHandler<T> {
             userAbortedOnStatusReceived.set(true);
             return AsyncHandler.STATE.CONTINUE;
         }
+        this.responseStatus = responseStatus;
         return userState;
     }
 
@@ -108,6 +111,7 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
+                    .status(getStatusCode(), getReasonMessage())
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
@@ -118,5 +122,20 @@ public class NRAsyncHandler<T> {
         }
 
         return Weaver.callOriginal();
+    }
+
+    private Integer getStatusCode() {
+        if (responseStatus != null)
+        {
+            return responseStatus.getStatusCode();
+        }
+        return null;
+    }
+
+    private String getReasonMessage() {
+        if (responseStatus != null) {
+            return responseStatus.getStatusText();
+        }
+        return null;
     }
 }

--- a/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -125,8 +125,7 @@ public class NRAsyncHandler<T> {
     }
 
     private Integer getStatusCode() {
-        if (responseStatus != null)
-        {
+        if (responseStatus != null) {
             return responseStatus.getStatusCode();
         }
         return null;

--- a/instrumentation/ning-async-http-client-1.0/src/test/java/com/nr/agent/instrumentation/asynchttpclient/NingAsyncHttpClient10Tests.java
+++ b/instrumentation/ning-async-http-client-1.0/src/test/java/com/nr/agent/instrumentation/asynchttpclient/NingAsyncHttpClient10Tests.java
@@ -90,6 +90,8 @@ public class NingAsyncHttpClient10Tests {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test
@@ -148,6 +150,8 @@ public class NingAsyncHttpClient10Tests {
         assertEquals("AsyncHttpClient", externalRequest.getLibrary());
 
         assertEquals("onCompleted", externalRequest.getOperation());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
 
         // netty?
     }

--- a/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -45,6 +45,8 @@ public class NRAsyncHandler<T> {
     public URI uri;
     @NewField
     private InboundWrapper inboundHeaders;
+    @NewField
+    private HttpResponseStatus responseStatus;
 
     public AsyncHandler.STATE onStatusReceived(HttpResponseStatus responseStatus) {
         AsyncHandler.STATE userState = Weaver.callOriginal();
@@ -55,6 +57,7 @@ public class NRAsyncHandler<T> {
             userAbortedOnStatusReceived.set(true);
             return AsyncHandler.STATE.CONTINUE;
         }
+        this.responseStatus = responseStatus;
         return userState;
     }
 
@@ -98,6 +101,7 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
+                    .status(getStatusCode(), getReasonMessage())
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
@@ -108,5 +112,20 @@ public class NRAsyncHandler<T> {
         }
 
         return Weaver.callOriginal();
+    }
+
+    private Integer getStatusCode() {
+        if (responseStatus != null)
+        {
+            return responseStatus.getStatusCode();
+        }
+        return null;
+    }
+
+    private String getReasonMessage() {
+        if (responseStatus != null) {
+            return responseStatus.getStatusText();
+        }
+        return null;
     }
 }

--- a/instrumentation/ning-async-http-client-1.1/src/test/java/com/nr/agent/instrumentation/asynchttpclient/NingAsyncHttpClient11Tests.java
+++ b/instrumentation/ning-async-http-client-1.1/src/test/java/com/nr/agent/instrumentation/asynchttpclient/NingAsyncHttpClient11Tests.java
@@ -88,6 +88,8 @@ public class NingAsyncHttpClient11Tests {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test
@@ -146,7 +148,8 @@ public class NingAsyncHttpClient11Tests {
         assertEquals(host, externalRequest.getHostname());
         assertEquals("AsyncHttpClient", externalRequest.getLibrary());
         assertEquals("onCompleted", externalRequest.getOperation());
-
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test

--- a/instrumentation/ning-async-http-client-1.6.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.6.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -45,6 +45,8 @@ public class NRAsyncHandler<T> {
     public URI uri;
     @NewField
     private InboundWrapper inboundHeaders;
+    @NewField
+    private HttpResponseStatus responseStatus;
 
     public AsyncHandler.STATE onStatusReceived(HttpResponseStatus responseStatus) {
         AsyncHandler.STATE userState = Weaver.callOriginal();
@@ -55,6 +57,7 @@ public class NRAsyncHandler<T> {
             userAbortedOnStatusReceived.set(true);
             return AsyncHandler.STATE.CONTINUE;
         }
+        this.responseStatus = responseStatus;
         return userState;
     }
 
@@ -98,6 +101,7 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
+                    .status(getStatusCode(), getReasonMessage())
                     .build());
             // This used to be segment.finish(t), but the agent doesn't automatically report it.
             segment.end();
@@ -108,5 +112,20 @@ public class NRAsyncHandler<T> {
         }
 
         return Weaver.callOriginal();
+    }
+
+    private Integer getStatusCode() {
+        if (responseStatus != null)
+        {
+            return responseStatus.getStatusCode();
+        }
+        return null;
+    }
+
+    private String getReasonMessage() {
+        if (responseStatus != null) {
+            return responseStatus.getStatusText();
+        }
+        return null;
     }
 }

--- a/instrumentation/ning-async-http-client-1.6.1/src/test/java/com/nr/agent/instrumentation/asynchttpclient/NingAsyncHttpClient161Tests.java
+++ b/instrumentation/ning-async-http-client-1.6.1/src/test/java/com/nr/agent/instrumentation/asynchttpclient/NingAsyncHttpClient161Tests.java
@@ -96,6 +96,8 @@ public class NingAsyncHttpClient161Tests {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test
@@ -153,7 +155,8 @@ public class NingAsyncHttpClient161Tests {
         assertEquals(host, externalRequest.getHostname());
         assertEquals("AsyncHttpClient", externalRequest.getLibrary());
         assertEquals("onCompleted", externalRequest.getOperation());
-
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK", externalRequest.getStatusText());
     }
 
     @Test

--- a/instrumentation/okhttp-3.0.0/src/main/java/com/nr/agent/instrumentation/okhttp30/internal/RealCall_Instrumentation.java
+++ b/instrumentation/okhttp-3.0.0/src/main/java/com/nr/agent/instrumentation/okhttp30/internal/RealCall_Instrumentation.java
@@ -64,6 +64,7 @@ abstract class RealCall_Instrumentation {
                     .uri(requestUri)
                     .procedure(PROCEDURE)
                     .inboundHeaders(new InboundWrapper(response))
+                    .status(response.code(), response.message())
                     .build());
         }
     }

--- a/instrumentation/okhttp-3.0.0/src/test/java/com/nr/agent/instrumentation/okhttp30/OkHttp30Test.java
+++ b/instrumentation/okhttp-3.0.0/src/test/java/com/nr/agent/instrumentation/okhttp30/OkHttp30Test.java
@@ -106,6 +106,8 @@ public class OkHttp30Test {
         Assert.assertEquals(host1, externalRequest.getHostname());
         Assert.assertEquals("OkHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     @Test
@@ -151,6 +153,8 @@ public class OkHttp30Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     private void httpClientExternal(String host) throws IOException {

--- a/instrumentation/okhttp-3.14.0/src/main/java/com/nr/agent/instrumentation/okhttp314/OkUtils.java
+++ b/instrumentation/okhttp-3.14.0/src/main/java/com/nr/agent/instrumentation/okhttp314/OkUtils.java
@@ -52,6 +52,7 @@ public class OkUtils {
                     .uri(requestUri)
                     .procedure(PROCEDURE)
                     .inboundHeaders(new InboundWrapper(response))
+                    .status(response.code(), response.message())
                     .build());
         }
     }

--- a/instrumentation/okhttp-3.14.0/src/test/java/com/nr/agent/instrumentation/okhttp314/OkHttp314Test.java
+++ b/instrumentation/okhttp-3.14.0/src/test/java/com/nr/agent/instrumentation/okhttp314/OkHttp314Test.java
@@ -108,6 +108,8 @@ public class OkHttp314Test {
         Assert.assertEquals(host1, externalRequest.getHostname());
         Assert.assertEquals("OkHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     @Test
@@ -153,6 +155,8 @@ public class OkHttp314Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     private void httpClientExternal(String host) throws IOException {

--- a/instrumentation/okhttp-3.4.0/src/main/java/com/nr/agent/instrumentation/okhttp34/internal/RealCall_Instrumentation.java
+++ b/instrumentation/okhttp-3.4.0/src/main/java/com/nr/agent/instrumentation/okhttp34/internal/RealCall_Instrumentation.java
@@ -66,6 +66,7 @@ abstract class RealCall_Instrumentation {
                     .uri(requestUri)
                     .procedure(PROCEDURE)
                     .inboundHeaders(new InboundWrapper(response))
+                    .status(response.code(), response.message())
                     .build());
         }
     }

--- a/instrumentation/okhttp-3.4.0/src/test/java/com/nr/agent/instrumentation/okhttp34/OkHttp34Test.java
+++ b/instrumentation/okhttp-3.4.0/src/test/java/com/nr/agent/instrumentation/okhttp34/OkHttp34Test.java
@@ -105,6 +105,8 @@ public class OkHttp34Test {
         Assert.assertEquals(host1, externalRequest.getHostname());
         Assert.assertEquals("OkHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     @Test
@@ -150,6 +152,8 @@ public class OkHttp34Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     private void httpClientExternal(String host) throws IOException {

--- a/instrumentation/okhttp-3.5.0/src/main/java/com/nr/agent/instrumentation/okhttp35/OkUtils.java
+++ b/instrumentation/okhttp-3.5.0/src/main/java/com/nr/agent/instrumentation/okhttp35/OkUtils.java
@@ -52,6 +52,7 @@ public class OkUtils {
                     .uri(requestUri)
                     .procedure(PROCEDURE)
                     .inboundHeaders(new InboundWrapper(response))
+                    .status(response.code(), response.message())
                     .build());
         }
     }

--- a/instrumentation/okhttp-3.5.0/src/test/java/com/nr/agent/instrumentation/okhttp35/OkHttp35Test.java
+++ b/instrumentation/okhttp-3.5.0/src/test/java/com/nr/agent/instrumentation/okhttp35/OkHttp35Test.java
@@ -106,6 +106,8 @@ public class OkHttp35Test {
         Assert.assertEquals(host1, externalRequest.getHostname());
         Assert.assertEquals("OkHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     @Test
@@ -151,6 +153,8 @@ public class OkHttp35Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     private void httpClientExternal(String host) throws IOException {

--- a/instrumentation/okhttp-3.6.0/src/main/java/com/nr/agent/instrumentation/okhttp36/OkUtils.java
+++ b/instrumentation/okhttp-3.6.0/src/main/java/com/nr/agent/instrumentation/okhttp36/OkUtils.java
@@ -52,6 +52,7 @@ public class OkUtils {
                     .uri(requestUri)
                     .procedure(PROCEDURE)
                     .inboundHeaders(new InboundWrapper(response))
+                    .status(response.code(), response.message())
                     .build());
         }
     }

--- a/instrumentation/okhttp-3.6.0/src/test/java/com/nr/agent/instrumentation/okhttp36/OkHttp36Test.java
+++ b/instrumentation/okhttp-3.6.0/src/test/java/com/nr/agent/instrumentation/okhttp36/OkHttp36Test.java
@@ -106,6 +106,8 @@ public class OkHttp36Test {
         Assert.assertEquals(host1, externalRequest.getHostname());
         Assert.assertEquals("OkHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     @Test
@@ -151,6 +153,8 @@ public class OkHttp36Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     private void httpClientExternal(String host) throws IOException {

--- a/instrumentation/okhttp-4.0.0/src/main/java/com/nr/agent/instrumentation/okhttp4/OkUtils.java
+++ b/instrumentation/okhttp-4.0.0/src/main/java/com/nr/agent/instrumentation/okhttp4/OkUtils.java
@@ -51,6 +51,7 @@ public class OkUtils {
                     .uri(requestUri)
                     .procedure(PROCEDURE)
                     .inboundHeaders(new InboundWrapper(response))
+                    .status(response.code(), response.message())
                     .build());
         }
     }

--- a/instrumentation/okhttp-4.0.0/src/test/java/com/nr/agent/instrumentation/okhttp4/OkHttp4Test.java
+++ b/instrumentation/okhttp-4.0.0/src/test/java/com/nr/agent/instrumentation/okhttp4/OkHttp4Test.java
@@ -109,6 +109,8 @@ public class OkHttp4Test {
         Assert.assertEquals(host1, externalRequest.getHostname());
         Assert.assertEquals("OkHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     @Test
@@ -154,6 +156,8 @@ public class OkHttp4Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     private void httpClientExternal(String host) throws IOException {

--- a/instrumentation/okhttp-4.4.0/src/main/java/com/nr/agent/instrumentation/okhttp44/OkUtils.java
+++ b/instrumentation/okhttp-4.4.0/src/main/java/com/nr/agent/instrumentation/okhttp44/OkUtils.java
@@ -51,6 +51,7 @@ public class OkUtils {
                     .uri(requestUri)
                     .procedure(PROCEDURE)
                     .inboundHeaders(new InboundWrapper(response))
+                    .status(response.code(), response.message())
                     .build());
         }
     }

--- a/instrumentation/okhttp-4.4.0/src/test/java/com/nr/agent/instrumentation/okhttp44/OkHttp44Test.java
+++ b/instrumentation/okhttp-4.4.0/src/test/java/com/nr/agent/instrumentation/okhttp44/OkHttp44Test.java
@@ -106,6 +106,8 @@ public class OkHttp44Test {
         Assert.assertEquals(host1, externalRequest.getHostname());
         Assert.assertEquals("OkHttp", externalRequest.getLibrary());
         Assert.assertEquals("execute", externalRequest.getOperation());
+        Assert.assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        Assert.assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     @Test
@@ -151,6 +153,8 @@ public class OkHttp44Test {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+        assertEquals(Integer.valueOf(200), externalRequest.getStatusCode());
+        assertEquals("OK ", externalRequest.getStatusText()); // the test server does return the trailing space, this client does not trim it
     }
 
     private void httpClientExternal(String host) throws IOException {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
@@ -32,6 +32,9 @@ public final class AttributeNames {
     public static final String HTTP_STATUS = "httpResponseCode";
     public static final String HTTP_STATUS_MESSAGE = "httpResponseMessage";
 
+    public static final String HTTP_STATUS_CODE = "http.statusCode";
+    public static final String HTTP_STATUS_TEXT = "http.statusText";
+
     public static final String LOCK_THREAD_NAME = "jvm.lock_thread_name";
     public static final String THREAD_NAME = "jvm.thread_name";
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
@@ -122,10 +122,13 @@ public class WebRequestDispatcher extends DefaultDispatcher implements WebRespon
                 if (getStatus() > 0) {
                     // http status is now being recorded as a string
                     getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS, String.valueOf(getStatus()));
+                    // http.statusCode is supposed to be an int
+                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_CODE, getStatus());
                 }
 
                 if (getStatusMessage() != null) {
                     getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_MESSAGE, getStatusMessage());
+                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_TEXT, getStatusMessage());
                 }
 
                 // adding request.uri here includes it in the Transaction event, which also propagates to any Transaction error events

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -200,6 +200,9 @@ public class SpanEventFactory {
         if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_CODE)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS_CODE, statusCode);
         }
+        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS)) {
+            builder.putAgentAttribute(AttributeNames.HTTP_STATUS, statusCode);
+        }
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -8,6 +8,9 @@
 package com.newrelic.agent.service.analytics;
 
 import com.google.common.base.Joiner;
+import com.newrelic.agent.Transaction;
+import com.newrelic.agent.TransactionData;
+import com.newrelic.agent.attributes.AttributeNames;
 import com.newrelic.agent.attributes.AttributeValidator;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.database.SqlObfuscator;
@@ -193,6 +196,20 @@ public class SpanEventFactory {
         return this;
     }
 
+    public SpanEventFactory setHttpStatusCode(Integer statusCode) {
+        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_CODE)) {
+            builder.putAgentAttribute(AttributeNames.HTTP_STATUS_CODE, statusCode);
+        }
+        return this;
+    }
+
+    public SpanEventFactory setHttpStatusText(String statusText) {
+        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_TEXT)) {
+            builder.putAgentAttribute(AttributeNames.HTTP_STATUS_TEXT, statusText);
+        }
+        return this;
+    }
+
     // datastore parameter
     public SpanEventFactory setDatabaseName(String databaseName) {
         builder.putIntrinsic("db.instance", databaseName);
@@ -301,6 +318,8 @@ public class SpanEventFactory {
             setCategory(SpanCategory.http);
             setUri(httpParameters.getUri());
             setHttpMethod(httpParameters.getProcedure());
+            setHttpStatusCode(httpParameters.getStatusCode());
+            setHttpStatusText(httpParameters.getStatusText());
             setHttpComponent((httpParameters).getLibrary());
             setKindFromUserAttributes();
         } else if (parameters instanceof DatastoreParameters) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static com.newrelic.agent.service.analytics.SpanEventFactory.DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -119,6 +120,50 @@ public class SpanEventFactoryTest {
 
         assertEquals("library", spanEvent.getIntrinsics().get("component"));
         assertNull(spanEvent.getAgentAttributes().get("http.method"));
+    }
+
+    @Test
+    public void shouldSetStatusCode() {
+        SpanEvent spanEvent = spanEventFactory.setHttpStatusCode(418).build();
+
+        assertEquals(418, spanEvent.getAgentAttributes().get("http.statusCode"));
+    }
+
+    @Test
+    public void shouldNotSetStatusCodeWhenFiltering() {
+        SpanEventFactory factory = new SpanEventFactory("blerb", new PassNothingAttributeFilter(), DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER);
+        SpanEvent spanEvent = factory.setHttpStatusCode(418).build();
+
+        assertNull(spanEvent.getAgentAttributes().get("http.statusCode"));
+    }
+
+    @Test
+    public void shouldNotSetNullStatusCode() {
+        SpanEvent spanEvent = spanEventFactory.setHttpStatusCode(null).build();
+
+        assertFalse(spanEvent.getAgentAttributes().containsKey("http.statusCode"));
+    }
+
+    @Test
+    public void shouldSetStatusText() {
+        SpanEvent spanEvent = spanEventFactory.setHttpStatusText("I'm a teapot.").build();
+
+        assertEquals("I'm a teapot.", spanEvent.getAgentAttributes().get("http.statusText"));
+    }
+
+    @Test
+    public void shouldNotSetStatusTextWhenFiltering() {
+        SpanEventFactory factory = new SpanEventFactory("blerb", new PassNothingAttributeFilter(), DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER);
+        SpanEvent spanEvent = factory.setHttpStatusText("I'm a teapot.").build();
+
+        assertNull(spanEvent.getAgentAttributes().get("http.statusText"));
+    }
+
+    @Test
+    public void shouldNotSetNullStatusText() {
+        SpanEvent spanEvent = spanEventFactory.setHttpStatusText(null).build();
+
+        assertFalse(spanEvent.getAgentAttributes().containsKey("http.statusText"));
     }
 
     @Test

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/HttpParameters.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/HttpParameters.java
@@ -31,6 +31,10 @@ public class HttpParameters implements ExternalParameters {
      */
     private final String procedure;
 
+    private final Integer statusCode;
+
+    private final String statusText;
+
     /**
      * The headers from the response of the external call.
      */
@@ -42,13 +46,16 @@ public class HttpParameters implements ExternalParameters {
     private final ExtendedInboundHeaders extendedInboundResponseHeaders;
 
     protected HttpParameters(String library, URI uri, String procedure, InboundHeaders inboundHeaders) {
-        this(library, uri, procedure, inboundHeaders, null);
+        this(library, uri, procedure, null, null, inboundHeaders, null);
     }
 
-    protected HttpParameters(String library, URI uri, String procedure, InboundHeaders inboundHeaders, ExtendedInboundHeaders extendedInboundHeaders) {
+    protected HttpParameters(String library, URI uri, String procedure, Integer statusCode, String statusText, InboundHeaders inboundHeaders,
+            ExtendedInboundHeaders extendedInboundHeaders) {
         this.library = library;
         this.uri = uri;
         this.procedure = procedure;
+        this.statusCode = statusCode;
+        this.statusText = statusText;
         this.inboundResponseHeaders = inboundHeaders;
         this.extendedInboundResponseHeaders = extendedInboundHeaders;
     }
@@ -57,6 +64,8 @@ public class HttpParameters implements ExternalParameters {
         this.library = httpParameters.library;
         this.uri = httpParameters.uri;
         this.procedure = httpParameters.procedure;
+        this.statusCode = httpParameters.statusCode;
+        this.statusText = httpParameters.statusText;
         this.inboundResponseHeaders = httpParameters.inboundResponseHeaders;
         this.extendedInboundResponseHeaders = null;
     }
@@ -92,6 +101,26 @@ public class HttpParameters implements ExternalParameters {
     }
 
     /**
+     * Returns the HTTP status code for the call.
+     *
+     * @return the status code for the call, null if not available
+     * @since 6.5.0
+     */
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Returns the HTTP reason message for the call.
+     *
+     * @return the text of the reason message, null if not available
+     * @since 6.5.0
+     */
+    public String getStatusText() {
+        return statusText;
+    }
+
+    /**
      * Returns the headers from the response of the external call.
      *
      * @return the response headers
@@ -115,6 +144,8 @@ public class HttpParameters implements ExternalParameters {
         private String library;
         private URI uri;
         private String procedure;
+        private Integer statusCode;
+        private String statusText;
         private InboundHeaders inboundHeaders;
         private ExtendedInboundHeaders extendedInboundHeaders;
 
@@ -147,8 +178,17 @@ public class HttpParameters implements ExternalParameters {
             return this;
         }
 
+        @Override
+        public Build status(Integer statusCode, String statusText) {
+            this.statusCode = statusCode;
+            if (statusText != null && !statusText.isEmpty()) {
+                this.statusText = statusText;
+            }
+            return this;
+        }
+
         public HttpParameters build() {
-            return new HttpParameters(library, uri, procedure, inboundHeaders, extendedInboundHeaders);
+            return new HttpParameters(library, uri, procedure, statusCode, statusText, inboundHeaders, extendedInboundHeaders);
         }
     }
 
@@ -201,7 +241,6 @@ public class HttpParameters implements ExternalParameters {
          * @return the completed HttpParameters object
          */
         Build extendedInboundHeaders(ExtendedInboundHeaders extendedInboundHeaders);
-
         /**
          * No inbound headers.
          *
@@ -211,6 +250,12 @@ public class HttpParameters implements ExternalParameters {
     }
 
     public interface Build {
+
+        /**
+         * Set the status code/text of the HTTP response.
+         * @return the builder in a buildable state.
+         */
+        Build status(Integer statusCode, String statusText);
 
         /**
          * Build the final {@link HttpParameters} for the API call.

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/HttpParameters.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/HttpParameters.java
@@ -113,7 +113,7 @@ public class HttpParameters implements ExternalParameters {
      * Returns the HTTP status code for the call.
      *
      * @return the status code for the call, null if not available
-     * @since 6.5.0
+     * @since 7.5.0
      */
     public Integer getStatusCode() {
         return statusCode;
@@ -123,7 +123,7 @@ public class HttpParameters implements ExternalParameters {
      * Returns the HTTP reason message for the call.
      *
      * @return the text of the reason message, null if not available
-     * @since 6.5.0
+     * @since 7.5.0
      */
     public String getStatusText() {
         return statusText;

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/HttpParameters.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/HttpParameters.java
@@ -46,16 +46,15 @@ public class HttpParameters implements ExternalParameters {
     private final ExtendedInboundHeaders extendedInboundResponseHeaders;
 
     protected HttpParameters(String library, URI uri, String procedure, InboundHeaders inboundHeaders) {
-        this(library, uri, procedure, null, null, inboundHeaders, null);
+        this(library, uri, procedure, inboundHeaders, null);
     }
 
-    protected HttpParameters(String library, URI uri, String procedure, Integer statusCode, String statusText, InboundHeaders inboundHeaders,
-            ExtendedInboundHeaders extendedInboundHeaders) {
+    protected HttpParameters(String library, URI uri, String procedure, InboundHeaders inboundHeaders, ExtendedInboundHeaders extendedInboundHeaders) {
         this.library = library;
         this.uri = uri;
         this.procedure = procedure;
-        this.statusCode = statusCode;
-        this.statusText = statusText;
+        this.statusCode = null;
+        this.statusText = null;
         this.inboundResponseHeaders = inboundHeaders;
         this.extendedInboundResponseHeaders = extendedInboundHeaders;
     }
@@ -68,6 +67,16 @@ public class HttpParameters implements ExternalParameters {
         this.statusText = httpParameters.statusText;
         this.inboundResponseHeaders = httpParameters.inboundResponseHeaders;
         this.extendedInboundResponseHeaders = null;
+    }
+
+    protected HttpParameters(Builder builder) {
+        this.library = builder.library;
+        this.uri = builder.uri;
+        this.procedure = builder.procedure;
+        this.statusCode = builder.statusCode;
+        this.statusText = builder.statusText;
+        this.inboundResponseHeaders = builder.inboundHeaders;
+        this.extendedInboundResponseHeaders = builder.extendedInboundHeaders;
     }
 
     /**
@@ -188,7 +197,7 @@ public class HttpParameters implements ExternalParameters {
         }
 
         public HttpParameters build() {
-            return new HttpParameters(library, uri, procedure, statusCode, statusText, inboundHeaders, extendedInboundHeaders);
+            return new HttpParameters(this);
         }
     }
 


### PR DESCRIPTION
### Overview
This adds the `http.statusCode` and `http.statusText` to spans and transactions.

### Related Github Issue
#225 

### Checks

[y] Are your contributions backwards compatible with relevant frameworks and APIs?
[n] Does your code contain any breaking changes? Please describe. 
[n] Does your code introduce any new dependencies? Please describe.
