### PR TITLE
additional null check for trasaction tracer

### DIFF
--- a/instrumentation/newrelic-cats-effect3-api/src/main/scala/com/newrelic/cats3/api/Util.scala
+++ b/instrumentation/newrelic-cats-effect3-api/src/main/scala/com/newrelic/cats3/api/Util.scala
@@ -9,37 +9,43 @@ import java.util.concurrent.atomic.AtomicInteger
 
 object Util {
   val RETURN_OPCODE = 176
-  def wrapTrace[S, F[_]: Sync](body: F[S]): F[S] =
-    Sync[F].delay{
-      val tracer = AgentBridge.instrumentation.createScalaTxnTracer()
-      tracer
-    }.redeemWith(
-        _ => body,
-        tracer => for {
-          txn <- Sync[F].delay(AgentBridge.getAgent.getTransaction(false))
-          _ <- setupTokenAndRefCount(txn)
-          res <- attachErrorEvent(body, tracer)
-          _ <- cleanupTxnAndTokenRefCount(txn)
-          _ <- Sync[F].delay(tracer.finish(RETURN_OPCODE, null))
-        } yield res
-      )
 
-  private def attachErrorEvent[S, F[_]: Sync](body: F[S], tracer: ExitTracer): F[S] =
+  def wrapTrace[S, F[_] : Sync](body: F[S]): F[S] =
+    Sync[F].delay(AgentBridge.instrumentation.createScalaTxnTracer())
+           .redeemWith(_ => body,
+             tracer =>
+               if (tracer == null) {
+                 body
+               } else {
+                 for {
+                   txn <- Sync[F].delay(AgentBridge.getAgent.getTransaction(false))
+                   _ <- setupTokenAndRefCount(txn)
+                   res <- attachErrorEvent(body, tracer)
+                   _ <- cleanupTxnAndTokenRefCount(txn)
+                   _ <- Sync[F].delay(tracer.finish(RETURN_OPCODE, null))
+                 } yield res
+               }
+           )
+
+  private def attachErrorEvent[S, F[_] : Sync](body: F[S], tracer: ExitTracer): F[S] =
     body
       .handleErrorWith(throwable => {
-      tracer.finish(throwable)
-      Sync[F].raiseError(throwable)
-    })
+        tracer.finish(throwable)
+        Sync[F].raiseError(throwable)
+      })
 
-  private def setupTokenAndRefCount[F[_]: Sync](txn: Transaction): F[Unit] = Sync[F].delay{
+  private def setupTokenAndRefCount[F[_] : Sync](txn: Transaction): F[Unit] = Sync[F].delay {
     if (txn != null) {
-      AgentBridge.activeToken.set(new AgentBridge.TokenAndRefCount(txn.getToken, AgentBridge.getAgent
-                                                                                            .getTracedMethod, new
-          AtomicInteger(0)))
+      AgentBridge.activeToken.set(
+        new AgentBridge.TokenAndRefCount(
+          txn.getToken,
+          AgentBridge.getAgent.getTracedMethod,
+          new AtomicInteger(0)
+        ))
     }
   }
 
-  private def cleanupTxnAndTokenRefCount[F[_]: Sync](txn: Transaction): F[Unit] = Sync[F].delay{
+  private def cleanupTxnAndTokenRefCount[F[_] : Sync](txn: Transaction): F[Unit] = Sync[F].delay {
     val tokenAndRefCount = AgentBridge.activeToken.get()
     if (tokenAndRefCount != null) {
       AgentBridge.activeToken.remove()

--- a/instrumentation/newrelic-scala-cats-api/src/main/scala/com/newrelic/cats/api/Util.scala
+++ b/instrumentation/newrelic-scala-cats-api/src/main/scala/com/newrelic/cats/api/Util.scala
@@ -16,11 +16,15 @@ object Util {
       tracer
     }.redeemWith(
         _ => body,
-        tracer => for {
-          _ <- Sync[F].delay(NewRelic.getAgent.getTransaction)
-          res <- attachErrorEvent(body, tracer)
-          _ <- Sync[F].delay(tracer.finish(172, null))
-        } yield res
+        tracer => if (tracer == null) {
+          body
+        } else {
+          for {
+            _ <- Sync[F].delay(NewRelic.getAgent.getTransaction)
+            res <- attachErrorEvent(body, tracer)
+            _ <- Sync[F].delay(tracer.finish(172, null))
+          } yield res
+        }
       )
 
   private def attachErrorEvent[S, F[_]: Sync](body: F[S], tracer: ExitTracer): F[S] =


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
`Instrumentation#createTracer` can return null in an error scenario rather than throw an exception. The cats effect and zio APIs instrumentation for creating a transaction had code to handle exceptions but not null. This PR adds null handling for the tracer. 

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[y] Are your contributions backwards compatible with relevant frameworks and APIs?
[n] Does your code contain any breaking changes? Please describe. 
[n ] Does your code introduce any new dependencies? Please describe.
