### PR TITLE
Change test to MongoDB version V4_0_2

### DIFF
--- a/instrumentation/mongodb-async-4.0/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDbAsync400Test.java
+++ b/instrumentation/mongodb-async-4.0/src/test/java/com/nr/agent/instrumentation/mongodb/MongoDbAsync400Test.java
@@ -49,7 +49,7 @@ public class MongoDbAsync400Test {
     public void startMongo() throws Exception {
         int port = Network.freeServerPort(getLocalHost());
         MongodConfig mongodConfig = ImmutableMongodConfig.builder()
-                .version(Version.V4_4_9) // MongoDB version, not Mongo client version
+                .version(Version.V4_0_2) // MongoDB version, not Mongo client version 4.0.26
                 .net(new Net(port, Network.localhostIsIPv6()))
                 .build();
         mongodExecutable = mongodStarter.prepare(mongodConfig);


### PR DESCRIPTION
Lowered the MongoDB version to one defined in a `PlatformMatchRule`:

https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/blob/45f37517309cf9a4848c43561bcf93def999305f/src/main/java/de/flapdoodle/embed/mongo/packageresolver/linux/LinuxPackageFinder.java#L115-L124