### PR TITLE
Fix Java 18 EA Instrumentation run to use reusable workflow in main

### DIFF
--- a/.github/workflows/Java-18-ea-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-18-ea-Instrumentation-Tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   tests:
-    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@java-18-ea
+    uses: newrelic/newrelic-java-agent/.github/workflows/X-Reusable-Test.yml@main
     with:
       jre: 18
     secrets:


### PR DESCRIPTION
Necessary evil to get reusable workflow usage corrected after commit to main until we move reusable workflows to separate repo.