### PR TITLE
Provide support for Datastax/Cassandra WrappedStatments.

### DIFF
--- a/instrumentation/cassandra-datastax-3.0.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraTest.java
+++ b/instrumentation/cassandra-datastax-3.0.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraTest.java
@@ -16,6 +16,7 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.StatementWrapper;
 import com.google.common.collect.Iterables;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
 import com.newrelic.agent.database.DatastoreMetrics;
@@ -167,6 +168,74 @@ public class CassandraTest {
 
         // Show that the user is gone
         session.execute("SELECT * FROM users");
+    }
+
+    @Test
+    public void testBasicWrapped() {
+        demoBasicWrapped();
+
+        assertEquals(1, InstrumentationTestRunner.getIntrospector().getFinishedTransactionCount(1000));
+        Collection<String> transactionNames = InstrumentationTestRunner.getIntrospector().getTransactionNames();
+        assertEquals(1, transactionNames.size());
+
+        String txName = transactionNames.iterator().next();
+        DatastoreHelper helper = new DatastoreHelper(CASSANDRA_PRODUCT);
+        helper.assertScopedStatementMetricCount(txName, "INSERT", "users", 1);
+        helper.assertScopedStatementMetricCount(txName, "SELECT", "users", 3);
+        helper.assertScopedStatementMetricCount(txName, "UPDATE", "users", 1);
+        helper.assertScopedStatementMetricCount(txName, "DELETE", "users", 1);
+
+        helper.assertAggregateMetrics();
+        helper.assertUnscopedOperationMetricCount("INSERT", 1);
+        helper.assertUnscopedOperationMetricCount("SELECT", 3);
+        helper.assertUnscopedOperationMetricCount("UPDATE", 1);
+        helper.assertUnscopedOperationMetricCount("DELETE", 1);
+        helper.assertUnscopedStatementMetricCount("INSERT", "users", 1);
+        helper.assertUnscopedStatementMetricCount("SELECT", "users", 3);
+        helper.assertUnscopedStatementMetricCount("UPDATE", "users", 1);
+        helper.assertUnscopedStatementMetricCount("DELETE", "users", 1);
+
+        Collection<TransactionTrace> traces =
+                InstrumentationTestRunner.getIntrospector().getTransactionTracesForTransaction(txName);
+        assertEquals(1, traces.size());
+        TransactionTrace trace = Iterables.getFirst(traces, null);
+        assertNotNull(trace);
+        assertBasicTraceSegmentAttributes(trace);
+    }
+
+
+    /*
+    A wrapped statement is a class that the driver supplies to support custom Retry and LoadBalancing policies.
+    */
+    class SimpleStatementWrapper extends StatementWrapper {
+        public SimpleStatementWrapper(Statement statement) {
+            super(statement);
+        }
+    }
+
+    @Trace(dispatcher = true)
+    public void demoBasicWrapped() {
+        SimpleStatement insertStatement = new SimpleStatement(
+                "/* This is an INSERT query. yay*/ INSERT INTO users (lastname, age, city, email, firstname) VALUES ('Jones', 35, 'Austin', 'bob@example.com', 'Bob')");
+        SimpleStatementWrapper wrappedInsertStatement = new SimpleStatementWrapper(insertStatement);
+
+        wrappedInsertStatement.enableTracing();
+        session.execute(wrappedInsertStatement);
+
+        // Use select to get the user we just entered
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("SELECT * FROM users WHERE lastname='Jones'")));
+
+        // Update the same user with a new age
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("update users set age = 36 where lastname = 'Jones'")));
+
+        // Select and show the change
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("select * from users where lastname='Jones'")));
+
+        // Delete the user from the users table
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("DELETE FROM users WHERE lastname = 'Jones'")));
+
+        // Show that the user is gone
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("SELECT * FROM users")));
     }
 
     @Test

--- a/instrumentation/cassandra-datastax-3.8.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraTest.java
+++ b/instrumentation/cassandra-datastax-3.8.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraTest.java
@@ -16,6 +16,7 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.StatementWrapper;
 import com.google.common.collect.Iterables;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
 import com.newrelic.agent.database.DatastoreMetrics;
