### PR TITLE
Http4s bug fix

### DIFF
--- a/instrumentation/http4s-blaze-server-2.12_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
@@ -30,12 +30,13 @@ object TransactionMiddleware {
     t.setWebRequest(RequestWrapper(request))
     token
   }
+
   private def completeTxn[F[_]:Sync](tracer: ExitTracer, token: Token): F[Unit] = construct {
     token.expire()
     tracer.finish(176, null)
   }.handleErrorWith(_ => Sync[F].unit)
 
-  private def construct[F[_]: Sync, T](t: T): F[T] = Sync[F].delay(t)
+  private def construct[F[_]: Sync, T](t: => T): F[T] = Sync[F].delay(t)
 
   private def attachErrorEvent[S, F[_]: Sync](body: F[S], tracer: ExitTracer, token: Token) =
     body.handleErrorWith(throwable => {

--- a/instrumentation/http4s-blaze-server-2.13_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
@@ -36,7 +36,7 @@ object TransactionMiddleware {
     tracer.finish(176, null)
   }.handleErrorWith(_ => Sync[F].unit)
 
-  private def construct[F[_] : Sync, T](t: T): F[T] = Sync[F].delay(t)
+  private def construct[F[_] : Sync, T](t: => T): F[T] = Sync[F].delay(t)
 
   private def attachErrorEvent[S, F[_] : Sync](body: F[S], tracer: ExitTracer, token: Token) =
     body.handleErrorWith(throwable => {


### PR DESCRIPTION
### Overview
This pr moves creation of the transaction to happen when the request is actually run and not during the construction of the effect itself. This seems to cause invalid tracer states and nullpointer exceptions in one of our application that uses cats effect and Doobie. 

This fix is only an assumption as debugging/reproducing this is relatively time consuming. 
According to how cats effect support is implemented the transaction creation should be delayed which is done by wrapping that into `Sync.delay(AgentBridge.instrumentation.createScalaTxnTracer())`. This works because delay take a call by name parameter. However, the construct helper method takes a call by value parameter and therefor circumvents the lazy evaluation of creating the transaction. 

In our application I believe that this leads to the tracer being null by the time completeTxn is run and therefor causes our backend to return 500 error. 

This PR adds an additional test for 2.12 blazeserver instrumentation

Related 'stack trace' (as seen in cloudwatch logs)
```
2021-10-11 17:06:55java.lang.NullPointerException: null
2021-10-11 17:06:55at com.nr.instrumentation.http4s.TransactionMiddleware$.completeTxn(TransactionMiddleware.scala:36)
2021-10-11 17:06:55at com.nr.instrumentation.http4s.TransactionMiddleware$.$anonfun$nrRequestResponse$5(TransactionMiddleware.scala:21)
2021-10-11 17:06:55at evalOn @ doobie.util.transactor$Transactor$fromDataSource$FromDataSourceUnapplied.$anonfun$apply$13(transactor.scala:294)
2021-10-11 17:06:55at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
2021-10-11 17:06:55at evalOn @ doobie.util.transactor$Transactor$fromDataSource$FromDataSourceUnapplied.$anonfun$apply$13(transactor.scala:294)
```

Other error logs during execution 
```
2021-10-11T15:06:55,882+0000 [1 35] com.newrelic ERROR: Inconsistent state! tracer != last tracer for com.newrelic.agent.TransactionActivity@0 (com.newrelic.agent.tracers.OtherRootTracer@5b415617 != com.newrelic.agent.tracers.OtherRootTracer@3d974848)
```

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
