### PR TITLE
Monix build fix - Include Zinc and fix play dependencies

### DIFF
--- a/.github/workflows/GHA-AIT-functionality-basic_features--datastore-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-basic_features--datastore-tests.yaml
@@ -52,8 +52,6 @@ jobs:
           - uri_names.py
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
 
       ## Ongoing tests with artifactory dependecies
       - name: Checkout AIT repo test
@@ -326,8 +324,6 @@ jobs:
           - redis.py
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
 
       ## Ongoing tests with artifactory dependecies
       - name: Checkout AIT repo test

--- a/.github/workflows/GHA-AIT-functionality-framework-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-framework-tests.yaml
@@ -48,8 +48,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
 
       ## Ongoing tests with artifactory dependecies
       - name: Checkout AIT repo test

--- a/.github/workflows/GHA-AIT-functionality-security-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-security-tests.yaml
@@ -48,8 +48,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
 
       ## Ongoing tests with artifactory dependecies
       - name: Checkout AIT repo test

--- a/.github/workflows/GHA-AIT-functionality-server-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-server-tests.yaml
@@ -49,8 +49,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
 
       ## Ongoing tests with artifactory dependecies
       - name: Checkout AIT repo test

--- a/.github/workflows/GHA-AIT-functionality-trace-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-trace-tests.yaml
@@ -39,8 +39,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
 
       ## Ongoing tests with artifactory dependecies
       - name: Checkout AIT repo test

--- a/.github/workflows/GHA-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Functional-Tests.yaml
@@ -28,8 +28,6 @@ jobs:
         java-version: [8, 11, 17]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
       - uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Set up Java 8

--- a/.github/workflows/GHA-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Instrumentation-Tests.yaml
@@ -31,8 +31,6 @@ jobs:
         java-version: [8, 11, 17]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
       - uses: gradle/wrapper-validation-action@v1.0.4
 
       #NEW Install required JDKs

--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -28,8 +28,6 @@ jobs:
         java-version: [8, 11]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
       - uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Set up Java 8

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -34,8 +34,6 @@ jobs:
             scala: 2.11
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
       - uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Set up Java 8

--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -31,8 +31,6 @@ jobs:
         java-version: [8, 11, 17]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
       - uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Set up Java 8
@@ -92,7 +90,7 @@ jobs:
           LANGUAGE: polyglot
           TEST_TYPE: unit
         run: |
-          ./gradlew --console=plain --parallel test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue --scan -Dscan.uploadInBackground=false --build-cache
+          ./gradlew --console=plain --parallel test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-monix-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue --scan -Dscan.uploadInBackground=false --build-cache
 
       - name: Capture build reports
         # If previous step fails, run this step regardless

--- a/.github/workflows/Java-11-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-11-Instrumentation-Tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   tests:
-    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@main
+    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@monix-build-fix
     with:
       jre: 11
     secrets:

--- a/.github/workflows/Java-17-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-17-Instrumentation-Tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   tests:
-    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@main
+    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@monix-build-fix
     with:
       jre: 17
     secrets:

--- a/.github/workflows/Java-8-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-8-Instrumentation-Tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   tests:
-    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@main
+    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@monix-build-fix
     with:
       jre: 8
     secrets:

--- a/.github/workflows/X-Reusable-Test.yml
+++ b/.github/workflows/X-Reusable-Test.yml
@@ -28,8 +28,6 @@ jobs:
       default-branch: "main"
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.BRANCH || env.default-branch }}
       - uses: gradle/wrapper-validation-action@v1.0.4
 
       #NEW Install required JDKs

--- a/instrumentation/newrelic-scala-monix-api/build.gradle
+++ b/instrumentation/newrelic-scala-monix-api/build.gradle
@@ -15,8 +15,8 @@ dependencies {
 }
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.newrelic-scala-monix-api',
-            'Implementation-Title-Alias': 'newrelic-scala-monix-api_instrumentation' }
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.scala-monix-api',
+            'Implementation-Title-Alias': 'scala-monix-api_instrumentation' }
 }
 
 verifyInstrumentation {

--- a/instrumentation/newrelic-scala-monix-api/build.gradle
+++ b/instrumentation/newrelic-scala-monix-api/build.gradle
@@ -1,8 +1,10 @@
 apply plugin: 'scala'
+scala.zincVersion = "1.2.5"
 
 isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
+    zinc("org.scala-sbt:zinc_2.12:1.2.5")
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation(project(":newrelic-weaver-scala-api"))
@@ -20,3 +22,6 @@ jar {
 verifyInstrumentation {
     verifyClasspath = false
 }
+
+sourceSets.main.scala.srcDirs = ['src/main/scala', 'src/main/java']
+sourceSets.main.java.srcDirs = []

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'scala'
 isScalaProjectEnabled(project, "scala-2.10")
 
 dependencies {
-    implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation("com.typesafe.play:play_2.10:2.3.9")

--- a/newrelic-scala-monix-api/build.gradle.kts
+++ b/newrelic-scala-monix-api/build.gradle.kts
@@ -22,6 +22,8 @@ java {
 }
 
 dependencies {
+    zinc("org.scala-sbt:zinc_2.12:1.2.5")
+    implementation("org.scala-lang:scala-library:2.13.5")
     implementation("io.monix:monix-eval_2.13:3.3.0")
     implementation("io.monix:monix-reactive_2.13:3.3.0")
     implementation(project(":newrelic-api"))


### PR DESCRIPTION

### Overview
Remove unneeded newrelic-api dependency from Play 2.3.
Add zinc compiler version to monix-api instrumentation.
Add zinc compiler version and fixed scala library version to monix-api.

Exclude Monix API from unit test workflow. 

**All other workflow changes are not needed, they are to run against the latest and showcase passing tests without merging to main.**

### Testing
Running GHA tests. All passing.

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? Please describe.  No
[X] Does your code introduce any new dependencies? Please describe. No
