### PR TITLE
Remove debug log

### DIFF
--- a/instrumentation/aws-java-sdk-s3-1.2.13/src/main/java/com/amazonaws/services/s3/AmazonS3_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-s3-1.2.13/src/main/java/com/amazonaws/services/s3/AmazonS3_Instrumentation.java
@@ -103,7 +103,6 @@ public class AmazonS3_Instrumentation {
             throw exception;
         } finally {
             String uri = "s3://" + getObjectRequest.getBucketName() + "/" + getObjectRequest.getKey();
-            System.out.println("URI:"  + uri);
             S3MetricUtil.reportExternalMetrics(NewRelic.getAgent().getTracedMethod(), uri, statusCode, "getObject");
         }
     }


### PR DESCRIPTION
### Overview
Removes a redundant debug log (System.out.println) in aws-java-sdk-s3.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/681

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
Yes
[ ] Does your code contain any breaking changes? Please describe. 
No
[ ] Does your code introduce any new dependencies? Please describe.
No
