### PR TITLE
Capping r2dbc-h2 instrumentation module

### DIFF
--- a/instrumentation/r2dbc-h2/build.gradle
+++ b/instrumentation/r2dbc-h2/build.gradle
@@ -10,7 +10,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.r2dbc:r2dbc-h2:[0,)'
+    passesOnly 'io.r2dbc:r2dbc-h2:[0,1.0.0.RC1)'
 }
 
 site {


### PR DESCRIPTION
### Overview
r2dbc-h2 released version 1.0.0.RC1 and it broke the verify instrumentation for our instrumentation module.
This PR caps our instrumentation module.