### PR TITLE
Upgrade log4j-core version bump to fix CVE-2021-44228

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.11.2'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.15.0'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'


### PR DESCRIPTION
### Overview

log4j-core version bump to fix CVE-2021-44228