### PR TITLE
Newrelic-scala-api scala-library to 2.13.7 - Local build issue

### DIFF
--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -23,7 +23,7 @@ java {
 
 dependencies {
     zinc("org.scala-sbt:zinc_2.12:1.2.5")
-    implementation("org.scala-lang:scala-library:2.13.5")
+    implementation("org.scala-lang:scala-library:2.13.7")
     implementation(project(":newrelic-api"))
     testImplementation(project(":instrumentation-test"))
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))


### PR DESCRIPTION
### Overview
Resolves build issue locally when running `./gradlew clean jar`.
Updated newrelic-scala-api scala-library dependency to 2.13.7

### Related Github Issue
None

### Testing
Ran command locally with success.
Ran green GHA builds

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? Please describe.  No
[X] Does your code introduce any new dependencies? Please describe. Updated newrelic-scala-api  scala-library dependency to 2.13.7
