### PR TITLE
optimization: change String.replaceAll in favor of Pattern.compile

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
@@ -183,6 +183,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
 
     // per protocol 15+, region aware license keys must match this regex before constructing collector host
     public static final Pattern REGION_AWARE = Pattern.compile("^.+?x");
+    private static final Pattern DOT_HYPHEN_PATTERN = Pattern.compile("[.-]");
 
     // root configs (alphabetized)
     private final long apdexTInMillis;
@@ -585,7 +586,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getValue(String path, T defaultValue) {
-        Object value = flattenedProperties.get(path.replaceAll("[.-]", "_"));
+        Object value = flattenedProperties.get(DOT_HYPHEN_PATTERN.matcher(path).replaceAll("_"));
         if (value == null) {
             value = flattenedProperties.get(path);
         }


### PR DESCRIPTION
### Overview
Small optimization reducing regex compilation (`String.replaceAll`) on every method call.

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
