### PR TITLE
Add additional exception case to catch ConnectionPoolTimeoutException…

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -860,21 +860,17 @@ public class RPMService extends AbstractService implements IRPMService, Environm
                 retry = true;
                 Agent.LOG.log(Level.INFO, "A connection error occurred contacting {0}. Please check your network / proxy settings.", e.getHostName());
                 Agent.LOG.log(Level.FINEST, e, e.toString());
-            } catch (ConnectionPoolTimeoutException e) {
-                Agent.LOG.log(Level.INFO, "A connection pool timeout error occurred.");
-                Agent.LOG.log(Level.FINEST, e, e.toString());
-                reconnectAsync();
-                retry = true;
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 // LicenseException handled here
                 logMetricDataError(e);
                 retry = true;
-                String message = e.getMessage().toLowerCase();
-                // if our data can't be parsed, we probably have a bad metric
-                // (web transaction maybe?). clear out the metrics
-                if (message.contains("json") && message.contains("parse")) {
-                    retry = false;
+                if(e.getMessage() != null) {
+                    String message = e.getMessage().toLowerCase();
+                    // if our data can't be parsed, we probably have a bad metric
+                    // (web transaction maybe?). clear out the metrics
+                    if (message.contains("json") && message.contains("parse")) {
+                        retry = false;
+                    }
                 }
             }
             long duration = System.nanoTime() - startTime;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -44,6 +44,7 @@ import com.newrelic.agent.transport.HostConnectException;
 import com.newrelic.agent.transport.HttpError;
 import com.newrelic.agent.transport.HttpResponseCode;
 import com.newrelic.agent.utilization.UtilizationData;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
 import org.json.simple.JSONStreamAware;
 
 import java.lang.management.ManagementFactory;
@@ -859,7 +860,13 @@ public class RPMService extends AbstractService implements IRPMService, Environm
                 retry = true;
                 Agent.LOG.log(Level.INFO, "A connection error occurred contacting {0}. Please check your network / proxy settings.", e.getHostName());
                 Agent.LOG.log(Level.FINEST, e, e.toString());
-            } catch (Exception e) {
+            } catch (ConnectionPoolTimeoutException e) {
+                Agent.LOG.log(Level.INFO, "A connection pool timeout error occurred.");
+                Agent.LOG.log(Level.FINEST, e, e.toString());
+                reconnectAsync();
+                retry = true;
+            }
+            catch (Exception e) {
                 // LicenseException handled here
                 logMetricDataError(e);
                 retry = true;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -44,7 +44,6 @@ import com.newrelic.agent.transport.HostConnectException;
 import com.newrelic.agent.transport.HttpError;
 import com.newrelic.agent.transport.HttpResponseCode;
 import com.newrelic.agent.utilization.UtilizationData;
-import org.apache.http.conn.ConnectionPoolTimeoutException;
 import org.json.simple.JSONStreamAware;
 
 import java.lang.management.ManagementFactory;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -863,7 +863,7 @@ public class RPMService extends AbstractService implements IRPMService, Environm
                 // LicenseException handled here
                 logMetricDataError(e);
                 retry = true;
-                if(e.getMessage() != null) {
+                if (e.getMessage() != null) {
                     String message = e.getMessage().toLowerCase();
                     // if our data can't be parsed, we probably have a bad metric
                     // (web transaction maybe?). clear out the metrics


### PR DESCRIPTION
### Overview
Handle possible Null Pointer Exception during exception handling in the RPMService. Found while investigation issues with `ConnectionPoolTimeoutException`

### Related Github Issue
[Include a link to the related GitHub issue, if applicable](https://github.com/newrelic/newrelic-java-agent/issues/256)

### Testing
Running metrics threw agent. Log line debugging. 

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? Please describe. No
[X] Does your code introduce any new dependencies? Please describe. No
