### PR TITLE
BlockingQueue and guard adding null

### DIFF
--- a/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
@@ -22,7 +22,6 @@ import com.newrelic.agent.dispatchers.WebRequestDispatcher;
 import com.newrelic.agent.environment.AgentIdentity;
 import com.newrelic.agent.errors.ErrorService;
 import com.newrelic.agent.errors.TracedError;
-import com.newrelic.agent.instrumentation.APISupportabilityTest;
 import com.newrelic.agent.metric.MetricName;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.stats.ResponseTimeStats;
@@ -1756,7 +1755,7 @@ public class ApiTest implements TransactionListener {
                 return null;
             }
         };
-        ServiceFactory.getStatsService().doStatsWork(statsWork);
+        ServiceFactory.getStatsService().doStatsWork(statsWork, "statsWorkName" );
 
         NewRelic.recordMetric(name.getName(), 1.0f);
     }

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorStatsService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorStatsService.java
@@ -38,7 +38,7 @@ class IntrospectorStatsService extends StatsServiceImpl implements StatsService 
     }
 
     @Override
-    public void doStatsWork(StatsWork statsWork) {
+    public void doStatsWork(StatsWork statsWork, String statsWorkName) {
         synchronized (this) {
             statsWork.doWork(engine);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -310,7 +310,7 @@ public final class Agent {
     private static void recordPremainTime(StatsService statsService, long startTime) {
         agentPremainTime = System.currentTimeMillis() - startTime;
         LOG.log(Level.INFO, "Premain startup complete in {0}ms", agentPremainTime);
-        statsService.doStatsWork(StatsWorks.getRecordResponseTimeWork(MetricNames.SUPPORTABILITY_TIMING_PREMAIN, agentPremainTime));
+        statsService.doStatsWork(StatsWorks.getRecordResponseTimeWork(MetricNames.SUPPORTABILITY_TIMING_PREMAIN, agentPremainTime), MetricNames.SUPPORTABILITY_TIMING_PREMAIN);
 
         Map<String, Object> environmentInfo = ImmutableMap.<String, Object>builder()
                 .put("Duration", agentPremainTime)
@@ -335,8 +335,8 @@ public final class Agent {
      */
     private static void recordAgentVersion(StatsService statsService) {
         statsService.doStatsWork(
-                StatsWorks.getIncrementCounterWork(MessageFormat.format(MetricNames.SUPPORTABILITY_JAVA_AGENTVERSION, getVersion()), 1)
-        );
+                StatsWorks.getIncrementCounterWork(MessageFormat.format(MetricNames.SUPPORTABILITY_JAVA_AGENTVERSION, getVersion()), 1),
+                MetricNames.SUPPORTABILITY_JAVA_AGENTVERSION );
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AsyncApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AsyncApiImpl.java
@@ -109,7 +109,7 @@ public class AsyncApiImpl implements AsyncApi {
     public void errorAsync(Object asyncContext, Throwable t) {
         logger.log(Level.FINEST, "Error async");
         ServiceFactory.getStatsService().doStatsWork(
-                StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_ERROR, 1), MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_COMPLETE);
+                StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_ERROR, 1), MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_ERROR);
         if (asyncContext == null || t == null) {
             logger.log(Level.FINEST, "Error async context or throwable is null");
             return;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AsyncApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AsyncApiImpl.java
@@ -42,7 +42,7 @@ public class AsyncApiImpl implements AsyncApi {
                 transactionState.suspendRootTracer();
                 asyncTransactions.put(asyncContext, currentTxn);
                 ServiceFactory.getStatsService().doStatsWork(
-                        StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_SUSPEND, 1));
+                        StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_SUSPEND, 1), MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_SUSPEND );
                 if (logger.isLoggable(Level.FINEST)) {
                     logger.log(Level.FINEST, "Suspended async: {0}, for Transaction: {1}", asyncContext, currentTxn);
                 }
@@ -72,7 +72,7 @@ public class AsyncApiImpl implements AsyncApi {
         if (asyncContext != null) {
             Transaction suspendedTx = asyncTransactions.get(asyncContext);
             ServiceFactory.getStatsService().doStatsWork(
-                    StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_RESUME, 1));
+                    StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_RESUME, 1), MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_RESUME);
             if (logger.isLoggable(Level.FINEST)) {
                 logger.log(Level.FINEST, "Resume async: {0}, for Transaction: {1}", asyncContext, suspendedTx);
             }
@@ -91,7 +91,7 @@ public class AsyncApiImpl implements AsyncApi {
     public void completeAsync(Object asyncContext) {
         logger.log(Level.FINEST, "Complete async");
         ServiceFactory.getStatsService().doStatsWork(
-                StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_COMPLETE, 1));
+                StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_COMPLETE, 1), MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_COMPLETE );
         if (asyncContext == null) {
             logger.log(Level.FINEST, "Complete async context is null");
             return;
@@ -109,7 +109,7 @@ public class AsyncApiImpl implements AsyncApi {
     public void errorAsync(Object asyncContext, Throwable t) {
         logger.log(Level.FINEST, "Error async");
         ServiceFactory.getStatsService().doStatsWork(
-                StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_ERROR, 1));
+                StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_ERROR, 1), MetricNames.SUPPORTABILITY_ASYNC_API_LEGACY_COMPLETE);
         if (asyncContext == null || t == null) {
             logger.log(Level.FINEST, "Error async context or throwable is null");
             return;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
@@ -87,7 +87,7 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
         Map<String, Object> spanHarvestConfig = config.getProperty(SERVER_SPAN_HARVEST_CONFIG);
         if (eventHarvestConfig == null) {
             ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(
-                    MetricNames.SUPPORTABILITY_CONNECT_MISSING_EVENT_DATA, 1));
+                    MetricNames.SUPPORTABILITY_CONNECT_MISSING_EVENT_DATA, 1), MetricNames.SUPPORTABILITY_CONNECT_MISSING_EVENT_DATA);
         }
 
         for (HarvestableTracker tracker : harvestables.values()) {
@@ -106,7 +106,8 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
                         maxSamplesStored = harvestLimit.intValue();
                         reportPeriodInMillis = (long) eventHarvestConfig.get(REPORT_PERIOD_MS);
                         ServiceFactory.getStatsService().doStatsWork(
-                                StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS, reportPeriodInMillis / 1000));
+                                StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS, reportPeriodInMillis / 1000),
+                                MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS );
                     }
                 } else if (!isSpanEventEndpoint) {
                     Agent.LOG.log(Level.FINE, "event_harvest_config from collector was null. Using default value: {0} samples stored for {1}", maxSamplesStored,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Harvestable.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Harvestable.java
@@ -56,7 +56,7 @@ public abstract class Harvestable {
             public String getAppName() {
                 return appName;
             }
-        });
+        }, "HarvestInterval");
     }
 
     public String getAppName() {
@@ -66,9 +66,9 @@ public abstract class Harvestable {
     public void configure(long reportPeriodInMillis, int maxSamplesStored) {
         long reportPeriodInSeconds = TimeUnit.MILLISECONDS.toSeconds(reportPeriodInMillis);
         ServiceFactory.getStatsService().doStatsWork(
-                StatsWorks.getRecordMetricWork(service.getReportPeriodInSecondsMetric(), reportPeriodInSeconds));
+                StatsWorks.getRecordMetricWork(service.getReportPeriodInSecondsMetric(), reportPeriodInSeconds), service.getReportPeriodInSecondsMetric());
         ServiceFactory.getStatsService().doStatsWork(
-                StatsWorks.getRecordMetricWork(service.getEventHarvestLimitMetric(), maxSamplesStored));
+                StatsWorks.getRecordMetricWork(service.getEventHarvestLimitMetric(), maxSamplesStored), service.getEventHarvestLimitMetric());
 
         if (maxSamplesStored != service.getMaxSamplesStored()) {
             service.setMaxSamplesStored(maxSamplesStored);
@@ -81,7 +81,7 @@ public abstract class Harvestable {
     private void maybeSendSpanLimitMetric(int maxSamplesStored) {
         if (service instanceof SpanEventsServiceImpl) {
             ServiceFactory.getStatsService().doStatsWork(
-                    StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_SPAN_EVENT_LIMIT, maxSamplesStored));
+                    StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_SPAN_EVENT_LIMIT, maxSamplesStored), MetricNames.SUPPORTABILITY_SPAN_EVENT_LIMIT);
         }
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TokenImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TokenImpl.java
@@ -156,7 +156,7 @@ public class TokenImpl implements Token {
         if (tracer != null) {
             tracer.setMetricNameFormatInfo(tracer.getMetricName(), "Truncated/" + tracer.getMetricName(), tracer.getTransactionSegmentUri());
             String timeoutCauseMetric = MessageFormat.format(MetricNames.SUPPORTABILITY_ASYNC_TOKEN_TIMEOUT_CAUSE, tracer.getClassMethodSignature());
-            ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(timeoutCauseMetric, 1));
+            ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(timeoutCauseMetric, 1), timeoutCauseMetric );
         } else {
             Agent.LOG.log(Level.FINEST, "Initiating tracer is null. Unable to mark segment as truncated.");
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -2001,7 +2001,8 @@ public class Transaction {
 
         synchronized (requestStateChangeLock) {
             ServiceFactory.getStatsService().doStatsWork(
-                    StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_INITIALIZED, 1));
+                    StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_INITIALIZED, 1),
+                    MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_INITIALIZED );
             if (this.isFinished()) {
                 return;
             }
