### PR TITLE
Refactor adding of agent linking metadata

### DIFF
--- a/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
+++ b/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
@@ -12,6 +12,7 @@ import com.newrelic.api.agent.NewRelic;
 import java.util.Map;
 
 public class AgentUtil {
+    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
     // Log message attributes
     public static final String MESSAGE = "message";
     public static final String TIMESTAMP = "timestamp";

--- a/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
+++ b/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
@@ -9,10 +9,7 @@ package com.nr.agent.instrumentation.log4j1;
 
 import com.newrelic.api.agent.NewRelic;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class AgentUtil {
     // Log message attributes
@@ -20,9 +17,6 @@ public class AgentUtil {
     public static final String TIMESTAMP = "timestamp";
     public static final String LOG_LEVEL = "log.level";
     public static final String UNKNOWN = "UNKNOWN";
-    // Linking metadata attributes to filter out
-    private static final String ENTITY_TYPE = "entity.type";
-    private static final String ENTITY_NAME = "entity.name";
     // Linking metadata attributes used in blob
     private static final String BLOB_PREFIX = "NR-LINKING";
     private static final String BLOB_DELIMITER = "|";
@@ -61,32 +55,6 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
-    }
-
-    /**
-     * Gets a map of agent linking metadata after filtering out
-     * entity.type, entity.name, and any attributes with an empty value.
-     *
-     * @return Filtered map of agent linking metadata
-     */
-    public static Map<String, String> getFilteredLinkingMetadataMap() {
-        Map<String, String> agentLinkingMetadata = NewRelic.getAgent().getLinkingMetadata();
-
-        if (agentLinkingMetadata != null && agentLinkingMetadata.size() > 0) {
-            Map<String, String> map = new HashMap<>();
-            Set<Map.Entry<String, String>> metadataSet = agentLinkingMetadata.entrySet();
-
-            for (Map.Entry<String, String> entry : metadataSet) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-                if (!key.equals(ENTITY_NAME) && !key.equals(ENTITY_TYPE) && !value.isEmpty()) {
-                    map.put(key, value);
-                }
-            }
-            return map;
-        } else {
-            return Collections.emptyMap();
-        }
     }
 
     /**

--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
@@ -13,20 +13,16 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class AgentUtil {
+    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
     // Log message attributes
     public static final String MESSAGE = "message";
     public static final String TIMESTAMP = "timestamp";
     public static final String LOG_LEVEL = "log.level";
     public static final String UNKNOWN = "UNKNOWN";
-    // Linking metadata attributes to filter out
-    private static final String ENTITY_TYPE = "entity.type";
-    private static final String ENTITY_NAME = "entity.name";
     // Linking metadata attributes used in blob
     private static final String BLOB_PREFIX = "NR-LINKING";
     private static final String BLOB_DELIMITER = "|";
@@ -52,7 +48,7 @@ public class AgentUtil {
                 String formattedMessage = message.getFormattedMessage();
                 // Bail out and don't create a LogEvent if log message is empty
                 if (formattedMessage != null && !formattedMessage.isEmpty()) {
-                    HashMap<String, Object> logEventMap = new HashMap<>(getFilteredLinkingMetadataMap());
+                    HashMap<String, Object> logEventMap = new HashMap<>(DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES);
 
                     logEventMap.put(MESSAGE, formattedMessage);
                     logEventMap.put(TIMESTAMP, event.getTimeMillis());
@@ -98,32 +94,6 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
-    }
-
-    /**
-     * Gets a map of agent linking metadata after filtering out
-     * entity.type, entity.name, and any attributes with an empty value.
-     *
-     * @return Filtered map of agent linking metadata
-     */
-    public static Map<String, String> getFilteredLinkingMetadataMap() {
-        Map<String, String> agentLinkingMetadata = NewRelic.getAgent().getLinkingMetadata();
-
-        if (agentLinkingMetadata != null && agentLinkingMetadata.size() > 0) {
-            Map<String, String> map = new HashMap<>();
-            Set<Map.Entry<String, String>> metadataSet = agentLinkingMetadata.entrySet();
-
-            for (Map.Entry<String, String> entry : metadataSet) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-                if (!key.equals(ENTITY_NAME) && !key.equals(ENTITY_TYPE) && !value.isEmpty()) {
-                    map.put(key, value);
-                }
-            }
-            return map;
-        } else {
-            return Collections.emptyMap();
-        }
     }
 
     /**

--- a/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
+++ b/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
@@ -9,10 +9,7 @@ package com.nr.instrumentation.jul;
 
 import com.newrelic.api.agent.NewRelic;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class AgentUtil {
     // Log message attributes
@@ -20,9 +17,6 @@ public class AgentUtil {
     public static final String TIMESTAMP = "timestamp";
     public static final String LOG_LEVEL = "log.level";
     public static final String UNKNOWN = "UNKNOWN";
-    // Linking metadata attributes to filter out
-    private static final String ENTITY_TYPE = "entity.type";
-    private static final String ENTITY_NAME = "entity.name";
     // Linking metadata attributes used in blob
     private static final String BLOB_PREFIX = "NR-LINKING";
     private static final String BLOB_DELIMITER = "|";
@@ -61,32 +55,6 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
-    }
-
-    /**
-     * Gets a map of agent linking metadata after filtering out
-     * entity.type, entity.name, and any attributes with an empty value.
-     *
-     * @return Filtered map of agent linking metadata
-     */
-    public static Map<String, String> getFilteredLinkingMetadataMap() {
-        Map<String, String> agentLinkingMetadata = NewRelic.getAgent().getLinkingMetadata();
-
-        if (agentLinkingMetadata != null && agentLinkingMetadata.size() > 0) {
-            Map<String, String> map = new HashMap<>();
-            Set<Map.Entry<String, String>> metadataSet = agentLinkingMetadata.entrySet();
-
-            for (Map.Entry<String, String> entry : metadataSet) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-                if (!key.equals(ENTITY_NAME) && !key.equals(ENTITY_TYPE) && !value.isEmpty()) {
-                    map.put(key, value);
-                }
-            }
-            return map;
-        } else {
-            return Collections.emptyMap();
-        }
     }
 
     /**

--- a/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
+++ b/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
@@ -12,6 +12,7 @@ import com.newrelic.api.agent.NewRelic;
 import java.util.Map;
 
 public class AgentUtil {
+    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
     // Log message attributes
     public static final String MESSAGE = "message";
     public static final String TIMESTAMP = "timestamp";

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
@@ -17,14 +17,12 @@ import java.util.Map;
 import java.util.Set;
 
 public class AgentUtil {
+    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
     // Log message attributes
     public static final String MESSAGE = "message";
     public static final String TIMESTAMP = "timestamp";
     public static final String LOG_LEVEL = "log.level";
     public static final String UNKNOWN = "UNKNOWN";
-    // Linking metadata attributes to filter out
-    private static final String ENTITY_TYPE = "entity.type";
-    private static final String ENTITY_NAME = "entity.name";
     // Linking metadata attributes used in blob
     private static final String BLOB_PREFIX = "NR-LINKING";
     private static final String BLOB_DELIMITER = "|";
@@ -48,7 +46,7 @@ public class AgentUtil {
     public static void recordNewRelicLogEvent(String message, long timeStampMillis, Level level) {
         // Bail out and don't create a LogEvent if log message is empty
         if (!message.isEmpty()) {
-            HashMap<String, Object> logEventMap = new HashMap<>(getFilteredLinkingMetadataMap());
+            HashMap<String, Object> logEventMap = new HashMap<>(DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES);
             logEventMap.put(MESSAGE, message);
             logEventMap.put(TIMESTAMP, timeStampMillis);
 
@@ -87,32 +85,6 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
-    }
-
-    /**
-     * Gets a map of agent linking metadata after filtering out
-     * entity.type, entity.name, and any attributes with an empty value.
-     *
-     * @return Filtered map of agent linking metadata
-     */
-    public static Map<String, String> getFilteredLinkingMetadataMap() {
-        Map<String, String> agentLinkingMetadata = NewRelic.getAgent().getLinkingMetadata();
-
-        if (agentLinkingMetadata != null && agentLinkingMetadata.size() > 0) {
-            Map<String, String> map = new HashMap<>();
-            Set<Map.Entry<String, String>> metadataSet = agentLinkingMetadata.entrySet();
-
-            for (Map.Entry<String, String> entry : metadataSet) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-                if (!key.equals(ENTITY_NAME) && !key.equals(ENTITY_TYPE) && !value.isEmpty()) {
-                    map.put(key, value);
-                }
-            }
-            return map;
-        } else {
-            return Collections.emptyMap();
-        }
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
@@ -30,6 +30,13 @@ public class AgentImpl implements com.newrelic.agent.bridge.Agent {
 
     private final Logger logger;
 
+    private static final String TRACE_ID = "trace.id";
+    private static final String SPAN_ID = "span.id";
+    private static final String HOSTNAME = "hostname";
+    private static final String ENTITY_GUID = "entity.guid";
+    private static final String ENTITY_NAME = "entity.name";
+    private static final String ENTITY_TYPE = "entity.type";
+
     public AgentImpl(Logger logger) {
         this.logger = logger;
     }
@@ -157,19 +164,19 @@ public class AgentImpl implements com.newrelic.agent.bridge.Agent {
 
         TraceMetadata traceMetadata = getTraceMetadata();
         String traceId = traceMetadata.getTraceId();
-        linkingMetadata.put("trace.id", traceId);
+        linkingMetadata.put(TRACE_ID, traceId);
 
         String spanId = traceMetadata.getSpanId();
-        linkingMetadata.put("span.id", spanId);
+        linkingMetadata.put(SPAN_ID, spanId);
 
         AgentConfig agentConfig = ServiceFactory.getConfigService().getDefaultAgentConfig();
-        linkingMetadata.put("hostname", getLinkingMetaHostname(agentConfig));
+        linkingMetadata.put(HOSTNAME, getLinkingMetaHostname(agentConfig));
         try {
             String entityGuid = ServiceFactory.getRPMService().getEntityGuid();
             if (!entityGuid.isEmpty()) {
-                linkingMetadata.put("entity.name", agentConfig.getApplicationName());
-                linkingMetadata.put("entity.type", "SERVICE");
-                linkingMetadata.put("entity.guid", entityGuid);
+                linkingMetadata.put(ENTITY_NAME, agentConfig.getApplicationName());
+                linkingMetadata.put(ENTITY_TYPE, "SERVICE");
+                linkingMetadata.put(ENTITY_GUID, entityGuid);
             }
         } catch (NullPointerException ignored) {
             // it's possible to call getLinkingMetadata in the premain before RPMService has been initialized which will NPE
@@ -179,7 +186,46 @@ public class AgentImpl implements com.newrelic.agent.bridge.Agent {
         return linkingMetadata;
     }
 
-    private String getLinkingMetaHostname(AgentConfig agentConfig) {
+    /**
+     * Gets a map of agent linking metadata minus entity.type,
+     * entity.name, and any attributes with an empty value.
+     * This subset of linking metadata is added to LogEvents.
+     *
+     * @return Filtered map of agent linking metadata
+     */
+    public static Map<String, String> getLogEventLinkingMetadata() {
+        Map<String, String> linkingMetadata = new ConcurrentHashMap<>();
+
+        TraceMetadata traceMetadata = TraceMetadataImpl.INSTANCE;
+        String traceId = traceMetadata.getTraceId();
+        if (!traceId.isEmpty()) {
+            linkingMetadata.put(TRACE_ID, traceId);
+        }
+
+        String spanId = traceMetadata.getSpanId();
+        if (!spanId.isEmpty()) {
+            linkingMetadata.put(SPAN_ID, spanId);
+        }
+
+        AgentConfig agentConfig = ServiceFactory.getConfigService().getDefaultAgentConfig();
+        String hostname = getLinkingMetaHostname(agentConfig);
+        if (!hostname.isEmpty()) {
+            linkingMetadata.put(HOSTNAME, hostname);
+        }
+        try {
+            String entityGuid = ServiceFactory.getRPMService().getEntityGuid();
+            if (!entityGuid.isEmpty()) {
+                linkingMetadata.put(ENTITY_GUID, entityGuid);
+            }
+        } catch (NullPointerException ignored) {
+            // it's possible to call getLinkingMetadata in the premain before RPMService has been initialized which will NPE
+            Agent.LOG.log(Level.WARNING, "Cannot get entity.guid from getLinkingMetadata() until RPMService has initialized.");
+        }
+
+        return linkingMetadata;
+    }
+
+    private static String getLinkingMetaHostname(AgentConfig agentConfig) {
         String fullHostname = Hostname.getFullHostname(agentConfig);
         if (fullHostname == null || fullHostname.isEmpty() || fullHostname.equals("localhost")) {
             return Hostname.getHostname(agentConfig);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentLinkingMetadata.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentLinkingMetadata.java
@@ -1,0 +1,137 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent;
+
+import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.ConfigService;
+import com.newrelic.agent.config.Hostname;
+import com.newrelic.api.agent.TraceMetadata;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+/**
+ * Utility class for providing agent linking metadata.
+ * This metadata can be used to link events to specific traces, spans, hosts, and entities.
+ */
+public class AgentLinkingMetadata {
+    public static final String ENTITY_TYPE_DEFAULT = "SERVICE";
+    public static final String LOCALHOST = "localhost";
+    // Agent linking metadata attributes
+    public static final String TRACE_ID = "trace.id";
+    public static final String SPAN_ID = "span.id";
+    public static final String HOSTNAME = "hostname";
+    public static final String ENTITY_GUID = "entity.guid";
+    public static final String ENTITY_NAME = "entity.name";
+    public static final String ENTITY_TYPE = "entity.type";
+
+    /**
+     * Get a map of all agent linking metadata.
+     *
+     * @param traceMetadata TraceMetadataImpl instance to get spanId and traceId
+     * @param configService ConfigService to get hostName and entityName
+     * @param rpmService    IRPMService to get entityGuid
+     * @return Map of all agent linking metadata
+     */
+    public static Map<String, String> getLinkingMetadata(TraceMetadata traceMetadata, ConfigService configService, IRPMService rpmService) {
+        AgentConfig agentConfig = configService.getDefaultAgentConfig();
+        Map<String, String> linkingMetadata = new ConcurrentHashMap<>();
+
+        linkingMetadata.put(TRACE_ID, getTraceId(traceMetadata));
+        linkingMetadata.put(SPAN_ID, getSpanId(traceMetadata));
+        linkingMetadata.put(HOSTNAME, getHostname(agentConfig));
+
+        try {
+            String entityGuid = getEntityGuid(rpmService);
+            if (!entityGuid.isEmpty()) {
+                linkingMetadata.put(ENTITY_NAME, getEntityName(agentConfig));
+                linkingMetadata.put(ENTITY_TYPE, getEntityType());
+                linkingMetadata.put(ENTITY_GUID, entityGuid);
+            }
+        } catch (NullPointerException ignored) {
+            logWarning();
+        }
+
+        return linkingMetadata;
+    }
+
+    /**
+     * Get a map of agent linking metadata minus entity.type,
+     * entity.name, and any attributes with an empty value.
+     * This subset of linking metadata is added to LogEvents.
+     *
+     * @param traceMetadata TraceMetadataImpl to get spanId and traceId
+     * @param configService ConfigService to get hostName and entityName
+     * @param rpmService    IRPMService to get entityGuid
+     * @return Filtered map of agent linking metadata
+     */
+    public static Map<String, String> getLogEventLinkingMetadata(TraceMetadata traceMetadata, ConfigService configService, IRPMService rpmService) {
+        AgentConfig agentConfig = configService.getDefaultAgentConfig();
+        Map<String, String> logEventLinkingMetadata = new ConcurrentHashMap<>();
+
+        String traceId = getTraceId(traceMetadata);
+        if (!traceId.isEmpty()) {
+            logEventLinkingMetadata.put(TRACE_ID, traceId);
+        }
+
+        String spanId = getSpanId(traceMetadata);
+        if (!spanId.isEmpty()) {
+            logEventLinkingMetadata.put(SPAN_ID, spanId);
+        }
+
+        String hostname = getHostname(agentConfig);
+        if (!hostname.isEmpty()) {
+            logEventLinkingMetadata.put(HOSTNAME, hostname);
+        }
+        try {
+            String entityGuid = rpmService.getEntityGuid();
+            if (!entityGuid.isEmpty()) {
+                logEventLinkingMetadata.put(ENTITY_GUID, entityGuid);
+            }
+        } catch (NullPointerException ignored) {
+            logWarning();
+        }
+
+        return logEventLinkingMetadata;
+    }
+
+    public static String getTraceId(TraceMetadata traceMetadata) {
+        return traceMetadata.getTraceId();
+    }
+
+    public static String getSpanId(TraceMetadata traceMetadata) {
+        return traceMetadata.getSpanId();
+    }
+
+    private static String getHostname(AgentConfig agentConfig) {
+        String fullHostname = Hostname.getFullHostname(agentConfig);
+        if (fullHostname == null || fullHostname.isEmpty() || fullHostname.equals(LOCALHOST)) {
+            return Hostname.getHostname(agentConfig);
+        }
+        return fullHostname;
+    }
+
+    public static String getEntityName(AgentConfig agentConfig) {
+        return agentConfig.getApplicationName();
+    }
+
+    public static String getEntityType() {
+        return ENTITY_TYPE_DEFAULT;
+    }
+
+    public static String getEntityGuid(IRPMService rpmService) {
+        return rpmService.getEntityGuid();
+    }
+
+    private static void logWarning() {
+        // It's possible to call getEntityGuid in the agent premain before the
+        // RPMService has been initialized, which will cause a NullPointerException.
+        Agent.LOG.log(Level.WARNING, "Cannot get entity.guid from getLinkingMetadata() until RPMService has initialized.");
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
@@ -11,6 +11,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
+import com.newrelic.agent.AgentImpl;
 import com.newrelic.agent.ExtendedTransactionListener;
 import com.newrelic.agent.Harvestable;
 import com.newrelic.agent.MetricNames;
@@ -471,7 +472,9 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
      * @return LogEvent instance
      */
     private static LogEvent createValidatedEvent(Map<String, ?> attributes) {
-        Map<String, Object> userAttributes = new HashMap<>(attributes.size());
+        // Initialize new userAttributes map with agent linking metadata required for LogEvents
+        Map<String, Object> userAttributes = new HashMap<>(AgentImpl.getLogEventLinkingMetadata());
+
         LogEvent event = new LogEvent(userAttributes, DistributedTraceServiceImpl.nextTruncatedFloat());
 
         // Now add the attributes from the argument map to the event using an AttributeSender.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
@@ -11,10 +11,11 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
-import com.newrelic.agent.AgentImpl;
+import com.newrelic.agent.AgentLinkingMetadata;
 import com.newrelic.agent.ExtendedTransactionListener;
 import com.newrelic.agent.Harvestable;
 import com.newrelic.agent.MetricNames;
+import com.newrelic.agent.TraceMetadataImpl;
 import com.newrelic.agent.Transaction;
 import com.newrelic.agent.TransactionData;
 import com.newrelic.agent.attributes.AttributeSender;
@@ -472,17 +473,19 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
      * @return LogEvent instance
      */
     private static LogEvent createValidatedEvent(Map<String, ?> attributes) {
-        // Initialize new userAttributes map with agent linking metadata required for LogEvents
-        Map<String, Object> userAttributes = new HashMap<>(AgentImpl.getLogEventLinkingMetadata());
+        Map<String, String> logEventLinkingMetadata = AgentLinkingMetadata.getLogEventLinkingMetadata(TraceMetadataImpl.INSTANCE,
+                ServiceFactory.getConfigService(), ServiceFactory.getRPMService());
+        // Initialize new logEventAttributes map with agent linking metadata
+        Map<String, Object> logEventAttributes = new HashMap<>(logEventLinkingMetadata);
 
-        LogEvent event = new LogEvent(userAttributes, DistributedTraceServiceImpl.nextTruncatedFloat());
+        LogEvent event = new LogEvent(logEventAttributes, DistributedTraceServiceImpl.nextTruncatedFloat());
 
         // Now add the attributes from the argument map to the event using an AttributeSender.
         // An AttributeSender is the way to reuse all the existing attribute validations. We
         // also locally "intern" Strings because we anticipate a lot of reuse of the keys and,
         // possibly, the values. But there's an interaction: if the key or value is chopped
         // within the attribute sender, the modified value won't be "interned" in our map.
-        AttributeSender sender = new LogEventAttributeSender(userAttributes);
+        AttributeSender sender = new LogEventAttributeSender(logEventAttributes);
 
         for (Map.Entry<String, ?> entry : attributes.entrySet()) {
             String key = entry.getKey();
@@ -519,11 +522,11 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
 
         private static final String ATTRIBUTE_TYPE = "log";
 
-        private final Map<String, Object> userAttributes;
+        private final Map<String, Object> logEventAttributes;
 
-        public LogEventAttributeSender(Map<String, Object> userAttributes) {
+        public LogEventAttributeSender(Map<String, Object> logEventAttributes) {
             super(new AttributeValidator(ATTRIBUTE_TYPE));
-            this.userAttributes = userAttributes;
+            this.logEventAttributes = logEventAttributes;
             setTransactional(false);
         }
 
@@ -535,7 +538,7 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
         @Override
         protected Map<String, Object> getAttributeMap() {
             if (ServiceFactory.getConfigService().getDefaultAgentConfig().isCustomParametersAllowed()) {
-                return userAttributes;
+                return logEventAttributes;
             }
             return null;
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/AgentLinkingMetadataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/AgentLinkingMetadataTest.java
@@ -1,0 +1,198 @@
+package com.newrelic.agent;
+
+import com.newrelic.agent.config.AgentConfigImpl;
+import com.newrelic.agent.config.ConfigServiceImpl;
+import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.service.ServiceManagerImpl;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AgentLinkingMetadataTest {
+
+    @Test
+    public void getLinkingMetadata() {
+        // Given
+        final String expectedTraceId = "traceId1234";
+        final String expectedSpanId = "spanId5678";
+        final String expectedEntityGuid = "entityGuid91011";
+        final String expectedEntityName = "entityName91011";
+        final String expectedEntityType = AgentLinkingMetadata.ENTITY_TYPE_DEFAULT;
+
+        TraceMetadataImpl traceMetadataMock = mock(TraceMetadataImpl.class);
+        ServiceManagerImpl serviceManagerMock = mock(ServiceManagerImpl.class);
+        RPMServiceManagerImpl rpmServiceManagerMock = mock(RPMServiceManagerImpl.class);
+        RPMService rpmServiceMock = mock(RPMService.class);
+        ConfigServiceImpl configServiceMock = mock(ConfigServiceImpl.class);
+        AgentConfigImpl agentConfigMock = mock(AgentConfigImpl.class);
+
+        ServiceFactory.setServiceManager(serviceManagerMock);
+
+        // When
+        when(traceMetadataMock.getTraceId()).thenReturn(expectedTraceId);
+        when(traceMetadataMock.getSpanId()).thenReturn(expectedSpanId);
+        when(serviceManagerMock.getRPMServiceManager()).thenReturn(rpmServiceManagerMock);
+        when(serviceManagerMock.getConfigService()).thenReturn(configServiceMock);
+        when(rpmServiceManagerMock.getRPMService()).thenReturn(rpmServiceMock);
+        when(configServiceMock.getDefaultAgentConfig()).thenReturn(agentConfigMock);
+        when(agentConfigMock.getApplicationName()).thenReturn(expectedEntityName);
+        when(rpmServiceMock.getEntityGuid()).thenReturn(expectedEntityGuid);
+
+        // Then
+        Map<String, String> linkingMetadata = AgentLinkingMetadata.getLinkingMetadata(traceMetadataMock, ServiceFactory.getConfigService(),
+                ServiceFactory.getRPMService());
+
+        assertFalse("linkingMetadata map shouldn't be empty", linkingMetadata.isEmpty());
+
+        // Can't assert on a specific hostname value as it will resolve to the actual hostname of the machine running the test
+        assertFalse("hostname shouldn't be empty", linkingMetadata.get(AgentLinkingMetadata.HOSTNAME).isEmpty());
+
+        assertEquals(expectedEntityGuid, linkingMetadata.get(AgentLinkingMetadata.ENTITY_GUID));
+        assertEquals(expectedEntityName, linkingMetadata.get(AgentLinkingMetadata.ENTITY_NAME));
+        assertEquals(expectedEntityType, linkingMetadata.get(AgentLinkingMetadata.ENTITY_TYPE));
+
+        assertEquals(expectedTraceId, linkingMetadata.get(AgentLinkingMetadata.TRACE_ID));
+        assertEquals(expectedSpanId, linkingMetadata.get(AgentLinkingMetadata.SPAN_ID));
+    }
+
+    @Test
+    public void getLinkingMetadataWithEmptyTraceAttributes() {
+        // Given
+        final String expectedTraceId = "";
+        final String expectedSpanId = "";
+        final String expectedEntityGuid = "entityGuid91011";
+        final String expectedEntityName = "entityName91011";
+        final String expectedEntityType = AgentLinkingMetadata.ENTITY_TYPE_DEFAULT;
+
+        TraceMetadataImpl traceMetadataMock = mock(TraceMetadataImpl.class);
+        ServiceManagerImpl serviceManagerMock = mock(ServiceManagerImpl.class);
+        RPMServiceManagerImpl rpmServiceManagerMock = mock(RPMServiceManagerImpl.class);
+        RPMService rpmServiceMock = mock(RPMService.class);
+        ConfigServiceImpl configServiceMock = mock(ConfigServiceImpl.class);
+        AgentConfigImpl agentConfigMock = mock(AgentConfigImpl.class);
+
+        ServiceFactory.setServiceManager(serviceManagerMock);
+
+        // When
+        when(traceMetadataMock.getTraceId()).thenReturn(expectedTraceId);
+        when(traceMetadataMock.getSpanId()).thenReturn(expectedSpanId);
+        when(serviceManagerMock.getRPMServiceManager()).thenReturn(rpmServiceManagerMock);
+        when(serviceManagerMock.getConfigService()).thenReturn(configServiceMock);
+        when(rpmServiceManagerMock.getRPMService()).thenReturn(rpmServiceMock);
+        when(configServiceMock.getDefaultAgentConfig()).thenReturn(agentConfigMock);
+        when(agentConfigMock.getApplicationName()).thenReturn(expectedEntityName);
+        when(rpmServiceMock.getEntityGuid()).thenReturn(expectedEntityGuid);
+
+        // Then
+        Map<String, String> linkingMetadata = AgentLinkingMetadata.getLinkingMetadata(traceMetadataMock, ServiceFactory.getConfigService(),
+                ServiceFactory.getRPMService());
+
+        assertFalse("linkingMetadata map shouldn't be empty", linkingMetadata.isEmpty());
+
+        // Can't assert on a specific hostname value as it will resolve to the actual hostname of the machine running the test
+        assertFalse("hostname shouldn't be empty", linkingMetadata.get(AgentLinkingMetadata.HOSTNAME).isEmpty());
+
+        assertEquals(expectedEntityGuid, linkingMetadata.get(AgentLinkingMetadata.ENTITY_GUID));
+        assertEquals(expectedEntityName, linkingMetadata.get(AgentLinkingMetadata.ENTITY_NAME));
+        assertEquals(expectedEntityType, linkingMetadata.get(AgentLinkingMetadata.ENTITY_TYPE));
+
+        // trace.id and span.id would be empty values if getLinkingMetadata was called outside of a transaction.
+        // With the getLinkingMetadata API the returned map includes keys with empty values
+        assertEquals(expectedTraceId, linkingMetadata.get(AgentLinkingMetadata.TRACE_ID));
+        assertEquals(expectedSpanId, linkingMetadata.get(AgentLinkingMetadata.SPAN_ID));
+    }
+
+    @Test
+    public void getLogEventLinkingMetadata() {
+        // Given
+        final String expectedTraceId = "traceId1234";
+        final String expectedSpanId = "spanId5678";
+        final String expectedEntityGuid = "entityGuid91011";
+        final String expectedEntityName = "entityName91011";
+
+        TraceMetadataImpl traceMetadataMock = mock(TraceMetadataImpl.class);
+        ServiceManagerImpl serviceManagerMock = mock(ServiceManagerImpl.class);
+        RPMServiceManagerImpl rpmServiceManagerMock = mock(RPMServiceManagerImpl.class);
+        RPMService rpmServiceMock = mock(RPMService.class);
+        ConfigServiceImpl configServiceMock = mock(ConfigServiceImpl.class);
+        AgentConfigImpl agentConfigMock = mock(AgentConfigImpl.class);
+
+        ServiceFactory.setServiceManager(serviceManagerMock);
+
+        // When
+        when(traceMetadataMock.getTraceId()).thenReturn(expectedTraceId);
+        when(traceMetadataMock.getSpanId()).thenReturn(expectedSpanId);
+        when(serviceManagerMock.getRPMServiceManager()).thenReturn(rpmServiceManagerMock);
+        when(serviceManagerMock.getConfigService()).thenReturn(configServiceMock);
+        when(rpmServiceManagerMock.getRPMService()).thenReturn(rpmServiceMock);
+        when(configServiceMock.getDefaultAgentConfig()).thenReturn(agentConfigMock);
+        when(agentConfigMock.getApplicationName()).thenReturn(expectedEntityName);
+        when(rpmServiceMock.getEntityGuid()).thenReturn(expectedEntityGuid);
+
+        // Then
+        Map<String, String> linkingMetadata = AgentLinkingMetadata.getLogEventLinkingMetadata(traceMetadataMock, ServiceFactory.getConfigService(),
+                ServiceFactory.getRPMService());
+
+        assertFalse("linkingMetadata map shouldn't be empty", linkingMetadata.isEmpty());
+
+        // Can't assert on a specific hostname value as it will resolve to the actual hostname of the machine running the test
+        assertFalse("hostname shouldn't be empty", linkingMetadata.get(AgentLinkingMetadata.HOSTNAME).isEmpty());
+
+        assertFalse("entity.name should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_NAME));
+        assertFalse("entity.type should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_TYPE));
+        assertEquals(expectedEntityGuid, linkingMetadata.get(AgentLinkingMetadata.ENTITY_GUID));
+
+        assertEquals(expectedTraceId, linkingMetadata.get(AgentLinkingMetadata.TRACE_ID));
+        assertEquals(expectedSpanId, linkingMetadata.get(AgentLinkingMetadata.SPAN_ID));
+    }
+
+    @Test
+    public void getLogEventLinkingMetadataWithEmptyTraceAttributes() {
+        // Given
+        final String expectedTraceId = "";
+        final String expectedSpanId = "";
+        final String expectedEntityGuid = "entityGuid91011";
+        final String expectedEntityName = "entityName91011";
+
+        TraceMetadataImpl traceMetadataMock = mock(TraceMetadataImpl.class);
+        ServiceManagerImpl serviceManagerMock = mock(ServiceManagerImpl.class);
+        RPMServiceManagerImpl rpmServiceManagerMock = mock(RPMServiceManagerImpl.class);
+        RPMService rpmServiceMock = mock(RPMService.class);
+        ConfigServiceImpl configServiceMock = mock(ConfigServiceImpl.class);
+        AgentConfigImpl agentConfigMock = mock(AgentConfigImpl.class);
+
+        ServiceFactory.setServiceManager(serviceManagerMock);
+
+        // When
+        when(traceMetadataMock.getTraceId()).thenReturn(expectedTraceId);
+        when(traceMetadataMock.getSpanId()).thenReturn(expectedSpanId);
+        when(serviceManagerMock.getRPMServiceManager()).thenReturn(rpmServiceManagerMock);
+        when(serviceManagerMock.getConfigService()).thenReturn(configServiceMock);
+        when(rpmServiceManagerMock.getRPMService()).thenReturn(rpmServiceMock);
+        when(configServiceMock.getDefaultAgentConfig()).thenReturn(agentConfigMock);
+        when(agentConfigMock.getApplicationName()).thenReturn(expectedEntityName);
+        when(rpmServiceMock.getEntityGuid()).thenReturn(expectedEntityGuid);
+
+        // Then
+        Map<String, String> linkingMetadata = AgentLinkingMetadata.getLogEventLinkingMetadata(traceMetadataMock, ServiceFactory.getConfigService(),
+                ServiceFactory.getRPMService());
+
+        assertFalse("linkingMetadata map shouldn't be empty", linkingMetadata.isEmpty());
+
+        // Can't assert on a specific hostname value as it will resolve to the actual hostname of the machine running the test
+        assertFalse("hostname shouldn't be empty", linkingMetadata.get(AgentLinkingMetadata.HOSTNAME).isEmpty());
+
+        assertFalse("entity.name should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_NAME));
+        assertFalse("entity.type should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_TYPE));
+        assertEquals(expectedEntityGuid, linkingMetadata.get(AgentLinkingMetadata.ENTITY_GUID));
+
+        // trace.id and span.id would be empty values if getLogEventLinkingMetadata was called outside of a transaction, in which case they are omitted
+        assertFalse("empty trace.id value should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.TRACE_ID));
+        assertFalse("empty span.id value should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.SPAN_ID));
+    }
+}


### PR DESCRIPTION
Moves the adding of agent linking metadata to `LogEvent`s out of individual instrumentation module and into the `LogSenderServiceImpl`.

Potential benefits:
- Might be slightly more performant as it no longer gets the full map of agent attributes and filters them down to just the ones used by `LogEvent`s. In reality this is pretty minor.
- If we ever wanted a public API like `NewRelic.getAgent().getLogSender().recordLogEvent(attributesMap)` then this is probably a better design as the linking metadata attributes (`span.id`, `entity.guid`, `hostname`, `trace.id`) are automatically added in core agent code when calling the API and the `attributesMap` only needs to contain the log attributes (`message`, `timestamp`, `log.level`). In the current design the `attributesMap` needs to have both linking metadata attributes and log attributes added before calling the API.
- Simplifies all log library instrumentation modules slightly

Cons:
- ~~Changes to `AgentImpl` are kind of gross (but can probably be cleaned up a bit)~~ This has since been refactored to address any issues.