### PR TITLE
#355 - Solr FilterCache Memory Leak - Replace SolrInfoBean in NRMetric with String

### DIFF
--- a/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/CacheMetric.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/CacheMetric.java
@@ -19,7 +19,7 @@ public class CacheMetric extends NRMetric {
     MetricsMap metric = null;
     String metricType = null;
 
-    public CacheMetric(String mt, String r, Metric m, SolrInfoBean b) {
+    public CacheMetric(String mt, String r, Metric m, String b) {
         super(r, b);
         metricType = mt;
         if (MetricsMap.class.isInstance(m)) {
@@ -49,7 +49,7 @@ public class CacheMetric extends NRMetric {
 
     @Override
     public String getMetricBase() {
-        return prefix + registry + "/" + metricType + "/" + info.getName();
+        return prefix + registry + "/" + metricType + "/" + name;
     }
 
 }

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/GaugeMetric.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/GaugeMetric.java
@@ -19,7 +19,7 @@ public class GaugeMetric extends NRMetric {
     String metricName;
 
     @SuppressWarnings("rawtypes")
-    public GaugeMetric(String mn, String mt, String r, Gauge m, SolrInfoBean b) {
+    public GaugeMetric(String mn, String mt, String r, Gauge m, String b) {
         super(r, b);
         metric = m;
         metricType = mt;
@@ -33,7 +33,7 @@ public class GaugeMetric extends NRMetric {
 
     @Override
     public String getMetricBase() {
-        return prefix + registry + "/" + metricType + "/" + info.getName();
+        return prefix + registry + "/" + metricType + "/" + name;
     }
 
     @Override

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/MeteredMetric.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/MeteredMetric.java
@@ -17,7 +17,7 @@ public class MeteredMetric extends NRMetric {
     String metricType;
     String metricName;
 
-    public MeteredMetric(String mn, String mt, String r, SolrInfoBean b, Metered m) {
+    public MeteredMetric(String mn, String mt, String r, String b, Metered m) {
         super(r, b);
         metered = m;
         metricType = mt;
@@ -31,7 +31,7 @@ public class MeteredMetric extends NRMetric {
 
     @Override
     public String getMetricBase() {
-        return prefix + registry + "/" + metricType + "/" + info.getName();
+        return prefix + registry + "/" + metricType + "/" + name;
     }
 
     @Override

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
@@ -8,6 +8,7 @@
 package com.agent.instrumentation.solr;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -46,6 +47,32 @@ public class MetricUtil {
     public static void addMetric(NRMetric metric) {
         String metricBase = metric.getMetricBase();
         metrics.put(metricBase, metric);
+    }
+
+    public static void removeMetric(String registry, String... metricPath) {
+        metrics.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().registry.equals(registry) && Arrays.stream(metricPath).anyMatch(path -> path.startsWith(entry.getValue().name)))
+                .forEach(x -> metrics.remove(x.getKey()));
+    }
+
+    public static void swapRegistries(String sourceRegistry, String targetRegistry) {
+        metrics.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().registry.equals(sourceRegistry))
+                .forEach(x -> {
+                    NRMetric metric = x.getValue();
+                    metric.setRegistry(targetRegistry);
+                    addMetric(metric);
+                    metrics.remove(x.getKey());
+                });
+    }
+
+    public static void clearRegistry(String registry) {
+        metrics.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().registry.equals(registry))
+                .forEach(x -> metrics.remove(x.getKey()));
     }
 
     public static String getRegistry(String r) {

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
@@ -59,12 +59,13 @@ public class MetricUtil {
     public static void swapRegistries(String sourceRegistry, String targetRegistry) {
         metrics.entrySet()
                 .stream()
-                .filter(entry -> entry.getValue().registry.equals(sourceRegistry))
+                .filter(entry -> entry.getValue().registry.equals(getRegistry(sourceRegistry)))
                 .forEach(x -> {
+                    String currentKey = x.getKey();
                     NRMetric metric = x.getValue();
-                    metric.setRegistry(targetRegistry);
+                    metric.setRegistry(getRegistry(targetRegistry));
                     addMetric(metric);
-                    metrics.remove(x.getKey());
+                    metrics.remove(currentKey);
                 });
     }
 

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
@@ -13,14 +13,14 @@ public abstract class NRMetric {
 
     protected static final String prefix = "JMX/solr/";
 
-    public NRMetric(String r, SolrInfoBean b) {
+    public NRMetric(String r, String b) {
         registry = r;
-        info = b;
+        name = b;
     }
 
     protected String registry;
 
-    protected SolrInfoBean info;
+    protected String name;
 
     public String getRegistry() {
         return registry;

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
@@ -7,8 +7,6 @@
 
 package com.agent.instrumentation.solr;
 
-import org.apache.solr.core.SolrInfoBean;
-
 public abstract class NRMetric {
 
     protected static final String prefix = "JMX/solr/";
@@ -24,6 +22,10 @@ public abstract class NRMetric {
 
     public String getRegistry() {
         return registry;
+    }
+
+    public void setRegistry(String registry) {
+        this.registry = registry;
     }
 
     public abstract String getMetricName(String name);

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
@@ -67,11 +67,13 @@ public abstract class SolrMetricManager_Instrumentation {
     public void removeRegistry(String registry) {
         Weaver.callOriginal();
         MetricUtil.clearRegistry(registry);
+        NewRelic.getAgent().getLogger().log(Level.FINEST, "Removed {0} metric registry", registry);
     }
 
     public void clearRegistry(String registry) {
         Weaver.callOriginal();
         MetricUtil.clearRegistry(registry);
+        NewRelic.getAgent().getLogger().log(Level.FINEST, "Cleared {0} metric registry", registry);
     }
 
     public Set<String> clearMetrics(String registry, String... metricPath) {
@@ -80,6 +82,7 @@ public abstract class SolrMetricManager_Instrumentation {
             for (String removedMetric: removedMetrics) {
                 MetricUtil.removeMetric(registry, removedMetric);
             }
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Cleared {0} metrics from {1} metric registry", removedMetrics.size(), registry);
         }
         return removedMetrics;
     }
@@ -87,5 +90,6 @@ public abstract class SolrMetricManager_Instrumentation {
     public void swapRegistries(String registry1, String registry2) {
         Weaver.callOriginal();
         MetricUtil.swapRegistries(registry1, registry2);
+        NewRelic.getAgent().getLogger().log(Level.FINEST, "Swapped {0} metric registry to {1} metric registry", registry1, registry2);
     }
 }

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
@@ -37,12 +37,12 @@ public abstract class SolrMetricManager_Instrumentation {
 
             if (isCacheMetric) {
                 MetricsMap mMap = (MetricsMap) metric;
-                CacheMetric nrMetric = new CacheMetric(desired, MetricUtil.getRegistry(registry), mMap, info);
+                CacheMetric nrMetric = new CacheMetric(desired, MetricUtil.getRegistry(registry), mMap, info.getName());
                 NewRelic.getAgent().getLogger().log(Level.FINEST, "Created CacheMetric of name {0}", metricName);
                 MetricUtil.addMetric(nrMetric);
             } else if (isGaugeMetric) {
                 Gauge gauge = (Gauge) metric;
-                GaugeMetric gMetric = new GaugeMetric(metricName, desired, MetricUtil.getRegistry(registry), gauge, info);
+                GaugeMetric gMetric = new GaugeMetric(metricName, desired, MetricUtil.getRegistry(registry), gauge, info.getName());
                 NewRelic.getAgent().getLogger().log(Level.FINEST, "Created GaugeMetric of name {0}", metricName);
                 MetricUtil.addMetric(gMetric);
             }
@@ -56,7 +56,7 @@ public abstract class SolrMetricManager_Instrumentation {
         if (MetricUtil.isDesired(metricName, metricPath)) {
             String mName = MetricUtil.getRemap(metricName);
             String desired = MetricUtil.getDesired(metricName, metricPath);
-            MeteredMetric meteredMetric = new MeteredMetric(mName, desired, MetricUtil.getRegistry(registry), info, meter);
+            MeteredMetric meteredMetric = new MeteredMetric(mName, desired, MetricUtil.getRegistry(registry), info.getName(), meter);
             MetricUtil.addMetric(meteredMetric);
             NewRelic.getAgent().getLogger().log(Level.FINEST, "Added NRMetric from ({0}, {1}, {2})", info, registry, metricName);
         }

--- a/instrumentation/solr-jmx-7.0.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
+++ b/instrumentation/solr-jmx-7.0.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
@@ -21,6 +21,7 @@ import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import org.apache.solr.core.SolrInfoBean;
 
+import java.util.Set;
 import java.util.logging.Level;
 
 @Weave(originalName = "org.apache.solr.metrics.SolrMetricManager", type = MatchType.ExactClass)
@@ -63,4 +64,28 @@ public abstract class SolrMetricManager_Instrumentation {
         return meter;
     }
 
+    public void removeRegistry(String registry) {
+        Weaver.callOriginal();
+        MetricUtil.clearRegistry(registry);
+    }
+
+    public void clearRegistry(String registry) {
+        Weaver.callOriginal();
+        MetricUtil.clearRegistry(registry);
+    }
+
+    public Set<String> clearMetrics(String registry, String... metricPath) {
+        Set<String> removedMetrics = Weaver.callOriginal();
+        if(removedMetrics != null) {
+            for (String removedMetric: removedMetrics) {
+                MetricUtil.removeMetric(registry, removedMetric);
+            }
+        }
+        return removedMetrics;
+    }
+
+    public void swapRegistries(String registry1, String registry2) {
+        Weaver.callOriginal();
+        MetricUtil.swapRegistries(registry1, registry2);
+    }
 }

--- a/instrumentation/solr-jmx-7.0.0/src/test/java/com/agent/instrumentation/solr/SolrMetricManagerInstrumentationTests.java
+++ b/instrumentation/solr-jmx-7.0.0/src/test/java/com/agent/instrumentation/solr/SolrMetricManagerInstrumentationTests.java
@@ -1,0 +1,121 @@
+package com.agent.instrumentation.solr;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.NoOpPrivateApi;
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+
+import org.apache.solr.core.SolrInfoBean;
+import org.apache.solr.metrics.MetricsMap;
+import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.store.blockcache.Metrics;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "org.apache.solr.metrics" })
+public class SolrMetricManagerInstrumentationTests {
+
+    @Before
+    public void before() {
+        MetricUtil.clearRegistry("exampleRegistry");
+        MetricUtil.clearRegistry("targetRegistry");
+    }
+
+    @Test
+    public void register() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.register(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(1, metricsReported);
+
+        String registryName = MetricUtil.getMetrics().values().stream().map(x -> x.registry).collect(Collectors.joining());
+        assertEquals("exampleRegistry", registryName);
+    }
+
+    @Test
+    public void removeRegistry() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.register(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.removeRegistry("exampleRegistry");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(0, metricsReported);
+    }
+
+    @Test
+    public void clearRegistry() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.register(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.clearRegistry("exampleRegistry");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(0, metricsReported);
+    }
+
+    @Test
+    public void clearMetrics() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.register(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.clearMetrics("exampleRegistry", "hdfsBlockCache");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(0, metricsReported);
+    }
+
+    @Test
+    public void swapRegistries() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.register(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.swapRegistries("exampleRegistry", "targetRegistry");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(1, metricsReported);
+
+        String registryName = MetricUtil.getMetrics().values().stream().map(x -> x.registry).collect(Collectors.joining());
+        assertEquals("targetRegistry", registryName);
+    }
+}

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/CacheMetric.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/CacheMetric.java
@@ -19,7 +19,7 @@ public class CacheMetric extends NRMetric {
     MetricsMap metric = null;
     String metricType = null;
 
-    public CacheMetric(String mt, String r, Metric m, SolrInfoBean b) {
+    public CacheMetric(String mt, String r, Metric m, String b) {
         super(r, b);
         metricType = mt;
         if (MetricsMap.class.isInstance(m)) {
@@ -49,7 +49,7 @@ public class CacheMetric extends NRMetric {
 
     @Override
     public String getMetricBase() {
-        return prefix + registry + "/" + metricType + "/" + info.getName();
+        return prefix + registry + "/" + metricType + "/" + name;
     }
 
 }

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/GaugeMetric.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/GaugeMetric.java
@@ -19,7 +19,7 @@ public class GaugeMetric extends NRMetric {
     String metricName;
 
     @SuppressWarnings("rawtypes")
-    public GaugeMetric(String mn, String mt, String r, Gauge m, SolrInfoBean b) {
+    public GaugeMetric(String mn, String mt, String r, Gauge m, String b) {
         super(r, b);
         metric = m;
         metricType = mt;
@@ -33,7 +33,7 @@ public class GaugeMetric extends NRMetric {
 
     @Override
     public String getMetricBase() {
-        return prefix + registry + "/" + metricType + "/" + info.getName();
+        return prefix + registry + "/" + metricType + "/" + name;
     }
 
     @Override

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/MeteredMetric.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/MeteredMetric.java
@@ -17,7 +17,7 @@ public class MeteredMetric extends NRMetric {
     String metricType;
     String metricName;
 
-    public MeteredMetric(String mn, String mt, String r, SolrInfoBean b, Metered m) {
+    public MeteredMetric(String mn, String mt, String r, String b, Metered m) {
         super(r, b);
         metered = m;
         metricType = mt;
@@ -31,7 +31,7 @@ public class MeteredMetric extends NRMetric {
 
     @Override
     public String getMetricBase() {
-        return prefix + registry + "/" + metricType + "/" + info.getName();
+        return prefix + registry + "/" + metricType + "/" + name;
     }
 
     @Override

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
@@ -8,6 +8,7 @@
 package com.agent.instrumentation.solr;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -46,6 +47,32 @@ public class MetricUtil {
     public static void addMetric(NRMetric metric) {
         String metricBase = metric.getMetricBase();
         metrics.put(metricBase, metric);
+    }
+
+    public static void removeMetric(String registry, String... metricPath) {
+        metrics.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().registry.equals(registry) && Arrays.stream(metricPath).anyMatch(path -> path.startsWith(entry.getValue().name)))
+                .forEach(x -> metrics.remove(x.getKey()));
+    }
+
+    public static void swapRegistries(String sourceRegistry, String targetRegistry) {
+        metrics.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().registry.equals(sourceRegistry))
+                .forEach(x -> {
+                    NRMetric metric = x.getValue();
+                    metric.setRegistry(targetRegistry);
+                    addMetric(metric);
+                    metrics.remove(x.getKey());
+                });
+    }
+
+    public static void clearRegistry(String registry) {
+        metrics.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().registry.equals(registry))
+                .forEach(x -> metrics.remove(x.getKey()));
     }
 
     public static String getRegistry(String r) {

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/MetricUtil.java
@@ -59,12 +59,13 @@ public class MetricUtil {
     public static void swapRegistries(String sourceRegistry, String targetRegistry) {
         metrics.entrySet()
                 .stream()
-                .filter(entry -> entry.getValue().registry.equals(sourceRegistry))
+                .filter(entry -> entry.getValue().registry.equals(getRegistry(sourceRegistry)))
                 .forEach(x -> {
+                    String currentKey = x.getKey();
                     NRMetric metric = x.getValue();
-                    metric.setRegistry(targetRegistry);
+                    metric.setRegistry(getRegistry(targetRegistry));
                     addMetric(metric);
-                    metrics.remove(x.getKey());
+                    metrics.remove(currentKey);
                 });
     }
 

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
@@ -7,20 +7,18 @@
 
 package com.agent.instrumentation.solr;
 
-import org.apache.solr.core.SolrInfoBean;
-
 public abstract class NRMetric {
 
     protected static final String prefix = "JMX/solr/";
 
-    public NRMetric(String r, SolrInfoBean b) {
+    public NRMetric(String r, String b) {
         registry = r;
-        info = b;
+        name = b;
     }
 
     protected String registry;
 
-    protected SolrInfoBean info;
+    protected String name;
 
     public String getRegistry() {
         return registry;

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/com/agent/instrumentation/solr/NRMetric.java
@@ -24,6 +24,10 @@ public abstract class NRMetric {
         return registry;
     }
 
+    public void setRegistry(String registry) {
+        this.registry = registry;
+    }
+
     public abstract String getMetricName(String name);
 
     public abstract int reportMetrics();

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
@@ -67,11 +67,13 @@ public abstract class SolrMetricManager_Instrumentation {
     public void removeRegistry(String registry) {
         Weaver.callOriginal();
         MetricUtil.clearRegistry(registry);
+        NewRelic.getAgent().getLogger().log(Level.FINEST, "Removed {0} metric registry", registry);
     }
 
     public void clearRegistry(String registry) {
         Weaver.callOriginal();
         MetricUtil.clearRegistry(registry);
+        NewRelic.getAgent().getLogger().log(Level.FINEST, "Cleared {0} metric registry", registry);
     }
 
     public Set<String> clearMetrics(String registry, String... metricPath) {
@@ -80,6 +82,7 @@ public abstract class SolrMetricManager_Instrumentation {
             for (String removedMetric: removedMetrics) {
                 MetricUtil.removeMetric(registry, removedMetric);
             }
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Cleared {0} metrics from {1} metric registry", removedMetrics.size(), registry);
         }
         return removedMetrics;
     }
@@ -87,5 +90,6 @@ public abstract class SolrMetricManager_Instrumentation {
     public void swapRegistries(String registry1, String registry2) {
         Weaver.callOriginal();
         MetricUtil.swapRegistries(registry1, registry2);
+        NewRelic.getAgent().getLogger().log(Level.FINEST, "Swapped {0} metric registry to {1} metric registry", registry1, registry2);
     }
 }

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
@@ -37,12 +37,12 @@ public abstract class SolrMetricManager_Instrumentation {
 
             if (isCacheMetric) {
                 MetricsMap mMap = (MetricsMap) metric;
-                CacheMetric nrMetric = new CacheMetric(desired, MetricUtil.getRegistry(registry), mMap, info);
+                CacheMetric nrMetric = new CacheMetric(desired, MetricUtil.getRegistry(registry), mMap, info.getName());
                 NewRelic.getAgent().getLogger().log(Level.FINEST, "Created CacheMetric of name {0}", metricName);
                 MetricUtil.addMetric(nrMetric);
             } else if (isGaugeMetric) {
                 Gauge gauge = (Gauge) metric;
-                GaugeMetric gMetric = new GaugeMetric(metricName, desired, MetricUtil.getRegistry(registry), gauge, info);
+                GaugeMetric gMetric = new GaugeMetric(metricName, desired, MetricUtil.getRegistry(registry), gauge, info.getName());
                 NewRelic.getAgent().getLogger().log(Level.FINEST, "Created GaugeMetric of name {0}", metricName);
                 MetricUtil.addMetric(gMetric);
             }
@@ -56,7 +56,7 @@ public abstract class SolrMetricManager_Instrumentation {
         if (MetricUtil.isDesired(metricName, metricPath)) {
             String mName = MetricUtil.getRemap(metricName);
             String desired = MetricUtil.getDesired(metricName, metricPath);
-            MeteredMetric meteredMetric = new MeteredMetric(mName, desired, MetricUtil.getRegistry(registry), info, meter);
+            MeteredMetric meteredMetric = new MeteredMetric(mName, desired, MetricUtil.getRegistry(registry), info.getName(), meter);
             MetricUtil.addMetric(meteredMetric);
             NewRelic.getAgent().getLogger().log(Level.FINEST, "Added NRMetric from ({0}, {1}, {2})", info, registry, metricName);
         }

--- a/instrumentation/solr-jmx-7.4.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
+++ b/instrumentation/solr-jmx-7.4.0/src/main/java/org/apache/solr/metrics/SolrMetricManager_Instrumentation.java
@@ -21,6 +21,7 @@ import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import org.apache.solr.core.SolrInfoBean;
 
+import java.util.Set;
 import java.util.logging.Level;
 
 @Weave(originalName = "org.apache.solr.metrics.SolrMetricManager", type = MatchType.ExactClass)
@@ -61,5 +62,30 @@ public abstract class SolrMetricManager_Instrumentation {
             NewRelic.getAgent().getLogger().log(Level.FINEST, "Added NRMetric from ({0}, {1}, {2})", info, registry, metricName);
         }
         return meter;
+    }
+
+    public void removeRegistry(String registry) {
+        Weaver.callOriginal();
+        MetricUtil.clearRegistry(registry);
+    }
+
+    public void clearRegistry(String registry) {
+        Weaver.callOriginal();
+        MetricUtil.clearRegistry(registry);
+    }
+
+    public Set<String> clearMetrics(String registry, String... metricPath) {
+        Set<String> removedMetrics = Weaver.callOriginal();
+        if(removedMetrics != null) {
+            for (String removedMetric: removedMetrics) {
+                MetricUtil.removeMetric(registry, removedMetric);
+            }
+        }
+        return removedMetrics;
+    }
+
+    public void swapRegistries(String registry1, String registry2) {
+        Weaver.callOriginal();
+        MetricUtil.swapRegistries(registry1, registry2);
     }
 }

--- a/instrumentation/solr-jmx-7.4.0/src/test/java/com/agent/instrumentation/solr/SolrMetricManagerInstrumentationTests.java
+++ b/instrumentation/solr-jmx-7.4.0/src/test/java/com/agent/instrumentation/solr/SolrMetricManagerInstrumentationTests.java
@@ -117,5 +117,8 @@ public class SolrMetricManagerInstrumentationTests {
 
         String registryName = MetricUtil.getMetrics().values().stream().map(x -> x.registry).collect(Collectors.joining());
         assertEquals("targetRegistry", registryName);
+
+        String metricBase = MetricUtil.getMetrics().values().stream().map(NRMetric::getMetricBase).collect(Collectors.joining());
+        assertEquals("JMX/solr/targetRegistry/filterCache/hdfsBlockCache", metricBase);
     }
 }

--- a/instrumentation/solr-jmx-7.4.0/src/test/java/com/agent/instrumentation/solr/SolrMetricManagerInstrumentationTests.java
+++ b/instrumentation/solr-jmx-7.4.0/src/test/java/com/agent/instrumentation/solr/SolrMetricManagerInstrumentationTests.java
@@ -1,0 +1,121 @@
+package com.agent.instrumentation.solr;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.NoOpPrivateApi;
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+
+import org.apache.solr.core.SolrInfoBean;
+import org.apache.solr.metrics.MetricsMap;
+import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.store.blockcache.Metrics;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "org.apache.solr.metrics" })
+public class SolrMetricManagerInstrumentationTests {
+
+    @Before
+    public void before() {
+        MetricUtil.clearRegistry("exampleRegistry");
+        MetricUtil.clearRegistry("targetRegistry");
+    }
+
+    @Test
+    public void register() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.registerMetric(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(1, metricsReported);
+
+        String registryName = MetricUtil.getMetrics().values().stream().map(x -> x.registry).collect(Collectors.joining());
+        assertEquals("exampleRegistry", registryName);
+    }
+
+    @Test
+    public void removeRegistry() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.registerMetric(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.removeRegistry("exampleRegistry");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(0, metricsReported);
+    }
+
+    @Test
+    public void clearRegistry() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.registerMetric(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.clearRegistry("exampleRegistry");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(0, metricsReported);
+    }
+
+    @Test
+    public void clearMetrics() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.registerMetric(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.clearMetrics("exampleRegistry", "hdfsBlockCache");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(0, metricsReported);
+    }
+
+    @Test
+    public void swapRegistries() {
+        //Given
+        AgentBridge.privateApi = new NoOpPrivateApi();
+        SolrMetricManager solrMetricManager = new SolrMetricManager();
+        SolrInfoBean solrInfoBean = new Metrics();
+        MetricsMap metricsMap = new MetricsMap((detailed, map) -> map.put("exampleMetric", 100));
+
+        //When
+        solrMetricManager.registerMetric(solrInfoBean, "exampleRegistry", metricsMap, false,"filterCache", "hdfsBlockCache");
+        solrMetricManager.swapRegistries("exampleRegistry", "targetRegistry");
+
+        //Then
+        int metricsReported = MetricUtil.getMetrics().values().stream().map(NRMetric::reportMetrics).mapToInt(Integer::intValue).sum();
+        assertEquals(1, metricsReported);
+
+        String registryName = MetricUtil.getMetrics().values().stream().map(x -> x.registry).collect(Collectors.joining());
+        assertEquals("targetRegistry", registryName);
+    }
+}


### PR DESCRIPTION
### Overview
Currently, the `SolrMetricManager` instrumentation in the `solr-jmx-7.0.0` and `solr-jmx-7.4.0` projects maintains a map of all tracked metrics using the `MetricUtil` class.
The SolrMetricManager instrumentation currently doesn't support removing metrics causing a memory leak.

This pull request adds additional instrumentation to the `SolrMetricManager` class to support removing metrics and renaming registries. It also reduces the memory footprint of the `NRMetric` class by replacing the `SolrInfoBean` used internally with a string. `SolrInfoBean` is only used to get the name of the bean which is now past directed as a string.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/355

### Testing
Ran verifyInstrumentation successfully.
Ran GHA build checks successfully.
Added SolrMetricManager unit tests to cover newly supported scenarios.
Reproduced and resolved the issue on a local instance of Solr and monitored using New Relic One.

### Checks

[X] Are your contributions backward compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? Please describe. No
[X] Does your code introduce any new dependencies? Please describe. No