@@ -2018,7 +2019,8 @@ public class Transaction {
             } else {
                 // JAVA-825. Ignore multiple requestInitialized() callbacks.
                 ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(
-                        MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_INITIALIZED_STARTED, 1));
+                        MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_INITIALIZED_STARTED, 1),
+                        MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_INITIALIZED_STARTED);
                 Agent.LOG.finer("requestInitialized(): transaction already started.");
             }
         }
@@ -2029,7 +2031,8 @@ public class Transaction {
 
         synchronized (requestStateChangeLock) {
             ServiceFactory.getStatsService().doStatsWork(
-                    StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_DESTROYED, 1));
+                    StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_DESTROYED, 1),
+                    MetricNames.SUPPORTABILITY_TRANSACTION_REQUEST_DESTROYED);
             if (!this.isInProgress()) {
                 return;
             }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionService.java
@@ -156,7 +156,7 @@ public class TransactionService extends AbstractService {
         }
         StatsService statsService = ServiceFactory.getStatsService();
         StatsWork statsWork = new MergeStatsEngineResolvingScope(transactionData.getBlameMetricName(), transactionData.getApplicationName(), transactionStats);
-        statsService.doStatsWork(statsWork);
+        statsService.doStatsWork(statsWork, transactionData.getBlameMetricName());
         if (transactionData.getDispatcher() != null) {
             for (TransactionStatsListener listener : transactionStatsListeners) {
                 listener.dispatcherTransactionStatsFinished(transactionData, transactionStats);
@@ -201,14 +201,21 @@ public class TransactionService extends AbstractService {
         StatsService statsService = ServiceFactory.getStatsService();
 
         //These three are so we can average the number of transactions happening per harvest cycle
-        statsService.doStatsWork(StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_STARTED, started));
-        statsService.doStatsWork(StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_FINISHED, finished));
-        statsService.doStatsWork(StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_CANCELLED, cancelled));
+        statsService.doStatsWork(StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_STARTED, started),
+                MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_STARTED);
+        statsService.doStatsWork(StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_FINISHED, finished),
+                MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_FINISHED);
+        statsService.doStatsWork(StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_CANCELLED, cancelled),
+                MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_CANCELLED);
 
         //These three are so we can get the total number of transactions ever, or the average among all apps' lifetime
-        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_STARTED, (int) started));
-        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_FINISHED, (int) finished));
-        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_CANCELLED, (int) cancelled));
+        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_STARTED, (int) started),
+                MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_STARTED);
+        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_FINISHED, (int) finished),
+                MetricNames.SUPPORTABILITY_TRANSACTION_FINISHED
+        );
+        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_TRANSACTION_CANCELLED, (int) cancelled),
+                MetricNames.SUPPORTABILITY_HARVEST_TRANSACTION_CANCELLED);
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/database/DatastoreMetrics.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/database/DatastoreMetrics.java
@@ -127,19 +127,19 @@ public class DatastoreMetrics {
         if (host == null) {
             String unknownHostMetric = new StringBuilder(MetricNames.SUPPORTABILITY_DATASTORE_PREFIX)
                     .append(vendor).append(MetricNames.SUPPORTABILITY_DATASTORE_UNKNOWN_HOST).toString();
-            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(unknownHostMetric, 1));
+            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(unknownHostMetric, 1), unknownHostMetric);
         }
 
         if (port == null && identifier == null) {
             String unknownPortMetric = new StringBuilder(MetricNames.SUPPORTABILITY_DATASTORE_PREFIX)
                     .append(vendor).append(MetricNames.SUPPORTABILITY_DATASTORE_UNKNOWN_PORT).toString();
-            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(unknownPortMetric, 1));
+            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(unknownPortMetric, 1), unknownPortMetric);
         }
 
         if (databaseName == null) {
             String unknownDatabaseNameMetric = new StringBuilder(MetricNames.SUPPORTABILITY_DATASTORE_PREFIX)
                     .append(vendor).append(MetricNames.SUPPORTABILITY_DATASTORE_UNKNOWN_DATABASE_NAME).toString();
-            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(unknownDatabaseNameMetric, 1));
+            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(unknownDatabaseNameMetric, 1), unknownDatabaseNameMetric);
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
@@ -179,7 +179,7 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
                     public String getAppName() {
                         return appName;
                     }
