### PR TITLE
Update to jfr-daemon 1.8.0

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         transitive = false
     }
     shadowIntoJar("com.newrelic.agent.java:newrelic-module-util-java:2.1")
-    shadowIntoJar("com.newrelic:jfr-daemon:1.7.0")
+    shadowIntoJar("com.newrelic:jfr-daemon:1.8.0")
     shadowIntoJar "org.ow2.asm:asm:$asmVersion"
     shadowIntoJar "org.ow2.asm:asm-tree:$asmVersion"
     shadowIntoJar "org.ow2.asm:asm-commons:$asmVersion"


### PR DESCRIPTION
Update to `jfr-daemon` 1.8.0 to address [CVE-2022-25647](https://github.com/advisories/GHSA-4jrv-ppp4-jm57) with GSON library.

Resolves https://github.com/newrelic/newrelic-java-agent/issues/867