### PR TITLE
Implement data usage metrics

### DIFF
--- a/infinite-tracing/src/main/java/com/newrelic/SpanEventSender.java
+++ b/infinite-tracing/src/main/java/com/newrelic/SpanEventSender.java
@@ -17,6 +17,8 @@ class SpanEventSender implements Runnable {
     private final BlockingQueue<SpanEvent> queue;
     private final MetricAggregator aggregator;
     private final ChannelManager channelManager;
+    // Destination for agent data
+    private static final String INFINITE_TRACING = "InfiniteTracing";
 
     SpanEventSender(InfiniteTracingConfig config, BlockingQueue<SpanEvent> queue, MetricAggregator aggregator, ChannelManager channelManager) {
         this.logger = config.getLogger();
@@ -97,6 +99,7 @@ class SpanEventSender implements Runnable {
             logger.log(Level.SEVERE, t, "Unable to send span.");
             throw t;
         }
+        // TODO record data usage metrics here for the INFINITE_TRACING destination
         aggregator.incrementCounter("Supportability/InfiniteTracing/Span/Sent");
     }
 

--- a/infinite-tracing/src/main/java/com/newrelic/SpanEventSender.java
+++ b/infinite-tracing/src/main/java/com/newrelic/SpanEventSender.java
@@ -99,7 +99,6 @@ class SpanEventSender implements Runnable {
             logger.log(Level.SEVERE, t, "Unable to send span.");
             throw t;
         }
-        // TODO record data usage metrics here for the INFINITE_TRACING destination
         aggregator.incrementCounter("Supportability/InfiniteTracing/Span/Sent");
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/DummyTransaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/DummyTransaction.java
@@ -26,6 +26,8 @@ import com.newrelic.agent.sql.SlowQueryListener;
 import com.newrelic.agent.stats.AbstractMetricAggregator;
 import com.newrelic.agent.stats.ApdexStats;
 import com.newrelic.agent.stats.ApdexStatsImpl;
+import com.newrelic.agent.stats.DataUsageStats;
+import com.newrelic.agent.stats.DataUsageStatsImpl;
 import com.newrelic.agent.stats.ResponseTimeStats;
 import com.newrelic.agent.stats.ResponseTimeStatsImpl;
 import com.newrelic.agent.stats.SimpleStatsEngine;
@@ -37,10 +39,8 @@ import com.newrelic.agent.trace.TransactionGuidFactory;
 import com.newrelic.agent.tracers.ClassMethodSignature;
 import com.newrelic.agent.tracers.MetricNameFormatWithHost;
 import com.newrelic.agent.tracers.NoOpTracer;
-import com.newrelic.agent.tracers.OtherRootTracer;
 import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.agent.tracers.TracerFactory;
-import com.newrelic.agent.tracers.metricname.SimpleMetricNameFormat;
 import com.newrelic.agent.transaction.PriorityTransactionName;
 import com.newrelic.agent.transaction.TransactionCache;
 import com.newrelic.agent.transaction.TransactionCounts;
@@ -70,6 +70,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * DummyTransaction is a lightweight Transaction that gets returned when the agent's circuit
+ * breaker has been tripped in order to minimize the agent's effects on a JVM running near its limits.
+ */
 public class DummyTransaction extends Transaction {
 
     private final String guid;
@@ -840,6 +844,7 @@ public class DummyTransaction extends Transaction {
         static final DummyStats stat = new DummyStats();
         static final DummyResponseTimeStats responseTimeStat = new DummyResponseTimeStats();
         static final DummyApdexStat apdexStat = new DummyApdexStat();
+        static final DummyDataUsageStats dataUsageStats = new DummyDataUsageStats();
 
         @Override
         public Map<String, StatsBase> getStatsMap() {
@@ -863,6 +868,11 @@ public class DummyTransaction extends Transaction {
         @Override
         public ApdexStats getApdexStats(String metricName) {
             return apdexStat;
+        }
+
+        @Override
+        public DataUsageStats getDataUsageStats(String metricName) {
+            return dataUsageStats;
         }
 
         @Override
@@ -1090,6 +1100,58 @@ public class DummyTransaction extends Transaction {
 
         @Override
         public void recordApdexResponseTime(long responseTimeMillis, long apdexTInMillis) {
+        }
+
+        @Override
+        public boolean hasData() {
+            return false;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void writeJSONString(Writer writer) throws IOException {
+        }
+
+        @Override
+        public void merge(StatsBase statsObj) {
+        }
+    }
+
+    static final class DummyDataUsageStats extends DataUsageStatsImpl {
+        DummyDataUsageStats() {
+            super();
+        }
+
+        @Override
+        public Object clone() throws CloneNotSupportedException {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "";
+        }
+
+        @Override
+        public void recordDataUsage(long bytesSent, long bytesReceived) {
+        }
+
+        @Override
+        public int getCount() {
+            return 0;
+        }
+
+        @Override
+        public long getBytesSent() {
+            return 0;
+        }
+
+        @Override
+        public long getBytesReceived() {
+            return 0;
         }
 
         @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -379,6 +379,12 @@ public class MetricNames {
     //Supportability metric indicating that the payload was too large
     public static final String SUPPORTABILITY_PAYLOAD_SIZE_EXCEEDS_MAX = "Supportability/Agent/Collector/MaxPayloadSizeLimit/{0}";
 
+    // Supportability metrics for uncompressed data payloads used to measure usage
+    // {0} = destination (Collector, OTLP, or InfiniteTracing).
+    public static final String SUPPORTABILITY_DATA_USAGE_DESTINATION_OUTPUT_BYTES = "Supportability/Java/{0}/Output/Bytes";
+    // {0} = destination (Collector, OTLP, or InfiniteTracing). {1} = agent endpoint (connect, analytic_event_data, error_data, etc)
+    public static final String SUPPORTABILITY_DATA_USAGE_DESTINATION_ENDPOINT_OUTPUT_BYTES = "Supportability/Java/{0}/{1}/Output/Bytes";
+
     public static final String SUPPORTABILITY_AGENT_CONNECT_BACKOFF_ATTEMPTS = "Supportability/Agent/Collector/Connect/BackoffAttempts";
 
     // expected errors

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/DataUsageStats.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/DataUsageStats.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.stats;
+
+/**
+ * Used to generate metrics on data usage
+ */
+public interface DataUsageStats extends StatsBase {
+
+    /**
+     * Record the uncompressed sizes of sent and received payloads in bytes for each agent endpoint.
+     *
+     * @param bytesSent uncompressed bytes sent to an agent endpoint
+     * @param bytesReceived uncompressed bytes received from an agent endpoint
+     */
+    void recordDataUsage(long bytesSent, long bytesReceived);
+
+    /**
+     * Get the count of the number of times the metric was set.
+     *
+     * @return count
+     */
+    int getCount();
+
+    /**
+     * Get the amount of uncompressed bytes sent for a metric representing calls to an agent endpoint.
+     *
+     * @return bytes sent
+     */
+    long getBytesSent();
+
+    /**
+     * Get the amount of uncompressed bytes received for a metric representing responses from an agent endpoint.
+     *
+     * @return bytes sent
+     */
+    long getBytesReceived();
+
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/DataUsageStatsImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/DataUsageStatsImpl.java
@@ -30,14 +30,6 @@ public class DataUsageStatsImpl implements DataUsageStats {
         super();
     }
 
-//    // Used by the server mode
-//    public DataUsageStatsImpl(int count, int bytesSent, int bytesReceived) {
-//        super();
-//        this.count = count;
-//        this.bytesSent = bytesSent;
-//        this.bytesReceived = bytesReceived;
-//    }
-
     /**
      * Record the uncompressed sizes of sent and received payloads in bytes for each agent endpoint.
      *

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/DataUsageStatsImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/DataUsageStatsImpl.java
@@ -1,0 +1,136 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.stats;
+
+import com.newrelic.agent.Agent;
+import com.newrelic.agent.config.AgentConfigImpl;
+import com.newrelic.api.agent.NewRelic;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+public class DataUsageStatsImpl implements DataUsageStats {
+
+    private static final int UNUSED = 0; // min, max, sum of squares
+    private final AtomicInteger count = new AtomicInteger(0); // count
+    private final AtomicLong bytesSent = new AtomicLong(0); // total time
+    private final AtomicLong bytesReceived = new AtomicLong(0); // exclusive time
+
+    protected DataUsageStatsImpl() {
+        super();
+    }
+
+//    // Used by the server mode
+//    public DataUsageStatsImpl(int count, int bytesSent, int bytesReceived) {
+//        super();
+//        this.count = count;
+//        this.bytesSent = bytesSent;
+//        this.bytesReceived = bytesReceived;
+//    }
+
+    /**
+     * Record the uncompressed sizes of sent and received payloads in bytes for each agent endpoint.
+     *
+     * @param bytesSent     uncompressed bytes sent to an agent endpoint
+     * @param bytesReceived uncompressed bytes received from an agent endpoint
+     */
+    @Override
+    public void recordDataUsage(long bytesSent, long bytesReceived) {
+        this.count.incrementAndGet();
+        this.bytesSent.addAndGet(bytesSent);
+        this.bytesReceived.addAndGet(bytesReceived);
+
+        if (NewRelic.getAgent().getConfig().getValue(AgentConfigImpl.METRIC_DEBUG, AgentConfigImpl.DEFAULT_METRIC_DEBUG)) {
+            if (this.count.get() < 0 || this.bytesSent.get() < 0 || this.bytesReceived.get() < 0) {
+                NewRelic.incrementCounter("Supportability/DataUsageStatsImpl/NegativeValue");
+                Agent.LOG.log(Level.INFO, "Invalid count {0}, bytesSent {1}, or bytesReceived {2}",
+                        this.count.get(), this.bytesSent.get(), this.bytesReceived.get());
+            }
+        }
+
+    }
+
+    /**
+     * Get the count of the number of times the metric was set.
+     *
+     * @return count
+     */
+    @Override
+    public int getCount() {
+        return count.get();
+    }
+
+    /**
+     * Get the amount of uncompressed bytes sent for a metric representing calls to an agent endpoint.
+     *
+     * @return bytes sent
+     */
+    @Override
+    public long getBytesSent() {
+        return bytesSent.get();
+    }
+
+    /**
+     * Get the amount of uncompressed bytes received for a metric representing responses from an agent endpoint.
+     *
+     * @return bytes sent
+     */
+    @Override
+    public long getBytesReceived() {
+        return bytesReceived.get();
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        DataUsageStatsImpl newStats = new DataUsageStatsImpl();
+        newStats.count.set(count.get());
+        newStats.bytesSent.set(bytesSent.get());
+        newStats.bytesReceived.set(bytesReceived.get());
+        return newStats;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " [count=" + count.get() + ", bytesSent=" + bytesSent.get() + ", bytesReceived=" + bytesReceived.get() + "]";
+    }
+
+    @Override
+    public boolean hasData() {
+        return count.get() > 0 || bytesSent.get() > 0 || bytesReceived.get() > 0;
+    }
+
+    @Override
+    public void reset() {
+        count.set(0);
+        bytesSent.set(0);
+        bytesReceived.set(0);
+    }
+
+    @Override
+    public void writeJSONString(Writer writer) throws IOException {
+        List<Number> data;
+        // These map to traditional metric values of: count, total time, exclusive time, min, max, sum of squares
+        data = Arrays.asList(count.get(), bytesSent.get(), bytesReceived.get(), UNUSED, UNUSED, UNUSED);
+        org.json.simple.JSONArray.writeJSONString(data, writer);
+    }
+
+    @Override
+    public void merge(StatsBase statsObj) {
+        if (statsObj instanceof DataUsageStatsImpl) {
+            DataUsageStatsImpl stats = (DataUsageStatsImpl) statsObj;
+            count.addAndGet(stats.count.get());
+            bytesSent.addAndGet(stats.bytesSent.get());
+            bytesReceived.addAndGet(stats.bytesReceived.get());
+        }
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/RecordDataUsageMetric.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/RecordDataUsageMetric.java
@@ -9,7 +9,7 @@ package com.newrelic.agent.stats;
 
 import com.newrelic.agent.metric.MetricName;
 
-final class RecordDataUsageMetric implements StatsWork {
+public final class RecordDataUsageMetric implements StatsWork {
     private final MetricName name;
     private final long bytesSent;
     private final long bytesReceived;
@@ -30,4 +30,15 @@ final class RecordDataUsageMetric implements StatsWork {
         return null;
     }
 
+    public String getName() {
+        return name.getName();
+    }
+
+    public long getBytesSent() {
+        return bytesSent;
+    }
+
+    public long getBytesReceived() {
+        return bytesReceived;
+    }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/RecordDataUsageMetric.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/RecordDataUsageMetric.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/RecordDataUsageMetric.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/RecordDataUsageMetric.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.stats;
+
+import com.newrelic.agent.metric.MetricName;
+
+final class RecordDataUsageMetric implements StatsWork {
+    private final MetricName name;
+    private final long bytesSent;
+    private final long bytesReceived;
+
+    public RecordDataUsageMetric(String name, long bytesSent, long bytesReceived) {
+        this.name = MetricName.create(name);
+        this.bytesSent = bytesSent;
+        this.bytesReceived = bytesReceived;
+    }
+
+    @Override
+    public void doWork(StatsEngine statsEngine) {
+        statsEngine.getDataUsageStats(name).recordDataUsage(bytesSent, bytesReceived);
+    }
+
+    @Override
+    public String getAppName() {
+        return null;
+    }
+
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/SimpleStatsEngine.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/SimpleStatsEngine.java
@@ -106,6 +106,23 @@ public class SimpleStatsEngine {
         }
     }
 
+    public DataUsageStats getDataUsageStats(String metricName) {
+        if (metricName == null) {
+            throw new RuntimeException("Cannot get a stat for a null metric");
+        }
+        StatsBase s = stats.get(metricName);
+        if (s == null) {
+            s = new DataUsageStatsImpl();
+            stats.put(metricName, s);
+        }
+        if (s instanceof DataUsageStats) {
+            return (DataUsageStats) s;
+        } else {
+            String msg = MessageFormat.format("The stats object for {0} is of type {1}", metricName, s.getClass().getName());
+            throw new RuntimeException(msg);
+        }
+    }
+
     public void mergeStats(SimpleStatsEngine other) {
         for (Entry<String, StatsBase> entry : other.stats.entrySet()) {
             StatsBase ourStats = stats.get(entry.getKey());

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsEngine.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsEngine.java
@@ -42,6 +42,8 @@ public interface StatsEngine {
 
     ApdexStats getApdexStats(MetricName metric);
 
+    DataUsageStats getDataUsageStats(MetricName metric);
+
     /**
      * This is now only used by tests.
      */

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsEngineImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsEngineImpl.java
@@ -115,6 +115,14 @@ public class StatsEngineImpl implements StatsEngine {
     }
 
     @Override
+    public DataUsageStats getDataUsageStats(MetricName metricName) {
+        if (metricName == null) {
+            throw new RuntimeException("Cannot get a stat for a null metric");
+        }
+        return getStatsEngine(metricName).getDataUsageStats(metricName.getName());
+    }
+
+    @Override
     public List<MetricName> getMetricNames() {
         List<MetricName> result = new ArrayList<>(getSize());
         for (String name : unscopedStats.getStatsMap().keySet()) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsWorks.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsWorks.java
@@ -21,6 +21,10 @@ public class StatsWorks {
         return new RecordMetric(name, value);
     }
 
+    public static StatsWork getRecordDataUsageMetricWork(String name, long bytesSent, long bytesReceived) {
+        return new RecordDataUsageMetric(name, bytesSent, bytesReceived);
+    }
+
     public static StatsWork getRecordResponseTimeWork(String name, long millis) {
         return new RecordResponseTimeMetric(millis, name, TimeUnit.MILLISECONDS);
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
@@ -89,7 +89,11 @@ public class DataSenderImpl implements DataSender {
     private static final String METADATA_PREFIX = "NEW_RELIC_METADATA_";
     // the block of env vars we send up to rpm
     private static final String ENV_METADATA = "metadata";
-    private static final int DEFAULT_MAX_PAYLOAD_SIZE_IN_BYTES = 1000000;
+    private static final int DEFAULT_MAX_PAYLOAD_SIZE_IN_BYTES = 1_000_000;
+
+    private static final String COLLECTOR = "Collector";
+    private static final String OTLP = "OTLP";
+    private static final String INFINITE_TRACING = "InfiniteTracing";
 
     // As of P17 these are the only agent endpoints that actually contain data in the response payload for a successful request
     private static final Set<String> METHODS_WITH_RESPONSE_BODY = ImmutableSet.of(
@@ -551,9 +555,10 @@ public class DataSenderImpl implements DataSender {
 
         ReadResult result = httpClientWrapper.execute(request, new TimingEventHandler(method, ServiceFactory.getStatsService()));
 
+        String payloadJsonSent = DataSenderWriter.toJSONString(params);
+
         if (auditMode && methodShouldBeAudited(method)) {
-            String msg = MessageFormat.format("Sent JSON({0}) to: {1}, with payload: {2}", method, url,
-                    DataSenderWriter.toJSONString(params));
+            String msg = MessageFormat.format("Sent JSON({0}) to: {1}, with payload: {2}", method, url, payloadJsonSent);
             logger.info(msg);
         }
 
@@ -565,16 +570,46 @@ public class DataSenderImpl implements DataSender {
             throwExceptionFromStatusCode(method, result, data, request);
         }
 
+        String payloadJsonReceived = result.getResponseBody();
+
         // received successful 2xx response
         if (auditMode && methodShouldBeAudited(method)) {
-            logger.info(MessageFormat.format("Received JSON({0}): {1}", method, result.getResponseBody()));
+            logger.info(MessageFormat.format("Received JSON({0}): {1}", method, payloadJsonReceived));
         }
+
+        // TODO some logic to determine the correct destination, maybe PROTOCOL?
+        //  Is this the right place to call this method??? Or should it be before the exception logic?
+        recordDataUsageMetrics(COLLECTOR, method, payloadJsonSent, payloadJsonReceived);
 
         if (dataSenderListener != null) {
             dataSenderListener.dataSent(method, encoding, uri, data);
         }
 
         return result;
+    }
+
+    /**
+     * Record metrics tracking amount of bytes sent and received for each agent endpoint payload
+     *
+     * @param destination data destination (COLLECTOR, OTLP, INFINITE_TRACING)
+     * @param method method for the agent endpoint
+     * @param payloadJsonSent JSON String of the payload that was sent
+     * @param payloadJsonReceived JSON String of the payload that was received
+     */
+    private void recordDataUsageMetrics(String destination, String method, String payloadJsonSent, String payloadJsonReceived) {
+        int payloadBytesSent = payloadJsonSent.getBytes().length;
+        int payloadBytesReceived = payloadJsonReceived.getBytes().length;
+
+        // TODO figure out how to tell the destination of the data Collector, OTLP, or InfiniteTracing
+        ServiceFactory.getStatsService().doStatsWork(
+                StatsWorks.getRecordDataUsageMetricWork(
+                        MessageFormat.format(MetricNames.SUPPORTABILITY_DATA_USAGE_DESTINATION_OUTPUT_BYTES, destination),
+                        payloadBytesSent, payloadBytesReceived));
+
+        ServiceFactory.getStatsService().doStatsWork(
+                StatsWorks.getRecordDataUsageMetricWork(
+                        MessageFormat.format(MetricNames.SUPPORTABILITY_DATA_USAGE_DESTINATION_ENDPOINT_OUTPUT_BYTES, COLLECTOR, method),
+                        payloadBytesSent, payloadBytesReceived));
     }
 
     private void throwExceptionFromStatusCode(String method, ReadResult result, byte[] data, HttpClientWrapper.Request request)

--- a/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsServiceTest.java
@@ -13,6 +13,7 @@ import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.ConfigService;
 import com.newrelic.agent.config.ConfigServiceFactory;
+import com.newrelic.agent.metric.MetricName;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.service.ServiceManager;
 import org.junit.After;
@@ -71,19 +72,51 @@ public class StatsServiceTest {
     @Test
     public void doStatsWork() throws Exception {
         String appName = serviceManager.getConfigService().getDefaultAgentConfig().getApplicationName();
-        StatsEngineImpl statsEngine = new StatsEngineImpl();
         StatsService statsService = serviceManager.getStatsService();
+
+        // RecordMetric count 1
+        StatsEngineImpl statsEngine = new StatsEngineImpl();
         Stats stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(100f);
         statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+
+        // RecordMetric count 2
         statsEngine = new StatsEngineImpl();
         stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(200f);
         statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+
+        // RecordMetric count 3
         statsService.doStatsWork(new RecordMetric("Test1", 300f));
+
+        // RecordDataUsageMetric count 1
+        statsEngine = new StatsEngineImpl();
+        DataUsageStats dataUsageStats = statsEngine.getDataUsageStats(MetricName.create("Test2"));
+        dataUsageStats.recordDataUsage(5000, 25);
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+
+        // RecordDataUsageMetric count 2
+        statsEngine = new StatsEngineImpl();
+        dataUsageStats = statsEngine.getDataUsageStats(MetricName.create("Test2"));
+        dataUsageStats.recordDataUsage(1000, 10);
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+
+        // RecordDataUsageMetric count 3
+        statsService.doStatsWork(new RecordDataUsageMetric("Test2", 100, 5));
+
         StatsEngine harvestStatsEngine = statsService.getStatsEngineForHarvest(appName);
-        Assert.assertEquals(1, harvestStatsEngine.getSize());
+
+        // Number of unique metrics (Test1 and Test2)
+        Assert.assertEquals(2, harvestStatsEngine.getSize());
+
+        // Test1 totals
+        Assert.assertEquals(3, harvestStatsEngine.getStats("Test1").getCallCount());
         Assert.assertEquals(600f, harvestStatsEngine.getStats("Test1").getTotal(), 0);
+
+        // Test2 totals
+        Assert.assertEquals(3, harvestStatsEngine.getDataUsageStats(MetricName.create("Test2")).getCount());
+        Assert.assertEquals(6100, harvestStatsEngine.getDataUsageStats(MetricName.create("Test2")).getBytesSent());
+        Assert.assertEquals(40, harvestStatsEngine.getDataUsageStats(MetricName.create("Test2")).getBytesReceived());
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/transport/DataSenderImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/transport/DataSenderImplTest.java
@@ -660,14 +660,6 @@ public class DataSenderImplTest {
         }
         return metricData;
     }
-//
-//    private List<MetricData> createMetricData(int metrics) {
-//        List<MetricData> metricData = new ArrayList<>();
-//        for (int i = 0; i < metrics; i++) {
-//            metricData.add(MetricData.create(MetricName.create(String.valueOf(i)), i, new StatsImpl(1, 1, 1, 1, 1)));
-//        }
-//        return metricData;
-//    }
 
     public Map<String, Object> configMap() {
         Map<String, Object> configMap = new HashMap<>();


### PR DESCRIPTION
This PR implements the [Data-Usage-Supportability-Metrics](https://source.datanerd.us/agents/agent-specs/blob/main/Data-Usage-Supportability-Metrics.md) agent spec with a couple of caveats.

The spec lists destinations for agent data as `Collector`, `OTLP`, and `InfiniteTracing`. This PR only generates metrics for the `Collector` destination. Generating data usage metrics for the `InfiniteTracing` destination is not currently implemented and can be done in a follow up PR at a later time (see https://github.com/newrelic/newrelic-java-agent/issues/717). The Java agent does not currently support `OTLP` as a destination to send data.

Example of metrics generated:

```
[
    ...
    [
        [
            {
                "name": "Supportability\/Java\/Collector\/transaction_sample_data\/Output\/Bytes"
            },
            [
                1,
                12215,
                0,
                0,
                0,
                0
            ]
        ],
        [
            {
                "name": "Supportability\/Java\/Collector\/span_event_data\/Output\/Bytes"
            },
            [
                1,
                144752,
                0,
                0,
                0,
                0
            ]
        ],
        [
            {
                "name": "Supportability\/Java\/Collector\/get_agent_commands\/Output\/Bytes"
            },
            [
                1,
                132,
                19,
                0,
                0,
                0
            ]
        ],
        [
            {
                "name": "Supportability\/Java\/Collector\/metric_data\/Output\/Bytes"
            },
            [
                1,
                37862,
                0,
                0,
                0,
                0
            ]
        ],
        [
            {
                "name": "Supportability\/Java\/Collector\/Output\/Bytes"
            },
            [
                10,
                206336,
                19,
                0,
                0,
                0
            ]
        ],
        [
            {
                "name": "Supportability\/Java\/Collector\/analytic_event_data\/Output\/Bytes"
            },
            [
                6,
                11375,
                0,
                0,
                0,
                0
            ]
        ]
    ]
]
```

In this example payload there are five metrics generated for specific agent endpoints (e.g. `Supportability/Java/Collector/analytic_event_data/Output/Bytes`) and one metric generated that sums all data sent to the Collector (i.e. `Supportability/Java/Collector/Output/Bytes`). The metric values in each of the metrics for individual endpoints should sum up to the values in the metric created for the total Collector data sent/received.