-                });
+                }, reservoir.getServiceName());
 
                 if (reservoir.size() < reservoir.getNumberOfTries()) {
                     int dropped = reservoir.getNumberOfTries() - reservoir.size();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/PointCutClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/PointCutClassTransformer.java
@@ -380,9 +380,9 @@ public class PointCutClassTransformer implements ContextClassTransformer {
 
         private void recordSupportabilityMetrics(List<PointCut> appliedPointCuts) {
             for (PointCut pointCut: appliedPointCuts) {
-                ServiceFactory.getStatsService().doStatsWork(StatsWorks.getRecordMetricWork(MessageFormat.format(
-                        MetricNames.SUPPORTABILITY_POINTCUT_LOADED, pointCut.getName()), 1), MetricNames.SUPPORTABILITY_POINTCUT_LOADED +
-                        " " + pointCut.getName());
+                String pointCutMetricName = MessageFormat.format(
+                        MetricNames.SUPPORTABILITY_POINTCUT_LOADED, pointCut.getName());
+                ServiceFactory.getStatsService().doStatsWork(StatsWorks.getRecordMetricWork(pointCutMetricName, 1), pointCutMetricName);
             }
         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/PointCutClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/PointCutClassTransformer.java
@@ -381,7 +381,8 @@ public class PointCutClassTransformer implements ContextClassTransformer {
         private void recordSupportabilityMetrics(List<PointCut> appliedPointCuts) {
             for (PointCut pointCut: appliedPointCuts) {
                 ServiceFactory.getStatsService().doStatsWork(StatsWorks.getRecordMetricWork(MessageFormat.format(
-                        MetricNames.SUPPORTABILITY_POINTCUT_LOADED, pointCut.getName()), 1));
+                        MetricNames.SUPPORTABILITY_POINTCUT_LOADED, pointCut.getName()), 1), MetricNames.SUPPORTABILITY_POINTCUT_LOADED +
+                        " " + pointCut.getName());
             }
         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/FinalClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/FinalClassTransformer.java
@@ -206,9 +206,10 @@ public class FinalClassTransformer implements ContextClassTransformer {
             for (Method m : context.getTimedMethods()) {
                 TraceDetails traceDetails = context.getTraceInformation().getTraceAnnotations().get(m);
                 if (traceDetails != null && traceDetails.isCustom()) {
-                    statsService.doStatsWork(StatsWorks.getRecordMetricWork(MessageFormat.format(
+                    String metricOrigin = MessageFormat.format(
                             MetricNames.SUPPORTABILITY_INSTRUMENT, className.replace('/', '.'), m.getName(),
-                            m.getDescriptor()), 1));
+                            m.getDescriptor());
+                    statsService.doStatsWork(StatsWorks.getRecordMetricWork(metricOrigin, 1), metricOrigin);
                 }
             }
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
@@ -142,7 +142,7 @@ public class InstrumentationClassTransformer implements ClassFileTransformer {
                         classBeingRedefined, protectionDomain, classfileBuffer, context, null);
                 ServiceFactory.getStatsService().doStatsWork(
                         StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_CLASSLOADER_TRANSFORM_TIME,
-                                System.nanoTime() - transformStartTimeInNs));
+                                System.nanoTime() - transformStartTimeInNs), MetricNames.SUPPORTABILITY_CLASSLOADER_TRANSFORM_TIME);
                 return transformation;
             }
         } catch (Throwable t) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/AgentWeaverListener.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/AgentWeaverListener.java
@@ -70,7 +70,7 @@ public class AgentWeaverListener implements WeavePackageLifetimeListener {
                 supportabilityLoadedMetric = MetricNames.SUPPORTABILITY_WEAVE_LOADED;
             }
             ServiceFactory.getStatsService().doStatsWork(StatsWorks.getRecordMetricWork(MessageFormat.format(
-                    supportabilityLoadedMetric, weavePackageName, weavePackageVersion), 1));
+                    supportabilityLoadedMetric, weavePackageName, weavePackageVersion), 1), supportabilityLoadedMetric);
             Agent.LOG.log(Level.FINE, "{0} - validated classloader {1}", weavePackageName, classloader);
         } else {
             WeavePackage weavePackage = packageResult.getWeavePackage();
@@ -88,7 +88,7 @@ public class AgentWeaverListener implements WeavePackageLifetimeListener {
             String supportabilitySkippedMetric = isCustom ? MetricNames.SUPPORTABILITY_WEAVE_CUSTOM_SKIPPED : MetricNames.SUPPORTABILITY_WEAVE_SKIPPED;
 
             ServiceFactory.getStatsService().doStatsWork(StatsWorks.getRecordMetricWork(MessageFormat.format(
-                    supportabilitySkippedMetric, weavePackageName, weavePackageVersion), 1));
+                    supportabilitySkippedMetric, weavePackageName, weavePackageVersion), 1), supportabilitySkippedMetric);
 
             weaveViolationLogger.logWeaveViolations(packageResult, classloader, isCustom);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
@@ -18,7 +18,6 @@ import com.newrelic.agent.instrumentation.PointCutClassTransformer;
 import com.newrelic.agent.instrumentation.classmatchers.OptimizedClassMatcher.Match;
 import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.instrumentation.context.ContextClassTransformer;
-import com.newrelic.agent.instrumentation.context.FinalClassTransformer;
 import com.newrelic.agent.instrumentation.context.InstrumentationContext;
 import com.newrelic.agent.instrumentation.weaver.errorhandler.LogAndReturnOriginal;
 import com.newrelic.agent.instrumentation.weaver.extension.ExtensionHolderFactoryImpl;
@@ -518,9 +517,10 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
                         Agent.LOG.log(Level.FINE, e, "Unable to add annotation proxy classes");
                     }
 
