### PR TITLE
Capping r2dbc-mariadb

### DIFF
--- a/instrumentation/r2dbc-mariadb/build.gradle
+++ b/instrumentation/r2dbc-mariadb/build.gradle
@@ -10,7 +10,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.mariadb:r2dbc-mariadb:[1.0.2,)'
+    passesOnly 'org.mariadb:r2dbc-mariadb:[1.0.2,1.1.2)'
     excludeRegex(".*(alpha|beta|rc).*")
 }
 


### PR DESCRIPTION
### Overview
r2dbc-mariadb instrumentation module fails to apply to version 1.1.2 of the artifact.
Capping the checked versions in verify instrumentation to prevent further errors.
A ticket has been filed.
