### PR TITLE
Adding attribute Automatic-Module-Name for JDK9/11

### DIFF
--- a/newrelic-api/build.gradle
+++ b/newrelic-api/build.gradle
@@ -8,7 +8,7 @@ plugins {
 jar {
     from("$rootDir/LICENSE")
     manifest {
-        attributes 'Implementation-Title': 'New Relic Agent API', 'Implementation-Version': project.version
+        attributes 'Implementation-Title': 'New Relic Agent API', 'Implementation-Version': project.version, 'Automatic-Module-Name': 'newrelic.api'
     }
 }
 


### PR DESCRIPTION
testing https://github.com/newrelic/newrelic-java-agent/pull/684
Concern...does adding explicit automatic name force others to explicitly require?

Also rebase to test.
### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
