### PR TITLE
Add tags to Gradle build scan

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,15 @@ gradleEnterprise {
         capture {
             taskInputFiles = true
         }
+        if (System.getenv("CI")) {
+            tag "CI"
+        } else {
+            tag "Local"
+        }
+        tag System.getenv("LANGUAGE")
+        tag System.getenv("JRE")
+        tag System.getenv("SCALA_VERSION")
+        tag System.getenv("TEST_TYPE")
     }
 }
 


### PR DESCRIPTION
We are going to need to use 'tags' to distinguish builds/tests easily.  Once again, I can't even test this out easily on GHA without it being on main.  Even testing with just instrumentation tests gets difficult to tell them apart pretty quickly.