### PR TITLE
pass transaction context between threads for akka

### DIFF
--- a/instrumentation/akka-2.2/src/main/java/akka/actor/ActorCell_Instrumentation.java
+++ b/instrumentation/akka-2.2/src/main/java/akka/actor/ActorCell_Instrumentation.java
@@ -23,15 +23,15 @@ public abstract class ActorCell_Instrumentation {
 
         String messageClassName = envelope.message().getClass().getName();
         if (receiver != null && !AkkaUtil.isHeartBeatMessage(messageClassName) && !AkkaUtil.isLogger(receiver)) {
-            if (envelope.token != null) {
-                if (envelope.token.link()) {
-                    AgentBridge.getAgent().getTracedMethod().setMetricName("Akka", "receive", receiver);
-                    AgentBridge.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW,
-                            false, "Actor", receiver, "invoke");
-                }
-                envelope.token.expire();
-                envelope.token = null;
-            }
+          if (envelope.token != null) {
+            envelope.token.link();
+            AgentBridge.getAgent().getTracedMethod().setMetricName("Akka", "receive", receiver);
+            AgentBridge.getAgent().getTransaction().setTransactionName(TransactionNamePriority.FRAMEWORK_LOW,
+                                                                       false, "Actor", receiver, "invoke");
+
+            envelope.token.expire();
+            envelope.token = null;
+          }
         }
 
         Weaver.callOriginal();

--- a/instrumentation/akka-2.2/src/main/java/akka/dispatch/ForkJoinExecutorConfigurator_Instrumentation.java
+++ b/instrumentation/akka-2.2/src/main/java/akka/dispatch/ForkJoinExecutorConfigurator_Instrumentation.java
@@ -1,0 +1,21 @@
+package akka.dispatch;
+
+import akka.dispatch.forkjoin.ForkJoinPool;
+import akka.dispatch.forkjoin.ForkJoinTask;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(originalName = "akka.dispatch.ForkJoinExecutorConfigurator")
+public class ForkJoinExecutorConfigurator_Instrumentation {
+
+  @Weave(originalName = "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinPool")
+
+  public static final class AkkaForkJoinPool_Instrumentation {
+    public void execute(Runnable runnable) {
+      if (runnable != null) {
+        runnable = new TokenAwareRunnable(runnable);
+      }
+      Weaver.callOriginal();
+    }
+  }
+}

--- a/instrumentation/akka-2.2/src/main/java/akka/dispatch/ThreadPoolConfig_Instrumentation.java
+++ b/instrumentation/akka-2.2/src/main/java/akka/dispatch/ThreadPoolConfig_Instrumentation.java
@@ -1,0 +1,26 @@
+package akka.dispatch;
+
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import scala.Function0;
+import scala.concurrent.duration.Duration;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+
+@Weave(originalName = "akka.dispatch.ThreadPoolConfig")
+public class ThreadPoolConfig_Instrumentation {
+
+  @Weave(originalName = "akka.dispatch.ThreadPoolConfig$ThreadPoolExecutorServiceFactory")
+  public static class ThreadPoolExecutorServiceFactory_Instrumentation {
+    private final ThreadFactory threadFactory = Weaver.callOriginal();
+
+    public ExecutorService createExecutorService() {
+      ExecutorService original = Weaver.callOriginal();
+      TokenAwareThreadPoolExecuter service = new TokenAwareThreadPoolExecuter(original);
+      return service;
+    }
+  }
+}

--- a/instrumentation/akka-2.2/src/main/java/akka/dispatch/TokenAwareRunnable.java
+++ b/instrumentation/akka-2.2/src/main/java/akka/dispatch/TokenAwareRunnable.java
@@ -1,0 +1,30 @@
+package akka.dispatch;
+
+import com.newrelic.agent.bridge.AgentBridge;
+
+import static akka.dispatch.Utils.*;
+
+public final class TokenAwareRunnable implements Runnable {
+  private final Runnable delegate;
+  private final AgentBridge.TokenAndRefCount tokenAndRefCount;
+
+  public TokenAwareRunnable(Runnable delegate) {
+    this.delegate = delegate;
+    this.tokenAndRefCount = getThreadTokenAndRefCount();
+    logTokenInfo(tokenAndRefCount, "TokenAwareRunnable token info set");
+  }
+
+  @Override
+  public void run() {
+    try {
+      if (delegate != null) {
+        logTokenInfo(tokenAndRefCount, "Token info set in thread");
+        setThreadTokenAndRefCount(tokenAndRefCount);
+        delegate.run();
+      }
+    } finally {
+      logTokenInfo(tokenAndRefCount, "Clearing token info from thread ");
+      clearThreadTokenAndRefCountAndTxn(tokenAndRefCount);
+    }
+  }
+}