+                    String weaveClassStat = MessageFormat.format(MetricNames.SUPPORTABILITY_WEAVE_CLASS,
+                            packageName, weaveResult.getClassName());
                     ServiceFactory.getStatsService().doStatsWork(
-                            StatsWorks.getRecordMetricWork(MessageFormat.format(MetricNames.SUPPORTABILITY_WEAVE_CLASS,
-                                    packageName, weaveResult.getClassName()), 1));
+                            StatsWorks.getRecordMetricWork(weaveClassStat, 1), weaveClassStat);
 
                     for (String originalName : weaveResult.getWeavedMethods().keySet()) {
                         Agent.LOG.log(Level.FINE, "{0}: weaved target {1}-{2}", packageName, classloader,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
@@ -29,7 +29,8 @@ public class LinkingMetadataRegistration {
             Object bean = new LinkingMetadata();
             server.registerMBean(bean, name);
             logger.log(Level.INFO, "JMX LinkingMetadata bean registered");
-            ServiceFactory.getStatsService().doStatsWork(getRecordMetricWork(MetricNames.LINKING_METADATA_MBEAN, 1));
+            ServiceFactory.getStatsService().doStatsWork(getRecordMetricWork(MetricNames.LINKING_METADATA_MBEAN, 1),
+                    MetricNames.LINKING_METADATA_MBEAN + " name: " + name);
         } catch (Exception | NoClassDefFoundError e) {
             logger.log(Level.INFO, "Error registering JMX LinkingMetadata MBean", e);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/LinkingMetadataRegistration.java
@@ -30,7 +30,7 @@ public class LinkingMetadataRegistration {
             server.registerMBean(bean, name);
             logger.log(Level.INFO, "JMX LinkingMetadata bean registered");
             ServiceFactory.getStatsService().doStatsWork(getRecordMetricWork(MetricNames.LINKING_METADATA_MBEAN, 1),
-                    MetricNames.LINKING_METADATA_MBEAN + " name: " + name);
+                    MetricNames.LINKING_METADATA_MBEAN);
         } catch (Exception | NoClassDefFoundError e) {
             logger.log(Level.INFO, "Error registering JMX LinkingMetadata MBean", e);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/language/SourceLibraryDetector.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/language/SourceLibraryDetector.java
@@ -147,12 +147,14 @@ public class SourceLibraryDetector implements Runnable {
     private void recordSourceLanguageMetric(String language, String version) {
         ServiceFactory
                 .getStatsService()
-                .doStatsWork(getRecordMetricWork(format(MetricNames.SUPPORTABILITY_SOURCE_LANGUAGE_VERSION, language, version), 1));
+                .doStatsWork(getRecordMetricWork(format(MetricNames.SUPPORTABILITY_SOURCE_LANGUAGE_VERSION, language, version), 1),
+                        MetricNames.SUPPORTABILITY_SOURCE_LANGUAGE_VERSION + " language: " + language );
     }
 
     private void recordJvmVendorMetric(String vendor) {
         ServiceFactory
                 .getStatsService()
-                .doStatsWork(getRecordMetricWork(format(MetricNames.SUPPORTABILITY_JVM_VENDOR, vendor), 1));
+                .doStatsWork(getRecordMetricWork(format(MetricNames.SUPPORTABILITY_JVM_VENDOR, vendor), 1),
+                        MetricNames.SUPPORTABILITY_JVM_VENDOR + " vendor: " + vendor  );
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/TransactionProfile.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/TransactionProfile.java
@@ -112,7 +112,7 @@ class TransactionProfile implements JSONStreamAware {
                     return null;
                 }
                 
-            });
+            }, transactionData.getBlameMetricName() );
         }
         
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/rpm/RPMConnectionServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/rpm/RPMConnectionServiceImpl.java
@@ -315,7 +315,7 @@ public class RPMConnectionServiceImpl extends AbstractService implements RPMConn
             long timeSinceLastConnectionAttemptInSeconds = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - lastConnectionAttempt.get());
 
             if (timeSinceLastConnectionAttemptInSeconds >= BACKOFF_INTERVAL_IN_SEC[backoffIndex.get()]) {
-                ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_AGENT_CONNECT_BACKOFF_ATTEMPTS, 1));
+                ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_AGENT_CONNECT_BACKOFF_ATTEMPTS, 1), MetricNames.SUPPORTABILITY_AGENT_CONNECT_BACKOFF_ATTEMPTS);
 
                 if (timeSinceLastConnectionAttemptInSeconds < MAX_BACKOFF_DELAY) {
                     backoffIndex.incrementAndGet();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/samplers/SamplerServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/samplers/SamplerServiceImpl.java
@@ -132,7 +132,7 @@ public class SamplerServiceImpl extends AbstractService implements SamplerServic
     private void mergeStatsEngine(String appName) {
         StatsService statsService = ServiceFactory.getStatsService();
         StatsWork work = new MergeStatsEngine(appName, statsEngine);
-        statsService.doStatsWork(work);
+        statsService.doStatsWork(work, statsService.getName());
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -607,7 +607,8 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
 
     private void replayStartupStatsWork() {
         for (StatsWork work : statsWork) {
-            statsService.doStatsWork(work);
+            //TODO: Figure out the best thing to do here. By this point, there is no way to have a null because LinkedBlockingQueue doesn't allow them and the queue is guarded against it anyway.
+            statsService.doStatsWork(work, statsService.getName());
         }
         statsWork.clear();
     }
@@ -651,11 +652,12 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
         }
 
         @Override
-        public void doStatsWork(StatsWork statsWork) {
+        public void doStatsWork(StatsWork statsWork, String statsWorkName) {
             if (statsWork != null) {
                 ServiceManagerImpl.this.statsWork.add(statsWork);
             } else {
-                initialStatsServiceLogger.log(Level.WARNING, "Problem adding a StatsWork to queue in InitialStatsService. StatsWork was null.");
+                initialStatsServiceLogger.log(Level.WARNING,
+                        "Problem adding a StatsWork to queue in InitialStatsService. StatsWork was null for: " + statsWorkName);
             }
 
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -607,7 +607,6 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
 
     private void replayStartupStatsWork() {
         for (StatsWork work : statsWork) {
-            //TODO: Figure out the best thing to do here. By this point, there is no way to have a null because LinkedBlockingQueue doesn't allow them and the queue is guarded against it anyway.
             statsService.doStatsWork(work, statsService.getName());
         }
         statsWork.clear();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -10,7 +10,17 @@ package com.newrelic.agent.service;
 import com.newrelic.Function;
 import com.newrelic.InfiniteTracing;
 import com.newrelic.InfiniteTracingConfig;
-import com.newrelic.agent.*;
+import com.newrelic.agent.Agent;
+import com.newrelic.agent.AgentConnectionEstablishedListener;
+import com.newrelic.agent.ExpirationService;
+import com.newrelic.agent.GCService;
+import com.newrelic.agent.HarvestService;
+import com.newrelic.agent.HarvestServiceImpl;
+import com.newrelic.agent.RPMServiceManager;
+import com.newrelic.agent.RPMServiceManagerImpl;
+import com.newrelic.agent.ThreadService;
+import com.newrelic.agent.TracerService;
+import com.newrelic.agent.TransactionService;
 import com.newrelic.agent.attributes.AttributesService;
 import com.newrelic.agent.browser.BrowserService;
 import com.newrelic.agent.browser.BrowserServiceImpl;
@@ -43,9 +53,23 @@ import com.newrelic.agent.samplers.CPUSamplerService;
 import com.newrelic.agent.samplers.NoopSamplerService;
 import com.newrelic.agent.samplers.SamplerService;
 import com.newrelic.agent.samplers.SamplerServiceImpl;
-import com.newrelic.agent.service.analytics.*;
+import com.newrelic.agent.service.analytics.InfiniteTracingEnabledCheck;
+import com.newrelic.agent.service.analytics.InsightsService;
+import com.newrelic.agent.service.analytics.InsightsServiceImpl;
+import com.newrelic.agent.service.analytics.SpanEventCreationDecider;
+import com.newrelic.agent.service.analytics.SpanEventsService;
+import com.newrelic.agent.service.analytics.TransactionDataToDistributedTraceIntrinsics;
+import com.newrelic.agent.service.analytics.TransactionEventsService;
 import com.newrelic.agent.service.async.AsyncTransactionService;
-import com.newrelic.agent.service.module.*;
+import com.newrelic.agent.service.module.JarAnalystFactory;
+import com.newrelic.agent.service.module.JarCollectorConnectionListener;
+import com.newrelic.agent.service.module.JarCollectorHarvestListener;
+import com.newrelic.agent.service.module.JarCollectorInputs;
+import com.newrelic.agent.service.module.JarCollectorService;
+import com.newrelic.agent.service.module.JarCollectorServiceImpl;
+import com.newrelic.agent.service.module.JarCollectorServiceProcessor;
+import com.newrelic.agent.service.module.JarData;
+import com.newrelic.agent.service.module.TrackedAddSet;
 import com.newrelic.agent.sql.SqlTraceService;
 import com.newrelic.agent.sql.SqlTraceServiceImpl;
 import com.newrelic.agent.stats.StatsEngine;
@@ -62,19 +86,20 @@ import com.newrelic.api.agent.MetricAggregator;
 import com.newrelic.api.agent.NewRelic;
 
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 /**
  * Service Manager implementation
- *
+ * <p>
  * This class is thread-safe.
  */
 public class ServiceManagerImpl extends AbstractService implements ServiceManager {
@@ -82,7 +107,7 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
     private final ConcurrentMap<String, Service> services = new ConcurrentHashMap<>();
     private final CoreService coreService;
     private final ConfigService configService;
-
+    private final BlockingQueue<StatsWork> statsWork = new LinkedBlockingQueue<>();
     private volatile ExtensionService extensionService;
     private volatile ProfilerService profilerService;
     private volatile TracerService tracerService;
@@ -587,44 +612,6 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
         statsWork.clear();
     }
 
-    private final List<StatsWork> statsWork = new ArrayList<>();
-
-    private class InitialStatsService extends AbstractService implements StatsService {
-        private final MetricAggregator metricAggregator = new StatsServiceMetricAggregator(this);
-
-        protected InitialStatsService() {
-            super("Bootstrap stats service");
-        }
-
-        @Override
-        public boolean isEnabled() {
-            return true;
-        }
-
-        @Override
-        public void doStatsWork(StatsWork statsWork) {
-            ServiceManagerImpl.this.statsWork.add(statsWork);
-        }
-
-        @Override
-        public StatsEngine getStatsEngineForHarvest(String appName) {
-            return null;
-        }
-
-        @Override
-        protected void doStart() throws Exception {
-        }
-
-        @Override
-        protected void doStop() throws Exception {
-        }
-
-        @Override
-        public MetricAggregator getMetricAggregator() {
-            return metricAggregator;
-        }
-    }
-
     @Override
     public UtilizationService getUtilizationService() {
         return utilizationService;
@@ -648,6 +635,48 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
     @Override
     public ExpirationService getExpirationService() {
         return expirationService;
+    }
+
+    private class InitialStatsService extends AbstractService implements StatsService {
+        private final MetricAggregator metricAggregator = new StatsServiceMetricAggregator(this);
+        private final Logger initialStatsServiceLogger = Agent.LOG.getChildLogger("com.newrelic.InitialStatsService");
+
+        protected InitialStatsService() {
+            super("Bootstrap stats service");
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+
+        @Override
+        public void doStatsWork(StatsWork statsWork) {
+            if (statsWork != null) {
+                ServiceManagerImpl.this.statsWork.add(statsWork);
+            } else {
+                initialStatsServiceLogger.log(Level.WARNING, "Problem adding a StatsWork to queue in InitialStatsService. StatsWork was null.");
+            }
+
+        }
+
+        @Override
+        public StatsEngine getStatsEngineForHarvest(String appName) {
+            return null;
+        }
+
+        @Override
+        protected void doStart() throws Exception {
+        }
+
+        @Override
+        protected void doStop() throws Exception {
+        }
+
+        @Override
+        public MetricAggregator getMetricAggregator() {
+            return metricAggregator;
+        }
     }
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/StatsServiceMetricAggregator.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/StatsServiceMetricAggregator.java
@@ -24,17 +24,17 @@ public class StatsServiceMetricAggregator extends AbstractMetricAggregator {
 
     @Override
     protected void doRecordResponseTimeMetric(String name, long totalTime, long exclusiveTime, TimeUnit timeUnit) {
-        statsService.doStatsWork(new RecordResponseTimeMetric(totalTime, exclusiveTime, name, timeUnit));
+        statsService.doStatsWork(new RecordResponseTimeMetric(totalTime, exclusiveTime, name, timeUnit), name );
     }
 
     @Override
     protected void doRecordMetric(String name, float value) {
-        statsService.doStatsWork(StatsWorks.getRecordMetricWork(name, value));
+        statsService.doStatsWork(StatsWorks.getRecordMetricWork(name, value), name);
     }
 
     @Override
     protected void doIncrementCounter(String name, int count) {
-        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(name, count));
+        statsService.doStatsWork(StatsWorks.getIncrementCounterWork(name, count), name);
     }
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/InsightsServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/InsightsServiceImpl.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -292,7 +291,7 @@ public class InsightsServiceImpl extends AbstractService implements InsightsServ
                     public String getAppName() {
                         return appName;
                     }
-                });
+                }, reservoir.getServiceName());
 
                 if (reservoir.size() < reservoir.getNumberOfTries()) {
                     int dropped = reservoir.getNumberOfTries() - reservoir.size();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventsServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventsServiceImpl.java
@@ -133,7 +133,7 @@ public class SpanEventsServiceImpl extends AbstractService implements AgentConfi
                 public String getAppName() {
                     return appName;
                 }
-            });
+            },  "HarvestResult");
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TransactionEventsService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TransactionEventsService.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -210,7 +209,7 @@ public class TransactionEventsService extends AbstractService implements EventSe
                     public String getAppName() {
                         return appName;
                     }
