### PR TITLE
issue 620 scala illegal access error

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/InstrumentingClassLoader.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/InstrumentingClassLoader.java
@@ -20,14 +20,12 @@ import com.newrelic.agent.deps.org.objectweb.asm.tree.ClassNode;
 import com.newrelic.agent.instrumentation.InstrumentationType;
 import com.newrelic.agent.instrumentation.classmatchers.ScalaTraitMatcher;
 import com.newrelic.agent.instrumentation.context.InstrumentationContext;
-import com.newrelic.agent.instrumentation.custom.ScalaTraitFinalFieldTransformer;
 import com.newrelic.agent.instrumentation.custom.ScalaTraitFinalFieldVisitor;
 import com.newrelic.agent.instrumentation.tracing.Annotation;
 import com.newrelic.agent.instrumentation.tracing.NoticeSqlVisitor;
 import com.newrelic.agent.instrumentation.tracing.TraceClassVisitor;
 import com.newrelic.agent.instrumentation.tracing.TraceDetailsBuilder;
 import com.newrelic.agent.instrumentation.weaver.ClassWeaverService;
-import com.newrelic.agent.instrumentation.weaver.errorhandler.LogAndReturnOriginal;
 import com.newrelic.agent.instrumentation.weaver.preprocessors.AgentPostprocessors;
 import com.newrelic.agent.instrumentation.weaver.preprocessors.AgentPreprocessors;
 import com.newrelic.agent.instrumentation.weaver.preprocessors.TracedWeaveInstrumentationTracker;
@@ -139,11 +137,11 @@ class InstrumentingClassLoader extends WeavingClassLoader {
             classBytes = weaved;
         }
 
