### PR TITLE
Log4shell fix for 7.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # The agent version.
-agentVersion=7.2.0
+agentVersion=7.2.1
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.11.2'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.17.1'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,6 @@ if (JavaVersion.current().isJava11Compatible()) {
 }
 
 // Weaver Instrumentation
-include 'instrumentation:anorm-2.0'
 include 'instrumentation:anorm-2.3'
 include 'instrumentation:anorm-2.4'
 include 'instrumentation:aws-java-sdk-sqs-1.10.44'


### PR DESCRIPTION
**I am unable to create a branch referencing tag v7.2.0, if this change is accepted then the base branch this merges into needs to change.**

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
Later versions of NR agent which include changes with a caffeine cache have a memory leak issue. Version 7.2.0 was the last version before this change was included. In the interim until this issue is fixed, a user should be able to decide if they want to use a patch of 7.2.0 in order to not have their application vulnerable to log4shell.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/623

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
[x] Does your code contain any breaking changes? Please describe. 
**The PR removes a reference to anorm 2.0, I cannot pull this as bintray has been shutdown and I cannot find it from other sources on the internet.**
[x] Does your code introduce any new dependencies? Please describe.
**log4j 2.17.1**
