### PR TITLE
Fixing version range that log instrumentation should apply

### DIFF
--- a/instrumentation/apache-log4j-2/build.gradle
+++ b/instrumentation/apache-log4j-2/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passesOnly("org.apache.logging.log4j:log4j-core:[2.0.0,)")
+    passesOnly("org.apache.logging.log4j:log4j-core:[2.6,)")
     excludeRegex '.*(alpha|beta|rc).*'
 }
 

--- a/instrumentation/logback-classic-1.2/build.gradle
+++ b/instrumentation/logback-classic-1.2/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passesOnly("ch.qos.logback:logback-classic:[0.9.3,)")
+    passesOnly("ch.qos.logback:logback-classic:[1.1.0,)")
     excludeRegex '.*(alpha|groovyless).*'
     excludeRegex 'ch.qos.logback:logback-classic:0.9.6'
 }


### PR DESCRIPTION
### Overview
Fixes the versions that log4j-2 and logback instrumentation should apply to.

### Checks

[y] Are your contributions backwards compatible with relevant frameworks and APIs?
[n] Does your code contain any breaking changes? Please describe. 
[n] Does your code introduce any new dependencies? Please describe.
