### PR TITLE
Running verify instrumentation tests with Java 11

### DIFF
--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -191,5 +191,12 @@ jobs:
       - name: Build agent
         run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
 
+      # Setting up 11 again so tests are run with it. This is so libraries build with 11 can pass.
+      - name: Set up Java 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
       - name: Running verifyInstrumentation on (${{ matrix.modules }})
         run: ./gradlew $GRADLE_OPTIONS --info :instrumentation:${{ matrix.modules }}:verifyInstrumentation


### PR DESCRIPTION
### Overview
Some libraries are built with Java 11. This cause errors when running the tests with Java 8.

It was not straightforward to use toolchain to run a single module with 11. So changing all tests to run with 11 allows all tests to pass.

### Related Github Issue
#830 
