### PR TITLE
update caffeine dep

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 
     shadowIntoJar('com.google.guava:guava:30.1.1-jre')
 
-    shadowIntoJar('com.github.ben-manes.caffeine:caffeine:2.9.0')
+    shadowIntoJar('com.github.ben-manes.caffeine:caffeine:2.9.3')
 
     shadowIntoJar("org.yaml:snakeyaml:1.27")
 


### PR DESCRIPTION

### Overview
Describe the changes present in the pull request

Caching with Caffeine can expose a bug in the JDK where the ForkJoinPool.commonPool (FJP) does not initialize appropriately.  With Caffeine this caused a resulting OOM when the caches were not being evicted.  Improvements were made for more aggressive eviction when there is a broken executor. 

This change mitigates the effect caused by the broken commonPool, by helping to avoid an OOM.  Of course, the broken FJP may have other negative effects.

https://bugs.openjdk.java.net/browse/JDK-8274349 v17.02 -fixed
https://bugs.openjdk.java.net/browse/JDK-8274756 v18 -fixed

Primarily taking this dependency update for this commit:

https://github.com/ben-manes/caffeine/commit/8c7160d008730b68974227b7d988362a4bc974d3

>Fixed reference eviction when used with a broken executor (JDK-8274349)

https://github.com/ben-manes/caffeine/releases/tag/v2.9.3

### Related Github Issue
Originally Reported OOM
https://github.com/newrelic/newrelic-java-agent/issues/558


### Checks

[ NA] Are your contributions backwards compatible with relevant frameworks and APIs?
[N ] Does your code contain any breaking changes? Please describe. 
[ N] Does your code introduce any new dependencies? Please describe.
