### PR TITLE
Forcing Gradle's toolchain to use setup-java's JDKs

### DIFF
--- a/.github/workflows/AITs-Basic-Features-Special-JREs.yml
+++ b/.github/workflows/AITs-Basic-Features-Special-JREs.yml
@@ -211,6 +211,10 @@ jobs:
           </toolchains>
           EOF
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       ## End JDK Install
 
       # Check ENV variables
@@ -240,7 +244,7 @@ jobs:
           echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: Check disk space

--- a/.github/workflows/AITs-Basic-Features-Special-JREs.yml
+++ b/.github/workflows/AITs-Basic-Features-Special-JREs.yml
@@ -213,7 +213,7 @@ jobs:
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       ## End JDK Install
 

--- a/.github/workflows/AITs-Basic-Features.yml
+++ b/.github/workflows/AITs-Basic-Features.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk17=${JAVA_HOME}" >> $GITHUB_ENV
 
-      # Install 18 EA
+      # Install 18
       - name: Set up Java 18
         uses: actions/setup-java@v2
         with:
@@ -227,7 +227,7 @@ jobs:
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       ## End JDK Install
 

--- a/.github/workflows/AITs-Basic-Features.yml
+++ b/.github/workflows/AITs-Basic-Features.yml
@@ -225,6 +225,10 @@ jobs:
           </toolchains>
           EOF
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       ## End JDK Install
 
       # Check ENV variables
@@ -254,7 +258,7 @@ jobs:
           echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: Check disk space

--- a/.github/workflows/AITs-Datastores.yml
+++ b/.github/workflows/AITs-Datastores.yml
@@ -155,7 +155,7 @@ jobs:
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       ## End JDK Install
 

--- a/.github/workflows/AITs-Datastores.yml
+++ b/.github/workflows/AITs-Datastores.yml
@@ -153,6 +153,10 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk8=${JAVA_HOME}" >> $GITHUB_ENV
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       ## End JDK Install
 
       # Check ENV variables
@@ -182,7 +186,7 @@ jobs:
           echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: CD to agent-integration-tests dir.

--- a/.github/workflows/AITs-Frameworks.yml
+++ b/.github/workflows/AITs-Frameworks.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk17=${JAVA_HOME}" >> $GITHUB_ENV
 
-      # Install 18 EA
+      # Install 18
       - name: Set up Java 18
         uses: actions/setup-java@v2
         with:
@@ -166,7 +166,7 @@ jobs:
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       ## End JDK Install
 

--- a/.github/workflows/AITs-Frameworks.yml
+++ b/.github/workflows/AITs-Frameworks.yml
@@ -164,6 +164,10 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk8=${JAVA_HOME}" >> $GITHUB_ENV
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       ## End JDK Install
 
       # Check ENV variables
@@ -193,7 +197,7 @@ jobs:
           echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: CD to agent-integration-tests dir.

--- a/.github/workflows/AITs-Security.yml
+++ b/.github/workflows/AITs-Security.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk17=${JAVA_HOME}" >> $GITHUB_ENV
 
-      # Install 18 EA
+      # Install 18
       - name: Set up Java 18
         uses: actions/setup-java@v2
         with:
@@ -165,7 +165,7 @@ jobs:
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       ## End JDK Install
 

--- a/.github/workflows/AITs-Security.yml
+++ b/.github/workflows/AITs-Security.yml
@@ -163,6 +163,10 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk8=${JAVA_HOME}" >> $GITHUB_ENV
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       ## End JDK Install
 
       # Check ENV variables
@@ -192,7 +196,7 @@ jobs:
           echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: CD to agent-integration-tests dir.

--- a/.github/workflows/AITs-Servers.yml
+++ b/.github/workflows/AITs-Servers.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk17=${JAVA_HOME}" >> $GITHUB_ENV
 
-      # Install 18 EA
+      # Install 18
       - name: Set up Java 18
         uses: actions/setup-java@v2
         with:
@@ -167,7 +167,7 @@ jobs:
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       ## End JDK Install
 

--- a/.github/workflows/AITs-Servers.yml
+++ b/.github/workflows/AITs-Servers.yml
@@ -165,6 +165,10 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk8=${JAVA_HOME}" >> $GITHUB_ENV
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       ## End JDK Install
 
       # Check ENV variables
@@ -194,7 +198,7 @@ jobs:
           echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: CD to agent-integration-tests dir.

--- a/.github/workflows/AITs-Traces.yml
+++ b/.github/workflows/AITs-Traces.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk17=${JAVA_HOME}" >> $GITHUB_ENV
 
-      # Install 18 EA
+      # Install 18
       - name: Set up Java 18
         uses: actions/setup-java@v2
         with:
