### PR TITLE
add bypass for agent version chck

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
@@ -48,6 +48,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     public static final String ENABLE_BOOTSTRAP_CLASS_INSTRUMENTATION = "enable_bootstrap_class_instrumentation";
     public static final String ENABLE_CLASS_RETRANSFORMATION = "enable_class_retransformation";
     public static final String ENABLE_CUSTOM_TRACING = "enable_custom_tracing";
+    public static final String EXPERIMENTAL_RUNTIME = "experimental_runtime";
     public static final String EXT_CONFIG_DIR = "extensions.dir";
     public static final String HIGH_SECURITY = "high_security";
     public static final String HOST = "host";
@@ -134,6 +135,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     public static final boolean DEFAULT_ENABLE_AUTO_APP_NAMING = false;
     public static final boolean DEFAULT_ENABLE_AUTO_TRANSACTION_NAMING = true;
     public static final boolean DEFAULT_ENABLE_CUSTOM_TRACING = true;
+    public static final boolean DEFAULT_EXPERIMENTAL_RUNTIME = false;
     public static final boolean DEFAULT_HIGH_SECURITY = false;
     public static final boolean DEFAULT_METRIC_DEBUG = false;
 
@@ -199,6 +201,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     private final boolean debug;
     private final boolean metricDebug;
     private final boolean enabled;
+    private final boolean experimentalRuntime;
     private final boolean genericJdbcSupportEnabled;
     private final boolean highSecurity;
     private final String host;
@@ -291,6 +294,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
         debug = Boolean.getBoolean(DEBUG);
         metricDebug = initMetricDebugConfig();
         enabled = getProperty(ENABLED, DEFAULT_ENABLED) && getProperty(AGENT_ENABLED, DEFAULT_ENABLED);
+        experimentalRuntime = allowExperimentalRuntimeVersions();
         licenseKey = getProperty(LICENSE_KEY);
         String region = parseRegion(licenseKey);
         host = parseHost(region);
@@ -434,7 +438,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
      * If metric ingest URI was set explicitly, then always use it and don't construct the metric ingest URI from the region parsed from the
      * license key. If the license key doesn't conform to protocol 15+, then return the default metric ingest URI, otherwise construct the
      * new metric ingest URI using the region section of the license key.
-     *
+     * <p>
      * US Prod metric ingest URI: https://metric-api.newrelic.com/metric/v1
      * EU Prod metric ingest URI: https://metric-api.eu.newrelic.com/metric/v1
      */
@@ -465,7 +469,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
      * If event ingest URI was set explicitly, then always use it and don't construct the event ingest URI from the region parsed from the
      * license key. If the license key doesn't conform to protocol 15+, then return the default event ingest URI, otherwise construct the
      * new event ingest URI using the region section of the license key.
-     *
+     * <p>
      * US Prod event ingest URI: https://insights-collector.newrelic.com/v1/accounts/events
      * EU Prod event ingest URI: https://insights-collector.eu01.nr-data.net/v1/accounts/events
      */
@@ -554,6 +558,14 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
             Agent.LOG.log(Level.INFO, "metric_debug is enabled");
         }
         return getProperty(METRIC_DEBUG, DEFAULT_METRIC_DEBUG);
+    }
+
+    private boolean allowExperimentalRuntimeVersions() {
+        Object val = getProperty(EXPERIMENTAL_RUNTIME);
+        if (val instanceof Boolean && (Boolean) val) {
+            Agent.LOG.log(Level.INFO, "experimental_runtime is enabled");
+        }
+        return getProperty(EXPERIMENTAL_RUNTIME, DEFAULT_EXPERIMENTAL_RUNTIME);
     }
 
     private void setServerSpanHarvestLimit() {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JavaVersionUtils.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JavaVersionUtils.java
@@ -16,6 +16,7 @@ public class JavaVersionUtils {
     private static final Pattern SUPPORTED_JAVA_VERSION_PATTERN = Pattern.compile("^(1\\.8|9|1[0-7])$");
     private static final Pattern EXCLUSIVE_MIN_JAVA_VERSION_PATTERN = Pattern.compile("^1\\.7$");
     private static final Pattern EXCLUSIVE_MAX_JAVA_VERSION_PATTERN = Pattern.compile("^18$");
+    private static final String MAX_SUPPORTED_VERSION = "17";
 
     public static final String JAVA_7 = "1.7";
     public static final String JAVA_8 = "1.8";
@@ -53,10 +54,10 @@ public class JavaVersionUtils {
         if (EXCLUSIVE_MIN_JAVA_VERSION_PATTERN.matcher(javaSpecificationVersion).matches()) {
             message.append("Java version is: ").append(javaSpecificationVersion).append(". ");
             message.append("This version of the New Relic Agent does not support Java 1.7 or below. ")
-            .append("Please use a 6.5.0 New Relic agent or a later version of Java.");
+                    .append("Please use a 6.5.0 New Relic agent or a later version of Java.");
         } else if (EXCLUSIVE_MAX_JAVA_VERSION_PATTERN.matcher(javaSpecificationVersion).matches()) {
             message.append("Java version is: ").append(javaSpecificationVersion).append(". ");
-            message.append("This version of the New Relic Agent does not support versions of Java greater than 17.");
+            message.append("This version of the New Relic Agent does not support versions of Java greater than " + MAX_SUPPORTED_VERSION + ".");
         }
         return message.toString();
     }


### PR DESCRIPTION
Feature https://github.com/newrelic/newrelic-java-agent/issues/628
This adds a configuration option (must use system property or environment variable) that bypasses the agents check on supported version. 
We currently check in JavaVersionUtils to see if the agent has been loaded in a supported Java version. We fail and exit if we detect the agent has been loaded in an unsupported version (both old and new jdk versions).

This bypass is to allow for experimental usage of an agent build in any forward JDK. This would allow for some simple smoke testing or other usages without having to do a build with changes  to JavaVersionUtils.

Describe Alternatives
continue as we do. Create a special branch and change what's needed to build and run on a future java runtime.

Given the faster cadence of jdk releases, this would help us be more nimble in getting ready for future releases and staying on top of breaking changes. Similarly, it would make it easier to do ad hoc tests of the agent on experimental JDK branches.

to use, build and configure either:
system property

`-Dnewrelic.config.experimental_runtime=true
`

ENVVAR

`NEW_RELIC_AGENT_EXPERIMENTAL_RUNTIME=true
`
### Checks

[ yes ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ no ] Does your code contain any breaking changes? Please describe. 
[ no  ] Does your code introduce any new dependencies? Please describe.