-                });
+                }, reservoirToSend.getServiceName());
             } catch (HttpError e) {
                 if (!e.discardHarvestData()) {
                     Agent.LOG.log(Level.FINE,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsService.java
@@ -16,7 +16,7 @@ public interface StatsService extends Service {
     /**
      * Process the given {@link StatsWork}.
      */
-    void doStatsWork(StatsWork statsWork);
+    void doStatsWork(StatsWork statsWork, String statsWorkName);
 
     /**
      * Get a {@link StatsEngine} containing the metric data to be sent to the server in the next harvest.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsServiceImpl.java
@@ -57,7 +57,7 @@ public class StatsServiceImpl extends AbstractService implements StatsService {
     }
 
     @Override
-    public void doStatsWork(StatsWork work) {
+    public void doStatsWork(StatsWork work, String statsWorkName) {
         String appName = work.getAppName();
         boolean done = false;
         while (!done) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadStateSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadStateSampler.java
@@ -136,14 +136,14 @@ public class ThreadStateSampler implements Runnable {
         @Override
         protected void doRecordResponseTimeMetric(String name, long totalTime, long exclusiveTime, TimeUnit timeUnit) {
             if (!isAutoAppNamingEnabled) {
-                statsService.doStatsWork(new RecordResponseTimeMetricWorker(null, totalTime, exclusiveTime, name, timeUnit));
+                statsService.doStatsWork(new RecordResponseTimeMetricWorker(null, totalTime, exclusiveTime, name, timeUnit), name);
             } else {
                 List<IRPMService> rpmServices = ServiceFactory.getRPMServiceManager().getRPMServices();
                 RecordResponseTimeMetricWorker responseTimeWorker = new RecordResponseTimeMetricWorker(null, totalTime, exclusiveTime, name, timeUnit);
                 for (IRPMService rpmService : rpmServices) {
                     String appName = rpmService.getApplicationName();
                     responseTimeWorker.setAppName(appName);
-                    statsService.doStatsWork(responseTimeWorker);
+                    statsService.doStatsWork(responseTimeWorker, name);
                 }
             }
         }
@@ -151,14 +151,14 @@ public class ThreadStateSampler implements Runnable {
         @Override
         protected void doRecordMetric(String name, float value) {
             if (!isAutoAppNamingEnabled) {
-                statsService.doStatsWork(new RecordMetricWorker(null, name, value));
+                statsService.doStatsWork(new RecordMetricWorker(null, name, value), name);
             } else {
                 List<IRPMService> rpmServices = ServiceFactory.getRPMServiceManager().getRPMServices();
                 RecordMetricWorker metricWorker = new RecordMetricWorker(null, name, value);
                 for (IRPMService rpmService : rpmServices) {
                     String appName = rpmService.getApplicationName();
                     metricWorker.setAppName(appName);
-                    statsService.doStatsWork(metricWorker);
+                    statsService.doStatsWork(metricWorker, name);
                 }
             }
         }
@@ -166,14 +166,14 @@ public class ThreadStateSampler implements Runnable {
         @Override
         protected void doIncrementCounter(String name, int count) {
             if (!isAutoAppNamingEnabled) {
-                statsService.doStatsWork(new IncrementCounterWorker(null, name, count));
+                statsService.doStatsWork(new IncrementCounterWorker(null, name, count), name);
             } else {
                 List<IRPMService> rpmServices = ServiceFactory.getRPMServiceManager().getRPMServices();
                 IncrementCounterWorker incrementCounterWorker = new IncrementCounterWorker(null, name, count);
                 for (IRPMService rpmService : rpmServices) {
                     String appName = rpmService.getApplicationName();
                     incrementCounterWorker.setAppName(appName);
-                    statsService.doStatsWork(incrementCounterWorker);
+                    statsService.doStatsWork(incrementCounterWorker, name);
                 }
             }
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
@@ -541,7 +541,7 @@ public class DataSenderImpl implements DataSender {
          */
         if (data.length > maxPayloadSizeInBytes && !method.equals(CollectorMethods.ERROR_DATA)) {
             ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(
-                    MessageFormat.format(MetricNames.SUPPORTABILITY_PAYLOAD_SIZE_EXCEEDS_MAX, method), 1));
+                    MessageFormat.format(MetricNames.SUPPORTABILITY_PAYLOAD_SIZE_EXCEEDS_MAX, method), 1), MetricNames.SUPPORTABILITY_PAYLOAD_SIZE_EXCEEDS_MAX);
             String msg = MessageFormat.format("Payload of size {0} exceeded maximum size {1} for {2} method ",
                     data.length, maxPayloadSizeInBytes, method);
             logger.log(Level.WARNING, msg);
@@ -564,7 +564,7 @@ public class DataSenderImpl implements DataSender {
 
         // Create supportability metric for all response codes
         ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(
-                MessageFormat.format(MetricNames.SUPPORTABILITY_HTTP_CODE, result.getStatusCode()), 1));
+                MessageFormat.format(MetricNames.SUPPORTABILITY_HTTP_CODE, result.getStatusCode()), 1), MetricNames.SUPPORTABILITY_HTTP_CODE);
 
         if (result.getStatusCode() != HttpResponseCode.OK && result.getStatusCode() != HttpResponseCode.ACCEPTED) {
             throwExceptionFromStatusCode(method, result, data, request);
@@ -603,21 +603,22 @@ public class DataSenderImpl implements DataSender {
         ServiceFactory.getStatsService().doStatsWork(
                 StatsWorks.getRecordDataUsageMetricWork(
                         MessageFormat.format(MetricNames.SUPPORTABILITY_DATA_USAGE_DESTINATION_OUTPUT_BYTES, COLLECTOR),
-                        payloadBytesSent, payloadBytesReceived));
+                        payloadBytesSent, payloadBytesReceived), MetricNames.SUPPORTABILITY_DATA_USAGE_DESTINATION_OUTPUT_BYTES + " " + COLLECTOR);
 
         ServiceFactory.getStatsService().doStatsWork(
                 StatsWorks.getRecordDataUsageMetricWork(
                         MessageFormat.format(MetricNames.SUPPORTABILITY_DATA_USAGE_DESTINATION_ENDPOINT_OUTPUT_BYTES, COLLECTOR, method),
-                        payloadBytesSent, payloadBytesReceived));
+                        payloadBytesSent, payloadBytesReceived),
+                        MetricNames.SUPPORTABILITY_DATA_USAGE_DESTINATION_ENDPOINT_OUTPUT_BYTES + " " + COLLECTOR);
     }
 
     private void throwExceptionFromStatusCode(String method, ReadResult result, byte[] data, HttpClientWrapper.Request request)
             throws HttpError, LicenseException, ForceRestartException, ForceDisconnectException {
         // Comply with spec and send supportability metric only for error responses
         ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(
-                MessageFormat.format(MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_HTTP_ERROR, result.getStatusCode()), 1));
+                MessageFormat.format(MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_HTTP_ERROR, result.getStatusCode()), 1), MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_HTTP_ERROR);
         ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(
-                MessageFormat.format(MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_ATTEMPTS, method), 1));
+                MessageFormat.format(MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_ATTEMPTS, method), 1), MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_ATTEMPTS);
 
         // HttpError exceptions are typically handled in RPMService or the harvestable service for the requested endpoint
         switch (result.getStatusCode()) {
@@ -763,7 +764,8 @@ public class DataSenderImpl implements DataSender {
             long requestDuration = System.currentTimeMillis() - requestSent;
 
             statsService.doStatsWork(StatsWorks.getRecordResponseTimeWork(
-                    MessageFormat.format(MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_DURATION, method), requestDuration));
+                    MessageFormat.format(MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_DURATION, method), requestDuration),
+                    MetricNames.SUPPORTABILITY_AGENT_ENDPOINT_DURATION + " " + method);
         }
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheHttpClientWrapper.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheHttpClientWrapper.java
@@ -138,12 +138,12 @@ public class ApacheHttpClientWrapper implements HttpClientWrapper {
         for (HttpRoute route : routes) {
             String hostName = route.getTargetHost().getHostName();
             if (hostName != null && hostName.equals(requestHost)) {
-                statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_CONNECTION_REUSED, 1));
+                statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_CONNECTION_REUSED, 1), MetricNames.SUPPORTABILITY_CONNECTION_REUSED);
                 willReuse = true;
             }
         }
         if (!willReuse) {
-            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_CONNECTION_NEW, 1));
+            statsService.doStatsWork(StatsWorks.getIncrementCounterWork(MetricNames.SUPPORTABILITY_CONNECTION_NEW, 1), MetricNames.SUPPORTABILITY_CONNECTION_NEW);
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/CloudUtility.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/CloudUtility.java
@@ -90,7 +90,7 @@ public class CloudUtility {
     }
 
     public void recordError(String metricName) {
-        ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(metricName, 1));
+        ServiceFactory.getStatsService().doStatsWork(StatsWorks.getIncrementCounterWork(metricName, 1), metricName);
     }
 
     /**

--- a/newrelic-agent/src/test/java/com/newrelic/agent/HarvestServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/HarvestServiceTest.java
@@ -117,7 +117,7 @@ public class HarvestServiceTest {
             Stats stats = statsEngine.getStats("Test" + String.valueOf(i));
             stats.recordDataPoint(100f);
         }
-        ServiceFactory.getStatsService().doStatsWork(new MergeStatsWork("test", statsEngine));
+        ServiceFactory.getStatsService().doStatsWork(new MergeStatsWork("test", statsEngine), "statsWorkTest");
         harvestService.startHarvest(rpmService);
         Assert.assertTrue(latch.await(5L, TimeUnit.SECONDS));
         harvestService.stop();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
@@ -45,7 +45,7 @@ public class SourceLibraryDetectorTest {
         sourceLibraryDetector.run();
         ArgumentCaptor<StatsWork> captor = ArgumentCaptor.forClass(StatsWork.class);
         //As of 7.0.0 we are pulling in kotlin as a transitive dependency of JFR-Daemon 
-        verify(ServiceFactory.getStatsService(), times(3)).doStatsWork(captor.capture());
+        verify(ServiceFactory.getStatsService(), times(3)).doStatsWork(captor.capture(), "statsWorkTest");
 
         StatsWork statsWork = captor.getValue();
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
@@ -17,7 +17,11 @@ import org.mockito.ArgumentCaptor;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class SourceLibraryDetectorTest {
 
@@ -45,7 +49,7 @@ public class SourceLibraryDetectorTest {
         sourceLibraryDetector.run();
         ArgumentCaptor<StatsWork> captor = ArgumentCaptor.forClass(StatsWork.class);
         //As of 7.0.0 we are pulling in kotlin as a transitive dependency of JFR-Daemon 
-        verify(ServiceFactory.getStatsService(), times(3)).doStatsWork(captor.capture(), "statsWorkTest");
+        verify(ServiceFactory.getStatsService(), times(3)).doStatsWork(captor.capture(), anyString());
 
         StatsWork statsWork = captor.getValue();
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsServiceTest.java
@@ -104,12 +104,6 @@ public class StatsServiceTest {
         // RecordDataUsageMetric count 3
         statsService.doStatsWork(new RecordDataUsageMetric("Test2", 100, 5), "statsWorkTest");
 
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
-        statsEngine = new StatsEngineImpl();
-        stats1 = statsEngine.getStats("Test1");
-        stats1.recordDataPoint(200f);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
-        statsService.doStatsWork(new RecordMetric("Test1", 300f), "statsWorkTest");
         StatsEngine harvestStatsEngine = statsService.getStatsEngineForHarvest(appName);
 
         // Number of unique metrics (Test1 and Test2)

--- a/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsServiceTest.java
@@ -78,32 +78,38 @@ public class StatsServiceTest {
         StatsEngineImpl statsEngine = new StatsEngineImpl();
         Stats stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(100f);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
 
         // RecordMetric count 2
         statsEngine = new StatsEngineImpl();
         stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(200f);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
 
         // RecordMetric count 3
-        statsService.doStatsWork(new RecordMetric("Test1", 300f));
+        statsService.doStatsWork(new RecordMetric("Test1", 300f), "statsWorkTest");
 
         // RecordDataUsageMetric count 1
         statsEngine = new StatsEngineImpl();
         DataUsageStats dataUsageStats = statsEngine.getDataUsageStats(MetricName.create("Test2"));
         dataUsageStats.recordDataUsage(5000, 25);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
 
         // RecordDataUsageMetric count 2
         statsEngine = new StatsEngineImpl();
         dataUsageStats = statsEngine.getDataUsageStats(MetricName.create("Test2"));
         dataUsageStats.recordDataUsage(1000, 10);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
 
         // RecordDataUsageMetric count 3
-        statsService.doStatsWork(new RecordDataUsageMetric("Test2", 100, 5));
+        statsService.doStatsWork(new RecordDataUsageMetric("Test2", 100, 5), "statsWorkTest");
 
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
+        statsEngine = new StatsEngineImpl();
+        stats1 = statsEngine.getStats("Test1");
+        stats1.recordDataPoint(200f);
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
+        statsService.doStatsWork(new RecordMetric("Test1", 300f), "statsWorkTest");
         StatsEngine harvestStatsEngine = statsService.getStatsEngineForHarvest(appName);
 
         // Number of unique metrics (Test1 and Test2)
@@ -145,7 +151,7 @@ public class StatsServiceTest {
 
             @Override
             public void run() {
-                statsService.doStatsWork(statsWork1);
+                statsService.doStatsWork(statsWork1, "statsWorkTest");
                 latch3.countDown();
             }
 
@@ -158,7 +164,7 @@ public class StatsServiceTest {
         stats = statsEngine2.getStats("Test1");
         stats.recordDataPoint(200f);
         final StatsWork statsWork2 = new MergeStatsWork(appName, statsEngine2);
-        statsService.doStatsWork(statsWork2);
+        statsService.doStatsWork(statsWork2, "statsWorkTest");
         latch2.countDown();
         latch3.await();
         StatsEngine harvestStatsEngine = statsService.getStatsEngineForHarvest(appName);
@@ -173,14 +179,14 @@ public class StatsServiceTest {
         StatsService statsService = serviceManager.getStatsService();
         Stats stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(100f);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine),"statsWorkTest" );
         StatsEngine harvestStatsEngine = statsService.getStatsEngineForHarvest(appName);
         Assert.assertEquals(1, harvestStatsEngine.getSize());
         Assert.assertEquals(100f, harvestStatsEngine.getStats("Test1").getTotal(), 0);
         statsEngine = new StatsEngineImpl();
         stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(200f);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine),"statsWorkTest");
         harvestStatsEngine = statsService.getStatsEngineForHarvest(appName);
         Assert.assertEquals(1, harvestStatsEngine.getSize());
         Assert.assertEquals(200f, harvestStatsEngine.getStats("Test1").getTotal(), 0);
@@ -194,19 +200,19 @@ public class StatsServiceTest {
         StatsEngineImpl statsEngine = new StatsEngineImpl();
         Stats stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(100f);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
         statsEngine = new StatsEngineImpl();
         stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(100f);
-        statsService.doStatsWork(new MergeStatsWork(appName2, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName2, statsEngine), "statsWorkTest");
         statsEngine = new StatsEngineImpl();
         stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(200f);
-        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName, statsEngine), "statsWorkTest");
         statsEngine = new StatsEngineImpl();
         stats1 = statsEngine.getStats("Test1");
         stats1.recordDataPoint(200f);
-        statsService.doStatsWork(new MergeStatsWork(appName2, statsEngine));
+        statsService.doStatsWork(new MergeStatsWork(appName2, statsEngine),"statsWorkTest");
         StatsEngine harvestStatsEngine = statsService.getStatsEngineForHarvest(appName);
         Assert.assertEquals(1, harvestStatsEngine.getSize());
         Assert.assertEquals(300f, harvestStatsEngine.getStats("Test1").getTotal(), 0);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/utilization/CloudUtilityTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/utilization/CloudUtilityTest.java
@@ -88,11 +88,11 @@ public class CloudUtilityTest {
     @Test
     public void recordsMetric() {
         ArgumentCaptor<StatsWork> captor = ArgumentCaptor.forClass(StatsWork.class);
-        doNothing().when(mockStatsService).doStatsWork(captor.capture());
+        doNothing().when(mockStatsService).doStatsWork(captor.capture(), "statsWorkTest");
 
         new CloudUtility().recordError("some error");
 
-        verify(mockStatsService, times(1)).doStatsWork(any(StatsWork.class));
+        verify(mockStatsService, times(1)).doStatsWork(any(StatsWork.class), "statsWorkTest");
 
         StatsWork argument = captor.getValue();
         assertTrue(argument instanceof IncrementCounter);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/utilization/CloudUtilityTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/utilization/CloudUtilityTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -88,11 +89,11 @@ public class CloudUtilityTest {
     @Test
     public void recordsMetric() {
         ArgumentCaptor<StatsWork> captor = ArgumentCaptor.forClass(StatsWork.class);
-        doNothing().when(mockStatsService).doStatsWork(captor.capture(), "statsWorkTest");
+        doNothing().when(mockStatsService).doStatsWork(captor.capture(), anyString());
 
         new CloudUtility().recordError("some error");
 
-        verify(mockStatsService, times(1)).doStatsWork(any(StatsWork.class), "statsWorkTest");
+        verify(mockStatsService, times(1)).doStatsWork(any(StatsWork.class), anyString());
 
         StatsWork argument = captor.getValue();
         assertTrue(argument instanceof IncrementCounter);


### PR DESCRIPTION
PR for:
https://github.com/newrelic/newrelic-java-agent/issues/621

We intermittently see NPEs from:
at com.newrelic.agent.stats.StatsServiceImpl.doStatsWork(StatsServiceImpl.java:61) ~[newrelic.jar:7.4.2]
at com.newrelic.agent.service.ServiceManagerImpl.replayStartupStatsWork(ServiceManagerImpl.java:585)
Which is preventing application startup with the agent.
They get the following error in newrelic.log when that happens. 

```
java.lang.NullPointerException: null
at com.newrelic.agent.stats.StatsServiceImpl.doStatsWork(StatsServiceImpl.java:61) ~[newrelic.jar:7.4.2]
at com.newrelic.agent.service.ServiceManagerImpl.replayStartupStatsWork(ServiceManagerImpl.java:585) ~[newrelic.jar:7.4.2]
at com.newrelic.agent.service.ServiceManagerImpl.doStart(ServiceManagerImpl.java:195) ~[newrelic.jar:7.4.2]
at com.newrelic.agent.service.AbstractService.start(AbstractService.java:63) ~[newrelic.jar:7.4.2]
at com.newrelic.agent.Agent.continuePremain(Agent.java:162) [newrelic.jar:7.4.2]
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_171]
```

We have been unable to replicate the issue. However there is general agreement that we can and should just guard against the NPE in that spot. It's also possible that another thread causes an issue. 

This PR changes the List holding StatsWork to a LinkedBlockingQueue and guards against attempting to add a null to the queue (which would throw an NPE for LBQ).  Logs that this occurred.

### Checks

