### PR TITLE
Updating version some instrumentation modules apply to

### DIFF
--- a/instrumentation/cats-effect-2/build.gradle
+++ b/instrumentation/cats-effect-2/build.gradle
@@ -16,9 +16,14 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'org.typelevel:cats-effect_2.13:[2.1,)'
-    passes 'org.typelevel:cats-effect_2.12:[2.1,)'
-    excludeRegex 'org.typelevel:cats-effect_2.1(2|3):3.*'
+    // scala 12
+    passes 'org.typelevel:cats-effect_2.12:[2.1,3.0)'
+    fails 'org.typelevel:cats-effect_2.12:[3.0,)'
+
+    // scala 13
+    passes 'org.typelevel:cats-effect_2.13:[2.1,3.0)'
+    fails 'org.typelevel:cats-effect_2.13:[3.0,)'
+
     excludeRegex '.*(RC|M)[0-9]*'
 }
 

--- a/instrumentation/cats-effect-3/build.gradle
+++ b/instrumentation/cats-effect-3/build.gradle
@@ -17,8 +17,8 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'org.typelevel:cats-effect_2.13:[3.2,)'
-    passes 'org.typelevel:cats-effect_2.12:[3.2,)'
+    passes 'org.typelevel:cats-effect_2.13:[3.2,3.3)'
+    passes 'org.typelevel:cats-effect_2.12:[3.2,3.3)'
     excludeRegex '.*(RC|M)[0-9]*'
 }
 

--- a/instrumentation/jedis-3.0.0/build.gradle
+++ b/instrumentation/jedis-3.0.0/build.gradle
@@ -11,9 +11,10 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passes 'redis.clients:jedis:[3.0.0,)'
+    passes 'redis.clients:jedis:[3.0.0,4.0.0)'
     fails 'redis.clients:jedis:[1.4.0,3.0.0)'
-    excludeRegex 'redis.clients:jedis:.*-(m|rc|RC)[0-9]*'
+    fails 'redis.clients:jedis:[4.0.0,)'
+    excludeRegex 'redis.clients:jedis:.*-(m|rc|RC|beta)[0-9]*'
     // there's something weird about how the verifier treats this version
     exclude 'redis.clients:jedis:3.6.2'
 }

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -21,9 +21,13 @@ jar {
 }
 
 verifyInstrumentation {
+    // scala 11 should be instrumented by another module
     fails 'com.typesafe.slick:slick_2.11:[3.2.0,)'
-    passesOnly 'com.typesafe.slick:slick_2.12:[3.2.0-M2,)'
-    exclude 'com.typesafe.slick:slick_2.11:3.2.0-M1'
+
+    // scala 12
+    passesOnly 'com.typesafe.slick:slick_2.12:[3.2.0,3.4.0)'
+
+    excludeRegex ".*(RC|M)[0-9].*"
 }
 
 test {

--- a/instrumentation/spring-ws-2.0/build.gradle
+++ b/instrumentation/spring-ws-2.0/build.gradle
@@ -18,6 +18,9 @@ verifyInstrumentation {
   }
   // version 3.1.0 fails but then 3.1.1 passes again
   exclude('org.springframework.ws:spring-ws-core:3.1.0')
+
+  // instrumentation does not work in 3.0.11. It was likely a bad release, 3.0.12 was released 2 days later.
+  exclude('org.springframework.ws:spring-ws-core:3.0.11.RELEASE')
 }
 
 test {


### PR DESCRIPTION
### Overview
Some instrumentation modules had the versions that they apply to outdated due to new releases of the libraries.
This PR fixes that and also improves some of the checks to certify that a module is not applied to a version of the library it should not apply to.