### PR TITLE
Changing setup-java to use temurin since adopt is dead

### DIFF
--- a/.github/workflows/AITs-Basic-Features-Flaky.yml
+++ b/.github/workflows/AITs-Basic-Features-Flaky.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       # Set the JDk variable
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       # Set the JDk variable
@@ -145,7 +145,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       # Set the JDk variable

--- a/.github/workflows/AITs-Basic-Features-Special-JREs.yml
+++ b/.github/workflows/AITs-Basic-Features-Special-JREs.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       # Set the JDk variable
@@ -134,7 +134,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       # Set the JDk variable
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       # Set the JDk variable

--- a/.github/workflows/AITs-Basic-Features.yml
+++ b/.github/workflows/AITs-Basic-Features.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       # Set the JDk variable
@@ -144,7 +144,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       # Set the JDk variable
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       # Set the JDk variable

--- a/.github/workflows/Datastore-AITs.yml
+++ b/.github/workflows/Datastore-AITs.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
           cache: 'gradle'
 
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/GHA-AIT-functionality-framework-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-framework-tests.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       # Save new JDK variable
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/GHA-AIT-functionality-security-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-security-tests.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Java 16
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 16
           cache: 'gradle'
 
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/GHA-AIT-functionality-server-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-server-tests.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 
@@ -134,7 +134,7 @@ jobs:
       - name: Set up Java 16
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 16
           cache: 'gradle'
 
@@ -147,7 +147,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/GHA-AIT-functionality-trace-tests.yaml
+++ b/.github/workflows/GHA-AIT-functionality-trace-tests.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Java 16
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 16
           cache: 'gradle'
 
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/GHA-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Functional-Tests.yaml
@@ -36,7 +36,7 @@ jobs:
         # https://github.com/actions/setup-java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       - name: Save JAVA_HOME as JDK8 for later usage
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Save JAVA_HOME as JDK11 for later usage
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       - name: Save JAVA_HOME as JDK17 for later usage

--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -36,7 +36,7 @@ jobs:
         # https://github.com/actions/setup-java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       - name: Save JAVA_HOME as JDK8 for later usage
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Save JAVA_HOME as JDK11 for later usage

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -43,7 +43,7 @@ jobs:
         # https://github.com/actions/setup-java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       - name: Save JAVA_HOME as JDK8 for later usage
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Save JAVA_HOME as JDK11 for later usage

--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       - name: Save JAVA_HOME as JDK8 for later usage
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Save JAVA_HOME as JDK11 for later usage
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       - name: Save JAVA_HOME as JDK17 for later usage

--- a/.github/workflows/X-Reusable-Test.yml
+++ b/.github/workflows/X-Reusable-Test.yml
@@ -39,7 +39,7 @@ jobs:
         # https://github.com/actions/setup-java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       # Save new JDK variable
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       # Save new JDK variable
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       # Save new JDK variable


### PR DESCRIPTION
### Overview
Adopt has been discontinued and temurin has taken over.
So we have to use temurin to be able to use the latest update of each Java version.

### Checks

[Y] Are your contributions backwards compatible with relevant frameworks and APIs?
[N] Does your code contain any breaking changes? Please describe. 
[N] Does your code introduce any new dependencies? Please describe.
