### PR TITLE
work-around ClassCircularityError

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/InitProblemClasses.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/InitProblemClasses.java
@@ -82,6 +82,17 @@ public class InitProblemClasses {
             } catch (ClassNotFoundException e) {
                 Agent.LOG.log(Level.WARNING, "Error working around class loading issue:", e);
             }
+
+            // This works around a ClassCircularityError with ThreadLocalRandom. The issue
+            // started after a change that adds an executor to Caffeine caches.
+            // resolving PR: work-around ClassCircularityError #600
+            try {
+                String holdCounterClassName = "java.util.concurrent.ThreadLocalRandom";
+                Class.forName(holdCounterClassName);
+                Agent.LOG.log(Level.FINE, "Worked around loading class " + holdCounterClassName);
+            } catch (ClassNotFoundException e) {
+                Agent.LOG.log(Level.WARNING, "Error working around class loading issue:", e);
+            }
         } catch (Throwable e) {
             Agent.LOG.log(Level.FINE, e, "Exception while performing initial loading");
         }


### PR DESCRIPTION
We were pretty regularly (but not every time) getting a `ClassCircularityError` when running tests for
https://github.com/newrelic/newrelic-java-agent/pull/576
This looks like a similar issue that used to happen with Guava, though it presented in a different class.

It may make more sense to find out why this happens during Weaving and see if we can find a root cause, but I believe (based on the previous issue history and notes) that it would be a considerable effort.  If we go that route, we should get this on the Engineering Board and prioritized.

This workaround should at least get us moving forward for this case. It's a workaround that's been implemented before, so there's some precedence for it. 

This change forces an early deterministic classload for ThreadLocalRandom.  It is comparable to similar existing work-arounds, as noted in https://github.com/newrelic/newrelic-java-agent/pull/106 .

##  java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom
<details><summary>error</summary>
<p>



```java
Error: Exception in thread "Thread-10" Exception in thread "Thread-11" Exception in thread "Thread-15" Exception in thread "Thread-9" Exception in thread "Thread-13" java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom
	at com.newrelic.agent.deps.com.github.benmanes.caffeine.cache.StripedBuffer.expandOrRetry(StripedBuffer.java:209)
	at com.newrelic.agent.deps.com.github.benmanes.caffeine.cache.StripedBuffer.offer(StripedBuffer.java:149)
	at com.newrelic.agent.deps.com.github.benmanes.caffeine.cache.BoundedLocalCache.afterRead(BoundedLocalCache.java:1166)
	at com.newrelic.agent.deps.com.github.benmanes.caffeine.cache.BoundedLocalCache.put(BoundedLocalCache.java:2066)
	at com.newrelic.agent.deps.com.github.benmanes.caffeine.cache.BoundedLocalCache.putIfAbsent(BoundedLocalCache.java:2003)
	at com.newrelic.weave.weavepackage.WeavePackageManager.getOptimizedWeavePackages(WeavePackageManager.java:606)
	at com.newrelic.weave.weavepackage.WeavePackageManager.match(WeavePackageManager.java:271)
	at com.newrelic.weave.weavepackage.WeavePackageManager.match(WeavePackageManager.java:261)
	at com.newrelic.agent.instrumentation.weaver.ClassWeaverService.newClassMatchVisitor(ClassWeaverService.java:455)
	at com.newrelic.agent.instrumentation.context.InstrumentationContext.match(InstrumentationContext.java:259)
	at com.newrelic.agent.instrumentation.context.InstrumentationContextClassMatcherHelper.isMatch(InstrumentationContextClassMatcherHelper.java:45)
	at com.newrelic.agent.instrumentation.context.ClassesMatcher$1.run(ClassesMatcher.java:55)
	at java.lang.Thread.run(Thread.java:748)

```
</details>
</p>




### Related Github Issue
Following a similar workaround pattern as the old workaround seems to work.
Old issue:
https://github.com/newrelic/newrelic-java-agent/pull/106
https://github.com/newrelic/newrelic-java-agent/pull/576
https://github.com/newrelic/newrelic-java-agent/pull/572
https://github.com/newrelic/newrelic-java-agent/issues/558


### Testing
I made this change in https://github.com/newrelic/newrelic-java-agent/pull/576 . <-edit: corrected where change was made
Have been running it to see if the `ClassCircularityError` shows itself again.  So far it has not. It was previously pretty consistent, though did not fail every time.

