### PR TITLE
#827 - CQLParser getOperationAndTableName exception handling

### DIFF
--- a/instrumentation/cassandra-datastax-2.1.2/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
+++ b/instrumentation/cassandra-datastax-2.1.2/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
@@ -7,8 +7,11 @@
 
 package com.nr.agent.instrumentation.cassandra;
 
+import com.newrelic.api.agent.NewRelic;
+
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,9 +44,9 @@ public class CQLParser {
     private static final Pattern CREATE_AGGREGATE_PATTERN = Pattern.compile("^(CREATE\\s+(?:OR\\s+REPLACE\\s+)?AGGREGATE)\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?(?:'|\")?(" + IDENTIFIER_REGEX + ")", FLAGS);
     private static final Pattern DROP_AGGREGATE_PATTERN = Pattern.compile("^(DROP\\s+AGGREGATE)\\s+(?:IF\\s+EXISTS\\s+)?(?:'|\")?(" + IDENTIFIER_REGEX + ")", FLAGS);
     private static final String COMMENT_PATTERN = "/\\*(?:.|[\\r\\n])*?\\*/";
-    
+
     private static final List<Pattern> PATTERNS = new LinkedList<>();
-    
+
     static {
         // The order here is a performance optimization to favor more common queries first
         PATTERNS.add(SELECT_PATTERN);
@@ -66,21 +69,26 @@ public class CQLParser {
     }
 
     public OperationAndTableName getOperationAndTableName(String rawQuery) {
-        rawQuery = rawQuery.replaceAll(COMMENT_PATTERN, "").trim();
+        try {
+            rawQuery = rawQuery.replaceAll(COMMENT_PATTERN, "").trim();
 
-        String operation = null;
-        String tableName = null;
-        for (Pattern pattern : PATTERNS) {
-            Matcher matcher = pattern.matcher(rawQuery);
-            if (matcher.find()) {
-                if (matcher.groupCount() >= 1) {
-                    operation = matcher.group(1);
+            String operation = null;
+            String tableName = null;
+            for (Pattern pattern : PATTERNS) {
+                Matcher matcher = pattern.matcher(rawQuery);
+                if (matcher.find()) {
+                    if (matcher.groupCount() >= 1) {
+                        operation = matcher.group(1);
+                    }
+                    if (matcher.groupCount() == 2) {
+                        tableName = matcher.group(2);
+                    }
+                    return new OperationAndTableName(operation, tableName);
                 }
-                if (matcher.groupCount() == 2) {
-                    tableName = matcher.group(2);
-                }
-                return new OperationAndTableName(operation, tableName);
             }
+        } catch (Exception ex) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name");
+            return null;
         }
         return null;
     }

--- a/instrumentation/cassandra-datastax-2.1.2/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
+++ b/instrumentation/cassandra-datastax-2.1.2/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
@@ -87,7 +87,7 @@ public class CQLParser {
                 }
             }
         } catch (Exception ex) {
-            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name");
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name", ex);
             return null;
         }
         return null;

--- a/instrumentation/cassandra-datastax-3.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
+++ b/instrumentation/cassandra-datastax-3.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
@@ -87,7 +87,7 @@ public class CQLParser {
                 }
             }
         } catch (Exception ex) {
-            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name");
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name", ex);
             return null;
         }
         return null;

--- a/instrumentation/cassandra-datastax-3.8.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
+++ b/instrumentation/cassandra-datastax-3.8.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
@@ -87,7 +87,7 @@ public class CQLParser {
                 }
             }
         } catch (Exception ex) {
-            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name");
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name", ex);
             return null;
         }
         return null;

--- a/instrumentation/cassandra-datastax-4.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
+++ b/instrumentation/cassandra-datastax-4.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
@@ -87,7 +87,7 @@ public class CQLParser {
                 }
             }
         } catch (Exception ex) {
-            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name");
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name", ex);
             return null;
         }
         return null;

--- a/instrumentation/cassandra-datastax-4.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
+++ b/instrumentation/cassandra-datastax-4.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
@@ -66,21 +66,25 @@ public class CQLParser {
     }
 
     public OperationAndTableName getOperationAndTableName(String rawQuery) {
-        rawQuery = rawQuery.replaceAll(COMMENT_PATTERN, "").trim();
+        try {
+            rawQuery = rawQuery.replaceAll(COMMENT_PATTERN, "").trim();
 
-        String operation = null;
-        String tableName = null;
-        for (Pattern pattern : PATTERNS) {
-            Matcher matcher = pattern.matcher(rawQuery);
-            if (matcher.find()) {
-                if (matcher.groupCount() >= 1) {
-                    operation = matcher.group(1);
+            String operation = null;
+            String tableName = null;
+            for (Pattern pattern : PATTERNS) {
+                Matcher matcher = pattern.matcher(rawQuery);
+                if (matcher.find()) {
+                    if (matcher.groupCount() >= 1) {
+                        operation = matcher.group(1);
+                    }
+                    if (matcher.groupCount() == 2) {
+                        tableName = matcher.group(2);
+                    }
+                    return new OperationAndTableName(operation, tableName);
                 }
-                if (matcher.groupCount() == 2) {
-                    tableName = matcher.group(2);
-                }
-                return new OperationAndTableName(operation, tableName);
             }
+        } catch (Exception ex) {
+            return null;
         }
         return null;
     }

--- a/instrumentation/cassandra-datastax-4.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
+++ b/instrumentation/cassandra-datastax-4.0.0/src/main/java/com/nr/agent/instrumentation/cassandra/CQLParser.java
@@ -7,8 +7,11 @@
 
 package com.nr.agent.instrumentation.cassandra;
 
+import com.newrelic.api.agent.NewRelic;
+
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,6 +87,7 @@ public class CQLParser {
                 }
             }
         } catch (Exception ex) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Exception getting operation and table name");
             return null;
         }
         return null;


### PR DESCRIPTION
### Overview
Capture and ignore exceptions in the CQLParser getOperationAndTableName method used by Cassandra 4.x to address https://github.com/newrelic/newrelic-java-agent/issues/827.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/827

### Testing
Ran module unit tests

### Checks

[X] Are your contributions backwards compatible with relevant frameworks and APIs? Yes
[X] Does your code contain any breaking changes? Please describe. No
[X] Does your code introduce any new dependencies? Please describe. No
