### PR TITLE
Configure Caffeine caches with a same-thread executor

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/ThreadService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/ThreadService.java
@@ -32,7 +32,7 @@ public class ThreadService extends AbstractService implements ThreadNames {
 
     public static final String NAME_PATTERN_CFG_KEY = "thread_sampler.name_pattern";
     private final Map<Long, Boolean> agentThreadIds;
-    private final Cache<Long, String> threadIdToName = Caffeine.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).build();
+    private final Cache<Long, String> threadIdToName = Caffeine.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).executor(Runnable::run).build();
     private volatile ThreadNameNormalizer threadNameNormalizer;
 
     public ThreadService() {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/DefaultDestinationPredicate.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/DefaultDestinationPredicate.java
@@ -56,7 +56,7 @@ public class DefaultDestinationPredicate implements DestinationPredicate {
         configTrie = generateConfigTrie(dest, exclude, include);
         defaultExcludeTrie = generateDefaultTrie(dest, defaultExcludes);
         destination = dest;
-        cache = Caffeine.newBuilder().maximumSize(MAX_CACHE_SIZE_BUFFER).build(this::isIncluded);
+        cache = Caffeine.newBuilder().maximumSize(MAX_CACHE_SIZE_BUFFER).executor(Runnable::run).build(this::isIncluded);
     }
 
     private Boolean isIncluded(String key) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/database/CachingDatabaseStatementParser.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/database/CachingDatabaseStatementParser.java
@@ -35,7 +35,7 @@ public class CachingDatabaseStatementParser implements DatabaseStatementParser {
         if (null == statements) {
             synchronized (this) {
                 if (null == statements) {
-                    statements = Caffeine.newBuilder().maximumSize(1000).weakKeys().build();
+                    statements = Caffeine.newBuilder().maximumSize(1000).weakKeys().executor(Runnable::run).build();
                 }
             }
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/extension/ExtensionHolderFactoryImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/extension/ExtensionHolderFactoryImpl.java
@@ -35,6 +35,7 @@ public class ExtensionHolderFactoryImpl implements ExtensionHolderFactory {
         private final Cache<Object, T> instanceCache = Caffeine.newBuilder()
                 .initialCapacity(32)
                 .weakKeys()
+                .executor(Runnable::run)
                 .build();
         // @formatter:on
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/DiscoveryProfile.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/DiscoveryProfile.java
@@ -40,7 +40,7 @@ public class DiscoveryProfile implements JSONStreamAware {
         this.threadNameNormalizer = threadNameNormalizer;
         this.profile = profile;
         discoveryProfileTrees = 
-            Caffeine.newBuilder().build(
+            Caffeine.newBuilder().executor(Runnable::run).build(
                     threadNameKey -> new ProfileTree(DiscoveryProfile.this.profile, false));
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/Profile.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/Profile.java
@@ -82,7 +82,7 @@ public class Profile implements IProfile {
     private int runnableThreadCount = 0;
     private final ThreadMXBean threadMXBean;
     private final LoadingCache<Long, Long> startThreadCpuTimes = 
-        Caffeine.newBuilder().build(
+        Caffeine.newBuilder().executor(Runnable::run).build(
             new CacheLoader<Long, Long>() {
 
                 @Override
@@ -95,7 +95,7 @@ public class Profile implements IProfile {
     
     private final Map<Long, ProfileTree> threadIdToProfileTrees = new HashMap<>();
     private final LoadingCache<String, ProfileTree> profileTrees =
-            Caffeine.newBuilder().build(createCacheLoader(true));
+            Caffeine.newBuilder().executor(Runnable::run).build(createCacheLoader(true));
     
     private final StringMap stringMap = new Murmur3StringMap();
     private final ProfiledMethodFactory profiledMethodFactory;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/TransactionProfile.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/TransactionProfile.java
@@ -55,8 +55,8 @@ class TransactionProfile implements JSONStreamAware {
     public TransactionProfile(final Profile profile, final ThreadNameNormalizer threadNameNormalizer) {
         this.threadMXBean = ManagementFactory.getThreadMXBean();
         this.threadNameNormalizer = threadNameNormalizer;
-        threadProfiles = Caffeine.newBuilder().build(profile.createCacheLoader(false));
-        threadActivityProfiles = Caffeine.newBuilder().build(
+        threadProfiles = Caffeine.newBuilder().executor(Runnable::run).build(profile.createCacheLoader(false));
+        threadActivityProfiles = Caffeine.newBuilder().executor(Runnable::run).build(
                 threadName -> new TransactionActivityTree(profile));
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/TransactionProfileSessionImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/TransactionProfileSessionImpl.java
@@ -84,11 +84,11 @@ public class TransactionProfileSessionImpl implements TransactionProfileSession 
         this.threadService = threadService;
         this.profile = profile; 
         this.transactionProfileTrees =
-                Caffeine.newBuilder().build(
+                Caffeine.newBuilder().executor(Runnable::run).build(
                         transactionName -> new TransactionProfile(profile, threadNameNormalizer));
         this.discoveryProfile = new DiscoveryProfile(profile, threadNameNormalizer);
         this.stackTraceLimits =
-                Caffeine.newBuilder().expireAfterAccess(5, TimeUnit.SECONDS).build(
+                Caffeine.newBuilder().expireAfterAccess(5, TimeUnit.SECONDS).executor(Runnable::run).build(
                         metricName -> new AtomicInteger(0));
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/InsightsServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/InsightsServiceImpl.java
@@ -60,7 +60,7 @@ public class InsightsServiceImpl extends AbstractService implements InsightsServ
     private final ConcurrentHashMap<String, DistributedSamplingPriorityQueue<CustomInsightsEvent>> reservoirForApp = new ConcurrentHashMap<>();
 
     private static final LoadingCache<String, String> stringCache = Caffeine.newBuilder().maximumSize(1000)
-            .expireAfterAccess(70, TimeUnit.SECONDS).build(key -> key);
+            .expireAfterAccess(70, TimeUnit.SECONDS).executor(Runnable::run).build(key -> key);
 
     protected final ExtendedTransactionListener transactionListener = new ExtendedTransactionListener() {
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TransactionEventsService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TransactionEventsService.java
@@ -125,6 +125,7 @@ public class TransactionEventsService extends AbstractService implements EventSe
         return Caffeine.newBuilder()
                 .maximumSize(maxSamplesStored)
                 .expireAfterAccess(5, TimeUnit.MINUTES)
+                .executor(Runnable::run)
                 .build(key -> key);
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/async/AsyncTransactionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/async/AsyncTransactionService.java
@@ -76,6 +76,7 @@ public class AsyncTransactionService extends AbstractService implements HarvestL
                 .expireAfterWrite(timeOutMilli, TimeUnit.MILLISECONDS)
                 .removalListener(removalListener)
                 .initialCapacity(8)
+                .executor(Runnable::run)
                 .build();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/sql/BoundedConcurrentCache.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/sql/BoundedConcurrentCache.java
@@ -43,6 +43,7 @@ public class BoundedConcurrentCache<K, V extends Comparable<V> & CacheValue<K>> 
         this.priorityQueue = new PriorityBlockingQueue<>(size, comparator);
         this.cache = Caffeine.newBuilder()
                 .initialCapacity(16)
+                .executor(Runnable::run)
                 .build();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadStateSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadStateSampler.java
@@ -33,7 +33,7 @@ public class ThreadStateSampler implements Runnable {
      * A cache of thread ids to some tracked thread state.  The cpu times reported by the Java apis we use are monotonically
      * increasing, so we have to track previous values and compute deltas.
      */
-    private final LoadingCache<Long, ThreadTracker> threads = Caffeine.newBuilder().expireAfterAccess(3, TimeUnit.MINUTES).build(
+    private final LoadingCache<Long, ThreadTracker> threads = Caffeine.newBuilder().expireAfterAccess(3, TimeUnit.MINUTES).executor(Runnable::run).build(
             threadId -> new ThreadTracker());
     private final ThreadMXBean threadMXBean;
     private final ThreadNameNormalizer threadNameNormalizer;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/metricname/MetricNameFormats.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/metricname/MetricNameFormats.java
@@ -19,6 +19,7 @@ import com.newrelic.agent.util.Strings;
 public class MetricNameFormats {
 
     private static final Cache<MNFKey, MetricNameFormat> cmsToMnf = Caffeine.newBuilder()
+                                                                                .executor(Runnable::run)
                                                                                 .build();
 
     private MetricNameFormats() {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transaction/TransactionCache.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transaction/TransactionCache.java
@@ -29,7 +29,7 @@ public class TransactionCache {
 
     private Cache<Object, MetricNameFormatWithHost> getInputStreamCache() {
         if (inputStreamCache == null) {
-            inputStreamCache = Caffeine.newBuilder().weakKeys().build();
+            inputStreamCache = Caffeine.newBuilder().weakKeys().executor(Runnable::run).build();
         }
         return inputStreamCache;
     }
@@ -44,7 +44,7 @@ public class TransactionCache {
 
     private Cache<Object, URL> getUrlCache() {
         if (urlCache == null) {
-            urlCache = Caffeine.newBuilder().weakKeys().build();
+            urlCache = Caffeine.newBuilder().weakKeys().executor(Runnable::run).build();
         }
         return urlCache;
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
@@ -17,7 +17,7 @@ public class AgentCollectionFactory implements CollectionFactory {
 
     @Override
     public <K, V> Map<K, V> createConcurrentWeakKeyedMap() {
-        Cache<K, V> cache = Caffeine.newBuilder().initialCapacity(32).weakKeys().build();
+        Cache<K, V> cache = Caffeine.newBuilder().initialCapacity(32).weakKeys().executor(Runnable::run).build();
         return cache.asMap();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/bootstrap/EmbeddedJarFilesImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/bootstrap/EmbeddedJarFilesImpl.java
@@ -28,7 +28,7 @@ public class EmbeddedJarFilesImpl implements EmbeddedJarFiles {
     /**
      * A map of jar names to the temp files containing those jars.
      */
-    private final LoadingCache<String, File> embeddedAgentJarFiles = Caffeine.newBuilder().build(
+    private final LoadingCache<String, File> embeddedAgentJarFiles = Caffeine.newBuilder().executor(Runnable::run).build(
             new CacheLoader<String, File>() {
 
                 @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/extension/DependencyRemapperTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/extension/DependencyRemapperTest.java
@@ -86,7 +86,7 @@ public class DependencyRemapperTest {
         public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
             // Make sure we pick up this Caffeine reference.
             Caffeine<Object, Object> newBuilder = Caffeine.newBuilder();
-            // Make sure we pick up this Caffeine reference.
+            // Make sure we pick up this Guava reference.
             ImmutableSet<Object> set = ImmutableSet.of();
             return super.visitMethod(access, name, desc, signature, exceptions);
         }

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageManager.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageManager.java
@@ -63,7 +63,7 @@ public class WeavePackageManager {
     /**
      * ClassLoader -> (WeavePackageName -> WeavePackage)
      */
-    private final Cache<ClassLoader, ConcurrentMap<String, WeavePackage>> optimizedWeavePackages = Caffeine.newBuilder().weakKeys().build();
+    private final Cache<ClassLoader, ConcurrentMap<String, WeavePackage>> optimizedWeavePackages = Caffeine.newBuilder().weakKeys().executor(Runnable::run).build();
 
     private final WeavePackageLifetimeListener packageListener;
     private final Instrumentation instrumentation;
@@ -88,12 +88,12 @@ public class WeavePackageManager {
      * classloader -> (weave package -> result of successful weaving)
      */
     Cache<ClassLoader, ConcurrentMap<WeavePackage, PackageValidationResult>> validPackages = Caffeine.newBuilder().weakKeys().initialCapacity(
-            8).maximumSize(MAX_VALID_PACKAGE_CACHE).build();
+            8).maximumSize(MAX_VALID_PACKAGE_CACHE).executor(Runnable::run).build();
     /**
      * classloader -> (weave package -> result of successful weaving)
      */
     Cache<ClassLoader, ConcurrentMap<WeavePackage, PackageValidationResult>> invalidPackages = Caffeine.newBuilder().weakKeys().initialCapacity(
-            8).maximumSize(MAX_INVALID_PACKAGE_CACHE).build();
+            8).maximumSize(MAX_INVALID_PACKAGE_CACHE).executor(Runnable::run).build();
 
     WeavePackageManager() {
         this(null);


### PR DESCRIPTION
By default Caffeine uses `ForkJoinPool.commonPool()`. When running Java 17, usage of `ForkJoinPool` early in the agent's life cycle may trigger an initialization failure which causes the pool to become non-functional. This may produce out-of-memory errors as well as functional errors in the instrumented application. See #558 for details.

_Note:_ this PR updates only caches for which some cleanup/expiry policy exists, as (IIUC) instances created using "just" `Caffeine.newBuilder().build(someLoader)` don't use the configured executor anyway. If I got that wrong, please let me know and I'll update also the remaining usages. (And if I got it right, please double-check that I didn't miss any.)