### PR TITLE
Preventing Kafka 3.0.0 instrumentation from applying on older versions

### DIFF
--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignor.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignor.java
@@ -1,0 +1,17 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.apache.kafka.clients.consumer.internals;
+
+import com.newrelic.api.agent.weaver.SkipIfPresent;
+
+/**
+ * This class was removed on Kafka 3. So this will prevent the module from applying on older versions.
+ */
+@SkipIfPresent
+public interface PartitionAssignor {
+}


### PR DESCRIPTION
### Overview
The Kafka 3 instrumentation was applying to some older versions.
This PR adds a verification to prevent that.

### Related Github Issue
#711 