### PR TITLE
fix: log4j duplicated log lines and counters

### DIFF
--- a/instrumentation/apache-log4j-2/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig_Instrumentation.java
+++ b/instrumentation/apache-log4j-2/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig_Instrumentation.java
@@ -37,7 +37,8 @@ public class LoggerConfig_Instrumentation {
 
     protected void callAppenders(LogEvent event) {
         // Do nothing if application_logging.enabled: false
-        if (isApplicationLoggingEnabled()) {
+        // Do nothing if logger has parents and isAdditive is set to true to avoid duplicated counters and logs
+        if (isApplicationLoggingEnabled() && getParent() == null || !isAdditive()) {
             if (isApplicationLoggingMetricsEnabled()) {
                 // Generate log level metrics
                 NewRelic.incrementCounter("Logging/lines");
@@ -51,4 +52,13 @@ public class LoggerConfig_Instrumentation {
         }
         Weaver.callOriginal();
     }
+
+    public LoggerConfig getParent() {
+        return Weaver.callOriginal();
+    }
+
+    public boolean isAdditive() {
+        return Weaver.callOriginal();
+    }
+
 }

--- a/instrumentation/apache-log4j-2/src/test/java/com/nr/agent/instrumentation/log4j2/LoggerConfig_InstrumentationTest.java
+++ b/instrumentation/apache-log4j-2/src/test/java/com/nr/agent/instrumentation/log4j2/LoggerConfig_InstrumentationTest.java
@@ -7,10 +7,17 @@ import junit.framework.TestCase;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,6 +30,11 @@ public class LoggerConfig_InstrumentationTest extends TestCase {
 
     // TODO add tests for LogEvents being created when recordNewRelicLogEvent is called
     //  this is probably blocked until the Introspector is updated
+
+    @Before
+    public void resetLoggerConfiguration() {
+        Configurator.reconfigure();
+    }
 
     @Test
     public void shouldIncrementEmittedLogsCountersIndependentlyIfLogLevelEnabled() {
@@ -71,6 +83,74 @@ public class LoggerConfig_InstrumentationTest extends TestCase {
         Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/INFO"));
         Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/WARN"));
         Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/ERROR"));
+    }
+
+    @Test
+    public void shouldIncrementAllEmittedLogCountersOnlyOnceWhenMultipleLoggersAreSet() {
+        // Given
+        createLogger("A_SPECIAL_LOGGER", createAppender("ConsoleAppender"), Level.TRACE, true);
+        final Logger logger = LogManager.getLogger("A_SPECIAL_LOGGER");
+        setLoggerLevel(Level.TRACE);
+
+        // When
+        logger.trace(CAPTURED);
+        logger.debug(CAPTURED);
+        logger.info(CAPTURED);
+        logger.warn(CAPTURED);
+        logger.error(CAPTURED);
+
+        // Then
+        Assert.assertEquals(5, MetricsHelper.getUnscopedMetricCount("Logging/lines"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/TRACE"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/DEBUG"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/INFO"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/WARN"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/ERROR"));
+    }
+
+    @Test
+    public void shouldIncrementAllEmittedLogCountersRespectingLevelFromOriginalLogger() {
+        // Given
+        createLogger("A_SPECIAL_LOGGER", createAppender("ConsoleAppender"), Level.INFO, true);
+        final Logger logger = LogManager.getLogger("A_SPECIAL_LOGGER");
+        setLoggerLevel(Level.ERROR);
+
+        // When
+        logger.trace(NOT_CAPTURED);
+        logger.debug(NOT_CAPTURED);
+        logger.info(CAPTURED);
+        logger.warn(CAPTURED);
+        logger.error(CAPTURED);
+
+        // Then
+        Assert.assertEquals(3, MetricsHelper.getUnscopedMetricCount("Logging/lines"));
+        Assert.assertEquals(0, MetricsHelper.getUnscopedMetricCount("Logging/lines/TRACE"));
+        Assert.assertEquals(0, MetricsHelper.getUnscopedMetricCount("Logging/lines/DEBUG"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/INFO"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/WARN"));
+        Assert.assertEquals(1, MetricsHelper.getUnscopedMetricCount("Logging/lines/ERROR"));
+    }
+
+    private void createLogger(String name, Appender appender, Level level, boolean additivity) {
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        final Configuration config = ctx.getConfiguration();
+        AppenderRef ref = AppenderRef.createAppenderRef("File", null, null);
+        AppenderRef[] refs = new AppenderRef[] {ref};
+        LoggerConfig loggerConfig = LoggerConfig.createLogger(additivity, level, name, "true", refs, null, config, null );
+        loggerConfig.addAppender(appender, level, null);
+        config.addLogger(name, loggerConfig);
+    }
+
+    private Appender createAppender(String name) {
+        Layout<String> layout = PatternLayout.newBuilder()
+            .withPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN)
+            .build();
+        Appender appender = ConsoleAppender.newBuilder()
+            .setName(name)
+            .setLayout(layout)
+            .build();
+        appender.start();
+        return appender;
     }
 
     private void setLoggerLevel(Level level) {


### PR DESCRIPTION
### Overview
Fix for duplicated logs being forwarded when using log4j2 and child loggers with additivity

### Related Github Issue
N/A

### Testing
Added unit tests for this case
