### PR TITLE
impelementation jakarta jax-rs

### DIFF
--- a/instrumentation/jax-rs-1.0/build.gradle
+++ b/instrumentation/jax-rs-1.0/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation(project(":agent-bridge"))
-    implementation("javax.ws.rs:javax.ws.rs-api:2.1")
+    implementation("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
 
     testImplementation("org.glassfish.jersey.containers:jersey-container-servlet:2.16")
     testImplementation("org.glassfish.jersey.test-framework:jersey-test-framework-core:2.16")


### PR DESCRIPTION
Jakarta EE 8 doesn't change functionality or package names, it only publishes the artifacts under new jakarta maven coordinates.

In theory our instrumentation should still compile and function properly when updated to use the jakarta 8 dependencies as the package names and code that we instrument haven't changed.

For existing instrumentation that has dependencies on the various javax.* packages we'll need to update them to use the Jakarta 8 EE version of the dependency and verify that the modules still compile and that all tests still pass.

 

jax-rs-1.0

Dependencies to use:
// https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api
implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0
Success Criteria
Existing instrumentation module successfully compiles and passes tests when using the Jakarta EE 8 maven artifacts.