### PR TITLE
Add entity.name to LogEvents. Fix tests.

### DIFF
--- a/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
+++ b/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
@@ -24,6 +24,7 @@ public class AgentUtil {
     private static final String TRACE_ID = "trace.id";
     private static final String HOSTNAME = "hostname";
     private static final String ENTITY_GUID = "entity.guid";
+    private static final String ENTITY_NAME = "entity.name";
     private static final String SPAN_ID = "span.id";
     // Enabled defaults
     private static final boolean APP_LOGGING_DEFAULT_ENABLED = true;
@@ -47,6 +48,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
+            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
         }
         return blob.toString();
     }

--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
@@ -29,6 +29,7 @@ public class AgentUtil {
     private static final String TRACE_ID = "trace.id";
     private static final String HOSTNAME = "hostname";
     private static final String ENTITY_GUID = "entity.guid";
+    private static final String ENTITY_NAME = "entity.name";
     private static final String SPAN_ID = "span.id";
     // Enabled defaults
     private static final boolean APP_LOGGING_DEFAULT_ENABLED = true;
@@ -85,6 +86,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
+            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
         }
         return blob.toString();
     }

--- a/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
+++ b/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
@@ -24,6 +24,7 @@ public class AgentUtil {
     private static final String TRACE_ID = "trace.id";
     private static final String HOSTNAME = "hostname";
     private static final String ENTITY_GUID = "entity.guid";
+    private static final String ENTITY_NAME = "entity.name";
     private static final String SPAN_ID = "span.id";
     // Enabled defaults
     private static final boolean APP_LOGGING_DEFAULT_ENABLED = true;
@@ -47,6 +48,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
+            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
         }
         return blob.toString();
     }

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
@@ -29,6 +29,7 @@ public class AgentUtil {
     private static final String TRACE_ID = "trace.id";
     private static final String HOSTNAME = "hostname";
     private static final String ENTITY_GUID = "entity.guid";
+    private static final String ENTITY_NAME = "entity.name";
     private static final String SPAN_ID = "span.id";
     // Enabled defaults
     private static final boolean APP_LOGGING_DEFAULT_ENABLED = true;
@@ -76,6 +77,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
+            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
         }
         return blob.toString();
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentLinkingMetadata.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentLinkingMetadata.java
@@ -62,8 +62,8 @@ public class AgentLinkingMetadata {
     }
 
     /**
-     * Get a map of agent linking metadata minus entity.type,
-     * entity.name, and any attributes with an empty value.
+     * Get a map of agent linking metadata minus
+     * entity.type and any attributes with an empty value.
      * This subset of linking metadata is added to LogEvents.
      *
      * @param traceMetadata TraceMetadataImpl to get spanId and traceId
@@ -93,6 +93,10 @@ public class AgentLinkingMetadata {
             String entityGuid = rpmService.getEntityGuid();
             if (!entityGuid.isEmpty()) {
                 logEventLinkingMetadata.put(ENTITY_GUID, entityGuid);
+            }
+            String entityName = getEntityName(agentConfig);
+            if (!entityName.isEmpty()) {
+                logEventLinkingMetadata.put(ENTITY_NAME, entityName);
             }
         } catch (NullPointerException ignored) {
             logWarning();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/AgentLinkingMetadataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/AgentLinkingMetadataTest.java
@@ -143,8 +143,8 @@ public class AgentLinkingMetadataTest {
         // Can't assert on a specific hostname value as it will resolve to the actual hostname of the machine running the test
         assertFalse("hostname shouldn't be empty", linkingMetadata.get(AgentLinkingMetadata.HOSTNAME).isEmpty());
 
-        assertFalse("entity.name should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_NAME));
-        assertFalse("entity.type should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_TYPE));
+        assertFalse("entity.type should not be included in LogEvent linking metadata", linkingMetadata.containsKey(AgentLinkingMetadata.ENTITY_TYPE));
+        assertEquals(expectedEntityName, linkingMetadata.get(AgentLinkingMetadata.ENTITY_NAME));
         assertEquals(expectedEntityGuid, linkingMetadata.get(AgentLinkingMetadata.ENTITY_GUID));
 
         assertEquals(expectedTraceId, linkingMetadata.get(AgentLinkingMetadata.TRACE_ID));
@@ -187,12 +187,12 @@ public class AgentLinkingMetadataTest {
         // Can't assert on a specific hostname value as it will resolve to the actual hostname of the machine running the test
         assertFalse("hostname shouldn't be empty", linkingMetadata.get(AgentLinkingMetadata.HOSTNAME).isEmpty());
 
-        assertFalse("entity.name should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_NAME));
-        assertFalse("entity.type should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.ENTITY_TYPE));
+        assertFalse("entity.type should not be included in LogEvent linking metadata", linkingMetadata.containsKey(AgentLinkingMetadata.ENTITY_TYPE));
+        assertEquals(expectedEntityName, linkingMetadata.get(AgentLinkingMetadata.ENTITY_NAME));
         assertEquals(expectedEntityGuid, linkingMetadata.get(AgentLinkingMetadata.ENTITY_GUID));
 
         // trace.id and span.id would be empty values if getLogEventLinkingMetadata was called outside of a transaction, in which case they are omitted
-        assertFalse("empty trace.id value should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.TRACE_ID));
-        assertFalse("empty span.id value should not be included in LogEvent linking metadata", linkingMetadata.containsValue(AgentLinkingMetadata.SPAN_ID));
+        assertFalse("empty trace.id value should not be included in LogEvent linking metadata", linkingMetadata.containsKey(AgentLinkingMetadata.TRACE_ID));
+        assertFalse("empty span.id value should not be included in LogEvent linking metadata", linkingMetadata.containsKey(AgentLinkingMetadata.SPAN_ID));
     }
 }


### PR DESCRIPTION
Adds `entity.name` as a `LogEvent` attribute as well as including it in the metadata that is appended to log lines. Updates related tests.

Resolves https://github.com/newrelic/newrelic-java-agent/issues/796