### PR TITLE
Upgrade log4j-core version to fix vulnerability (CVE-2021-44832)

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.17.0'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.17.1'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
Upgrade log4j-core version to fix vulnerability (CVE-2021-44832)
[See More](https://logging.apache.org/log4j/2.x/security.html)

### Related Github Issue
#624 