### PR TITLE
feature(logback-classic): add ability to include stack traces when forwarding logs

### DIFF
--- a/instrumentation/logback-classic-1.2/src/main/java/ch/qos/logback/classic/spi/LoggingEvent_Instrumentation.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/ch/qos/logback/classic/spi/LoggingEvent_Instrumentation.java
@@ -67,7 +67,7 @@ public class LoggingEvent_Instrumentation {
 
         if (applicationLoggingEnabled && isApplicationLoggingForwardingEnabled()) {
             // Record and send LogEvent to New Relic
-            recordNewRelicLogEvent(getFormattedMessage(), timeStamp, level);
+            recordNewRelicLogEvent(getFormattedMessage(), timeStamp, level, throwable);
         }
     }
 

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
@@ -11,6 +11,8 @@ import ch.qos.logback.classic.Level;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.api.agent.NewRelic;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -21,6 +23,7 @@ public class AgentUtil {
     public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
     // Log message attributes
     public static final String MESSAGE = "message";
+    public static final String STACKTRACE = "stacktrace";
     public static final String TIMESTAMP = "timestamp";
     public static final String LOG_LEVEL = "log.level";
     public static final String UNKNOWN = "UNKNOWN";
@@ -36,6 +39,7 @@ public class AgentUtil {
     private static final boolean APP_LOGGING_DEFAULT_ENABLED = true;
     private static final boolean APP_LOGGING_METRICS_DEFAULT_ENABLED = true;
     private static final boolean APP_LOGGING_FORWARDING_DEFAULT_ENABLED = true;
+    private static final boolean APP_LOGGING_FORWARD_STACK_TRACES_ENABLED = false;
     private static final boolean APP_LOGGING_LOCAL_DECORATING_DEFAULT_ENABLED = false;
 
     /**
@@ -45,7 +49,7 @@ public class AgentUtil {
      * @param timeStampMillis log timestamp
      * @param level           log level
      */
-    public static void recordNewRelicLogEvent(String message, long timeStampMillis, Level level) {
+    public static void recordNewRelicLogEvent(String message, long timeStampMillis, Level level, Throwable t) {
         // Bail out and don't create a LogEvent if log message is empty
         if (!message.isEmpty()) {
             HashMap<String, Object> logEventMap = new HashMap<>(DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES);
@@ -56,6 +60,13 @@ public class AgentUtil {
                 logEventMap.put(LOG_LEVEL, UNKNOWN);
             } else {
                 logEventMap.put(LOG_LEVEL, level);
+            }
+
+            if (t != null && isApplicationForwardStackTracesEnabled()) {
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                t.printStackTrace(pw);
+                logEventMap.put(STACKTRACE, sw.toString());
             }
 
             AgentBridge.getAgent().getLogSender().recordLogEvent(logEventMap);
@@ -132,6 +143,15 @@ public class AgentUtil {
      */
     public static boolean isApplicationLoggingForwardingEnabled() {
         return NewRelic.getAgent().getConfig().getValue("application_logging.forwarding.enabled", APP_LOGGING_FORWARDING_DEFAULT_ENABLED);
+    }
+
+    /**
+     * Check if the application_logging forward_stack_traces feature is enabled.
+     *
+     * @return true if enabled, else false
+     */
+    public static boolean isApplicationForwardStackTracesEnabled() {
+        return NewRelic.getAgent().getConfig().getValue("application_logging.forward_stack_traces.enabled", APP_LOGGING_FORWARD_STACK_TRACES_ENABLED);
     }
 
     /**


### PR DESCRIPTION
### Overview
This PR adds the ability to for logback classic log forwarding to include stack traces.

I complied this and included it in one of my apps.

With out the feature flag, the logs have no stack trace just like it is today:
![image](https://user-images.githubusercontent.com/711726/168214106-7be78d41-4287-407b-8629-81a0b2879d87.png)

With the feature flag, the logs now include the stack trace:
![image](https://user-images.githubusercontent.com/711726/168214240-9a5a2b65-4ccd-4c85-a57e-6a2eed2b2acb.png)
![image](https://user-images.githubusercontent.com/711726/168214203-82dde008-4024-49ad-aea9-6d9654b20d66.png)


### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.