--- a/instrumentation/akka-2.2/src/main/java/akka/dispatch/TokenAwareThreadPoolExecuter.java
+++ b/instrumentation/akka-2.2/src/main/java/akka/dispatch/TokenAwareThreadPoolExecuter.java
@@ -1,0 +1,94 @@
+package akka.dispatch;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class TokenAwareThreadPoolExecuter implements ExecutorService, LoadMetrics {
+
+  private final ExecutorService delegate;
+
+  public TokenAwareThreadPoolExecuter(ExecutorService threadPoolExecutor) {
+    this.delegate = threadPoolExecutor;
+  }
+  @Override
+  public void execute(Runnable runnable) {
+    if (runnable != null) {
+      runnable = new TokenAwareRunnable(runnable);
+    }
+    delegate.execute(runnable);
+  }
+
+  @Override
+  public boolean atFullThrottle() {
+    if(delegate instanceof LoadMetrics) {
+      return ((LoadMetrics) delegate).atFullThrottle();
+    }
+    return false;
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return delegate.submit(task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return delegate.submit(task, result);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return delegate.submit(task);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    return delegate.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    return delegate.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.invokeAny(tasks, timeout, unit);
+  }
+}

--- a/instrumentation/akka-2.2/src/main/java/akka/dispatch/Utils.java
+++ b/instrumentation/akka-2.2/src/main/java/akka/dispatch/Utils.java
@@ -1,0 +1,49 @@
+package akka.dispatch;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.Transaction;
+
+import java.text.MessageFormat;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+public class Utils {
+
+  public static AgentBridge.TokenAndRefCount getThreadTokenAndRefCount() {
+    AgentBridge.TokenAndRefCount tokenAndRefCount = AgentBridge.activeToken.get();
+    if (tokenAndRefCount == null) {
+      Transaction tx = AgentBridge.getAgent().getTransaction(false);
+      if (tx != null) {
+        tokenAndRefCount = new AgentBridge.TokenAndRefCount(tx.getToken(), AgentBridge.getAgent().getTracedMethod(), new AtomicInteger(1));
+      }
+    } else {
+      tokenAndRefCount.refCount.incrementAndGet();
+    }
+    return tokenAndRefCount;
+  }
+
+  public static void setThreadTokenAndRefCount(AgentBridge.TokenAndRefCount tokenAndRefCount) {
+    if (tokenAndRefCount != null) {
+      AgentBridge.activeToken.set(tokenAndRefCount);
+      tokenAndRefCount.token.link();
+    }
+  }
+
+  public static void clearThreadTokenAndRefCountAndTxn(AgentBridge.TokenAndRefCount tokenAndRefCount) {
+    AgentBridge.activeToken.remove();
+    if (tokenAndRefCount != null && tokenAndRefCount.refCount.decrementAndGet() <= 0) {
+      tokenAndRefCount.token.expire();
+      tokenAndRefCount.token = null;
+    }
+  }
+
+  public static void logTokenInfo(AgentBridge.TokenAndRefCount tokenAndRefCount, String msg) {
+    if (AgentBridge.getAgent().getLogger().isLoggable(Level.FINEST)) {
+      String tokenMsg = (tokenAndRefCount != null && tokenAndRefCount.token != null)
+              ? String.format("[%s:%s:%d]", tokenAndRefCount.token, tokenAndRefCount.token.getTransaction(),
+              tokenAndRefCount.refCount.get())
+              : "[Empty token]";
+      AgentBridge.getAgent().getLogger().log(Level.FINEST, MessageFormat.format("{0}: token info {1}", tokenMsg, msg));
+    }
+  }
+}


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
This is a fix for where 2 separate transactions are created for the same  Akka Http request

### Related Github Issue
 #787 

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[Y] Are your contributions backwards compatible with relevant frameworks and APIs?
[N] Does your code contain any breaking changes? Please describe. 
[N] Does your code introduce any new dependencies? Please describe.
