### PR TITLE
Log the number of events stored per harvest

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
@@ -125,6 +125,8 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
                             tracker.harvestable.getEndpointMethodName());
                     Long harvestLimit = (Long) spanHarvestConfig.get(SERVER_SPAN_HARVEST_LIMIT);
                     if (harvestLimit != null) {
+                        Agent.LOG.log(Level.FINE, "harvest limit from collector is: {0} samples stored per harvest for {1}", harvestLimit,
+                                tracker.harvestable.getEndpointMethodName());
                         maxSamplesStored = harvestLimit.intValue();
                         reportPeriodInMillis = (long) spanHarvestConfig.get(REPORT_PERIOD_MS);
                     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
@@ -106,6 +106,8 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
 
                     Long harvestLimit = (Long) harvestLimits.get(tracker.harvestable.getEndpointMethodName());
                     if (harvestLimit != null) {
+                        Agent.LOG.log(Level.FINE, "harvest limit from collector is: {0} samples stored per harvest for {1}", harvestLimit,
+                                tracker.harvestable.getEndpointMethodName());
                         maxSamplesStored = harvestLimit.intValue();
                         reportPeriodInMillis = (long) eventHarvestConfig.get(REPORT_PERIOD_MS); // faster event harvest report period
                         ServiceFactory.getStatsService().doStatsWork(

--- a/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
@@ -100,8 +100,8 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
                 // The event_harvest_config.harvest_limits received from server-side during the connect lifecycle
                 // contains config for error_event_data, analytic_event_data, custom_event_data, and log_event_data
                 if (eventHarvestConfig != null && !isSpanEventEndpoint) {
-                     Agent.LOG.log(Level.FINE, "event_harvest_config from collector is: {0} samples stored for {1}", maxSamplesStored,
-                            tracker.harvestable.getEndpointMethodName());
+                     Agent.LOG.log(Level.FINE, "event_harvest_config from collector for {0} is: {1} max samples stored per minute",
+                             tracker.harvestable.getEndpointMethodName(), maxSamplesStored);
                     Map<String, Object> harvestLimits = (Map<String, Object>) eventHarvestConfig.get(HARVEST_LIMITS);
 
                     Long harvestLimit = (Long) harvestLimits.get(tracker.harvestable.getEndpointMethodName());
@@ -109,32 +109,32 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
                         maxSamplesStored = harvestLimit.intValue();
                         reportPeriodInMillis = (long) eventHarvestConfig.get(REPORT_PERIOD_MS); // faster event harvest report period
                         float reportPeriodInSeconds = reportPeriodInMillis / 1000;
-                        Agent.LOG.log(Level.FINE, "harvest limit from collector for {0} is: {1} samples stored per every {2} second harvest",
+                        Agent.LOG.log(Level.FINE, "harvest limit from collector for {0} is: {1} max samples stored per every {2} second harvest",
                                 tracker.harvestable.getEndpointMethodName(), harvestLimit, reportPeriodInSeconds);
                         ServiceFactory.getStatsService().doStatsWork(
                                 StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS, reportPeriodInSeconds),
                                 MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS );
                     }
                 } else if (!isSpanEventEndpoint) {
-                    Agent.LOG.log(Level.FINE, "event_harvest_config from collector was null. Using default value: {0} samples stored for {1}", maxSamplesStored,
-                            tracker.harvestable.getEndpointMethodName());
+                    Agent.LOG.log(Level.FINE, "event_harvest_config from collector for {0} was null. Using default value: {1} max samples stored per minute",
+                            tracker.harvestable.getEndpointMethodName(), maxSamplesStored);
                 }
 
                 // The span_event_harvest_config received from server-side during the connect lifecycle contains config for span_event_data
                 if (spanHarvestConfig != null && isSpanEventEndpoint) {
-                    Agent.LOG.log(Level.FINE, "span_event_harvest_config from collector is: {0} samples stored for {1}", maxSamplesStored,
-                            tracker.harvestable.getEndpointMethodName());
+                    Agent.LOG.log(Level.FINE, "span_event_harvest_config from collector for {0} is: {1} max samples stored per minute",
+                            tracker.harvestable.getEndpointMethodName(), maxSamplesStored);
                     Long harvestLimit = (Long) spanHarvestConfig.get(SERVER_SPAN_HARVEST_LIMIT);
                     if (harvestLimit != null) {
                         maxSamplesStored = harvestLimit.intValue();
                         reportPeriodInMillis = (long) spanHarvestConfig.get(REPORT_PERIOD_MS);
                         float reportPeriodInSeconds = reportPeriodInMillis / 1000;
-                        Agent.LOG.log(Level.FINE, "harvest limit from collector for {0} is: {1} samples stored per every {2} second harvest",
+                        Agent.LOG.log(Level.FINE, "harvest limit from collector for {0} is: {1} max samples stored per every {2} second harvest",
                                 tracker.harvestable.getEndpointMethodName(), harvestLimit, reportPeriodInSeconds);
                     }
                 } else if (isSpanEventEndpoint) {
-                    Agent.LOG.log(Level.FINE, "span_event_harvest_config from collector was null. Using default value: {0} samples stored for {1}", maxSamplesStored,
-                            tracker.harvestable.getEndpointMethodName());
+                    Agent.LOG.log(Level.FINE, "span_event_harvest_config from collector for {0} was null. Using default value: {1} max samples stored per minute",
+                            tracker.harvestable.getEndpointMethodName(), maxSamplesStored);
                 }
 
                 tracker.start(reportPeriodInMillis, maxSamplesStored);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
@@ -106,12 +106,13 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
 
                     Long harvestLimit = (Long) harvestLimits.get(tracker.harvestable.getEndpointMethodName());
                     if (harvestLimit != null) {
-                        Agent.LOG.log(Level.FINE, "harvest limit from collector is: {0} samples stored per harvest for {1}", harvestLimit,
-                                tracker.harvestable.getEndpointMethodName());
                         maxSamplesStored = harvestLimit.intValue();
                         reportPeriodInMillis = (long) eventHarvestConfig.get(REPORT_PERIOD_MS); // faster event harvest report period
+                        float reportPeriodInSeconds = reportPeriodInMillis / 1000;
+                        Agent.LOG.log(Level.FINE, "harvest limit from collector for {0} is: {1} samples stored per every {2} second harvest",
+                                tracker.harvestable.getEndpointMethodName(), harvestLimit, reportPeriodInSeconds);
                         ServiceFactory.getStatsService().doStatsWork(
-                                StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS, reportPeriodInMillis / 1000),
+                                StatsWorks.getRecordMetricWork(MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS, reportPeriodInSeconds),
                                 MetricNames.SUPPORTABILITY_EVENT_HARVEST_REPORT_PERIOD_IN_SECONDS );
                     }
                 } else if (!isSpanEventEndpoint) {
@@ -125,10 +126,11 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
                             tracker.harvestable.getEndpointMethodName());
                     Long harvestLimit = (Long) spanHarvestConfig.get(SERVER_SPAN_HARVEST_LIMIT);
                     if (harvestLimit != null) {
-                        Agent.LOG.log(Level.FINE, "harvest limit from collector is: {0} samples stored per harvest for {1}", harvestLimit,
-                                tracker.harvestable.getEndpointMethodName());
                         maxSamplesStored = harvestLimit.intValue();
                         reportPeriodInMillis = (long) spanHarvestConfig.get(REPORT_PERIOD_MS);
+                        float reportPeriodInSeconds = reportPeriodInMillis / 1000;
+                        Agent.LOG.log(Level.FINE, "harvest limit from collector for {0} is: {1} samples stored per every {2} second harvest",
+                                tracker.harvestable.getEndpointMethodName(), harvestLimit, reportPeriodInSeconds);
                     }
                 } else if (isSpanEventEndpoint) {
                     Agent.LOG.log(Level.FINE, "span_event_harvest_config from collector was null. Using default value: {0} samples stored for {1}", maxSamplesStored,


### PR DESCRIPTION
This will log the harvest limit details for all event types (both those with faster event harvest and also SpanEvents without it). Also standardizes the format of these log messages a bit.

Example log output:

```
2022-03-17T15:45:12,930-0700 [57270 1] com.newrelic FINE: harvest limit from collector for log_event_data is: 0 max samples stored per every 5 second harvest
2022-03-17T15:45:12,931-0700 [57270 1] com.newrelic FINE: harvest limit from collector for custom_event_data is: 833 max samples stored per every 5 second harvest
2022-03-17T15:45:12,940-0700 [57270 1] com.newrelic FINE: harvest limit from collector for analytic_event_data is: 166 max samples stored per every 5 second harvest
2022-03-17T15:45:12,941-0700 [57270 1] com.newrelic FINE: harvest limit from collector for error_event_data is: 8 max samples stored per every 5 second harvest
```

This supplements the log messages that detail the `max_samples_stored` value for different event types.

```
2022-03-17T15:45:12,929-0700 [57270 1] com.newrelic FINE: event_harvest_config from collector for log_event_data is: 11 max samples stored per minute
2022-03-17T15:45:12,931-0700 [57270 1] com.newrelic FINE: event_harvest_config from collector for custom_event_data is: 10,000 max samples stored per minute
2022-03-17T15:45:12,939-0700 [57270 1] com.newrelic FINE: event_harvest_config from collector for analytic_event_data is: 2,000 max samples stored per minute
2022-03-17T15:45:12,941-0700 [57270 1] com.newrelic FINE: event_harvest_config from collector for error_event_data is: 100 max samples stored per minute
2022-03-17T15:45:12,941-0700 [57270 1] com.newrelic FINE: span_event_harvest_config from collector for span_event_data was null. Using default value: 10,000 max samples stored per minute
```