### PR TITLE
cats effect 3: pass transaction info by implicits

### DIFF
--- a/instrumentation/cats-effect-3/src/main/java/cats/effect/internals/Utils.java
+++ b/instrumentation/cats-effect-3/src/main/java/cats/effect/internals/Utils.java
@@ -51,7 +51,7 @@ public final class Utils {
   }
 
   public static void setThreadTokenAndRefCount(AgentBridge.TokenAndRefCount tokenAndRefCount) {
-    if (tokenAndRefCount != null) {
+    if (tokenAndRefCount != null && tokenAndRefCount.token != null) {
       logTokenInfo(tokenAndRefCount, "setting token to thread");
       AgentBridge.activeToken.set(tokenAndRefCount);
       tokenAndRefCount.token.link();

--- a/instrumentation/newrelic-cats-effect3-api/src/main/scala/com/newrelic/cats3/api/TraceOps_Instrumentation.scala
+++ b/instrumentation/newrelic-cats-effect3-api/src/main/scala/com/newrelic/cats3/api/TraceOps_Instrumentation.scala
@@ -1,12 +1,13 @@
 package com.newrelic.cats3.api
 
 import cats.effect.Sync
+import com.newrelic.api.agent.NewRelic
 import com.newrelic.api.agent.weaver.Weaver
 import com.newrelic.api.agent.weaver.scala.{ScalaMatchType, ScalaWeave}
 
 @ScalaWeave(`type` = ScalaMatchType.Object, `originalName` = "com.newrelic.cats3.api.TraceOps")
 class TraceOps_Instrumentation {
-  def txn[S, F[_]:Sync](body: F[S]): F[S] = {
-    Util.wrapTrace(Weaver.callOriginal)
+  def txn[S, F[_]:Sync](body: TxnInfo => F[S]): F[S] = {
+    Util.wrapTrace(body)
   }
 }

--- a/instrumentation/newrelic-cats-effect3-api/src/main/scala/com/newrelic/cats3/api/Util.scala
+++ b/instrumentation/newrelic-cats-effect3-api/src/main/scala/com/newrelic/cats3/api/Util.scala
@@ -2,32 +2,46 @@ package com.newrelic.cats3.api
 
 import cats.effect.Sync
 import cats.implicits._
-import com.newrelic.agent.bridge.{AgentBridge, ExitTracer, Transaction, TracedMethod}
+import com.newrelic.agent.bridge.{AgentBridge, ExitTracer, Token, Transaction}
+import com.newrelic.api.agent.NewRelic
 
 import java.util.concurrent.atomic.AtomicInteger
 
 object Util {
   val RETURN_OPCODE = 176
 
-  def wrapTrace[S, F[_] : Sync](body: F[S]): F[S] =
-    Sync[F].delay(AgentBridge.instrumentation.createScalaTxnTracer())
-           .redeemWith(_ => body,
-             tracer =>
-               if (tracer == null) {
-                 body
-               } else {
-                 for {
-                   txnWithTracedMethod <- Sync[F].delay {
-                     val agent = AgentBridge.getAgent
-                     (agent.getTransaction(false), agent.getTracedMethod)
-                   }
-                   _ <- setupTokenAndRefCount(txnWithTracedMethod)
-                   res <- attachErrorEvent(body, tracer)
-                   _ <- cleanupTxnAndTokenRefCount(txnWithTracedMethod._1)
-                   _ <- Sync[F].delay(tracer.finish(RETURN_OPCODE, null))
-                 } yield res
-               }
-           )
+  def wrapTrace[S, F[_] : Sync](body: TxnInfo => F[S]): F[S] =
+    Sync[F].delay {
+      val tracer = AgentBridge.instrumentation.createScalaTxnTracer()
+      (tracer, optTxnInfo())
+    }.redeemWith(
+      _ => body(txnInfo),
+      tracerAndTxnInfo => {
+        val (tracer, optTxnInfo) = tracerAndTxnInfo
+        for {
+          _ <- Sync[F].delay(AgentBridge.getAgent.getTransaction(false))
+          updatedTxnInfo <- setupTokenAndRefCount(optTxnInfo, txnInfo)
+          res <- attachErrorEvent(body(updatedTxnInfo), tracer)
+          _ <- cleanupTxnAndTokenRefCount(updatedTxnInfo)
+          _ <- Sync[F].delay(tracer.finish(RETURN_OPCODE, null))
+        } yield res
+      }
+    )
+
+  private def txnInfo = {
+    val txn = NewRelic.getAgent.getTransaction
+    TxnInfo(txn, txn.getToken)
+  }
+
+  def optTxnInfo(): (Transaction, Token) = {
+    val txn = AgentBridge.getAgent.getTransaction(false)
+    if (txn != null) {
+      (txn, txn.getToken)
+    } else {
+      null
+    }
+  }
+
 
   private def attachErrorEvent[S, F[_] : Sync](body: F[S], tracer: ExitTracer): F[S] =
     body
@@ -36,23 +50,29 @@ object Util {
         Sync[F].raiseError(throwable)
       })
 
-  private def setupTokenAndRefCount[F[_] : Sync](txnWithTracerMethod: (Transaction, TracedMethod)): F[Unit] = Sync[F].delay {
-
-    val (txn, tracedMethod) = txnWithTracerMethod
-    if (txn != null && tracedMethod != null) {
-      AgentBridge.activeToken.set(
-        new AgentBridge.TokenAndRefCount(
-          txn.getToken,
-          tracedMethod,
-          new AtomicInteger(0)
-        ))
+  private def setupTokenAndRefCount[F[_] : Sync](optTxn: (Transaction, Token), fallback: => TxnInfo)
+  : F[TxnInfo] =
+    Sync[F].delay {
+      if (optTxn != null) {
+        val (txn, token) = optTxn
+        AgentBridge.activeToken.set(
+          new AgentBridge.TokenAndRefCount(
+            token,
+            AgentBridge.getAgent.getTracedMethod,
+            new AtomicInteger(0)
+          )
+        )
+        TxnInfo(txn, token)
+      } else {
+        fallback
+      }
     }
-  }
 
-  private def cleanupTxnAndTokenRefCount[F[_] : Sync](txn: Transaction): F[Unit] = Sync[F].delay {
-    AgentBridge.activeToken.remove()
-    if (txn != null) {
-      txn.expireAllTokens()
+  private def cleanupTxnAndTokenRefCount[F[_] : Sync](txnInfo: TxnInfo): F[Unit] = Sync[F].delay {
+    val tokenAndRefCount = AgentBridge.activeToken.get()
+    if (tokenAndRefCount != null) {
+      AgentBridge.activeToken.remove()
     }
+    txnInfo.transaction.asInstanceOf[Transaction].expireAllTokens()
   }
 }

--- a/newrelic-cats-effect3-api/src/test/scala/com/newrelic/cats3/api/CatsEffectIOTest3.scala
+++ b/newrelic-cats-effect3-api/src/test/scala/com/newrelic/cats3/api/CatsEffectIOTest3.scala
@@ -6,8 +6,9 @@ import TraceOps._
 import com.newrelic.agent.introspec._
 import org.junit.runner.RunWith
 import org.junit.{After, Assert, Test}
+
 import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 import scala.util.Try
@@ -16,30 +17,28 @@ import cats.effect.unsafe.implicits.global
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("none"))
 class CatsEffectIOTest3 {
-  private def executorService(nThreads: Int) = {
+  private def executorService(nThreads: Int): ExecutionContextExecutor = {
     ExecutionContext.fromExecutor(Executors.newFixedThreadPool(nThreads))
   }
-
-  def threadPoolOne: ExecutionContext = executorService(3)
-
-  def threadPoolTwo: ExecutionContext = executorService(3)
-
-  def threadPoolThree: ExecutionContext = executorService(3)
 
   @After
   def resetTxn(): Unit = {
     com.newrelic.agent.Transaction.clearTransaction()
   }
 
+  /**
+    * asyncTraceProducesOneSegment: simple test to check a transaction with 1 segement
+    * returning the correct result when run
+    */
   @Test
   def asyncTraceProducesOneSegment(): Unit = {
     //Given
     val introspector: Introspector = InstrumentationTestRunner.getIntrospector
     //When
-    val txnBlock: IO[Int] = txn {
+    val txnBlock: IO[Int] = txn { implicit txnInfo =>
       asyncTrace("getNumber")(IO(1))
     }
-    val result = txnBlock.unsafeRunTimed(2.seconds)
+    val result = txnBlock.evalOn(executorService(2)).unsafeRunTimed(2.seconds)
     val txnCount = introspector.getFinishedTransactionCount()
     val traces = getTraces(introspector)
     val segments = getSegments(traces)
@@ -48,46 +47,55 @@ class CatsEffectIOTest3 {
     Assert.assertTrue("transaction finished", txnCount >= 1)
     Assert.assertTrue("Trace present", traces.nonEmpty)
     Assert.assertTrue("getFirstNumber segment exists", segments.exists(_.getName == s"Custom/getNumber"))
+    introspector.clear()
   }
 
+  /**
+    * chainedSyncAndAsyncTraceSegmentsCaptured: test to check a transaction with 3 segements
+    * created using `asyncTrace`, `traceFun` and `asyncTraceFun` together
+    */
   @Test
   def chainedSyncAndAsyncTraceSegmentsCaptured(): Unit = {
     //Given
     val introspector: Introspector = InstrumentationTestRunner.getIntrospector
     //When
-    val txnBlock: IO[Int] = txn(
+    val txnBlock: IO[Int] = txn(implicit txnInfo =>
       asyncTrace("getNumber") {
         IO(1)
-      }
-        .map(traceFun("incrementNumber")(_ + 1))
-        .flatMap(asyncTraceFun("flatMapIncrementNumber")(res => IO(res + 1)))
+      }.map(traceFun("incrementNumber")(_ + 1))
+       .flatMap(asyncTraceFun("flatMapIncrementNumber")(res => IO(res + 1)))
     )
-    val result = txnBlock.unsafeRunTimed(2.seconds)
+    val result = txnBlock.evalOn(executorService(2)).unsafeRunTimed(2.seconds)
     val txnCount = introspector.getFinishedTransactionCount()
     val traces = getTraces(introspector)
     val segments = getSegments(traces)
     //Then
     Assert.assertEquals("Result correct", Option(3), result)
-    Assert.assertEquals("Transaction finished", 1, txnCount)
+    Assert.assertTrue("Transaction finished", txnCount >= 1)
     Assert.assertTrue("Trace present", traces.nonEmpty)
     Assert.assertTrue("getNumber segment exists", segments.exists(_.getName == s"Custom/getNumber"))
     Assert.assertTrue("incrementNumber segment exists", segments.exists(_.getName == s"Custom/incrementNumber"))
     Assert.assertTrue("flatMapIncrementNumber segment exists", segments.exists(_.getName == s"Custom/flatMapIncrementNumber"))
+    introspector.clear()
   }
 
+  /**
+    * forComprehensionSegments: test to check a transaction with 3 segments
+    * created inside a for comprehension.
+    */
   @Test
   def forComprehensionSegments(): Unit = {
     //Given
     val introspector: Introspector = InstrumentationTestRunner.getIntrospector
     //When
-    val txnBlock: IO[Int] = txn(
+    val txnBlock: IO[Int] = txn(implicit txnInfo =>
       for {
         one <- asyncTrace("one")(IO(1))
         two <- asyncTrace("two")(IO(one + 1))
         three <- asyncTrace("three")(IO(two + 1))
       } yield three
     )
-    val result = txnBlock.unsafeRunTimed(2.seconds)
+    val result = txnBlock.evalOn(executorService(2)).unsafeRunTimed(2.seconds)
     val txnCount = introspector.getFinishedTransactionCount()
     val traces = getTraces(introspector)
     val segments = getSegments(traces)
@@ -98,20 +106,93 @@ class CatsEffectIOTest3 {
     Assert.assertTrue("one segment exists", segments.exists(_.getName == s"Custom/one"))
     Assert.assertTrue("two segment exists", segments.exists(_.getName == s"Custom/two"))
     Assert.assertTrue("three segment exists", segments.exists(_.getName == s"Custom/three"))
+    introspector.clear()
   }
 
+  /**
+    * forComprehensionSegmentsSeparateExecutors: test to check a transaction with 3 segments
+    * created inside a for comprehension. Each segement is executed on a separate thread pool
+    * using cats-effect `evalOn`
+    */
+  @Test
+  def forComprehensionSegmentsSeparateExecutors(): Unit = {
+    //Given
+    val introspector: Introspector = InstrumentationTestRunner.getIntrospector
+    val txnBlock: IO[Int] = txn(implicit txnInfo =>
+      for {
+        one <- asyncTrace("one")(IO(1).evalOn(executorService(3)))
+        two <- asyncTrace("two")(IO(one + 1).evalOn(executorService(5)))
+        three <- asyncTrace("three")(IO(two + 1).evalOn(executorService(10)))
+      } yield three)
+    //When
+    val result = txnBlock.evalOn(executorService(2)).unsafeRunTimed(2.seconds)
+    val txnCount = introspector.getFinishedTransactionCount()
+    val traces = getTraces(introspector)
+    val segments = getSegments(traces)
+    val segmentNames = segments.map(_.getName).toList
+    //Then
+    Assert.assertEquals("Result correct", Some(3), result)
+    Assert.assertTrue("Transaction finished", txnCount >= 1)
+    Assert.assertTrue("Trace present", traces.nonEmpty)
+    Assert.assertTrue(s"one segment exists $segmentNames", segments.exists(_.getName == s"Custom/one"))
+    Assert.assertTrue(s"two segment exists $segmentNames", segments.exists(_.getName == s"Custom/two"))
+    Assert.assertTrue(s"three segment exists $segmentNames", segments.exists(_.getName == s"Custom/three"))
+    introspector.clear()
+  }
+
+  /**
+    * sequentialAsyncTraceSegmentTimeCaptured: test to check a transaction with 3 segments
+    * created inside a for comprehension.
+    * The 2nd segment "sleep" is scheduled to complete after 1500 milliseconds, the test asserts that
+    * the segment takes at least 1500 milliseconds to complete
+    */
+  @Test
+  def sequentialAsyncTraceSegmentTimeCaptured(): Unit = {
+    //Given
+    val introspector: Introspector = InstrumentationTestRunner.getIntrospector
+    val delayMillis = 1500
+    //When
+    val txnBlock: IO[Int] = txn(implicit txnInfo =>
+      for {
+        one <- asyncTrace("one")(IO(1))
+        _ <- asyncTrace("sleep")(IO.sleep(delayMillis.millis).evalOn(executorService(3)))
+        two <- asyncTrace("two")(IO(one + 1))
+      } yield two
+    )
+    val result = txnBlock.evalOn(executorService(2)).unsafeRunTimed(2.seconds)
+    val txnCount = introspector.getFinishedTransactionCount()
+    val traces = getTraces(introspector)
+    val segments = getSegments(traces)
+    //Then
+    Assert.assertEquals("Result correct", Option(2), result)
+    Assert.assertTrue("Transaction finished", txnCount >= 1)
+    Assert.assertTrue("Trace present", traces.nonEmpty)
+    Assert.assertTrue("one segment exists", segments.exists(_.getName == s"Custom/one"))
+    Assert.assertTrue("two segment exists", segments.exists(_.getName == s"Custom/two"))
+    assertSegmentExistsAndTimeInRange("sleep", segments, delayMillis)
+    introspector.clear()
+  }
+
+
+  /**
+    * segmentCompletedIfIOErrors: test to check a transaction with 2 segments
+    * created inside a for comprehension.
+    * The 2nd segment "sleep" is creates an error causing the block to also yield an
+    * error when run.
+    * The test asserts that both successfull and error segments are captured
+    */
   @Test
   def segmentCompletedIfIOErrors(): Unit = {
     //Given
     val introspector: Introspector = InstrumentationTestRunner.getIntrospector
     //When
-    val txnBlock: IO[Int] = txn(
+    val txnBlock: IO[Int] = txn(implicit txnInfo =>
       for {
-        one <- asyncTrace("one")(IO(1).evalOn(threadPoolOne))
+        one <- asyncTrace("one")(IO(1).evalOn(executorService(3)))
         _ <- asyncTrace("boom")(IO.raiseError(new Throwable("Boom!")))
       } yield one
     )
-    val result = Try(txnBlock.unsafeRunSync())
+    val result = Try(txnBlock.evalOn(executorService(2)).unsafeRunSync())
     val txnCount = introspector.getFinishedTransactionCount()
     val traces = getTraces(introspector)
     val segments = getSegments(traces)
@@ -121,13 +202,21 @@ class CatsEffectIOTest3 {
     Assert.assertTrue("Trace present", traces.nonEmpty)
     Assert.assertTrue("one segment exists", segments.exists(_.getName == s"Custom/one"))
     Assert.assertTrue("two segment exists", segments.exists(_.getName == s"Custom/boom"))
+    introspector.clear()
   }
 
+  /**
+    * parallelTraverse: test to check a transaction with 6 segments
+    * created inside a for comprehension.
+    * Segments 2-5 are created in parallel, the final segment is executed after
+    * the others complete summing the results of Ints returned from each segment
+    * The test asserts that both sequential and parrallel segments are captured
+    */
   @Test
   def parallelTraverse(): Unit = {
     //Given
     val introspector: Introspector = InstrumentationTestRunner.getIntrospector
-    val txnBlock: IO[Int] = txn(
+    val txnBlock: IO[Int] = txn(implicit txnInfo =>
       for {
         one <- IO(trace("segment 1")(1))
         rest <- List(2, 3, 4, 5).parTraverse(i => asyncTrace(s"segment $i")(IO(i)))
@@ -135,19 +224,20 @@ class CatsEffectIOTest3 {
       } yield sum
     )
 
-    val result = txnBlock.unsafeRunTimed(2.seconds)
+    val result = txnBlock.evalOn(executorService(2)).unsafeRunTimed(2.seconds)
 
-      val txnCount = introspector.getFinishedTransactionCount()
-      val traces = getTraces(introspector)
-      val segments = getSegments(traces)
+    val txnCount = introspector.getFinishedTransactionCount()
+    val traces = getTraces(introspector)
+    val segments = getSegments(traces)
 
-      Assert.assertEquals("Result correct", Some(15), result)
-      Assert.assertTrue("Transaction finished", txnCount >= 1)
-      Assert.assertTrue("Trace present", traces.nonEmpty)
-      List(1, 2, 3, 4, 5).foreach(i =>
-        Assert.assertTrue(s"$i segment exists: ${segments.map(_.getName)}", segments.exists(_.getName == s"Custom/segment $i"))
-      )
-      Assert.assertTrue(s"sum segments exists", segments.exists(_.getName == s"Custom/sum segments"))
+    Assert.assertEquals("Result correct", Some(15), result)
+    Assert.assertTrue("Transaction finished", txnCount >= 1)
+    Assert.assertTrue("Trace present", traces.nonEmpty)
+    List(1, 2, 3, 4, 5).foreach(i =>
+      Assert.assertTrue(s"$i segment exists: ${segments.map(_.getName)}", segments.exists(_.getName == s"Custom/segment $i"))
+    )
+    Assert.assertTrue(s"sum segments exists", segments.exists(_.getName == s"Custom/sum segments"))
+    introspector.clear()
   }
 
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
@@ -174,4 +264,5 @@ class CatsEffectIOTest3 {
       )
     })
   }
+
 }


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
This is a change to the newrelic scala cats 3 api. The change ensures transaction and current token information is passed by parameters rather than ThreadLocal variables. Parameters used are [implicit](https://docs.scala-lang.org/tour/implicit-parameters.html), this helps to keep API changes to a minimum

### Related Github Issue
Include a link to the related GitHub issue, if applicable
#406

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[N] Are your contributions backwards compatible with relevant frameworks and APIs?
A small breaking change was necessary for the Cats Effect 3 API. 
```
    val txnBlock: IO[Int] = txn(
      for {
        one <- asyncTrace("one")(IO(1))
        two <- asyncTrace("two")(IO(one + 1))
        three <- asyncTrace("three")(IO(two + 1))
      } yield three
    )
```
now becomes 
```
    val txnBlock: IO[Int] = txn(implicit txnInfo =>
      for {
        one <- asyncTrace("one")(IO(1))
        two <- asyncTrace("two")(IO(one + 1))
        three <- asyncTrace("three")(IO(two + 1))
      } yield three
    )
```    
[ Y] Does your code contain any breaking changes? Please describe. 
See above
[ N] Does your code introduce any new dependencies? Please describe.

