### PR TITLE
Update GHA Gradle caching and don't build class files twice

### DIFF
--- a/.github/workflows/GHA-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Functional-Tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v1.0.4
 
       #NEW Install required JDKs
       # Install 8
@@ -42,6 +42,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
+          cache: 'gradle'
 
       # Save new JDK variable
       - name: Save JAVA_HOME as JDK8 for later usage
@@ -79,22 +80,6 @@ jobs:
       - name: Check environmental variables
         run: printenv | sort -f
 
-      # Restore the gradle cache
-      - name: Restore the gradle caches
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          # The docs say to use hashfiles, but gradle itself is smart enough to
-          # re-download dependencies if it couldn't resolve them.
-          # Because our gradle cache is _so big_, I think a 90% cache is far
-          # better than a 0% cache.
-          key: ${{ runner.os }}-gradle
-          restore-keys: |
-            ${{ runner.os }}-gradle
-
-
       # GHA run functional tests
 
       # Rewrite gradle.properties
@@ -126,7 +111,7 @@ jobs:
           # Changed log level to --warn from --info
           # ./gradlew --console=plain --parallel functional_test:test -Ptest${{ matrix.java-version }} --continue --warn
           # -Ptest${{ matrix.java-version }} added below from the command integrated from https://github.com/newrelic/newrelic-java-agent/pull/451
-          ./gradlew --console=plain --parallel clean :functional_test:test -Ptest${{ matrix.java-version }} --continue
+          ./gradlew --console=plain --parallel :functional_test:test -Ptest${{ matrix.java-version }} --continue
 
       # Capture HTML build result in artifacts
       - name: Capture build reports

--- a/.github/workflows/GHA-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Instrumentation-Tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v1.0.4
 
       #NEW Install required JDKs
       # Install 8
@@ -43,6 +43,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
+          cache: 'gradle'
 
       # Save new JDK variable
       - name: Save JAVA_HOME as JDK8 for later usage
@@ -79,21 +80,6 @@ jobs:
       # Check ENV variables
       - name: Check environmental variables
         run: printenv | sort -f
-
-      # Restore the gradle cache
-      - name: Restore the gradle caches
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          # The docs say to use hashfiles, but gradle itself is smart enough to
-          # re-download dependencies if it couldn't resolve them.
-          # Because our gradle cache is _so big_, I think a 90% cache is far
-          # better than a 0% cache.
-          key: ${{ runner.os }}-gradle
-          restore-keys: |
-            ${{ runner.os }}-gradle
 
       ## AWS jars - plan to cache
       - name: Configure AWS Credentials
@@ -143,7 +129,7 @@ jobs:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
           # Below per https://github.com/newrelic/newrelic-java-agent/pull/451, adding the matrix value to Ptest
-          ./gradlew --console=plain --parallel clean :instrumentation:test -Ptest${{ matrix.java-version }} -PnoScala --continue
+          ./gradlew --console=plain :instrumentation:test -Ptest${{ matrix.java-version }} -PnoScala --continue
 
       # Capture HTML build result in artifacts
       - name: Capture build reports

--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v1.0.4
 
       #NEW Install required JDKs
       # Install 8

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v1.0.4
 
       #NEW Install required JDKs
       # Install 8

--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v1.0.4
 
       #NEW Install required JDKs
       # Install 8
@@ -53,6 +53,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
+          cache: 'gradle'
 
       # Save new JDK variable
       - name: Save JAVA_HOME as JDK8 for later usage
@@ -90,21 +91,6 @@ jobs:
       - name: Check environmental variables
         run: printenv | sort -f
 
-      # Restore the gradle cache
-      - name: Restore the gradle caches
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          # The docs say to use hashfiles, but gradle itself is smart enough to
-          # re-download dependencies if it couldn't resolve them.
-          # Because our gradle cache is _so big_, I think a 90% cache is far
-          # better than a 0% cache.
-          key: ${{ runner.os }}-gradle
-          restore-keys: |
-            ${{ runner.os }}-gradle
-
       # Is newrelicJar present in newrelic-agent/build
       # TO DO: Below version number has to be dynamic
       - name: Build newrelicJar
@@ -139,7 +125,7 @@ jobs:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
           # Updated Gradle command per https://github.com/newrelic/newrelic-java-agent/pull/451
-          ./gradlew --console=plain --parallel clean test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue
+          ./gradlew --console=plain --parallel test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue
 
       # Capture HTML build result in artifacts
       # https://github.com/actions/upload-artifact


### PR DESCRIPTION
### Overview
Update Gradle caching for GHA and don't build class files twice per test run.