-        if (classBytes != null && context.isModified() && !context.getNonFinalFields().isEmpty()) {
+        if (classBytes != null && context.isModified() && !context.getScalaFinalFields().isEmpty()) {
             ClassReader reader = new ClassReader(classBytes);
             ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
             ClassVisitor cv = writer;
-            cv = new ScalaTraitFinalFieldVisitor(cv, context.getNonFinalFields());
+            cv = new ScalaTraitFinalFieldVisitor(cv, context.getScalaFinalFields());
             reader.accept(cv, ClassReader.SKIP_FRAMES);
             classBytes = writer.toByteArray();
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ScalaTraitMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ScalaTraitMatcher.java
@@ -70,7 +70,7 @@ public class ScalaTraitMatcher implements ClassMatchVisitorFactory {
       @Override
       public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
         if(isScalaSource && this.interfaces.size() > 0 && ((access & Opcodes.ACC_FINAL) == Opcodes.ACC_FINAL)) {
-          context.addNonFinalFields(name);
+          context.addScalaFinalField(name);
         }
         return super.visitField(access, name, descriptor, signature, value);
       }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ScalaTraitMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ScalaTraitMatcher.java
@@ -6,6 +6,7 @@ import com.newrelic.agent.instrumentation.context.InstrumentationContext;
 import com.newrelic.weave.utils.WeaveUtils;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.Method;
@@ -64,6 +65,14 @@ public class ScalaTraitMatcher implements ClassMatchVisitorFactory {
       public void visitSource(String source, String debug) {
         super.visitSource(source, debug);
         this.isScalaSource = source.endsWith(".scala");
+      }
+
+      @Override
+      public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+        if(isScalaSource && this.interfaces.size() > 0 && ((access & Opcodes.ACC_FINAL) == Opcodes.ACC_FINAL)) {
+          context.addNonFinalFields(name);
+        }
+        return super.visitField(access, name, descriptor, signature, value);
       }
 
       @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContext.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContext.java
@@ -48,7 +48,7 @@ public class InstrumentationContext implements TraceDetailsList {
     private boolean modified;
     private Multimap<Method, String> weavedMethods;
     private Multimap<Method, String> skipMethods;
-    private Set<String> nonFinalFields;
+    private Set<String> scalaFinalFields;
     private Set<Method> timedMethods;
     private Map<Method, PointCut> oldReflectionStyleInstrumentationMethods;
     private Map<Method, PointCut> oldInvokerStyleInstrumentationMethods;
@@ -123,11 +123,11 @@ public class InstrumentationContext implements TraceDetailsList {
       skipMethods.put(method, owningClass);
     }
 
-    public void addNonFinalFields(String fieldName) {
-      if (nonFinalFields == null) {
-        nonFinalFields = new HashSet<>();
+    public void addScalaFinalField(String fieldName) {
+      if (scalaFinalFields == null) {
+        scalaFinalFields = new HashSet<>();
       }
-      nonFinalFields.add(fieldName);
+      scalaFinalFields.add(fieldName);
     }
 
     public PointCut getOldStylePointCut(Method method) {
@@ -156,8 +156,8 @@ public class InstrumentationContext implements TraceDetailsList {
     return skipMethods == null ? Collections.emptyMap() : skipMethods.asMap();
   }
 
-  public Set<String> getNonFinalFields() {
-      return nonFinalFields == null ? Collections.emptySet() : new HashSet<>(nonFinalFields);
+  public Set<String> getScalaFinalFields() {
+      return scalaFinalFields == null ? Collections.emptySet() : new HashSet<>(scalaFinalFields);
   }
 
   /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContext.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContext.java
@@ -48,6 +48,7 @@ public class InstrumentationContext implements TraceDetailsList {
     private boolean modified;
     private Multimap<Method, String> weavedMethods;
     private Multimap<Method, String> skipMethods;
+    private Set<String> nonFinalFields;
     private Set<Method> timedMethods;
     private Map<Method, PointCut> oldReflectionStyleInstrumentationMethods;
     private Map<Method, PointCut> oldInvokerStyleInstrumentationMethods;
@@ -122,6 +123,12 @@ public class InstrumentationContext implements TraceDetailsList {
       skipMethods.put(method, owningClass);
     }
 
+    public void addNonFinalFields(String fieldName) {
+      if (nonFinalFields == null) {
+        nonFinalFields = new HashSet<>();
+      }
+      nonFinalFields.add(fieldName);
+    }
 
     public PointCut getOldStylePointCut(Method method) {
         PointCut pc = getOldInvokerStyleInstrumentationMethods().get(method);
@@ -147,6 +154,10 @@ public class InstrumentationContext implements TraceDetailsList {
 
   public Map<Method, Collection<String>> getSkipMethods() {
     return skipMethods == null ? Collections.emptyMap() : skipMethods.asMap();
+  }
+
+  public Set<String> getNonFinalFields() {
+      return nonFinalFields == null ? Collections.emptySet() : new HashSet<>(nonFinalFields);
   }
 
   /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
@@ -16,6 +16,7 @@ import com.newrelic.agent.instrumentation.ClassNameFilter;
 import com.newrelic.agent.instrumentation.api.ApiImplementationUpdate;
 import com.newrelic.agent.instrumentation.classmatchers.ScalaTraitMatcher;
 import com.newrelic.agent.instrumentation.classmatchers.TraceLambdaVisitor;
+import com.newrelic.agent.instrumentation.custom.ScalaTraitFinalFieldTransformer;
 import com.newrelic.agent.instrumentation.ejb3.EJBAnnotationVisitor;
 import com.newrelic.agent.instrumentation.tracing.TraceClassTransformer;
 import com.newrelic.agent.instrumentation.weaver.ClassLoaderClassTransformer;
@@ -68,7 +69,7 @@ public class InstrumentationContextManager {
         this.classWeaverService = new ClassWeaverService(instrumentation);
 
         // these matchers only modify the InstrumentationContext, they don't actually transform classes
-        matchVisitors.put(new ScalaTraitMatcher(), NO_OP_TRANSFORMER);
+        matchVisitors.put(new ScalaTraitMatcher(), new ScalaTraitFinalFieldTransformer());
         matchVisitors.put(new TraceMatchVisitor(), NO_OP_TRANSFORMER);
         matchVisitors.put(new GeneratedClassDetector(), NO_OP_TRANSFORMER);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
@@ -16,7 +16,6 @@ import com.newrelic.agent.instrumentation.ClassNameFilter;
 import com.newrelic.agent.instrumentation.api.ApiImplementationUpdate;
 import com.newrelic.agent.instrumentation.classmatchers.ScalaTraitMatcher;
 import com.newrelic.agent.instrumentation.classmatchers.TraceLambdaVisitor;
-import com.newrelic.agent.instrumentation.custom.ScalaTraitFinalFieldTransformer;
 import com.newrelic.agent.instrumentation.ejb3.EJBAnnotationVisitor;
 import com.newrelic.agent.instrumentation.tracing.TraceClassTransformer;
 import com.newrelic.agent.instrumentation.weaver.ClassLoaderClassTransformer;
@@ -69,7 +68,7 @@ public class InstrumentationContextManager {
         this.classWeaverService = new ClassWeaverService(instrumentation);
 
         // these matchers only modify the InstrumentationContext, they don't actually transform classes
-        matchVisitors.put(new ScalaTraitMatcher(), new ScalaTraitFinalFieldTransformer());
+        matchVisitors.put(new ScalaTraitMatcher(), NO_OP_TRANSFORMER);
         matchVisitors.put(new TraceMatchVisitor(), NO_OP_TRANSFORMER);
         matchVisitors.put(new GeneratedClassDetector(), NO_OP_TRANSFORMER);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/custom/ScalaTraitFinalFieldTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/custom/ScalaTraitFinalFieldTransformer.java
@@ -28,15 +28,15 @@ public class ScalaTraitFinalFieldTransformer implements ContextClassTransformer 
   private byte[] doTransform(ClassLoader loader, String className, Class<?> classBeingRedefined,
                              ProtectionDomain protectionDomain, byte[] classfileBuffer, InstrumentationContext context) {
 
-    if (context.getNonFinalFields().isEmpty()) {
+    if (context.getScalaFinalFields().isEmpty()) {
       return null;
     }
 
     LOG.debug("Instrumenting class " + className);
     ClassReader reader = new ClassReader(classfileBuffer);
-    ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+    ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
     ClassVisitor cv = writer;
-    cv = new ScalaTraitFinalFieldVisitor(cv, context.getNonFinalFields());
+    cv = new ScalaTraitFinalFieldVisitor(cv, context.getScalaFinalFields());
     reader.accept(cv, ClassReader.SKIP_FRAMES);
 
     return writer.toByteArray();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/custom/ScalaTraitFinalFieldTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/custom/ScalaTraitFinalFieldTransformer.java
@@ -1,0 +1,44 @@
+package com.newrelic.agent.instrumentation.custom;
+
+import com.newrelic.agent.instrumentation.classmatchers.OptimizedClassMatcher;
+import com.newrelic.agent.instrumentation.context.ContextClassTransformer;
+import com.newrelic.agent.instrumentation.context.InstrumentationContext;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import java.util.logging.Level;
+
+import static com.newrelic.agent.Agent.LOG;
+
+public class ScalaTraitFinalFieldTransformer implements ContextClassTransformer {
+  @Override
+  public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer, InstrumentationContext context, OptimizedClassMatcher.Match match) throws IllegalClassFormatException {
+    try {
+      return doTransform(loader, className, classBeingRedefined, protectionDomain, classfileBuffer, context);
+    } catch (Throwable t) {
+      LOG.log(Level.FINE, "Unable to transform class " + className, t);
+      return null;
+    }
+  }
+
+
+  private byte[] doTransform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                             ProtectionDomain protectionDomain, byte[] classfileBuffer, InstrumentationContext context) {
+
+    if (context.getNonFinalFields().isEmpty()) {
+      return null;
+    }
+
+    LOG.debug("Instrumenting class " + className);
+    ClassReader reader = new ClassReader(classfileBuffer);
+    ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+    ClassVisitor cv = writer;
+    cv = new ScalaTraitFinalFieldVisitor(cv, context.getNonFinalFields());
+    reader.accept(cv, ClassReader.SKIP_FRAMES);
+
+    return writer.toByteArray();
+  }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/custom/ScalaTraitFinalFieldVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/custom/ScalaTraitFinalFieldVisitor.java
@@ -1,0 +1,25 @@
+package com.newrelic.agent.instrumentation.custom;
+
+import com.newrelic.weave.utils.WeaveUtils;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.util.Set;
+
+public class ScalaTraitFinalFieldVisitor extends ClassVisitor {
+  private final Set<String> finalFieldNames;
+
+  public ScalaTraitFinalFieldVisitor(ClassVisitor cv,  Set<String> finalFieldNames) {
+    super(WeaveUtils.ASM_API_LEVEL, cv);
+    this.finalFieldNames = finalFieldNames;
+  }
+
+  @Override
+  public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+    if(finalFieldNames.contains(name)) {
+      access &= ~Opcodes.ACC_FINAL;
+    }
+    return super.visitField(access, name, descriptor, signature, value);
+  }
+}

--- a/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
+++ b/newrelic-weaver-scala/src/test/scala/com/nr/weave/weavepackage/language/scala/ScalaAdapterTest.scala
@@ -16,7 +16,7 @@ import com.newrelic.test.marker.{Java11IncompatibleTest, Java12IncompatibleTest,
 
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("com.nr.weave.weavepackage.language.scala.weaveclasses."))
-@Category(Array(classOf[Java11IncompatibleTest],classOf[Java12IncompatibleTest],classOf[Java13IncompatibleTest],
+@Category(Array(classOf[Java12IncompatibleTest],classOf[Java13IncompatibleTest],
   classOf[Java14IncompatibleTest],classOf[Java15IncompatibleTest],classOf[Java16IncompatibleTest], classOf[Java17IncompatibleTest],
   classOf[Java18IncompatibleTest]))
 class ScalaAdapterTest {
@@ -50,6 +50,10 @@ class ScalaAdapterTest {
     Assert.assertEquals("weaved-ChildNonWeaveTrait", multipleOverridingNonWeaved.traitmethod())
   }
 
+  @Test
+  def weaveChildObjectWithTraitField() {
+    Assert.assertEquals("weaved-other-method", new ChildFieldClass().otherMethod())
+  }
 }
 
 object ScalaAdapterTest {
@@ -94,6 +98,15 @@ package testclasses {
   class MultipleOverridingNonWeaved extends ChildWeaveTrait with ChildNonWeaveTrait
   class MultipleOverridingWeaved extends ChildNonWeaveTrait with ChildWeaveTrait
 
+  trait FieldTrait {
+    val finalField: String = "field-name"
+    var nonFinalField: String = "non-final-field"
+    def otherMethod(): String = "other-method"
+  }
+
+  trait ChildFieldTrait  extends FieldTrait
+  class ChildFieldClass extends ChildFieldTrait
+
 }
 
 package weaveclasses {
@@ -121,6 +134,11 @@ package weaveclasses {
     def traitmethod(): String = {
       "weaved"+Weaver.callOriginal()
     }
+  }
+
+  @ScalaWeave(originalName="com.nr.weave.weavepackage.language.scala.testclasses.FieldTrait", `type`=ScalaMatchType.Trait)
+  class FieldTraitWeave {
+    def otherMethod(): String = "weaved-"+Weaver.callOriginal()
   }
 
   @ScalaWeave(originalName="com.nr.weave.weavepackage.language.scala.testclasses.ChildWeaveTrait", `type`=ScalaMatchType.Trait)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
This PR fixes issue #620 where an Illegal Access Exception was being thrown from apps using NR agent with scala 2.12 and Java 11. The issue is related to  https://github.com/scala/scala-dev/issues/408 where a scala trait has a `val` field and synthetic setter methods in the trait are called by implementing child class breaking a constraint set in the JMM in JDK 9+. 
The workarround for this is similar to  scala 2.13 where the trait field is marked as not final in the bytecode. 

### Related Github Issue #620 

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ Y ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ N ] Does your code contain any breaking changes? Please describe. 
[ N ] Does your code introduce any new dependencies? Please describe.
