### PR TITLE
Capping version of play and wildfly instrumentation modules

### DIFF
--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -40,8 +40,8 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'com.typesafe.play:play-server_2.12:[2.7.0-M1,)'
-    passesOnly 'com.typesafe.play:play-server_2.11:[2.7.0-M1,)'
+    passesOnly 'com.typesafe.play:play-server_2.12:[2.7.0-M1,2.8.16)'
+    passesOnly 'com.typesafe.play:play-server_2.11:[2.7.0-M1,2.8.16)'
 
     // build snapshots
     excludeRegex '.*-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]{7}$'

--- a/instrumentation/wildfly-8/build.gradle
+++ b/instrumentation/wildfly-8/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.undertow:undertow-servlet:[1.0.0.Alpha19,)'
+    passesOnly 'io.undertow:undertow-servlet:[1.0.0.Alpha19,2.3.0.Alpha1)'
 }
 
 site {


### PR DESCRIPTION
### Overview
New versions of play and wildfly are not being instrumented.
This PR prevents the tests from failing. Follow up tickets will be written.
