### PR TITLE
upgrade scala weaver to 2.12 to allow use with java 11+

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/InstrumentingClassLoader.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/InstrumentingClassLoader.java
@@ -18,6 +18,7 @@ import com.newrelic.agent.deps.org.objectweb.asm.Type;
 import com.newrelic.agent.deps.org.objectweb.asm.commons.Method;
 import com.newrelic.agent.deps.org.objectweb.asm.tree.ClassNode;
 import com.newrelic.agent.instrumentation.InstrumentationType;
+import com.newrelic.agent.instrumentation.classmatchers.ScalaTraitMatcher;
 import com.newrelic.agent.instrumentation.context.InstrumentationContext;
 import com.newrelic.agent.instrumentation.tracing.Annotation;
 import com.newrelic.agent.instrumentation.tracing.NoticeSqlVisitor;
@@ -100,9 +101,10 @@ class InstrumentingClassLoader extends WeavingClassLoader {
         }
 
         final InstrumentationContext context = new InstrumentationContext(classBytes, null, null);
-
+        new ClassReader(classBytes).accept(new ScalaTraitMatcher().newClassMatchVisitor(null, null, null,null,  context)
+                                             , ClassReader.SKIP_FRAMES);
         // weave
-        byte[] weaved = weave(className, classBytes, new ClassWeavedListener() {
+        byte[] weaved = weave(className, classBytes, context.getSkipMethods(), new ClassWeavedListener() {
             @Override
             public void classWeaved(PackageWeaveResult weaveResult, ClassLoader classloader, ClassCache cache) {
                 if (weaveResult.weavedClass()) {

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/WeavingClassLoader.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/WeavingClassLoader.java
@@ -11,6 +11,7 @@ import com.newrelic.agent.deps.org.objectweb.asm.AnnotationVisitor;
 import com.newrelic.agent.deps.org.objectweb.asm.ClassReader;
 import com.newrelic.agent.deps.org.objectweb.asm.ClassVisitor;
 import com.newrelic.agent.deps.org.objectweb.asm.MethodVisitor;
+import com.newrelic.agent.deps.org.objectweb.asm.commons.Method;
 import com.newrelic.agent.deps.org.objectweb.asm.Type;
 import com.newrelic.agent.deps.org.objectweb.asm.tree.ClassNode;
 import com.newrelic.agent.introspec.InstrumentationTestConfig;
@@ -32,10 +33,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 
 class WeavingClassLoader extends TransformingClassLoader {
 
@@ -223,13 +227,17 @@ class WeavingClassLoader extends TransformingClassLoader {
         return super.getResource(name);
     }
 
-    protected byte[] weave(String className, byte[] classBytes, ClassWeavedListener listener) throws IOException {
-        return weavePackageManager.weave(this, classCache, className.replace('.', '/'), classBytes, listener);
+    protected byte[] weave(String className,
+                           byte[] classBytes,
+                           Map<Method, Collection<String>> skipMethods,
+                           ClassWeavedListener listener) throws IOException {
+        return weavePackageManager.weave(this, classCache, className.replace('.', '/'), classBytes, skipMethods,
+                                         listener);
     }
 
     @Override
     protected byte[] transform(String className) throws Exception {
         byte[] classBytes = WeaveUtils.getClassBytesFromClassLoaderResource(className, this);
-        return classBytes == null ? null : weave(className, classBytes, null);
+        return classBytes == null ? null : weave(className, classBytes, Collections.emptyMap(), null);
     }
 }

--- a/instrumentation/akka-2.2/src/test/java/com/nr/instrumentation/akka22/test/AkkaTest.java
+++ b/instrumentation/akka-2.2/src/test/java/com/nr/instrumentation/akka22/test/AkkaTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 // Not compatible with Java 11+ and Scala 2.13+ https://github.com/scala/bug/issues/12340
-@Category({Java11IncompatibleTest.class, Java12IncompatibleTest.class, Java13IncompatibleTest.class, Java14IncompatibleTest.class,
+@Category({Java12IncompatibleTest.class, Java13IncompatibleTest.class, Java14IncompatibleTest.class,
         Java15IncompatibleTest.class, Java16IncompatibleTest.class, Java17IncompatibleTest.class, Java18IncompatibleTest.class})
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = {"akka.actor", "akka.dispatch", "akka.pattern", "akka.routing"})

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ScalaTraitMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ScalaTraitMatcher.java
@@ -1,0 +1,90 @@
+package com.newrelic.agent.instrumentation.classmatchers;
+
+
+import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
+import com.newrelic.agent.instrumentation.context.InstrumentationContext;
+import com.newrelic.weave.utils.WeaveUtils;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.Method;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Scala traits (interfaces) produce a static synthetic method `Interface#method$`
+ * These are called by implementing classes if not overridden. We skip mark the child class
+ * method call to be skipped from weaving if the trait is weaved to prevent a "Double weave"
+ *
+ * trait example with synthetic method
+ *
+ * Scala trait `SomeTrait` converted to Java
+ *
+ * ```Scala
+ *  trait SomeTrait {
+ *     def traitmethod(): String = {
+ *       "original"
+ *     }
+ *   }
+ * ```
+ * ```Java
+ * public interface SomeTrait {
+ *    // $FF: synthetic method
+ *    static String traitmethod$(final SomeTrait $this) {
+ *       return $this.traitmethod();
+ *    }
+ *    default String traitmethod() {
+ *       return "original";
+ *    }
+ *    static void $init$(final SomeTrait $this) {
+ *    }
+ * }
+ * ```
+ */
+public class ScalaTraitMatcher implements ClassMatchVisitorFactory {
+
+  @Override
+  public ClassVisitor newClassMatchVisitor(ClassLoader loader, Class<?> classBeingRedefined, ClassReader reader, ClassVisitor cv, InstrumentationContext context) {
+    return new ClassVisitor(WeaveUtils.ASM_API_LEVEL, cv) {
+      private boolean isScalaSource;
+      private List<String> interfaces;
+      private String className;
+
+      @Override
+      public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        super.visit(version, access, name, signature, superName, interfaces);
+        this.interfaces = interfaces != null ? Arrays.asList(interfaces) : new ArrayList<>();
+        this.className = name;
+      }
+
+      @Override
+      public void visitSource(String source, String debug) {
+        super.visitSource(source, debug);
+        this.isScalaSource = source.endsWith(".scala");
+      }
+
+      @Override
+      public MethodVisitor visitMethod(int access, String methodName, String methodDesc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, methodName, methodDesc, signature, exceptions);
+        if (isScalaSource && this.interfaces.size() > 0) {
+          mv = new MethodVisitor(WeaveUtils.ASM_API_LEVEL, mv) {
+            @Override
+            public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+              if (itf && opcode == Opcodes.INVOKESTATIC &&
+                  (methodName + "$").equals(name) &&
+                  !owner.equalsIgnoreCase(className)) {
+                context.putMatch(ScalaTraitMatcher.this, null);
+                context.addSkipMethod(new Method(methodName, methodDesc), owner);
+              }
+              super.visitMethodInsn(opcode, owner, name, desc, itf);
+            }
+          };
+        }
+        return mv;
+      }
+    };
+  }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContext.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContext.java
@@ -7,7 +7,7 @@
 
 package com.newrelic.agent.instrumentation.context;
 
-import com.google.common.base.Supplier;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -47,6 +47,7 @@ public class InstrumentationContext implements TraceDetailsList {
     protected final byte[] bytes;
     private boolean modified;
     private Multimap<Method, String> weavedMethods;
+    private Multimap<Method, String> skipMethods;
     private Set<Method> timedMethods;
     private Map<Method, PointCut> oldReflectionStyleInstrumentationMethods;
     private Map<Method, PointCut> oldInvokerStyleInstrumentationMethods;
@@ -106,17 +107,21 @@ public class InstrumentationContext implements TraceDetailsList {
      */
     public void addWeavedMethod(Method method, String instrumentationTitle) {
         if (weavedMethods == null) {
-            weavedMethods = Multimaps.newSetMultimap(new HashMap<Method, Collection<String>>(),
-                    new Supplier<Set<String>>() {
-                        @Override
-                        public Set<String> get() {
-                            return new HashSet<>();
-                        }
-                    });
+            weavedMethods = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
         }
-        weavedMethods.put(method, instrumentationTitle);
-        modified = true;
+        if(skipMethods== null || !skipMethods.containsKey(method)) {
+          weavedMethods.put(method, instrumentationTitle);
+          modified = true;
+        }
     }
+
+    public void addSkipMethod(Method method, String owningClass) {
+      if (skipMethods == null) {
+        skipMethods = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
+      }
+      skipMethods.put(method, owningClass);
+    }
+
 
     public PointCut getOldStylePointCut(Method method) {
         PointCut pc = getOldInvokerStyleInstrumentationMethods().get(method);
@@ -140,7 +145,11 @@ public class InstrumentationContext implements TraceDetailsList {
         return weavedMethods == null ? Collections.<Method>emptySet() : weavedMethods.keySet();
     }
 
-    /**
+  public Map<Method, Collection<String>> getSkipMethods() {
+    return skipMethods == null ? Collections.emptyMap() : skipMethods.asMap();
+  }
+
+  /**
      * Returns methods that are timed with instrumentation injected by the new {@link TraceClassVisitor} or the old
      * GenericClassAdapter.
      */
@@ -262,7 +271,7 @@ public class InstrumentationContext implements TraceDetailsList {
             }
         }
         if (visitor != null) {
-            reader.accept(visitor, ClassReader.SKIP_CODE);
+            reader.accept(visitor, ClassReader.SKIP_FRAMES);
             if (bridgeMethods != null) {
                 // resolve bridge methods
                 resolveBridgeMethods(reader);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.config.ClassTransformerConfig;
 import com.newrelic.agent.config.Config;
 import com.newrelic.agent.instrumentation.ClassNameFilter;
 import com.newrelic.agent.instrumentation.api.ApiImplementationUpdate;
+import com.newrelic.agent.instrumentation.classmatchers.ScalaTraitMatcher;
 import com.newrelic.agent.instrumentation.classmatchers.TraceLambdaVisitor;
 import com.newrelic.agent.instrumentation.ejb3.EJBAnnotationVisitor;
 import com.newrelic.agent.instrumentation.tracing.TraceClassTransformer;
@@ -67,6 +68,7 @@ public class InstrumentationContextManager {
         this.classWeaverService = new ClassWeaverService(instrumentation);
 
         // these matchers only modify the InstrumentationContext, they don't actually transform classes
+        matchVisitors.put(new ScalaTraitMatcher(), NO_OP_TRANSFORMER);
         matchVisitors.put(new TraceMatchVisitor(), NO_OP_TRANSFORMER);
         matchVisitors.put(new GeneratedClassDetector(), NO_OP_TRANSFORMER);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
@@ -32,11 +32,13 @@ import com.newrelic.weave.violation.WeaveViolation;
 import com.newrelic.weave.weavepackage.ExtensionClassTemplate;
 import com.newrelic.weave.weavepackage.NewClassAppender;
 import com.newrelic.weave.weavepackage.PackageValidationResult;
+import com.newrelic.weave.weavepackage.PackageWeaveResult;
 import com.newrelic.weave.weavepackage.WeavePackage;
 import com.newrelic.weave.weavepackage.WeavePackageConfig;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.IOException;
@@ -45,6 +47,8 @@ import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -354,12 +358,16 @@ public class ClassLoaderClassTransformer implements ClassMatchVisitorFactory, Co
                     superNames = new String[] { "java/lang/ClassLoader" };
                 }
 
-                // This applies the "checkPackageAccess" weaved code only if it should be enabled from the constructor above
+                Map<Method, Collection<String>> skipMethods = (context != null)
+                  ? context.getSkipMethods()
+                  : Collections.emptyMap();
+
+              // This applies the "checkPackageAccess" weaved code only if it should be enabled from the constructor above
                 byte[] newBytes = classfileBuffer;
                 if (checkPackageAccessPackage != null && newBytes != null && className.equals("java/lang/ClassLoader")) {
                     PackageValidationResult checkPackageAccessResult = checkPackageAccessPackage.validate(cache);
                     if (checkPackageAccessResult.succeeded()) {
-                        newBytes = checkPackageAccessResult.weave(className, superNames, new String[0], newBytes, cache).getCompositeBytes(cache);
+                        newBytes = checkPackageAccessResult.weave(className, superNames, new String[0], newBytes, cache, skipMethods).getCompositeBytes(cache);
                     } else {
                         logClassLoaderWeaveViolations(checkPackageAccessResult, className);
                     }
@@ -369,8 +377,10 @@ public class ClassLoaderClassTransformer implements ClassMatchVisitorFactory, Co
                     }
                 }
 
+              PackageWeaveResult packageWeaveResult = result.weave(className, superNames, new String[0], newBytes,
+                                                                   cache, skipMethods);
                 // Do the weaving and use our "non-findResource" cache from above
-                newBytes = result.weave(className, superNames, new String[0], newBytes, cache).getCompositeBytes(cache);
+                newBytes = packageWeaveResult.getCompositeBytes(cache);
                 if (newBytes != null) {
                     Agent.LOG.log(Level.FINE, "ClassLoaderClassTransformer patched {0} -- {1}", loader, className);
                     return newBytes;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
@@ -18,6 +18,7 @@ import com.newrelic.agent.instrumentation.PointCutClassTransformer;
 import com.newrelic.agent.instrumentation.classmatchers.OptimizedClassMatcher.Match;
 import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.instrumentation.context.ContextClassTransformer;
+import com.newrelic.agent.instrumentation.context.FinalClassTransformer;
 import com.newrelic.agent.instrumentation.context.InstrumentationContext;
 import com.newrelic.agent.instrumentation.weaver.errorhandler.LogAndReturnOriginal;
 import com.newrelic.agent.instrumentation.weaver.extension.ExtensionHolderFactoryImpl;
@@ -540,7 +541,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
         };
         try {
             return weavePackageManager.weave(loader, getClassCache(loader), className, classfileBuffer,
-                    classWeavedCallback);
+                    context.getSkipMethods(), classWeavedCallback);
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }

--- a/newrelic-weaver-scala/build.gradle
+++ b/newrelic-weaver-scala/build.gradle
@@ -8,7 +8,7 @@ configurations {
 
 dependencies {
     compileFirst project(path: ":newrelic-agent", configuration: "finalArtifact")
-    implementation("org.scala-lang:scala-library:2.11.1")
+    implementation("org.scala-lang:scala-library:2.12.10")
     testImplementation("org.ow2.asm:asm:$asmVersion")
     testImplementation("org.ow2.asm:asm-util:$asmVersion")
     testImplementation("org.ow2.asm:asm-tree:$asmVersion")

--- a/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
+++ b/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
@@ -33,11 +33,21 @@ class ScalaAdapterTest {
   }
 
   @Test
-  def weaveTraitTest() {
-    val nonoverriding: SomeTrait = new NonOverridingTrait()
+  def weaveClassExtendingTraitTest() {
     val overriding: SomeTrait = new OverridingTrait()
-    Assert.assertEquals("weavedoriginal", nonoverriding.traitmethod())
     Assert.assertEquals("weavedoverride", overriding.traitmethod())
+  }
+
+  @Test
+  def weaveChildClassWithMultipleTraitsTest() {
+    val multipleOverridingWeaved: BaseTrait = new MultipleOverridingWeaved
+    Assert.assertEquals("weaved-ChildWeaveTrait", multipleOverridingWeaved.traitmethod())
+  }
+
+  @Test
+  def nonWeaveChildClassWithMultipleTraitsTest() {
+    val multipleOverridingNonWeaved: BaseTrait = new MultipleOverridingNonWeaved
+    Assert.assertEquals("weaved-ChildNonWeaveTrait", multipleOverridingNonWeaved.traitmethod())
   }
 
 }
@@ -64,14 +74,25 @@ package testclasses {
       "original"
     }
   }
+  trait BaseTrait {
+    def traitmethod(): String
+  }
 
   class OverridingTrait extends SomeTrait {
     override def traitmethod(): String = {
       "override"
     }
   }
-  class NonOverridingTrait extends SomeTrait {
+
+  trait ChildWeaveTrait extends BaseTrait {
+    override def traitmethod(): String = "ChildWeaveTrait"
   }
+  trait ChildNonWeaveTrait extends BaseTrait {
+    override def traitmethod(): String = "ChildNonWeaveTrait"
+  }
+
+  class MultipleOverridingNonWeaved extends ChildWeaveTrait with ChildNonWeaveTrait
+  class MultipleOverridingWeaved extends ChildNonWeaveTrait with ChildWeaveTrait
 
 }
 
@@ -99,6 +120,13 @@ package weaveclasses {
   class TraitWeave {
     def traitmethod(): String = {
       "weaved"+Weaver.callOriginal()
+    }
+  }
+
+  @ScalaWeave(originalName="com.nr.weave.weavepackage.language.scala.testclasses.ChildWeaveTrait", `type`=ScalaMatchType.Trait)
+  class ChildTraitWeave {
+    def traitmethod(): String = {
+      "weaved-"+Weaver.callOriginal()
     }
   }
 

--- a/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/violations/ScalaViolationsTest.scala
+++ b/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/violations/ScalaViolationsTest.scala
@@ -24,7 +24,6 @@ class ScalaViolationsTest {
   def onlyWeaveClasses {
     val classesToLoad: Array[String] = Array[String](
       "com.nr.weave.weavepackage.language.scala.violations.weaveclasses.WeaveTrait"
-        ,"com.nr.weave.weavepackage.language.scala.violations.weaveclasses.WeaveTrait$class"
         ,"com.nr.weave.weavepackage.language.scala.violations.weaveclasses.WeaveObject"
         ,"com.nr.weave.weavepackage.language.scala.violations.weaveclasses.WeaveObject$")
     var weaveBytes: java.util.List[Array[Byte]] = new java.util.ArrayList[Array[Byte]]()
@@ -48,7 +47,6 @@ class ScalaViolationsTest {
   def utilTraitsAndObjectsOkay {
     val classesToLoad: Array[String] = Array[String](
       "com.nr.weave.weavepackage.language.scala.violations.weaveclasses.UtilTrait"
-        ,"com.nr.weave.weavepackage.language.scala.violations.weaveclasses.UtilTrait$class"
         ,"com.nr.weave.weavepackage.language.scala.violations.weaveclasses.UtilObject"
         ,"com.nr.weave.weavepackage.language.scala.violations.weaveclasses.UtilObject$")
     var weaveBytes: java.util.List[Array[Byte]] = new java.util.ArrayList[Array[Byte]]()

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageManager.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageManager.java
@@ -21,6 +21,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.IOException;
@@ -293,10 +294,11 @@ public class WeavePackageManager {
      * @param targetBytes target class bytes
      * @return composite class bytes, or <code>null</code> if no weaving occurred
      */
-    public byte[] weave(ClassLoader classloader, String className, byte[] targetBytes) throws IOException {
+    public byte[] weave(ClassLoader classloader, String className, byte[] targetBytes,
+                        Map<Method, Collection<String>> skipMethods) throws IOException {
         classloader = classLoaderSub(classloader);
         ClassCache cache = new ClassCache(new ClassLoaderFinder(classloader));
-        return weave(classloader, cache, className, targetBytes, null);
+        return weave(classloader, cache, className, targetBytes, skipMethods, null);
     }
 
     /**
@@ -309,7 +311,8 @@ public class WeavePackageManager {
      * @param weaveListener listener containing callback if/when the composite is created
      * @return composite class bytes, or <code>null</code> if no weaving occurred
      */
-    public byte[] weave(ClassLoader classloader, ClassCache cache, String className, byte[] targetBytes,
+    public byte[] weave(ClassLoader classloader, ClassCache cache, String className,
+                        byte[] targetBytes, Map<Method, Collection<String>> skipMethods,
             ClassWeavedListener weaveListener) throws IOException {
         classloader = classLoaderSub(classloader);
 
@@ -337,7 +340,8 @@ public class WeavePackageManager {
         ClassNode composite = WeaveUtils.convertToClassNode(targetBytes);
         PackageWeaveResult finalResult = null;
         for (PackageValidationResult weavePackageResult : matchedPackageResults) {
-            PackageWeaveResult result = weavePackageResult.weave(className, superNames, interfaceNames, composite, cache);
+            PackageWeaveResult result = weavePackageResult.weave(className, superNames, interfaceNames, composite,
+                                                                 cache, skipMethods);
             if (null != weaveListener) {
                 weaveListener.classWeaved(result, classloader, cache);
             }

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/EnumAccessTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/EnumAccessTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -44,11 +45,13 @@ public class EnumAccessTest {
         WeaveTestUtils.loadUtilityClasses(EnumAccessTest.class.getClassLoader(), result.computeUtilityClassBytes(cache));
 
         byte[] stateCompositeBytes = result.weave("com/newrelic/weave/EnumAccessTest$Foo$State", new String[0],
-                new String[0], WeaveTestUtils.getClassBytes("com.newrelic.weave.EnumAccessTest$Foo$State"), cache).getCompositeBytes(
+                                                  new String[0], WeaveTestUtils.getClassBytes("com.newrelic.weave.EnumAccessTest$Foo$State"), cache,
+                                                  Collections.emptyMap()).getCompositeBytes(
                 cache);
         Assert.assertNotNull(stateCompositeBytes);
         byte[] aCompositeBytes = result.weave("com/newrelic/weave/EnumAccessTest$Foo", new String[0], new String[0],
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.EnumAccessTest$Foo"), cache).getCompositeBytes(cache);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.EnumAccessTest$Foo"), cache,
+                                              Collections.emptyMap()).getCompositeBytes(cache);
         Assert.assertNotNull(aCompositeBytes);
 
         WeaveTestUtils.addToContextClassloader("com.newrelic.weave.EnumAccessTest$Foo$State", stateCompositeBytes);

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveTestUtils.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveTestUtils.java
@@ -458,7 +458,7 @@ public class WeaveTestUtils {
         }
 
         // weave target using the specified match and add composite class to classloader
-        return ClassWeave.weave(preparedMatch, target, null);
+        return ClassWeave.weave(preparedMatch, target, null, Collections.emptyMap());
     }
 
     /**

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/ConcurrentWeaveTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/ConcurrentWeaveTest.java
@@ -16,6 +16,7 @@ import org.objectweb.asm.tree.ClassNode;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -145,7 +146,7 @@ public class ConcurrentWeaveTest {
         result = testPackage.validate(cache);
 
         Assert.assertFalse(result.weave("", new String[0], new String[0],
-                WeaveTestUtils.getClassBytes(String.class.getCanonicalName()), cache).weavedClass());
+                WeaveTestUtils.getClassBytes(String.class.getCanonicalName()), cache, Collections.emptyMap()).weavedClass());
         WeaveTestUtils.expectViolations(result.getViolations());
         
         // This is here to tease out a ClassNode race condition with multiple classloaders sharing the same utility classes
@@ -162,13 +163,14 @@ public class ConcurrentWeaveTest {
 
         // exact
         PackageWeaveResult packageWeaveResult = result.weave(
-                "com/newrelic/weave/weavepackage/testclasses/MyOriginalExact", new String[0], new String[0],
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact"), cache);
+          "com/newrelic/weave/weavepackage/testclasses/MyOriginalExact", new String[0], new String[0],
+          WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact"), cache,
+          Collections.emptyMap());
         Assert.assertTrue(packageWeaveResult.weavedClass());
 
         packageWeaveResult = result.weave("com/newrelic/weave/weavepackage/testclasses/MyOriginalBase", new String[0],
                 new String[0],
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), cache);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), cache, Collections.emptyMap());
         Assert.assertTrue(packageWeaveResult.weavedClass());
 
         String[] superClasses = { "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase" };
@@ -177,13 +179,13 @@ public class ConcurrentWeaveTest {
         // super
         packageWeaveResult = result.weave("com/newrelic/weave/weavepackage/testclasses/MyOriginalTarget1",
                 superClasses, interfaces,
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget1"), cache);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget1"), cache, Collections.emptyMap());
         Assert.assertTrue(packageWeaveResult.weavedClass());
 
         // interface
         packageWeaveResult = result.weave("com/newrelic/weave/weavepackage/testclasses/MyOriginalTarget2",
                 new String[0], interfaces,
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget2"), cache);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget2"), cache, Collections.emptyMap());
         Assert.assertTrue(packageWeaveResult.weavedClass());
     }
 }

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/PublicNewFieldTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/PublicNewFieldTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PublicNewFieldTest {
@@ -64,7 +65,7 @@ public class PublicNewFieldTest {
         byte[] compositeBytes = result.weave(WeaveUtils.getClassInternalName(origName),
                 ci.getAllSuperNames(cache).toArray(new String[0]),
                 ci.getAllInterfaces(cache).toArray(new String[0]),
-                WeaveTestUtils.getClassBytes(origName), cache).getCompositeBytes(cache);
+                WeaveTestUtils.getClassBytes(origName), cache, Collections.emptyMap()).getCompositeBytes(cache);
         Assert.assertNotNull("Unable to weave: " + origName, compositeBytes);
         Assert.assertFalse("Original class should not be already loaded: " + origName,
                 ClassLoaderUtils.isClassLoadedOnClassLoader(CLASSLOADER, WeaveUtils.getClassBinaryName(origName)));

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeaveInterfaceConcretePackageTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeaveInterfaceConcretePackageTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class WeaveInterfaceConcretePackageTest {
@@ -54,7 +55,7 @@ public class WeaveInterfaceConcretePackageTest {
         WeaveTestUtils.loadUtilityClasses(classloader, result.computeUtilityClassBytes(cache));
 
         Assert.assertFalse(result.weave("", new String[0], new String[0],
-                WeaveTestUtils.getClassBytes(String.class.getCanonicalName()), cache).weavedClass());
+                WeaveTestUtils.getClassBytes(String.class.getCanonicalName()), cache, Collections.emptyMap()).weavedClass());
 
         String[] superClasses = { "com/newrelic/weave/weavepackage/testclasses/BearBaseClass" };
         String[] interfaces = { "com/newrelic/weave/weavepackage/testclasses/BearInterface" };
@@ -62,7 +63,8 @@ public class WeaveInterfaceConcretePackageTest {
         // super
         byte[] compositeBytes = result.weave("com/newrelic/weave/weavepackage/testclasses/BearConcrete", superClasses,
                 interfaces,
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.BearConcrete"), cache)
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.BearConcrete"), cache,
+                                             Collections.emptyMap())
                 .getCompositeBytes(
                         cache);
         Assert.assertNotNull(compositeBytes);

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageManagerTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageManagerTest.java
@@ -79,7 +79,8 @@ public class WeavePackageManagerTest {
         byte[] compositeBytes = WeaveTestUtils.getClassBytes(className);
         Assert.assertNotNull(compositeBytes);
         // /*-
-        compositeBytes = wpm.weave(Thread.currentThread().getContextClassLoader(), internalName, compositeBytes);
+        compositeBytes = wpm.weave(Thread.currentThread().getContextClassLoader(), internalName, compositeBytes,
+                                   Collections.emptyMap());
         for (PackageValidationResult res :
                 wpm.validPackages.getIfPresent(Thread.currentThread().getContextClassLoader()).values()) {
             WeaveTestUtils.expectViolations(res);
@@ -122,7 +123,7 @@ public class WeavePackageManagerTest {
 
         Assert.assertEquals(1, wpm.match(classloader, targetInternalName, cache).size());
         byte[] result = wpm.weave(classloader, targetInternalName,
-                WeaveTestUtils.getClassBytes(targetClassName));
+                WeaveTestUtils.getClassBytes(targetClassName), Collections.emptyMap());
         Assert.assertTrue(bsPackage.hasMatcher(targetInternalName, superNames, interfaceNames,
                 Collections.<String>emptySet(), Collections.<String>emptySet(), null));
         Assert.assertEquals(0, getCacheSize(wpm.invalidPackages));
@@ -147,7 +148,7 @@ public class WeavePackageManagerTest {
         String className = "com.newrelic.weave.weavepackage.WeavePackageManagerTest$OriginalCacheTestClass";
         byte[] compositeBytes = WeaveTestUtils.getClassBytes(className);
         Assert.assertNotNull(compositeBytes);
-        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes);
+        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes, Collections.emptyMap());
         Assert.assertEquals(1, getCacheSize(wpm.validPackages));
         Assert.assertEquals(1, wpm.validPackages.getIfPresent(originalClassLoader).size());
 
@@ -168,14 +169,15 @@ public class WeavePackageManagerTest {
             classloaders.add(cl);
 
             wpm.weave(cl, "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"));
+                      WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                      Collections.emptyMap());
         }
         Assert.assertTrue(getCacheSize(wpm.validPackages) <= WeavePackageManager.MAX_VALID_PACKAGE_CACHE);
 
         // 3) load the original class and a new class with the original classloader and verify they load + weave
 
         // Original class
-        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes);
+        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes, Collections.emptyMap());
         Assert.assertNotNull(compositeBytes);
         octc = new OriginalCacheTestClass();
         Assert.assertEquals(0, octc.originalCacheTestWeaveInvokes);
@@ -187,7 +189,7 @@ public class WeavePackageManagerTest {
         String newClassName = "com.newrelic.weave.weavepackage.WeavePackageManagerTest$NewCacheTestClass";
         byte[] newCompositeBytes = WeaveTestUtils.getClassBytes(newClassName);
         Assert.assertNotNull(newCompositeBytes);
-        newCompositeBytes = wpm.weave(originalClassLoader, newInternalName, newCompositeBytes);
+        newCompositeBytes = wpm.weave(originalClassLoader, newInternalName, newCompositeBytes, Collections.emptyMap());
         Assert.assertTrue(getCacheSize(wpm.validPackages) <= WeavePackageManager.MAX_VALID_PACKAGE_CACHE);
         Assert.assertEquals(1, wpm.validPackages.getIfPresent(originalClassLoader).size());
 
@@ -218,7 +220,7 @@ public class WeavePackageManagerTest {
         String className = "com.newrelic.weave.weavepackage.WeavePackageManagerTest$NoMatchClass";
         byte[] compositeBytes = WeaveTestUtils.getClassBytes(className);
         Assert.assertNotNull(compositeBytes);
-        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes);
+        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes, Collections.emptyMap());
         Assert.assertEquals(1, getCacheSize(wpm.invalidPackages));
         Assert.assertEquals(1, wpm.invalidPackages.getIfPresent(originalClassLoader).size());
 
@@ -238,13 +240,16 @@ public class WeavePackageManagerTest {
             classloaders.add(cl);
 
             wpm.weave(cl, "com/newrelic/weave/weavepackage/WeavePackageManagerTest$NewNoMatchClass",
-                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.WeavePackageManagerTest$NewNoMatchClass"));
+                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.WeavePackageManagerTest$NewNoMatchClass"),
+                      Collections.emptyMap()
+            );
+
         }
         Assert.assertTrue(WeavePackageManager.MAX_INVALID_PACKAGE_CACHE >= getCacheSize(wpm.invalidPackages));
 
         // 3) load with the original classloader again and verify that class loads but doesn't weave (pushes to invalid)
         compositeBytes = WeaveTestUtils.getClassBytes(className);
-        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes);
+        compositeBytes = wpm.weave(originalClassLoader, internalName, compositeBytes, Collections.emptyMap());
         Assert.assertNull(compositeBytes);
         nmc = new NoMatchClass();
         Assert.assertEquals(0, nmc.noMatchWeaveInvokes);
@@ -268,7 +273,8 @@ public class WeavePackageManagerTest {
             classloaders.add(cl);
 
             wpm.weave(cl, "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"));
+                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                      Collections.emptyMap());
         }
         Assert.assertEquals(numClassLoaders, getCacheSize(wpm.validPackages));
 
@@ -277,7 +283,8 @@ public class WeavePackageManagerTest {
             ClassLoader cl = new ClassLoader(context) {
             };
             wpm.weave(cl, "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"));
+                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                      Collections.emptyMap());
         }
         Assert.assertTrue(getCacheSize(wpm.validPackages) >= numClassLoaders);
 
@@ -287,7 +294,8 @@ public class WeavePackageManagerTest {
             ClassLoader cl = new ClassLoader(context) {
             };
             wpm.weave(cl, "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"));
+                    WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                      Collections.emptyMap());
             wpm.invalidPackages.invalidate(cl);
             wpm.validPackages.invalidate(cl);
         }
@@ -305,12 +313,14 @@ public class WeavePackageManagerTest {
         WeavePackageManager wpm = new WeavePackageManager();
         byte[] result = wpm.weave(cl, new ClassCache(new ClassLoaderFinder(cl)),
                 "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), null);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                                  Collections.emptyMap(), null);
         Assert.assertNull(result);
         wpm.register(testPackage1);
         result = wpm.weave(cl, new ClassCache(new ClassLoaderFinder(cl)),
                 "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), null);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                           Collections.emptyMap(), null);
         Assert.assertNotNull(result);
     }
 
@@ -341,7 +351,8 @@ public class WeavePackageManagerTest {
                                 Thread.currentThread().setContextClassLoader(originalCl);
                                 byte[] result = wpm.weave(cl, classCache,
                                         "com/newrelic/weave/weavepackage/testclasses/MyOriginalExact",
-                                        WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact"), null);
+                                        WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact"),
+                                                          Collections.emptyMap(), null);
 
                                 Thread.currentThread().setContextClassLoader(cl);
                                 WeaveTestUtils.addToContextClassloader("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact", result);
@@ -355,7 +366,8 @@ public class WeavePackageManagerTest {
                                 Thread.currentThread().setContextClassLoader(originalCl);
                                 byte[] result = wpm.weave(cl, classCache,
                                         "com/newrelic/weave/weavepackage/testclasses/OriginalNameInterface",
-                                        WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.OriginalNameInterface"), null);
+                                        WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.OriginalNameInterface"),
+                                                          Collections.emptyMap(), null);
 
                                 Thread.currentThread().setContextClassLoader(cl);
                                 WeaveTestUtils.addToContextClassloader("com.newrelic.weave.weavepackage.testclasses.OriginalNameInterface", result);
@@ -363,7 +375,8 @@ public class WeavePackageManagerTest {
                                 Thread.currentThread().setContextClassLoader(originalCl);
                                 byte[] result2 = wpm.weave(cl, classCache,
                                         "com/newrelic/weave/weavepackage/testclasses/OriginalNameInterfaceImpl",
-                                        WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.OriginalNameInterfaceImpl"), null);
+                                        WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.OriginalNameInterfaceImpl"),
+                                                           Collections.emptyMap(), null);
 
                                 Thread.currentThread().setContextClassLoader(cl);
                                 WeaveTestUtils.addToContextClassloader("com.newrelic.weave.weavepackage.testclasses.OriginalNameInterfaceImpl", result2);
@@ -417,14 +430,16 @@ public class WeavePackageManagerTest {
         };
         byte[] result = wpm.weave(cl, new ClassCache(new ClassLoaderFinder(cl)),
                 "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), listener);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                                  Collections.emptyMap(), listener);
         Assert.assertNotNull(result);
         expectedInvokeCount += 4; // two packages, each with a match and weave
         Assert.assertTrue(expectedInvokeCount == listener.invokeCount);
 
         byte[] result2 = wpm.weave(cl, new ClassCache(new ClassLoaderFinder(cl)),
                 "com/newrelic/weave/weavepackage/testclasses/MyOriginalBase",
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), listener);
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"),
+                                   Collections.emptyMap(), listener);
         Assert.assertNotNull(result2);
         expectedInvokeCount += 2; // shouldn't validate again. Only weave.
         Assert.assertTrue(expectedInvokeCount == listener.invokeCount);

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,12 +76,14 @@ public class WeavePackageTest {
         WeaveTestUtils.loadUtilityClasses(classloader, result.computeUtilityClassBytes(cache));
 
         Assert.assertFalse(result.weave("", new String[0], new String[0],
-                WeaveTestUtils.getClassBytes(String.class.getCanonicalName()), cache).weavedClass());
+                                        WeaveTestUtils.getClassBytes(String.class.getCanonicalName()), cache,
+                                        Collections.emptyMap()).weavedClass());
 
         // exact
         byte[] compositeBytes = result.weave("com/newrelic/weave/weavepackage/testclasses/MyOriginalExact",
                 new String[0], new String[0],
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact"), cache).getCompositeBytes(
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact"), cache,
+                                             Collections.emptyMap()).getCompositeBytes(
                 cache);
         Assert.assertNotNull(compositeBytes);
         WeaveTestUtils.addToContextClassloader("com.newrelic.weave.weavepackage.testclasses.MyOriginalExact",
@@ -91,7 +94,8 @@ public class WeavePackageTest {
 
         compositeBytes = result.weave("com/newrelic/weave/weavepackage/testclasses/MyOriginalBase", new String[0],
                 new String[0],
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), cache).getCompositeBytes(
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase"), cache,
+                                      Collections.emptyMap()).getCompositeBytes(
                 cache);
         Assert.assertNotNull(compositeBytes);
         WeaveTestUtils.addToContextClassloader("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase",
@@ -103,7 +107,8 @@ public class WeavePackageTest {
         // super
         compositeBytes = result.weave("com/newrelic/weave/weavepackage/testclasses/MyOriginalTarget1", superClasses,
                 interfaces,
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget1"), cache).getCompositeBytes(
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget1"), cache,
+                                      Collections.emptyMap()).getCompositeBytes(
                 cache);
         Assert.assertNotNull(compositeBytes);
         classloader.loadClass("com.newrelic.weave.weavepackage.testclasses.MyOriginalBase");
@@ -120,7 +125,8 @@ public class WeavePackageTest {
         // interface
         compositeBytes = result.weave("com/newrelic/weave/weavepackage/testclasses/MyOriginalTarget2", new String[0],
                 interfaces,
-                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget2"), cache).getCompositeBytes(
+                WeaveTestUtils.getClassBytes("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget2"), cache,
+                                      Collections.emptyMap()).getCompositeBytes(
                 cache);
         Assert.assertNotNull(compositeBytes);
         WeaveTestUtils.addToContextClassloader("com.newrelic.weave.weavepackage.testclasses.MyOriginalTarget2",


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
This PR enables the scala weaver to work with Java 11+ JREs

### Related Github Issue
#438 

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs?
[] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
