### PR TITLE
add logging metric tests (ApplicationLoggingMetricsConfig)

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingMetricsConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingMetricsConfigTest.java
@@ -1,7 +1,65 @@
 package com.newrelic.agent.config;
 
+import com.newrelic.agent.SaveSystemPropertyProviderRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import static org.junit.Assert.*;
 
 public class ApplicationLoggingMetricsConfigTest {
-    // TODO
+
+    private Map<String, Object> localProps;
+
+    @Rule
+    public SaveSystemPropertyProviderRule saveSystemPropertyProviderRule = new SaveSystemPropertyProviderRule();
+
+    @Before
+    public void setup() {
+        localProps = new HashMap<>();
+    }
+
+    @Test
+    public void defaultLocalDecoratingConfig() {
+        ApplicationLoggingMetricsConfig config = new ApplicationLoggingMetricsConfig(localProps,
+                ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT);
+        assertTrue(config.getEnabled());
+
+    }
+
+    @Test
+    public void usesEnvVarForLocalDecoratingConfig() {
+
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new SaveSystemPropertyProviderRule.TestSystemProps(),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(
+                        Collections.singletonMap("NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED", "false"))
+        ));
+
+        ApplicationLoggingMetricsConfig config = new ApplicationLoggingMetricsConfig(Collections.emptyMap(),
+                ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT);
+        assertFalse(config.getEnabled());
+
+    }
+
+    @Test
+    public void usesSysPropForLocalDecoratingConfig() {
+        Properties properties = new Properties();
+
+        properties.put("newrelic.config.application_logging.metrics.enabled", "" + "false");
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new SaveSystemPropertyProviderRule.TestSystemProps(properties),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade()
+        ));
+
+        ApplicationLoggingMetricsConfig config = new ApplicationLoggingMetricsConfig(Collections.emptyMap(),
+                ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT);
+        assertFalse(config.getEnabled());
+
+    }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingMetricsConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingMetricsConfigTest.java
@@ -51,7 +51,7 @@ public class ApplicationLoggingMetricsConfigTest {
     public void usesSysPropForLocalDecoratingConfig() {
         Properties properties = new Properties();
 
-        properties.put("newrelic.config.application_logging.metrics.enabled", "" + "false");
+        properties.put("newrelic.config.application_logging.metrics.enabled", "false");
         SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
                 new SaveSystemPropertyProviderRule.TestSystemProps(properties),
                 new SaveSystemPropertyProviderRule.TestEnvironmentFacade()


### PR DESCRIPTION
Adds tests for `ApplicationLoggingMetricsConfig`

Part of:
https://github.com/newrelic/newrelic-java-agent/issues/733