### PR TITLE
Capping Solr JMX instrumentation

### DIFF
--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -119,6 +119,7 @@ jobs:
         run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
 
   verify-module:
+    name: ${{ matrix.modules }}
     runs-on: ubuntu-latest
     needs: [read-modules, build-agent]
     strategy:

--- a/instrumentation/solr-jmx-7.4.0/build.gradle
+++ b/instrumentation/solr-jmx-7.4.0/build.gradle
@@ -16,7 +16,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.apache.solr:solr-core:[7.4.0,)'
+    passesOnly 'org.apache.solr:solr-core:[7.4.0,9.0.0)'
 
     excludeRegex 'org.apache.solr:solr-core:.*(ALPHA|BETA)+$'
 }


### PR DESCRIPTION
### Overview
Caps the solr-jmx-7.4.0 instrumentation to version 9.0.0 of Solr

### Related Github Issue
#847 

