### PR TITLE
Upgrade log4j-core version bump 2.16.0

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.15.0'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.16.0'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'


### PR DESCRIPTION
Bumping to version 2.16.0 to users are protected from potential bypasses existing in pattern formatters.

Apache's patch notes for 2.16.0:
`The mitigation advice for CVE-2021-4428 suggests that for Log4j > 2.10.0 and < 2.15.0, the vulnerability can be avoided by setting -Dlog4j2.formatMsgNoLookups=true or upgrading to 2.15.0. However, many users may not be aware that even in this case, lookups used in pattern formatters to provide specific pieces of context information will still recursively resolve, possibly triggering JNDI lookups.`

REF: https://issues.apache.org/jira/plugins/servlet/mobile#issue/LOG4J2-3221

Issue Link: https://github.com/newrelic/newrelic-java-agent/issues/605