### PR TITLE
Upgrade log4j-core version to fix CVE-2021-45105

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.16.0'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.17.0'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'


### PR DESCRIPTION
### Overview
This PR upgrades `log4j-core` to the latest version (`2.17.0`) to protect from uncontrolled recursion from self-referential lookups, fixing [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105) relevant for Java 8 and later.

References: 
https://logging.apache.org/log4j/2.x/security.html
https://issues.apache.org/jira/browse/LOG4J2-3230

### Related Github Issue
#605 

### Related PR
#603 
#610 