### PR TITLE
Fix cacheability for JavaCompile, ScalaCompile and Test tasks

### DIFF
--- a/agent-interfaces/build.gradle
+++ b/agent-interfaces/build.gradle
@@ -7,11 +7,3 @@ dependencies {
     api(project(":newrelic-api"))
     implementation(project(":agent-model"))
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}

--- a/agent-model/build.gradle
+++ b/agent-model/build.gradle
@@ -5,11 +5,3 @@ plugins {
 dependencies {
     api 'com.googlecode.json-simple:json-simple:1.1'
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}

--- a/functional_test/build.gradle
+++ b/functional_test/build.gradle
@@ -84,14 +84,6 @@ dependencies {
     testImplementation("javax.ws.rs:javax.ws.rs-api:2.1")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 def functional_test_args = [
         "-javaagent:${project.jar.archivePath.absolutePath}",
         "-javaagent:${JarUtil.getNewRelicJar(project(':newrelic-agent')).absolutePath}",
@@ -108,32 +100,10 @@ test {
     forkEvery = 1
     maxParallelForks = Runtime.runtime.availableProcessors()
     //testLogging.showStandardStreams = true
-    if (project.hasProperty("test17")) {
-        executable = jdk17 + '/bin/java'
-        jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED'
-    } else if (project.hasProperty("test16")) {
-        executable = jdk16 + '/bin/java'
-        jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED'
-    } else if (project.hasProperty("test15")) {
-        executable = jdk15 + '/bin/java'
-    } else if (project.hasProperty("test14")) {
-        executable = jdk14 + '/bin/java'
-    } else if (project.hasProperty("test13")) {
-        executable = jdk13 + '/bin/java'
-    } else if (project.hasProperty("test12")) {
-        executable = jdk12 + '/bin/java'
-    } else if (project.hasProperty("test11")) {
-        executable = jdk11 + '/bin/java'
-    } else if (project.hasProperty("test10")) {
-        executable = jdk10 + '/bin/java'
+    if (project.hasProperty("test10")) {
         jvmArgs += ["--add-modules", "java.xml.bind"]
     } else if (project.hasProperty("test9")) {
-        executable = jdk9 + '/bin/java'
         jvmArgs += ["--add-modules", "java.xml.bind"]
-    } else if (project.hasProperty("test8")) {
-        executable = jdk8 + '/bin/java'
-    } else if (project.hasProperty("test7")) {
-        executable = jdk7 + '/bin/java'
     }
 
     minHeapSize = "256m"

--- a/gradle/script/cache_weave_attributes.gradle.kts
+++ b/gradle/script/cache_weave_attributes.gradle.kts
@@ -31,6 +31,8 @@ val writeCachedWeaveAttributes = tasks.create<JavaExec>("writeCachedWeaveAttribu
     val outputFile = "$buildDir/weaveAttributes/MANIFEST.MF"
     outputs.file(outputFile)
 
+    outputs.cacheIf { true }
+
     classpath = instrumentationBuildConfiguration
     main = "com.nr.instrumentation.builder.CacheWeaveAttributesInManifest"
     argumentProviders.add(AttributeCommandLineArgumentProvider(project, outputFile))

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -27,11 +27,15 @@ jar {
     includeEmptyDirs false
 }
 
+def compiler = javaToolchains.compilerFor {
+    languageVersion = JavaLanguageVersion.of(8)
+}
+
 // Some modules need to be compiled with JDK8.
 task requiresJava8 {
     doLast {
-        if (!project.hasProperty('jdk8')) {
-            throw new GradleException("Please set the jdk8 property to a valid jdk1.8 path in ~/.gradle/gradle.properties")
+        if (!compiler.isPresent()) {
+            throw new GradleException("Please set the 'org.gradle.java.installations.paths' property to a valid jdk1.8 path in ~/.gradle/gradle.properties")
         }
         if (!JavaVersion.current().isJava8Compatible()) {
             throw new GradleException("Please set JAVA_HOME to a 1.8 JDK (detected ${JavaVersion.current()})")
@@ -47,33 +51,32 @@ tasks.withType(ScalaCompile) {
     options.fork = true
 }
 
-compileJava.dependsOn 'requiresJava8'
-
-compileJava.options.encoding = 'UTF-8'
-// Compile all Java projects with 1.8
-compileJava.options.fork = true
-compileJava.options.forkOptions.executable = jdk8 + '/bin/javac'
-compileJava.options.compilerArgs += '-proc:none'
-
-compileTestJava.options.encoding = 'UTF-8'
-// Compile all Java test projects with 1.8
-compileTestJava.options.fork = true
-compileTestJava.options.forkOptions.executable = jdk8 + '/bin/javac'
-compileTestJava.options.compilerArgs += '-proc:none'
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    toolchain {
+        // Compile all Java projects with 1.8
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+tasks.withType(JavaCompile).configureEach {
+    dependsOn 'requiresJava8'
+    options.encoding = 'UTF-8'
+    options.fork = true
+    compileJava.options.compilerArgs += '-proc:none'
+}
 
 // Compile all Java projects with jdk8 bootstrap classpath (to properly support target compatibility)
-compileJava.options.bootstrapClasspath = files("${jdk8}/jre/lib/rt.jar", "${jdk8}/jre/lib/jsse.jar")
+def jdkPath = compiler.get().metadata.installationPath.asFile.absolutePath
+compileJava.options.bootstrapClasspath = files("${jdkPath}/jre/lib/rt.jar", "${jdkPath}/jre/lib/jsse.jar")
 
 // There is no clear way to run the same task under multiple JDKs, so we use the following gradle properties
-// and jenkins matrix plugin to run the instrumentation module tests
+// and jenkins matrix plugin to run the instrumentation module tests.
+//
+// This should really use java toolchains instead of setting the executable, but in its current form, toolchains
+// can only select a JDK based on the version, vendor and implementation (i.e. J9).  Unfortunately, Zulu and Zing
+// have the same vendor, which means toolchain selection cannot differentiate between say, Zulu11 and Zing11.  This
+// will be better once https://github.com/gradle/gradle/issues/18896 is implemented, at which point the below could
+// be changed to simply select a toolchain based on appropriately specific criteria.
 //
 // These properties must be set in gradle.properties to point to the java executable.
 // For example: java8=/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/bin/java
@@ -83,6 +86,8 @@ compileJava.options.bootstrapClasspath = files("${jdk8}/jre/lib/rt.jar", "${jdk8
 // This could lead to an "Unrecognized option" with the failure "Could not create the Java Virtual Machine".
 test {
     if (project.hasProperty("test17")) {
+        // Add an input property so that we differentiate between JDKs with the same version
+        inputs.property("test.jdk", "jdk17")
         executable = jdk17 + '/bin/java'
         jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
                 '--add-opens=java.base/java.util=ALL-UNNAMED',
@@ -96,6 +101,7 @@ test {
         }
     }
     if (project.hasProperty("test16")) {
+        inputs.property("test.jdk", "jdk16")
         executable = jdk16 + '/bin/java'
         jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
                 '--add-opens=java.base/java.util=ALL-UNNAMED',
@@ -109,84 +115,98 @@ test {
         }
     }
     if (project.hasProperty("test15")) {
+        inputs.property("test.jdk", "jdk15")
         executable = jdk15 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java15IncompatibleTest'
         }
     }
     if (project.hasProperty("test14")) {
+        inputs.property("test.jdk", "jdk14")
         executable = jdk14 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java14IncompatibleTest'
         }
     }
     if (project.hasProperty("test13")) {
+        inputs.property("test.jdk", "jdk13")
         executable = jdk13 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java13IncompatibleTest'
         }
     }
     if (project.hasProperty("test12")) {
+        inputs.property("test.jdk", "jdk12")
         executable = jdk12 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java12IncompatibleTest'
         }
     }
     if (project.hasProperty("testCoretto8")) {
+        inputs.property("test.jdk", "coretto8")
         executable = coretto8 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
         }
     }
     if (project.hasProperty("testDragonWell8")) {
+        inputs.property("test.jdk", "dragonWell8")
         executable = dragonWell8 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
         }
     }
     if (project.hasProperty("testZulu11")) {
+        inputs.property("test.jdk", "zulu11")
         executable = zulu11 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
         }
     }
     if (project.hasProperty("testZing8")) {
+        inputs.property("test.jdk", "zing8")
         executable = zing8 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
         }
     }
     if (project.hasProperty("testZing11")) {
+        inputs.property("test.jdk", "zing11")
         executable = zing11 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
         }
     }
     if (project.hasProperty("test11")) {
+        inputs.property("test.jdk", "jdk11")
         executable = jdk11 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
         }
     }
     if (project.hasProperty("test10")) {
+        inputs.property("test.jdk", "jdk10")
         executable = jdk10 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java10IncompatibleTest'
         }
     }
     if (project.hasProperty("test9")) {
+        inputs.property("test.jdk", "jdk9")
         executable = jdk9 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java9IncompatibleTest'
         }
     }
     if (project.hasProperty("test8")) {
+        inputs.property("test.jdk", "jdk8")
         executable = jdk8 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
         }
     }
     if (project.hasProperty("test7")) {
+        inputs.property("test.jdk", "jdk7")
         executable = jdk7 + '/bin/java'
         useJUnit {
             excludeCategories 'com.newrelic.test.marker.Java7IncompatibleTest'
@@ -208,4 +228,16 @@ dependencies {
     testImplementation("org.mockito:mockito-core:3.9.0")
     testImplementation("org.hamcrest:hamcrest-library:1.3")
     testImplementation(project(":test-annotations"))
+}
+
+// Make ScalaCompile tasks cacheable.  This is a workaround for a defect fixed in Gradle 7.1.0.
+tasks.withType(ScalaCompile).configureEach {
+    options.getForkOptions().setExecutable(null)
+    def launcher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+    inputs.property("javaLauncherVersion", launcher.map { it.metadata.languageVersion })
+    doFirst {
+        options.getForkOptions().setExecutable(launcher.get().getExecutablePath().asFile.absolutePath)
+    }
 }

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -85,131 +85,139 @@ compileJava.options.bootstrapClasspath = files("${jdkPath}/jre/lib/rt.jar", "${j
 // their own build.gradle to force the use of a specific version of Java (e.g. instrumentation/async-http-client-2.0.0).
 // This could lead to an "Unrecognized option" with the failure "Could not create the Java Virtual Machine".
 test {
-    if (project.hasProperty("test17")) {
+    ext.configureTest = { String jdkName, Closure configuration ->
         // Add an input property so that we differentiate between JDKs with the same version
-        inputs.property("test.jdk", "jdk17")
-        executable = jdk17 + '/bin/java'
-        jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        inputs.property("test.jdk", jdkName)
+        // Null out the launcher so we can set an executable instead
+        javaLauncher.convention(null).value(null)
+        executable = project.property(jdkName) + '/bin/java'
+        configuration.call()
+    }
+
+    if (project.hasProperty("test17")) {
+        configureTest("jdk17") {
+            jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
                 '--add-opens=java.base/java.util=ALL-UNNAMED',
                 '--add-opens=java.base/java.net=ALL-UNNAMED',
                 '--add-opens=java.base/java.io=ALL-UNNAMED',
                 '--add-opens=java.base/sun.net.spi=ALL-UNNAMED',
                 '--add-exports=java.base/sun.net.spi=ALL-UNNAMED',
                 '--add-exports=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java17IncompatibleTest'
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java17IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test16")) {
-        inputs.property("test.jdk", "jdk16")
-        executable = jdk16 + '/bin/java'
-        jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        configureTest("jdk16") {
+            jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
                 '--add-opens=java.base/java.util=ALL-UNNAMED',
                 '--add-opens=java.base/java.net=ALL-UNNAMED',
                 '--add-opens=java.base/java.io=ALL-UNNAMED',
                 '--add-opens=java.base/sun.net.spi=ALL-UNNAMED',
                 '--add-exports=java.base/sun.net.spi=ALL-UNNAMED',
                 '--add-exports=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java16IncompatibleTest'
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java16IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test15")) {
-        inputs.property("test.jdk", "jdk15")
-        executable = jdk15 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java15IncompatibleTest'
+        configureTest("jdk15") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java15IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test14")) {
-        inputs.property("test.jdk", "jdk14")
-        executable = jdk14 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java14IncompatibleTest'
+        configureTest("jdk14") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java14IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test13")) {
-        inputs.property("test.jdk", "jdk13")
-        executable = jdk13 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java13IncompatibleTest'
+        configureTest("jdk13") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java13IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test12")) {
-        inputs.property("test.jdk", "jdk12")
-        executable = jdk12 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java12IncompatibleTest'
+        configureTest("jdk12") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java12IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("testCoretto8")) {
-        inputs.property("test.jdk", "coretto8")
-        executable = coretto8 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+        configureTest("coretto8") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("testDragonWell8")) {
-        inputs.property("test.jdk", "dragonWell8")
-        executable = dragonWell8 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+        configureTest("dragonWell8") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("testZulu11")) {
-        inputs.property("test.jdk", "zulu11")
-        executable = zulu11 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
+        configureTest("zulu11") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("testZing8")) {
-        inputs.property("test.jdk", "zing8")
-        executable = zing8 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+        configureTest("zing8") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("testZing11")) {
-        inputs.property("test.jdk", "zing11")
-        executable = zing11 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
+        configureTest("zing11") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test11")) {
-        inputs.property("test.jdk", "jdk11")
-        executable = jdk11 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
+        configureTest("jdk11") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test10")) {
-        inputs.property("test.jdk", "jdk10")
-        executable = jdk10 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java10IncompatibleTest'
+        configureTest("jdk10") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java10IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test9")) {
-        inputs.property("test.jdk", "jdk9")
-        executable = jdk9 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java9IncompatibleTest'
+        configureTest("jdk9") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java9IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test8")) {
-        inputs.property("test.jdk", "jdk8")
-        executable = jdk8 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+        configureTest("jdk8") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+            }
         }
     }
     if (project.hasProperty("test7")) {
-        inputs.property("test.jdk", "jdk7")
-        executable = jdk7 + '/bin/java'
-        useJUnit {
-            excludeCategories 'com.newrelic.test.marker.Java7IncompatibleTest'
+        configureTest("jdk7") {
+            useJUnit {
+                excludeCategories 'com.newrelic.test.marker.Java7IncompatibleTest'
+            }
         }
     }
 

--- a/infinite-tracing/build.gradle.kts
+++ b/infinite-tracing/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 group = "com.newrelic.agent.java"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-
     disableAutoTargetJvm()
 }
 
@@ -21,6 +18,13 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testImplementation("org.mockito:mockito-junit-jupiter:3.3.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+}
+
+java {
+    toolchain {
+        // Compile all Java projects with 1.8
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 tasks.test {

--- a/infinite-tracing/build.gradle.kts
+++ b/infinite-tracing/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
 
 java {
     toolchain {
-        // Compile all Java projects with 1.8
         languageVersion.set(JavaLanguageVersion.of(8))
     }
 }

--- a/instrumentation-build/build.gradle.kts
+++ b/instrumentation-build/build.gradle.kts
@@ -5,10 +5,9 @@ plugins {
 }
 
 java {
-    // These classes are only used during the build. Since the build requires Java 8+,
-    // these class files can also be Java 8.
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 tasks.test {

--- a/instrumentation/async-http-client-2.0.0/build.gradle
+++ b/instrumentation/async-http-client-2.0.0/build.gradle
@@ -36,8 +36,6 @@ test {
         enabled = false
     } else if (project.hasProperty("test17")) {
         enabled = false
-    } else {
-        executable = jdk8 + '/bin/java'
     }
 }
 

--- a/instrumentation/async-http-client-2.1.0/build.gradle
+++ b/instrumentation/async-http-client-2.1.0/build.gradle
@@ -35,8 +35,6 @@ test {
         enabled = false
     } else if (project.hasProperty("test17")) {
         enabled = false
-    } else {
-        executable = jdk8 + '/bin/java'
     }
 }
 

--- a/instrumentation/aws-java-sdk-s3-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-s3-2.0/build.gradle
@@ -2,14 +2,6 @@ jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-java-sdk-s3-2.0' }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/aws-java-sdk-sns-1.11.12/build.gradle
+++ b/instrumentation/aws-java-sdk-sns-1.11.12/build.gradle
@@ -3,12 +3,6 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-sns:1.11.676")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/aws-java-sdk-sns-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-sns-2.0/build.gradle
@@ -3,12 +3,6 @@ dependencies {
     implementation("software.amazon.awssdk:sns:2.10.19")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/aws-java-sdk-sqs-1.10.44/build.gradle
+++ b/instrumentation/aws-java-sdk-sqs-1.10.44/build.gradle
@@ -5,14 +5,6 @@ dependencies {
     testImplementation("org.elasticmq:elasticmq-rest-sqs_2.13:0.15.3")
 }
 
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
@@ -5,14 +5,6 @@ dependencies {
     testImplementation("org.elasticmq:elasticmq-rest-sqs_2.13:0.15.3")
 }
 
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 compileJava.options.bootstrapClasspath = null
 
 test {

--- a/instrumentation/grpc-1.30.0/build.gradle
+++ b/instrumentation/grpc-1.30.0/build.gradle
@@ -10,13 +10,6 @@ buildscript {
 apply plugin: 'com.google.protobuf'
 compileJava.options.bootstrapClasspath = null
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation(project(":agent-bridge"))
     implementation("io.grpc:grpc-all:1.30.1")

--- a/instrumentation/grpc-1.40.0/build.gradle
+++ b/instrumentation/grpc-1.40.0/build.gradle
@@ -10,13 +10,6 @@ buildscript {
 apply plugin: 'com.google.protobuf'
 compileJava.options.bootstrapClasspath = null
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation(project(":agent-bridge"))
     implementation("io.grpc:grpc-all:1.40.1")

--- a/instrumentation/httpclient-jdk11/build.gradle
+++ b/instrumentation/httpclient-jdk11/build.gradle
@@ -12,13 +12,14 @@ verifyInstrumentation {
     verifyClasspath = false // We don't want to verify classpath since these are JDK classes
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
 
 compileJava {
     options.fork = true
-    options.forkOptions.executable = jdk11 + '/bin/javac'
-    options.forkOptions.javaHome = new File(jdk11)
     options.bootstrapClasspath = null
 }
 

--- a/instrumentation/java.completable-future-jdk8/build.gradle
+++ b/instrumentation/java.completable-future-jdk8/build.gradle
@@ -13,13 +13,6 @@ verifyInstrumentation {
     verifyClasspath = false // We don't want to verify classpath since these are JDK classes
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 site {
     title 'Java Completable futures'
     type 'Other'

--- a/instrumentation/java.completable-future-jdk8u40/build.gradle
+++ b/instrumentation/java.completable-future-jdk8u40/build.gradle
@@ -5,13 +5,6 @@ dependencies {
 // This instrumentation module should not use the bootstrap classpath
 compileJava.options.bootstrapClasspath = null
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.java.completable-future-jdk8u40' }
 }

--- a/instrumentation/kafka-clients-metrics-2.0.0/build.gradle
+++ b/instrumentation/kafka-clients-metrics-2.0.0/build.gradle
@@ -4,14 +4,6 @@ dependencies {
     implementation("org.apache.kafka:kafka-clients:2.0.0")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/netty-reactor-0.7.0/build.gradle
+++ b/instrumentation/netty-reactor-0.7.0/build.gradle
@@ -3,14 +3,6 @@ dependencies {
     implementation("io.projectreactor.ipc:reactor-netty:0.7.0.RELEASE")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/netty-reactor-0.8.0/build.gradle
+++ b/instrumentation/netty-reactor-0.8.0/build.gradle
@@ -3,14 +3,6 @@ dependencies {
     implementation("io.projectreactor.netty:reactor-netty:0.8.0.RELEASE")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/netty-reactor-0.9.0/build.gradle
+++ b/instrumentation/netty-reactor-0.9.0/build.gradle
@@ -3,14 +3,6 @@ dependencies {
     implementation("io.projectreactor.netty:reactor-netty:0.9.0.RELEASE")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/okhttp-4.4.0/build.gradle
+++ b/instrumentation/okhttp-4.4.0/build.gradle
@@ -17,9 +17,6 @@ jar {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-
     // IDEA refused to find 4.4.0 without this.
     disableAutoTargetJvm()
 }

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -53,19 +53,29 @@ test {
     }
 }
 
+
 compileTestScala {
+    def routeFile = file("src/test/resources/conf/routes")
+    def generatedSourcesDir = layout.buildDirectory.dir("generated/scala")
+
     options.compilerArgs += '-proc:none'
+
+    inputs.file(routeFile)
+    localState.register(generatedSourcesDir)
 
     // this manually compiles the conf/routes file into an Routes.scala file, which is subsequently read on startup by our test application
     doFirst {
-        def routeFile = file("src/test/resources/conf/routes")
-        def outputDirectory = file("src/test/scala")
-
         def RoutesCompiler.RoutesCompilerTask routesCompilerTask = new RoutesCompiler.RoutesCompilerTask(
                 routeFile, JavaConversions.asScalaBuffer(Collections.<String> emptyList()).toSeq(),
                 true, false, false)
-        RoutesCompiler$.MODULE$.compile(routesCompilerTask, InjectedRoutesGenerator$.MODULE$, outputDirectory)
+        RoutesCompiler$.MODULE$.compile(routesCompilerTask, InjectedRoutesGenerator$.MODULE$, generatedSourcesDir.get().asFile)
+        source generatedSourcesDir
     }
+}
+
+clean {
+    // Clean up any residual generated Routes files to avoid duplicate classes
+    delete 'src/test/scala/router'
 }
 
 site {

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -22,14 +22,6 @@ sourceSets.test.java.srcDirs = []
 
 compileJava.options.bootstrapClasspath = null
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -54,18 +54,27 @@ test {
 }
 
 compileTestScala {
+    def routeFile = file("src/test/resources/conf/routes")
+    def generatedSourcesDir = layout.buildDirectory.dir("generated/scala")
+
     options.compilerArgs += '-proc:none'
+
+    inputs.file(routeFile)
+    localState.register(generatedSourcesDir)
 
     // this manually compiles the conf/routes file into an Routes.scala file, which is subsequently read on startup by our test application
     doFirst {
-        def routeFile = file("src/test/resources/conf/routes")
-        def outputDirectory = file("src/test/scala")
-
         def RoutesCompiler.RoutesCompilerTask routesCompilerTask = new RoutesCompiler.RoutesCompilerTask(
                 routeFile, JavaConversions.asScalaBuffer(Collections.<String> emptyList()).toSeq(),
                 true, false, false)
-        RoutesCompiler$.MODULE$.compile(routesCompilerTask, InjectedRoutesGenerator$.MODULE$, outputDirectory)
+        RoutesCompiler$.MODULE$.compile(routesCompilerTask, InjectedRoutesGenerator$.MODULE$, generatedSourcesDir.get().asFile)
+        source generatedSourcesDir
     }
+}
+
+clean {
+    // Clean up any residual generated Routes files to avoid duplicate classes
+    delete 'src/test/scala/router'
 }
 
 site {

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -22,14 +22,6 @@ sourceSets.test.java.srcDirs = []
 
 compileJava.options.bootstrapClasspath = null
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -56,18 +56,27 @@ test {
 }
 
 compileTestScala {
+    def routeFile = file("src/test/resources/conf/routes")
+    def generatedSourcesDir = layout.buildDirectory.dir("generated/scala")
+
     options.compilerArgs += '-proc:none'
+
+    inputs.file(routeFile)
+    localState.register(generatedSourcesDir)
 
     // this manually compiles the conf/routes file into an Routes.scala file, which is subsequently read on startup by our test application
     doFirst {
-        def routeFile = file("src/test/resources/conf/routes")
-        def outputDirectory = file("src/test/scala")
-
         def RoutesCompiler.RoutesCompilerTask routesCompilerTask = new RoutesCompiler.RoutesCompilerTask(
                 routeFile, JavaConversions.asScalaBuffer(Collections.<String> emptyList()).toSeq(),
                 true, false, false)
-        RoutesCompiler$.MODULE$.compile(routesCompilerTask, InjectedRoutesGenerator$.MODULE$, outputDirectory)
+        RoutesCompiler$.MODULE$.compile(routesCompilerTask, InjectedRoutesGenerator$.MODULE$, generatedSourcesDir.get().asFile)
+        source generatedSourcesDir
     }
+}
+
+clean {
+    // Clean up any residual generated Routes files to avoid duplicate classes
+    delete 'src/test/scala/router'
 }
 
 site {

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -22,14 +22,6 @@ sourceSets.test.java.srcDirs = []
 
 compileJava.options.bootstrapClasspath = null
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-shaded-async-http-client-1.0.0/build.gradle
+++ b/instrumentation/play-shaded-async-http-client-1.0.0/build.gradle
@@ -39,7 +39,5 @@ test {
         enabled = false
     } else if (project.hasProperty("test17")) {
         enabled = false
-    } else {
-        executable = jdk8 + '/bin/java'
     }
 }

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -5,14 +5,6 @@ isScalaProjectEnabled(project, "scala-2.11")
 
 compileJava.options.bootstrapClasspath = null
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-scala-api"))
@@ -55,8 +47,6 @@ test {
         enabled = false
     } else if (project.hasProperty("test17")) {
         enabled = false
-    } else {
-        executable = jdk8 + '/bin/java'
     }
 }
 

--- a/instrumentation/rabbit-amqp-5.0.0/build.gradle
+++ b/instrumentation/rabbit-amqp-5.0.0/build.gradle
@@ -6,14 +6,6 @@ dependencies {
     testImplementation("org.slf4j:slf4j-simple:1.7.30")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.rabbit-amqp-5.0.0' }
 }

--- a/instrumentation/spring-webclient-5.0/build.gradle
+++ b/instrumentation/spring-webclient-5.0/build.gradle
@@ -5,14 +5,6 @@ dependencies {
 
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/spring-webflux-5.0.0/build.gradle
+++ b/instrumentation/spring-webflux-5.0.0/build.gradle
@@ -8,14 +8,6 @@ dependencies {
     testImplementation(project(":instrumentation:spring-webclient-5.0"))
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/spring-webflux-5.1.0/build.gradle
+++ b/instrumentation/spring-webflux-5.1.0/build.gradle
@@ -8,14 +8,6 @@ dependencies {
     testImplementation(project(":instrumentation:spring-webclient-5.0"))
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/spring-webflux-5.3.0/build.gradle
+++ b/instrumentation/spring-webflux-5.3.0/build.gradle
@@ -8,14 +8,6 @@ dependencies {
     testImplementation(project(":instrumentation:spring-webclient-5.0"))
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 jar {

--- a/instrumentation/vertx-core-3.3.0/build.gradle
+++ b/instrumentation/vertx-core-3.3.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-core-3.3.3/build.gradle
+++ b/instrumentation/vertx-core-3.3.3/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-core-3.4.1/build.gradle
+++ b/instrumentation/vertx-core-3.4.1/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-core-3.6.0/build.gradle
+++ b/instrumentation/vertx-core-3.6.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-core-3.8.0/build.gradle
+++ b/instrumentation/vertx-core-3.8.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-core-3.9.0/build.gradle
+++ b/instrumentation/vertx-core-3.9.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.2.0/build.gradle
+++ b/instrumentation/vertx-web-3.2.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.3.0/build.gradle
+++ b/instrumentation/vertx-web-3.3.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.5.0/build.gradle
+++ b/instrumentation/vertx-web-3.5.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.5.1/build.gradle
+++ b/instrumentation/vertx-web-3.5.1/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.5.2/build.gradle
+++ b/instrumentation/vertx-web-3.5.2/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.6.0/build.gradle
+++ b/instrumentation/vertx-web-3.6.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.8.0/build.gradle
+++ b/instrumentation/vertx-web-3.8.0/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/instrumentation/vertx-web-3.8.3/build.gradle
+++ b/instrumentation/vertx-web-3.8.3/build.gradle
@@ -4,14 +4,6 @@ jar {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava.options.bootstrapClasspath = null
 
 dependencies {

--- a/module_test_10/build.gradle
+++ b/module_test_10/build.gradle
@@ -24,27 +24,21 @@ compileJava {
         ]
         classpath = files()
     }
+    // Boot classpath no longer works in JDK 9+ so we should ignore it here
+    options.bootstrapClasspath = null
 }
 
-compileJava.options.encoding = 'UTF-8'
-compileJava.options.fork = true
+java {
+    toolchain {
+        // Compile with Java 10 to test module support
+        languageVersion.set(JavaLanguageVersion.of(10))
+    }
+}
 
-// Compile with Java 10 to test module support
-compileJava.options.forkOptions.executable = jdk10 + '/bin/javac'
-compileJava.options.forkOptions.javaHome = new File(jdk10)
-
-compileTestJava.options.encoding = 'UTF-8'
-compileTestJava.options.fork = true
-
-// Compile with Java 10 to test module support
-compileTestJava.options.forkOptions.executable = jdk10 + '/bin/javac'
-compileTestJava.options.forkOptions.javaHome = new File(jdk10)
-
-// Boot classpath no longer works in JDK 9+ so we should ignore it here
-compileJava.options.bootstrapClasspath = null
-
-sourceCompatibility = JavaVersion.VERSION_1_10
-targetCompatibility = JavaVersion.VERSION_1_10
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.fork = true
+}
 
 def module_test_args = [
         "-javaagent:${project.jar.archivePath.absolutePath}",
@@ -58,12 +52,15 @@ def module_test_args = [
         "--module junit/org.junit.runner.JUnitCore"
 ]
 
+def compiler = javaToolchains.compilerFor {
+    languageVersion = JavaLanguageVersion.of(10)
+}
+
 test {
+    inputs.property("test.jdk", "jdk10")
     dependsOn(project(":newrelic-agent").getTasksByName("newrelicJar", false))
     forkEvery = 1
     maxParallelForks = Runtime.runtime.availableProcessors()
-
-    executable = jdk10 + '/bin/java'
 
     minHeapSize = "256m"
     maxHeapSize = "256m"

--- a/module_test_10/build.gradle
+++ b/module_test_10/build.gradle
@@ -65,6 +65,13 @@ test {
     minHeapSize = "256m"
     maxHeapSize = "256m"
 
+    // We have to set this because java.gradle sets the executable.  This project should only have a subset of
+    // java.gradle applied to it rather than having to reset this after the fact.
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(10)
+    }
+    executable = null
+
     beforeSuite {
         descriptor ->
             // We get two notifications per Test class. One of them is simply the Gradle executor used to run the test

--- a/module_test_11/build.gradle
+++ b/module_test_11/build.gradle
@@ -61,6 +61,13 @@ test {
     minHeapSize = "256m"
     maxHeapSize = "256m"
 
+    // We have to set this because java.gradle sets the executable.  This project should only have a subset of
+    // java.gradle applied to it rather than having to reset this after the fact.
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+    executable = null
+
     beforeSuite {
         descriptor ->
             // We get two notifications per Test class. One of them is simply the Gradle executor used to run the test

--- a/module_test_11/build.gradle
+++ b/module_test_11/build.gradle
@@ -15,6 +15,13 @@ dependencies {
     implementation("junit:junit:4.13")
 }
 
+java {
+    toolchain {
+        // Compile with Java 11 to test module support
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 compileJava {
     inputs.property("moduleName", "com.greetings")
     doFirst {
@@ -24,27 +31,14 @@ compileJava {
         ]
         classpath = files()
     }
+    // Boot classpath no longer works in JDK 9+ so we should ignore it here
+    options.bootstrapClasspath = null
 }
 
-compileJava.options.encoding = 'UTF-8'
-compileJava.options.fork = true
-
-// Compile with Java 11 to test module support
-compileJava.options.forkOptions.executable = jdk11 + '/bin/javac'
-compileJava.options.forkOptions.javaHome = new File(jdk11)
-
-compileTestJava.options.encoding = 'UTF-8'
-compileTestJava.options.fork = true
-
-// Compile with Java 11 to test module support
-compileTestJava.options.forkOptions.executable = jdk11 + '/bin/javac'
-compileTestJava.options.forkOptions.javaHome = new File(jdk11)
-
-// Boot classpath no longer works in JDK 9+ so we should ignore it here
-compileJava.options.bootstrapClasspath = null
-
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.fork = true
+}
 
 def module_test_args = [
         "-javaagent:${project.jar.archivePath.absolutePath}",
@@ -59,11 +53,10 @@ def module_test_args = [
 ]
 
 test {
+    inputs.property("test.jdk", "jdk11")
     dependsOn(project(":newrelic-agent").getTasksByName("newrelicJar", false))
     forkEvery = 1
     maxParallelForks = Runtime.runtime.availableProcessors()
-
-    executable = jdk11 + '/bin/java'
 
     minHeapSize = "256m"
     maxHeapSize = "256m"

--- a/module_test_9/build.gradle
+++ b/module_test_9/build.gradle
@@ -24,27 +24,21 @@ compileJava {
         ]
         classpath = files()
     }
+    // Boot classpath no longer works in JDK 9+ so we should ignore it here
+    options.bootstrapClasspath = null
 }
 
-compileJava.options.encoding = 'UTF-8'
-compileJava.options.fork = true
+java {
+    toolchain {
+        // Compile with Java 9 to test module support
+        languageVersion.set(JavaLanguageVersion.of(9))
+    }
+}
 
-// Compile with Java 9 to test module support
-compileJava.options.forkOptions.executable = jdk9 + '/bin/javac'
-compileJava.options.forkOptions.javaHome = new File(jdk9)
-
-compileTestJava.options.encoding = 'UTF-8'
-compileTestJava.options.fork = true
-
-// Compile with Java 9 to test module support
-compileTestJava.options.forkOptions.executable = jdk9 + '/bin/javac'
-compileTestJava.options.forkOptions.javaHome = new File(jdk9)
-
-// Boot classpath no longer works in JDK 9+ so we should ignore it here
-compileJava.options.bootstrapClasspath = null
-
-sourceCompatibility = JavaVersion.VERSION_1_9
-targetCompatibility = JavaVersion.VERSION_1_9
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.fork = true
+}
 
 def module_test_args = [
         "-javaagent:${project.jar.archivePath.absolutePath}",
@@ -59,11 +53,10 @@ def module_test_args = [
 ]
 
 test {
+    inputs.property("test.jdk", "jdk9")
     dependsOn(project(":newrelic-agent").getTasksByName("newrelicJar", false))
     forkEvery = 1
     maxParallelForks = Runtime.runtime.availableProcessors()
-
-    executable = jdk9 + '/bin/java'
 
     minHeapSize = "256m"
     maxHeapSize = "256m"

--- a/module_test_9/build.gradle
+++ b/module_test_9/build.gradle
@@ -61,6 +61,13 @@ test {
     minHeapSize = "256m"
     maxHeapSize = "256m"
 
+    // We have to set this because java.gradle sets the executable.  This project should only have a subset of
+    // java.gradle applied to it rather than having to reset this after the fact.
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(9)
+    }
+    executable = null
+
     beforeSuite {
         descriptor ->
             // We get two notifications per Test class. One of them is simply the Gradle executor used to run the test

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -319,16 +319,6 @@ test {
     minHeapSize = "256m"
     maxHeapSize = "768m"
 
-    // This was previously using the same JVM as the build process, but com.newrelic.agent.jfr.JfrServiceTest
-    // requires a JDK9+ JDK.  This means we can't use the same JDK as the toolchain (JDK8) and we have to
-    // specify a launcher.  For now, use the same JDK as the build process.
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
-    }
-    // We have to set this because java.gradle sets the executable.  This project should only have a subset of
-    // java.gradle applied to it rather than having to reset this after the fact.
-    executable = null
-
     if (System.getProperty('DEBUG', 'false') == 'true') {
         jvmArgs '-Xdebug',
                 '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9999',

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -320,11 +320,14 @@ test {
     maxHeapSize = "768m"
 
     // This was previously using the same JVM as the build process, but com.newrelic.agent.jfr.JfrServiceTest
-    // requires a JDK9+ JDK.  This means we can't use the same JDK as the toolchain (JDK8) and have to
+    // requires a JDK9+ JDK.  This means we can't use the same JDK as the toolchain (JDK8) and we have to
     // specify a launcher.  For now, use the same JDK as the build process.
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
     }
+    // We have to set this because java.gradle sets the executable.  This project should only have a subset of
+    // java.gradle applied to it rather than having to reset this after the fact.
+    executable = null
 
     if (System.getProperty('DEBUG', 'false') == 'true') {
         jvmArgs '-Xdebug',

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -319,6 +319,13 @@ test {
     minHeapSize = "256m"
     maxHeapSize = "768m"
 
+    // This was previously using the same JVM as the build process, but com.newrelic.agent.jfr.JfrServiceTest
+    // requires a JDK9+ JDK.  This means we can't use the same JDK as the toolchain (JDK8) and have to
+    // specify a launcher.  For now, use the same JDK as the build process.
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+    }
+
     if (System.getProperty('DEBUG', 'false') == 'true') {
         jvmArgs '-Xdebug',
                 '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9999',

--- a/newrelic-api/build.gradle
+++ b/newrelic-api/build.gradle
@@ -21,11 +21,13 @@ tasks.withType(GenerateModuleMetadata.class) {
     enabled = false
 }
 
-javadoc {
-    if (JavaVersion.current() == JavaVersion.VERSION_11) {
-        options.addBooleanOption("-frames", true)
-        options.addBooleanOption("-no-module-directories", true)
+tasks.withType(Javadoc).configureEach {
+    javadocTool = javaToolchains.javadocToolFor {
+        languageVersion = JavaLanguageVersion.of(11)
     }
+
+    options.addBooleanOption("-frames", true)
+    options.addBooleanOption("-no-module-directories", true)
 }
 
 PublishConfig.config(

--- a/newrelic-cats-effect3-api/build.gradle.kts
+++ b/newrelic-cats-effect3-api/build.gradle.kts
@@ -67,24 +67,10 @@ tasks {
         val jdk9: String by project
         val jdk8: String by project
 
-        if (project.hasProperty("test15")) {
-            executable = "$jdk15/bin/java"
-        } else if (project.hasProperty("test14")) {
-            executable = "$jdk14/bin/java"
-        } else if (project.hasProperty("test13")) {
-            executable = "$jdk13/bin/java"
-        } else if (project.hasProperty("test12")) {
-            executable = "$jdk12/bin/java"
-        } else if (project.hasProperty("test11")) {
-            executable = "$jdk11/bin/java"
-        } else if (project.hasProperty("test10")) {
-            executable = "$jdk10/bin/java"
+        if (project.hasProperty("test10")) {
             jvmArgs("--add-modules", "java.xml.bind")
         } else if (project.hasProperty("test9")) {
-            executable = "$jdk9/bin/java"
             jvmArgs("--add-modules", "java.xml.bind")
-        } else if (project.hasProperty("test8")) {
-            executable = "$jdk8/bin/java"
         }
 
         minHeapSize = "256m"

--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -62,41 +62,10 @@ tasks {
         setForkEvery(1)
         maxParallelForks = Runtime.getRuntime().availableProcessors()
 
-        val jdk17: String by project
-        val jdk16: String by project
-        val jdk15: String by project
-        val jdk14: String by project
-        val jdk13: String by project
-        val jdk12: String by project
-        val jdk11: String by project
-        val jdk10: String by project
-        val jdk9: String by project
-        val jdk8: String by project
-
-        if (project.hasProperty("test17")) {
-            executable = "$jdk17/bin/java"
-            jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
-        } else if (project.hasProperty("test16")) {
-            executable = "$jdk16/bin/java"
-            jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
-        } else if (project.hasProperty("test15")) {
-            executable = "$jdk15/bin/java"
-        } else if (project.hasProperty("test14")) {
-            executable = "$jdk14/bin/java"
-        } else if (project.hasProperty("test13")) {
-            executable = "$jdk13/bin/java"
-        } else if (project.hasProperty("test12")) {
-            executable = "$jdk12/bin/java"
-        } else if (project.hasProperty("test11")) {
-            executable = "$jdk11/bin/java"
-        } else if (project.hasProperty("test10")) {
-            executable = "$jdk10/bin/java"
+        if (project.hasProperty("test10")) {
             jvmArgs("--add-modules", "java.xml.bind")
         } else if (project.hasProperty("test9")) {
-            executable = "$jdk9/bin/java"
             jvmArgs("--add-modules", "java.xml.bind")
-        } else if (project.hasProperty("test8")) {
-            executable = "$jdk8/bin/java"
         }
 
         minHeapSize = "256m"

--- a/newrelic-scala-cats-api/build.gradle.kts
+++ b/newrelic-scala-cats-api/build.gradle.kts
@@ -58,33 +58,10 @@ tasks {
         setForkEvery(1)
         maxParallelForks = Runtime.getRuntime().availableProcessors()
 
-        val jdk15: String by project
-        val jdk14: String by project
-        val jdk13: String by project
-        val jdk12: String by project
-        val jdk11: String by project
-        val jdk10: String by project
-        val jdk9: String by project
-        val jdk8: String by project
-
-        if (project.hasProperty("test15")) {
-            executable = "$jdk15/bin/java"
-        } else if (project.hasProperty("test14")) {
-            executable = "$jdk14/bin/java"
-        } else if (project.hasProperty("test13")) {
-            executable = "$jdk13/bin/java"
-        } else if (project.hasProperty("test12")) {
-            executable = "$jdk12/bin/java"
-        } else if (project.hasProperty("test11")) {
-            executable = "$jdk11/bin/java"
-        } else if (project.hasProperty("test10")) {
-            executable = "$jdk10/bin/java"
+        if (project.hasProperty("test10")) {
             jvmArgs("--add-modules", "java.xml.bind")
         } else if (project.hasProperty("test9")) {
-            executable = "$jdk9/bin/java"
             jvmArgs("--add-modules", "java.xml.bind")
-        } else if (project.hasProperty("test8")) {
-            executable = "$jdk8/bin/java"
         }
 
         minHeapSize = "256m"

--- a/newrelic-scala-monix-api/build.gradle.kts
+++ b/newrelic-scala-monix-api/build.gradle.kts
@@ -62,33 +62,10 @@ tasks {
         setForkEvery(1)
         maxParallelForks = Runtime.getRuntime().availableProcessors()
 
-        val jdk15: String by project
-        val jdk14: String by project
-        val jdk13: String by project
-        val jdk12: String by project
-        val jdk11: String by project
-        val jdk10: String by project
-        val jdk9: String by project
-        val jdk8: String by project
-
-        if (project.hasProperty("test15")) {
-            executable = "$jdk15/bin/java"
-        } else if (project.hasProperty("test14")) {
-            executable = "$jdk14/bin/java"
-        } else if (project.hasProperty("test13")) {
-            executable = "$jdk13/bin/java"
-        } else if (project.hasProperty("test12")) {
-            executable = "$jdk12/bin/java"
-        } else if (project.hasProperty("test11")) {
-            executable = "$jdk11/bin/java"
-        } else if (project.hasProperty("test10")) {
-            executable = "$jdk10/bin/java"
+        if (project.hasProperty("test10")) {
             jvmArgs("--add-modules", "java.xml.bind")
         } else if (project.hasProperty("test9")) {
-            executable = "$jdk9/bin/java"
             jvmArgs("--add-modules", "java.xml.bind")
-        } else if (project.hasProperty("test8")) {
-            executable = "$jdk8/bin/java"
         }
 
         minHeapSize = "256m"

--- a/newrelic-scala-zio-api/build.gradle.kts
+++ b/newrelic-scala-zio-api/build.gradle.kts
@@ -61,33 +61,10 @@ tasks {
         setForkEvery(1)
         maxParallelForks = Runtime.getRuntime().availableProcessors()
 
-        val jdk15: String by project
-        val jdk14: String by project
-        val jdk13: String by project
-        val jdk12: String by project
-        val jdk11: String by project
-        val jdk10: String by project
-        val jdk9: String by project
-        val jdk8: String by project
-
-        if (project.hasProperty("test15")) {
-            executable = "$jdk15/bin/java"
-        } else if (project.hasProperty("test14")) {
-            executable = "$jdk14/bin/java"
-        } else if (project.hasProperty("test13")) {
-            executable = "$jdk13/bin/java"
-        } else if (project.hasProperty("test12")) {
-            executable = "$jdk12/bin/java"
-        } else if (project.hasProperty("test11")) {
-            executable = "$jdk11/bin/java"
-        } else if (project.hasProperty("test10")) {
-            executable = "$jdk10/bin/java"
+        if (project.hasProperty("test10")) {
             jvmArgs("--add-modules", "java.xml.bind")
         } else if (project.hasProperty("test9")) {
-            executable = "$jdk9/bin/java"
             jvmArgs("--add-modules", "java.xml.bind")
-        } else if (project.hasProperty("test8")) {
-            executable = "$jdk8/bin/java"
         }
 
         minHeapSize = "256m"


### PR DESCRIPTION
### Overview
These changes fix the cacheability of of JavaCompile, ScalaCompile and Test tasks.  There are a few changes:

- Use toolchains instead of executable for java compilation
- Set "test.jdk" input property to avoid getting false cache hits across the crossversion jdk test tasks using the same JDK version
- Unset executable for ScalaCompile to workaround Gradle defect
- Refactor the play-2.6, play-2.6.13 and play-2.7 instrumentation projects to make their Scala test compile tasks cacheable
- Add cacheability to the `writeCachedWeaveAttributes` tasks

A couple of assumptions/caveats:
- The crossversion jdk tests tasks should really use toolchains instead of properties to select different JDKs.  This would allow the build to be specific about what the expectations are for each testing scenario.  However, the selection criteria in its current form only allows the specification of version, vendor and implementation (see https://github.com/gradle/gradle/blob/c53d50f1e81500f2f84f98d2e2e3f65739c15c66/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java).  This is a problem for this use case because some of the JDKs that are being tested against use the same vendor/version/implementation. 
 https://github.com/gradle/gradle/issues/18896 addresses adding further criteria (such as `java.vm.name`).  Once that is available, this could be converted to using toolchains as well and eliminate the need for the JDK properties.
- The newrelic-agent test task was setting the source/target compatibility, but was always running tests with whatever JDK the build was running with.  I've converted that to use toolchains and keep the same behavior, but one of the tests _can't_ run with a JDK < 9 (`JfrServiceTest`).  This should really target a specific JDK, rather than relying on the build process JDK.
- The routes compilation for the play-2.6, play-2.6.13 and play-2.7 instrumentation projects was generating sources into the source directory of the test compile task.  This meant that the task was _never_ up-to-date or cacheable since every time it would run, it would change its inputs.  I've changed it so that it generates the sources outside of the source directories and set these up as local state of the task (neither an input or an output) and added the routes file as an input.  This should make these tasks up-to-date and cacheable now.  Since it was generating the Routes source files outside of the build directory, it would not clean these up with the "clean" task and you could get duplicate class files.  To fix this, I added `src/test/scala/routes` to the clean task, but this is only necessary to clean up what it was generating before.  There are other options for this if this approach seems too heavy-handed.
- The newrelic-api Javadoc task had a conditional set of arguments if the build was run with JDK11.  Rather than try to react to an unknown condition (i.e. the JDK the build process is executing with) it seemed better to just specifically use JDK11.  This can obviously be handled differently if there is some reason why we shouldn't be more specific here.

### Related Github Issue
N/A

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
There should be no impacts on backwards compatibility.
[x ] Does your code contain any breaking changes? Please describe. 
There should not be any, beyond the minor assumptions stated above.
[x] Does your code introduce any new dependencies? Please describe.
No.