@@ -172,6 +173,74 @@ public class CassandraTest {
 
         // Show that the user is gone
         session.execute("SELECT * FROM users");
+    }
+
+    @Test
+    public void testBasicWrapped() {
+        demoBasicWrapped();
+
+        assertEquals(1, InstrumentationTestRunner.getIntrospector().getFinishedTransactionCount(1000));
+        Collection<String> transactionNames = InstrumentationTestRunner.getIntrospector().getTransactionNames();
+        assertEquals(1, transactionNames.size());
+
+        String txName = transactionNames.iterator().next();
+        DatastoreHelper helper = new DatastoreHelper(CASSANDRA_PRODUCT);
+        helper.assertScopedStatementMetricCount(txName, "INSERT", "users", 1);
+        helper.assertScopedStatementMetricCount(txName, "SELECT", "users", 3);
+        helper.assertScopedStatementMetricCount(txName, "UPDATE", "users", 1);
+        helper.assertScopedStatementMetricCount(txName, "DELETE", "users", 1);
+
+        helper.assertAggregateMetrics();
+        helper.assertUnscopedOperationMetricCount("INSERT", 1);
+        helper.assertUnscopedOperationMetricCount("SELECT", 3);
+        helper.assertUnscopedOperationMetricCount("UPDATE", 1);
+        helper.assertUnscopedOperationMetricCount("DELETE", 1);
+        helper.assertUnscopedStatementMetricCount("INSERT", "users", 1);
+        helper.assertUnscopedStatementMetricCount("SELECT", "users", 3);
+        helper.assertUnscopedStatementMetricCount("UPDATE", "users", 1);
+        helper.assertUnscopedStatementMetricCount("DELETE", "users", 1);
+
+        Collection<TransactionTrace> traces =
+                InstrumentationTestRunner.getIntrospector().getTransactionTracesForTransaction(txName);
+        assertEquals(1, traces.size());
+        TransactionTrace trace = Iterables.getFirst(traces, null);
+        assertNotNull(trace);
+        assertBasicTraceSegmentAttributes(trace);
+    }
+
+
+    /*
+    A wrapped statement is a class that the driver supplies to support custom Retry and LoadBalancing policies.
+    */
+    class SimpleStatementWrapper extends StatementWrapper {
+        public SimpleStatementWrapper(Statement  wrapped){
+            super(wrapped);
+        }
+    }
+
+    @Trace(dispatcher = true)
+    public void demoBasicWrapped() {
+        SimpleStatement insertStatement = new SimpleStatement(
+                "/* This is an INSERT query. yay*/ INSERT INTO users (lastname, age, city, email, firstname) VALUES ('Jones', 35, 'Austin', 'bob@example.com', 'Bob')");
+        SimpleStatementWrapper wrappedInsertStatement = new SimpleStatementWrapper(insertStatement);
+
+        wrappedInsertStatement.enableTracing();
+        session.execute(wrappedInsertStatement);
+
+        // Use select to get the user we just entered
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("SELECT * FROM users WHERE lastname='Jones'")));
+
+        // Update the same user with a new age
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("update users set age = 36 where lastname = 'Jones'")));
+
+        // Select and show the change
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("select * from users where lastname='Jones'")));
+
+        // Delete the user from the users table
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("DELETE FROM users WHERE lastname = 'Jones'")));
+
+        // Show that the user is gone
+        session.execute(new SimpleStatementWrapper(new SimpleStatement("SELECT * FROM users")));
     }
 
     @Test


### PR DESCRIPTION
A wrapped statement is a class that the driver supplies to support custom Retry and LoadBalancing policies.

If developers implement and extend [com.datastax.driver.core.StatementWrapper](https://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/StatementWrapper.html) as part of a custom Retry or LoadBalancing policy, the statements were being rejected as ```unsupported statement type```.

### Overview
Changes include:
* checking if the statement is a WrappedStatement
* if it is, get the statement that is being wrapped and use it as the Query to use for metrics. Otherwise use the original statement.
* Unit tests to verify Wrapped statements work
* Applied to version 3.0.0 and 3.8.0 of the Datastax driver. (This class looks like it may have been present in some version of 2.0 - but not in the dependency included in this 2.0.0 project).

### Related Github Issue
Since it may be called a bug ? I didn't create a github issue for it.

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[Yes] Are your contributions backwards compatible with relevant frameworks and APIs?
[No] Does your code contain any breaking changes? Please describe. 
[NO] Does your code introduce any new dependencies? Please describe.