@@ -160,7 +160,7 @@ jobs:
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       ## End JDK Install
 

--- a/.github/workflows/AITs-Traces.yml
+++ b/.github/workflows/AITs-Traces.yml
@@ -158,6 +158,10 @@ jobs:
         run: |
           echo "ORG_GRADLE_PROJECT_jdk8=${JAVA_HOME}" >> $GITHUB_ENV
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       ## End JDK Install
 
       # Check ENV variables
@@ -187,7 +191,7 @@ jobs:
           echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: CD to agent-integration-tests dir.

--- a/.github/workflows/X-Reusable-Test.yml
+++ b/.github/workflows/X-Reusable-Test.yml
@@ -87,6 +87,10 @@ jobs:
           echo "Current JAVA_HOME = ${JAVA_HOME}"
           echo "ORG_GRADLE_PROJECT_jdk18=$JAVA_HOME" >> $GITHUB_ENV
 
+      # Needed for toolchains and GHA.
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+
       # Check ENV variables
       - name: Check environmental variables
         run: printenv | sort -f
@@ -134,7 +138,7 @@ jobs:
           echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
           ls -la
           cat settings.gradle
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       - name: Build newrelicJar w/o GE
@@ -145,7 +149,7 @@ jobs:
           echo "*** NOT PUBLISHING BUILD SCANS ***"
           ls -la
           cat settings.gradle
-          ./gradlew clean jar --parallel
+          ./gradlew $GRADLE_OPTIONS clean jar --parallel
           ls -la newrelic-agent/build/
 
       # GHA run instrumentation tests
@@ -174,7 +178,7 @@ jobs:
           LANGUAGE: java
           TEST_TYPE: instrumentation
         run: |
-          ./gradlew --console=plain :instrumentation:test -Ptest${{ inputs.jre }} --continue
+          ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ inputs.jre }} --continue
 
       # Run the build without Gradle Enterprise
       - name: Run instrumentation tests for Java ${{ inputs.jre }} w/o GE
@@ -183,7 +187,7 @@ jobs:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
           echo "*** NOT PUBLISHING BUILD SCANS OR CACHE ***"
-          ./gradlew --console=plain :instrumentation:test -Ptest${{ inputs.jre }} --continue
+          ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ inputs.jre }} --continue
 
       # Capture HTML build result in artifacts
       - name: Capture build reports

--- a/.github/workflows/X-Reusable-Test.yml
+++ b/.github/workflows/X-Reusable-Test.yml
@@ -82,14 +82,14 @@ jobs:
           java-version: 18
 
       # Save new JDK variable
-      - name: Save JAVA_HOME as JDK18ea for later usage
+      - name: Save JAVA_HOME as JDK18 for later usage
         run: |
           echo "Current JAVA_HOME = ${JAVA_HOME}"
           echo "ORG_GRADLE_PROJECT_jdk18=$JAVA_HOME" >> $GITHUB_ENV
 
       # Needed for toolchains and GHA.
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
 
       # Check ENV variables
       - name: Check environmental variables

--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -72,7 +72,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish
+        run: ./gradlew $GRADLE_OPTIONS publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish
       - name: Publish snapshot apis
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -80,6 +80,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish
 
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -41,6 +41,9 @@ jobs:
           $ORG_GRADLE_PROJECT_jdk11/bin/java -version
       - name: correct JAVA_HOME
         run: echo "JAVA_HOME=$ORG_GRADLE_PROJECT_jdk8" >> $GITHUB_ENV
+      # these options are required so toolchain only uses the JDKs we specified
+      - name: setup gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
       # Restore the gradle cache
       - uses: actions/cache@v2
         with:
@@ -73,7 +76,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish -Prelease=true
+        run: ./gradlew $GRADLE_OPTIONS publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish -Prelease=true
       - name: Publish release apis
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -81,4 +84,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish -Prelease=true
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish -Prelease=true

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "JAVA_HOME=$ORG_GRADLE_PROJECT_jdk8" >> $GITHUB_ENV
       # these options are required so toolchain only uses the JDKs we specified
       - name: setup gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=$ORG_GRADLE_PROJECT_jdk8,$ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=ORG_GRADLE_PROJECT_jdk8,ORG_GRADLE_PROJECT_jdk11" >> $GITHUB_ENV
       # Restore the gradle cache
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
### Overview
Forces Gradle's toolchains to use the JDKs installed by `setup-java`.

### Related Github Issue
Fixes #723 

### Checks

[y] Are your contributions backwards compatible with relevant frameworks and APIs?
[n] Does your code contain any breaking changes? Please describe. 
[n] Does your code introduce any new dependencies? Please describe.
