### PR TITLE
Exclude Scala test tasks by default

### DIFF
--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -111,7 +111,7 @@ jobs:
           TEST_TYPE: functional
         run: |
           # Removed ":newrelic-cats-effect3-api:test" temporarily
-          ./gradlew --console=plain --parallel :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test :newrelic-scala-monix-api:test -Ptest${{ matrix.java-version }} --continue --scan -Dscan.uploadInBackground=false --build-cache
+          ./gradlew --console=plain --parallel :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test :newrelic-scala-monix-api:test -PincludeScala -Ptest${{ matrix.java-version }} --continue --scan -Dscan.uploadInBackground=false --build-cache
 
       - name: Run functional tests against version defined in matrix w/o GE
         if: ${{ env.GRADLE_KEY == '' }}
@@ -119,7 +119,7 @@ jobs:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
           # Removed ":newrelic-cats-effect3-api:test" temporarily
-          ./gradlew --console=plain --parallel :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test :newrelic-scala-monix-api:test -Ptest${{ matrix.java-version }} --continue
+          ./gradlew --console=plain --parallel :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test :newrelic-scala-monix-api:test -PincludeScala -Ptest${{ matrix.java-version }} --continue
 
       # Capture HTML build result in artifacts
       - name: Capture build reports

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -142,13 +142,13 @@ jobs:
           LANGUAGE: scala
           SCALA_VERSION: scala${{ matrix.scala }}
           TEST_TYPE: instrumentation
-        run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -PnoScala -Pscala-${{ matrix.scala }} --continue --scan -Dscan.uploadInBackground=false --build-cache
+        run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue --scan -Dscan.uploadInBackground=false --build-cache
 
       - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} w/o GE
         if: ${{ env.GRADLE_KEY == '' }}
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
-        run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -PnoScala -Pscala-${{ matrix.scala }} --continue
+        run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
 
       - name: Capture build reports
         if: ${{ failure() }}

--- a/.github/workflows/X-Reusable-Test.yml
+++ b/.github/workflows/X-Reusable-Test.yml
@@ -160,7 +160,7 @@ jobs:
           LANGUAGE: java
           TEST_TYPE: instrumentation
         run: |
-          ./gradlew --console=plain :instrumentation:test -Ptest${{ inputs.jre }} -PnoScala --continue -Dscan.uploadInBackground=false --build-cache
+          ./gradlew --console=plain :instrumentation:test -Ptest${{ inputs.jre }} --continue -Dscan.uploadInBackground=false --build-cache
 
       # Run the build without Gradle Enterprise
       - name: Run instrumentation tests for Java ${{ inputs.jre }} w/o GE
@@ -169,7 +169,7 @@ jobs:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
           echo "*** NOT PUBLISHING BUILD SCANS OR CACHE ***"
-          ./gradlew --console=plain :instrumentation:test -Ptest${{ inputs.jre }} -PnoScala --continue
+          ./gradlew --console=plain :instrumentation:test -Ptest${{ inputs.jre }} --continue
 
       # Capture HTML build result in artifacts
       - name: Capture build reports

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The Java agent utilizes the following four distinct test suites, each of which i
 
 #### Conventional unit tests
 
-The unit tests are conventional JUnit tests. The supporting framework is the industry-standard JUnit dependency. Unit tests rely on a variety of different mock object frameworks combined with complex test initialization patterns that simulate agent initialization.
+The unit tests are conventional JUnit tests. The supporting framework is the industry-standard JUnit dependency. Unit tests rely on a variety of different mock object frameworks combined with complex test initialization patterns that simulate agent initialization. Scala test tasks are excluded by default. Including the -PincludeScala project property includes Scala test tasks.
 
 Run all unit tests:
 
@@ -140,6 +140,11 @@ Run all tests for a specific instrumentation module:
 Run a single test for a specific instrumentation module:
 ```
 ./gradlew instrumentation:vertx-web-3.2.0:test --tests com.nr.vertx.instrumentation.RoutingTest --parallel
+```
+
+Run all tests for a specific Scala instrumentation module:
+```
+./gradlew -PincludeScala instrumentation:sttp-2.13_2.2.3:test --parallel
 ```
 
 ## Support

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -45,7 +45,6 @@ task test {
 
 def isScalaProjectEnabled(Project project, String... scalaVersions) {
     return scalaVersions.any {scalaVersion -> project.hasProperty(scalaVersion) }  ? project.tasks.all { task -> task.enabled = true }  // Enable tasks if project property matching scala version is passed
-            : project.hasProperty("noScala") ? project.tasks.all { task -> task.enabled = false } // Disable tasks if  project property noScala is passed
             : project.hasProperty('noInstrumentation') ? project.tasks.all { task -> task.enabled = false } // Disable tasks if project property noInstrumentation is passed
-            : project.tasks.all { task -> task.enabled = task.enabled }  // Default to task enabled flag
+            : project.tasks.all { task -> task.enabled = task.name != "test" ? task.enabled : task.enabled && project.hasProperty('includeScala')  }  // Default to task enabled flag
 }


### PR DESCRIPTION
### Overview
Zinc compiler issues prevent compiling multiple scala versions together.
Exclude Scala test tasks by default. 
Include -PincludeScala project property to enable Scala test tasks.
 Provide an example of new project property usage in the readme. 
Remove noScala project property and usage.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/584

### Testing
Local test runs
Ran green GHA checks against draft pull request

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? Please describe. No
[X] Does your code introduce any new dependencies? Please describe. No
