### PR TITLE
Adding attribute Automatic-Module-Name for JDK9/11

### DIFF
--- a/newrelic-api/build.gradle
+++ b/newrelic-api/build.gradle
@@ -8,7 +8,7 @@ plugins {
 jar {
     from("$rootDir/LICENSE")
     manifest {
-        attributes 'Implementation-Title': 'New Relic Agent API', 'Implementation-Version': project.version
+        attributes 'Implementation-Title': 'New Relic Agent API', 'Implementation-Version': project.version, 'Automatic-Module-Name': 'newrelic.api'
     }
 }
 


### PR DESCRIPTION

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
Our platform is updating from Java 8 to Java 11. We're building module-info.java files and we're currently experiencing an error because the `requires newrelic.api` module is not found.  My understanding is that this identifier needs to be in the MANIFEST.MF file.

### Related Github Issue
No linked issue available

### Checks

[X ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
