### PR TITLE
get rid of support@newrelic refs

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -329,12 +329,12 @@ public class RPMService extends AbstractService implements IRPMService, Environm
 
     private void logForceDisconnectException(ForceDisconnectException e) {
         Agent.LOG.log(Level.SEVERE, "Received a ForceDisconnectException: {0}. The agent is no longer reporting"
-                + " information. If this is not a misconfiguration, please contact support@newrelic.com.", e.toString());
+                + " information. If this is not a misconfiguration, please contact support via https://support.newrelic.com/.", e.toString());
     }
 
     private void logLicenseException(LicenseException e) {
         Agent.LOG.log(Level.SEVERE, "Invalid license key, the agent is no longer reporting"
-                + " information. If this is not a misconfiguration, please contact support@newrelic.com.", e.toString());
+                + " information. If this is not a misconfiguration, please contact support via https://support.newrelic.com/.", e.toString());
     }
 
     private void shutdownAsync() {
@@ -343,7 +343,7 @@ public class RPMService extends AbstractService implements IRPMService, Environm
 
     private void logForceRestartException(ForceRestartException e) {
         Agent.LOG.log(Level.WARNING, "Received a ForceRestartException: {0}. The agent will attempt to reconnect for"
-                + " data reporting. If this message continues, please contact support@newrelic.com.", e.toString());
+                + " data reporting. If this message continues, please contact support via https://support.newrelic.com/.", e.toString());
     }
 
     private void reconnectSync() throws Exception {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockCollectorServlet.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockCollectorServlet.java
@@ -64,7 +64,7 @@ public class MockCollectorServlet extends HttpServlet {
             if ("xxxxxxxxxxxxxxxxxxxxxxxxxxx".equals(request.getParameter("license_key"))) {
                 response.setStatus(401);
                 JSONObject inner = new JSONObject();
-                inner.put("message", "Invalid license key, please contact support@newrelic.com");
+                inner.put("message", "Invalid license key, please contact support via https://support.newrelic.com/.");
                 json.put("exception", inner);
             } else {
                 JSONObject inner = new JSONObject();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/jasper/GeneratorVisitTracerFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/jasper/GeneratorVisitTracerFactoryTest.java
@@ -598,7 +598,6 @@ public class GeneratorVisitTracerFactoryTest {
         sb.append("<meta http-equiv=\"Pragma\" content=\"no-cache\"/>\n");
         sb.append("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"/>\n");
         sb.append("<meta name=\"Author\" content=\"my author\"/>\n");
-        sb.append("<meta name=\"INFO\" content=\"mailto:support@newrelic.com\"/>\n");
         sb.append("<meta name=\"description\" content=\"We have a lot of fun in what we do.\"/>\n");
         sb.append("<meta name=\"KEYWORDS\" content=\"observability, new, relic\"/>\n");
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/jasper/GeneratorVisitTracerFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/jasper/GeneratorVisitTracerFactoryTest.java
@@ -598,6 +598,7 @@ public class GeneratorVisitTracerFactoryTest {
         sb.append("<meta http-equiv=\"Pragma\" content=\"no-cache\"/>\n");
         sb.append("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"/>\n");
         sb.append("<meta name=\"Author\" content=\"my author\"/>\n");
+        sb.append("<meta name=\"INFO\" content=\"mailto:support@newrelic.com\"/>\n");
         sb.append("<meta name=\"description\" content=\"We have a lot of fun in what we do.\"/>\n");
         sb.append("<meta name=\"KEYWORDS\" content=\"observability, new, relic\"/>\n");
 


### PR DESCRIPTION
Logging and one test change.
https://github.com/newrelic/newrelic-java-agent/issues/687
Java agent log messages still contain the support email address support@newrelic.com
That email address is no longer active and is not a way that customers can contact support. Update the logs be updated to point to the support portal at https://support.newrelic.com
```
2022-01-27T21:24:59,085+0000 [1 63] com.newrelic WARN: Received a ForceRestartException: com.newrelic.agent.ForceRestartException: . The agent will attempt to reconnect for data reporting. If this message continues, please contact support@newrelic.com.

```