### PR TITLE
Update weaver to use caffeine 2.9.3

### DIFF
--- a/newrelic-weaver/build.gradle
+++ b/newrelic-weaver/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation("com.google.guava:guava:30.1.1-jre") {
         transitive = false
     }
-    implementation("com.github.ben-manes.caffeine:caffeine:2.9.0")
+    implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
 
     // used to invoke agentmain
     testImplementation(files(jdk8 + "/lib/tools.jar"))


### PR DESCRIPTION
Use same version of caffeine in `newrelic-weaver` that is used in `newrelic-agent`.