### PR TITLE
URL encode entity.name for local_decorating metadata blob

### DIFF
--- a/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
+++ b/instrumentation/apache-log4j-1/src/main/java/com/nr/agent/instrumentation/log4j1/AgentUtil.java
@@ -9,7 +9,11 @@ package com.nr.agent.instrumentation.log4j1;
 
 import com.newrelic.api.agent.NewRelic;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class AgentUtil {
     public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
@@ -48,7 +52,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
-            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
+            appendAttributeToBlob(urlEncode(agentLinkingMetadata.get(ENTITY_NAME)), blob);
         }
         return blob.toString();
     }
@@ -58,6 +62,21 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
+    }
+
+    /**
+     * URL encode a String value.
+     *
+     * @param value String to encode
+     * @return URL encoded String
+     */
+    static String urlEncode(String value) {
+        try {
+            value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            NewRelic.getAgent().getLogger().log(Level.WARNING, "Unable to URL encode entity.name for application_logging.local_decorating", e);
+        }
+        return value;
     }
 
     /**

--- a/instrumentation/apache-log4j-1/src/test/java/com/nr/agent/instrumentation/log4j1/AgentUtilTest.java
+++ b/instrumentation/apache-log4j-1/src/test/java/com/nr/agent/instrumentation/log4j1/AgentUtilTest.java
@@ -1,0 +1,23 @@
+package com.nr.agent.instrumentation.log4j1;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AgentUtilTest {
+
+    @Test
+    public void testUrlEncoding() {
+        final String ENCODED_PIPE = "%7C";
+        final String ENCODED_SPACE = "+";
+        // The main goal of the encoding is to eliminate | characters from the entity.name as | is used as
+        // the BLOB_DELIMITER for separating the agent metadata attributes that are appended to log files
+        final String valueToEncode = "|My Application|";
+        final String expectedEncodedValue = ENCODED_PIPE + "My" + ENCODED_SPACE + "Application" + ENCODED_PIPE;
+
+        String encodedValue = AgentUtil.urlEncode(valueToEncode);
+
+        Assert.assertEquals(expectedEncodedValue, encodedValue);
+    }
+
+}

--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
@@ -13,6 +13,9 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -86,7 +89,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
-            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
+            appendAttributeToBlob(urlEncode(agentLinkingMetadata.get(ENTITY_NAME)), blob);
         }
         return blob.toString();
     }
@@ -96,6 +99,21 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
+    }
+
+    /**
+     * URL encode a String value.
+     *
+     * @param value String to encode
+     * @return URL encoded String
+     */
+    static String urlEncode(String value) {
+        try {
+            value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            NewRelic.getAgent().getLogger().log(java.util.logging.Level.WARNING, "Unable to URL encode entity.name for application_logging.local_decorating", e);
+        }
+        return value;
     }
 
     /**

--- a/instrumentation/apache-log4j-2/src/test/java/com/nr/agent/instrumentation/log4j2/AgentUtilTest.java
+++ b/instrumentation/apache-log4j-2/src/test/java/com/nr/agent/instrumentation/log4j2/AgentUtilTest.java
@@ -1,0 +1,22 @@
+package com.nr.agent.instrumentation.log4j2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AgentUtilTest {
+
+    @Test
+    public void testUrlEncoding() {
+        final String ENCODED_PIPE = "%7C";
+        final String ENCODED_SPACE = "+";
+        // The main goal of the encoding is to eliminate | characters from the entity.name as | is used as
+        // the BLOB_DELIMITER for separating the agent metadata attributes that are appended to log files
+        final String valueToEncode = "|My Application|";
+        final String expectedEncodedValue = ENCODED_PIPE + "My" + ENCODED_SPACE + "Application" + ENCODED_PIPE;
+
+        String encodedValue = AgentUtil.urlEncode(valueToEncode);
+
+        Assert.assertEquals(expectedEncodedValue, encodedValue);
+    }
+
+}

--- a/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
+++ b/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/AgentUtil.java
@@ -9,7 +9,11 @@ package com.nr.instrumentation.jul;
 
 import com.newrelic.api.agent.NewRelic;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class AgentUtil {
     public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
@@ -48,7 +52,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
-            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
+            appendAttributeToBlob(urlEncode(agentLinkingMetadata.get(ENTITY_NAME)), blob);
         }
         return blob.toString();
     }
@@ -58,6 +62,21 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
+    }
+
+    /**
+     * URL encode a String value.
+     *
+     * @param value String to encode
+     * @return URL encoded String
+     */
+    static String urlEncode(String value) {
+        try {
+            value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            NewRelic.getAgent().getLogger().log(Level.WARNING, "Unable to URL encode entity.name for application_logging.local_decorating", e);
+        }
+        return value;
     }
 
     /**

--- a/instrumentation/java.logging-jdk8/src/test/java/com/nr/instrumentation/jul/AgentUtilTest.java
+++ b/instrumentation/java.logging-jdk8/src/test/java/com/nr/instrumentation/jul/AgentUtilTest.java
@@ -1,0 +1,22 @@
+package com.nr.instrumentation.jul;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AgentUtilTest {
+
+    @Test
+    public void testUrlEncoding() {
+        final String ENCODED_PIPE = "%7C";
+        final String ENCODED_SPACE = "+";
+        // The main goal of the encoding is to eliminate | characters from the entity.name as | is used as
+        // the BLOB_DELIMITER for separating the agent metadata attributes that are appended to log files
+        final String valueToEncode = "|My Application|";
+        final String expectedEncodedValue = ENCODED_PIPE + "My" + ENCODED_SPACE + "Application" + ENCODED_PIPE;
+
+        String encodedValue = AgentUtil.urlEncode(valueToEncode);
+
+        Assert.assertEquals(expectedEncodedValue, encodedValue);
+    }
+
+}

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
@@ -11,6 +11,9 @@ import ch.qos.logback.classic.Level;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.api.agent.NewRelic;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +80,7 @@ public class AgentUtil {
             appendAttributeToBlob(agentLinkingMetadata.get(HOSTNAME), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(TRACE_ID), blob);
             appendAttributeToBlob(agentLinkingMetadata.get(SPAN_ID), blob);
-            appendAttributeToBlob(agentLinkingMetadata.get(ENTITY_NAME), blob);
+            appendAttributeToBlob(urlEncode(agentLinkingMetadata.get(ENTITY_NAME)), blob);
         }
         return blob.toString();
     }
@@ -87,6 +90,21 @@ public class AgentUtil {
             blob.append(attribute);
         }
         blob.append(BLOB_DELIMITER);
+    }
+
+    /**
+     * URL encode a String value.
+     *
+     * @param value String to encode
+     * @return URL encoded String
+     */
+    static String urlEncode(String value) {
+        try {
+            value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            NewRelic.getAgent().getLogger().log(java.util.logging.Level.WARNING, "Unable to URL encode entity.name for application_logging.local_decorating", e);
+        }
+        return value;
     }
 
     /**

--- a/instrumentation/logback-classic-1.2/src/test/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtilTest.java
+++ b/instrumentation/logback-classic-1.2/src/test/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtilTest.java
@@ -1,0 +1,22 @@
+package com.nr.agent.instrumentation.logbackclassic12;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AgentUtilTest {
+
+    @Test
+    public void testUrlEncoding() {
+        final String ENCODED_PIPE = "%7C";
+        final String ENCODED_SPACE = "+";
+        // The main goal of the encoding is to eliminate | characters from the entity.name as | is used as
+        // the BLOB_DELIMITER for separating the agent metadata attributes that are appended to log files
+        final String valueToEncode = "|My Application|";
+        final String expectedEncodedValue = ENCODED_PIPE + "My" + ENCODED_SPACE + "Application" + ENCODED_PIPE;
+
+        String encodedValue = AgentUtil.urlEncode(valueToEncode);
+
+        Assert.assertEquals(expectedEncodedValue, encodedValue);
+    }
+
+}


### PR DESCRIPTION
There was a [spec change](https://source.datanerd.us/agents/agent-specs/pull/570/commits/cda9b9b5e6bc12e61e4edeb7d140c72b2e53533d) that requires the `entity.name` to be URL encoded when added to the agent metadata blob for local log file decorating. The purpose is to avoid any entity names using the `|` character as it is also used as the delimiter of attributes in the blob.

Previously the blob appended to logs would look like this with an app name of `|My Application|`:

```
NR-LINKING|entityGuid123|199.199.1.19|traceId123|spanId123||My Application||
```

With URL encoding it is now:

```
NR-LINKING|entityGuid123|199.199.1.19|traceId123|spanId123|%7CMy+Application%7C|
```
