### PR TITLE
Enable application_logging by default

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
@@ -17,7 +17,7 @@ import static com.newrelic.agent.config.AgentConfigImpl.APPLICATION_LOGGING;
  * application_logging:
  *   enabled: true
  *   forwarding:
- *     enabled: false
+ *     enabled: true
  *     max_samples_stored: 10000
  *   metrics:
  *     enabled: true
@@ -69,6 +69,7 @@ public class ApplicationLoggingConfigImpl extends BaseConfig implements Applicat
         return new ApplicationLoggingConfigImpl(settings, highSecurity);
     }
 
+    @Override
     public boolean isEnabled() {
         return applicationLoggingEnabled;
     }
@@ -88,6 +89,7 @@ public class ApplicationLoggingConfigImpl extends BaseConfig implements Applicat
         return applicationLoggingEnabled && applicationLoggingForwardingConfig.getEnabled();
     }
 
+    @Override
     public int getMaxSamplesStored() {
         return applicationLoggingForwardingConfig.getMaxSamplesStored();
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfig.java
@@ -17,7 +17,7 @@ public class ApplicationLoggingForwardingConfig extends BaseConfig {
     public static final String ENABLED = "enabled";
     public static final String MAX_SAMPLES_STORED = "max_samples_stored";
 
-    public static final boolean DEFAULT_ENABLED = false;
+    public static final boolean DEFAULT_ENABLED = true;
     public static final int DEFAULT_MAX_SAMPLES_STORED = 10000;
 
     private final boolean enabled;

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -95,10 +95,10 @@ common: &default_settings
 
     # The agent will automatically forward application logs to New Relic in
     # a format that includes agent metadata for linking them to traces and errors.
-    #forwarding:
+    forwarding:
 
-      # When true, application logs will be forwarded to New Relic. The default is false.
-      #enabled: false
+      # When true, application logs will be forwarded to New Relic. The default is true.
+      enabled: true
 
       # Application log events are collected up to the configured amount. Afterwards,
       # events are sampled to maintain an even distribution across the harvest cycle.

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
@@ -1255,11 +1255,10 @@ public class AgentConfigImplTest {
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
         assertEquals(ApplicationLoggingConfigImpl.DEFAULT_ENABLED, config.getApplicationLoggingConfig().isEnabled());
-        assertTrue(config.getApplicationLoggingConfig().isForwardingEnabled());
+        assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
         assertEquals(NOT_DEFAULT_MAX_SAMPLES_STORED, config.getApplicationLoggingConfig().getMaxSamplesStored());
         assertFalse(config.getApplicationLoggingConfig().isMetricsEnabled());
         assertTrue(config.getApplicationLoggingConfig().isLocalDecoratingEnabled());
-
     }
 
     @Test
@@ -1268,16 +1267,14 @@ public class AgentConfigImplTest {
         AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
 
         assertTrue(config.getApplicationLoggingConfig().isEnabled());
-        assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
+        assertTrue(config.getApplicationLoggingConfig().isForwardingEnabled());
         assertEquals(ApplicationLoggingForwardingConfig.DEFAULT_MAX_SAMPLES_STORED, config.getApplicationLoggingConfig().getMaxSamplesStored());
         assertTrue(config.getApplicationLoggingConfig().isMetricsEnabled());
         assertFalse(config.getApplicationLoggingConfig().isLocalDecoratingEnabled());
-
     }
 
     @Test
     public void getApplicationLoggingConfigSystemProperty() {
-
         String key = ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT + ApplicationLoggingConfigImpl.ENABLED;
         String val = String.valueOf(!ApplicationLoggingConfigImpl.DEFAULT_ENABLED);
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfigTest.java
@@ -12,14 +12,13 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ApplicationLoggingForwardingConfigTest {
-    private Map<String, Object> localProps;
     private static final int TEST_MAX_SAMPLES_STORED = 5000;
-
     @Rule
     public SaveSystemPropertyProviderRule saveSystemPropertyProviderRule = new SaveSystemPropertyProviderRule();
+    private Map<String, Object> localProps;
 
     @Before
     public void setup() {
@@ -30,8 +29,7 @@ public class ApplicationLoggingForwardingConfigTest {
     public void defaultForwardingConfig() {
         ApplicationLoggingForwardingConfig config = new ApplicationLoggingForwardingConfig(localProps, ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT,
                 false);
-        assertFalse(config.getEnabled());
-
+        assertTrue(config.getEnabled());
     }
 
     @Test
@@ -46,7 +44,8 @@ public class ApplicationLoggingForwardingConfigTest {
         Map<String, Object> maxSamplesStoreTooLarge = new HashMap<>(localProps);
         maxSamplesStoreTooLarge.put(ApplicationLoggingForwardingConfig.MAX_SAMPLES_STORED, new BigInteger("9999999999999999999999"));
 
-        ApplicationLoggingForwardingConfig config = new ApplicationLoggingForwardingConfig(maxSamplesStoreTooLarge, ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT,
+        ApplicationLoggingForwardingConfig config = new ApplicationLoggingForwardingConfig(maxSamplesStoreTooLarge,
+                ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT,
                 false);
         assertEquals(ApplicationLoggingForwardingConfig.DEFAULT_MAX_SAMPLES_STORED, config.getMaxSamplesStored());
     }
@@ -61,7 +60,6 @@ public class ApplicationLoggingForwardingConfigTest {
 
     @Test
     public void usesEnvVarForNestedConfig() {
-
         SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
                 new SaveSystemPropertyProviderRule.TestSystemProps(),
                 new SaveSystemPropertyProviderRule.TestEnvironmentFacade(
@@ -71,13 +69,11 @@ public class ApplicationLoggingForwardingConfigTest {
         ApplicationLoggingForwardingConfig config = new ApplicationLoggingForwardingConfig(Collections.emptyMap(),
                 ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT, false);
         assertEquals(TEST_MAX_SAMPLES_STORED, config.getMaxSamplesStored());
-
     }
 
     @Test
     public void usesSysPropForNestedConfig() {
         Properties properties = new Properties();
-
         properties.put("newrelic.config.application_logging.forwarding.max_samples_stored", "" + TEST_MAX_SAMPLES_STORED);
         SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
                 new SaveSystemPropertyProviderRule.TestSystemProps(properties),
@@ -87,7 +83,6 @@ public class ApplicationLoggingForwardingConfigTest {
         ApplicationLoggingForwardingConfig config = new ApplicationLoggingForwardingConfig(Collections.emptyMap(),
                 ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT, false);
         assertEquals(TEST_MAX_SAMPLES_STORED, config.getMaxSamplesStored());
-
     }
 
 }


### PR DESCRIPTION
Resolves https://github.com/newrelic/newrelic-java-agent/issues/814

---

Logging AITs pass

```
./bin/runtest.sh tests/java/functionality/basic_features/logging_test.py
runtest.sh: firing up...
runtest.sh: all tests to run tests/java/functionality/basic_features/logging_test.py
AIT validate: start.
AIT validate: success.
runtest.sh: Python interpreter: /path/to/java-agent-integration-tests/bin/python
runtest.sh: running test tests/java/functionality/basic_features/logging_test.py with args 

test_application_logging_disabled (__main__.LoggingTest) ... 2022-04-11 16:15:34,991 - INFO: run: /path/to/java-agent-integration-tests/tests/java/functionality/basic_features/logging_test.py:test_application_logging_disabled, tmpdir: /tmp/tmpzsj_gm67
2022-04-11 16:15:34,997 - INFO: ............... collector [10]
2022-04-11 16:15:34,998 - INFO: ................. java_agent [master]
2022-04-11 16:15:34,998 - INFO: ................... java [8]
2022-04-11 16:15:34,998 - INFO: ..................... log_collector_app [master]
2022-04-11 16:15:34,999 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:17:55,105 - INFO: ................... java [11]
2022-04-11 16:17:55,106 - INFO: ..................... log_collector_app [master]
2022-04-11 16:17:55,107 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:20:09,653 - INFO: ................... java [17]
2022-04-11 16:20:09,654 - INFO: ..................... log_collector_app [master]
2022-04-11 16:20:09,655 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:22:25,439 - INFO: ................... java [18]
2022-04-11 16:22:25,439 - INFO: ..................... log_collector_app [master]
2022-04-11 16:22:25,440 - INFO: ....................... embedded_jetty [9.3]
ok

test_application_logging_forwarding (__main__.LoggingTest) ... 2022-04-11 16:24:42,446 - INFO: run: /path/to/java-agent-integration-tests/tests/java/functionality/basic_features/logging_test.py:test_application_logging_forwarding, tmpdir: /tmp/tmpvt9taphp
2022-04-11 16:24:42,446 - INFO: ............... collector [10]
2022-04-11 16:24:42,446 - INFO: ................. java_agent [master]
2022-04-11 16:24:42,446 - INFO: ................... java [8]
2022-04-11 16:24:42,447 - INFO: ..................... log_collector_app [master]
2022-04-11 16:24:42,447 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:24:59,342 - INFO: ................... java [11]
2022-04-11 16:24:59,342 - INFO: ..................... log_collector_app [master]
2022-04-11 16:24:59,344 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:25:13,183 - INFO: ................... java [17]
2022-04-11 16:25:13,184 - INFO: ..................... log_collector_app [master]
2022-04-11 16:25:13,185 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:25:27,101 - INFO: ................... java [18]
2022-04-11 16:25:27,102 - INFO: ..................... log_collector_app [master]
2022-04-11 16:25:27,103 - INFO: ....................... embedded_jetty [9.3]
ok

test_application_logging_log4j_local_decorating (__main__.LoggingTest) ... 2022-04-11 16:25:41,680 - INFO: run: /path/to/java-agent-integration-tests/tests/java/functionality/basic_features/logging_test.py:test_application_logging_log4j_local_decorating, tmpdir: /tmp/tmp3815e8m0
2022-04-11 16:25:41,680 - INFO: ............... collector [10]
2022-04-11 16:25:41,680 - INFO: ................. java_agent [master]
2022-04-11 16:25:41,680 - INFO: ................... java [8]
2022-04-11 16:25:41,681 - INFO: ..................... log_collector_app [master]
2022-04-11 16:25:41,681 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:26:00,816 - INFO: ................... java [11]
2022-04-11 16:26:00,816 - INFO: ..................... log_collector_app [master]
2022-04-11 16:26:00,817 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:26:16,205 - INFO: ................... java [17]
2022-04-11 16:26:16,206 - INFO: ..................... log_collector_app [master]
2022-04-11 16:26:16,207 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:26:29,340 - INFO: ................... java [18]
2022-04-11 16:26:29,340 - INFO: ..................... log_collector_app [master]
2022-04-11 16:26:29,341 - INFO: ....................... embedded_jetty [9.3]
ok

test_application_logging_log4j_metrics (__main__.LoggingTest) ... 2022-04-11 16:26:43,454 - INFO: run: /path/to/java-agent-integration-tests/tests/java/functionality/basic_features/logging_test.py:test_application_logging_log4j_metrics, tmpdir: /tmp/tmpujaxjdhn
2022-04-11 16:26:43,455 - INFO: ............... collector [10]
2022-04-11 16:26:43,455 - INFO: ................. java_agent [master]
2022-04-11 16:26:43,455 - INFO: ................... java [8]
2022-04-11 16:26:43,455 - INFO: ..................... log_collector_app [master]
2022-04-11 16:26:43,456 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:26:58,347 - INFO: ................... java [11]
2022-04-11 16:26:58,347 - INFO: ..................... log_collector_app [master]
2022-04-11 16:26:58,349 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:27:10,315 - INFO: ................... java [17]
2022-04-11 16:27:10,315 - INFO: ..................... log_collector_app [master]
2022-04-11 16:27:10,316 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:27:22,104 - INFO: ................... java [18]
2022-04-11 16:27:22,104 - INFO: ..................... log_collector_app [master]
2022-04-11 16:27:22,106 - INFO: ....................... embedded_jetty [9.3]
ok

test_application_logging_logback_local_decorating (__main__.LoggingTest) ... 2022-04-11 16:27:33,269 - INFO: run: /path/to/java-agent-integration-tests/tests/java/functionality/basic_features/logging_test.py:test_application_logging_logback_local_decorating, tmpdir: /tmp/tmp7nn4dfss
2022-04-11 16:27:33,269 - INFO: ............... collector [10]
2022-04-11 16:27:33,270 - INFO: ................. java_agent [master]
2022-04-11 16:27:33,270 - INFO: ................... java [8]
2022-04-11 16:27:33,270 - INFO: ..................... log_collector_app [master]
2022-04-11 16:27:33,271 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:27:49,156 - INFO: ................... java [11]
2022-04-11 16:27:49,156 - INFO: ..................... log_collector_app [master]
2022-04-11 16:27:49,158 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:28:03,127 - INFO: ................... java [17]
2022-04-11 16:28:03,128 - INFO: ..................... log_collector_app [master]
2022-04-11 16:28:03,128 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:28:17,014 - INFO: ................... java [18]
2022-04-11 16:28:17,015 - INFO: ..................... log_collector_app [master]
2022-04-11 16:28:17,016 - INFO: ....................... embedded_jetty [9.3]
ok

test_application_logging_logback_metrics (__main__.LoggingTest) ... 2022-04-11 16:28:31,423 - INFO: run: /path/to/java-agent-integration-tests/tests/java/functionality/basic_features/logging_test.py:test_application_logging_logback_metrics, tmpdir: /tmp/tmplm1t5kzc
2022-04-11 16:28:31,423 - INFO: ............... collector [10]
2022-04-11 16:28:31,424 - INFO: ................. java_agent [master]
2022-04-11 16:28:31,424 - INFO: ................... java [8]
2022-04-11 16:28:31,424 - INFO: ..................... log_collector_app [master]
2022-04-11 16:28:31,425 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:28:46,282 - INFO: ................... java [11]
2022-04-11 16:28:46,282 - INFO: ..................... log_collector_app [master]
2022-04-11 16:28:46,284 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:28:57,576 - INFO: ................... java [17]
2022-04-11 16:28:57,577 - INFO: ..................... log_collector_app [master]
2022-04-11 16:28:57,578 - INFO: ....................... embedded_jetty [9.3]
2022-04-11 16:29:09,402 - INFO: ................... java [18]
2022-04-11 16:29:09,402 - INFO: ..................... log_collector_app [master]
2022-04-11 16:29:09,404 - INFO: ....................... embedded_jetty [9.3]
ok

----------------------------------------------------------------------
Ran 6 tests in 826.613s

OK
runtest.sh: test run OK
```