### PR TITLE
update dependencies for jersey-client-2.26

### DIFF
--- a/instrumentation/jersey-client-2.26/build.gradle
+++ b/instrumentation/jersey-client-2.26/build.gradle
@@ -1,9 +1,10 @@
 dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-api"))
-    implementation("org.glassfish.jersey.core:jersey-client:2.26")
-    testImplementation("org.glassfish.jersey.inject:jersey-hk2:2.26")
-    testImplementation("org.glassfish.jersey.core:jersey-common:2.26")
+    implementation("org.glassfish.jersey.core:jersey-client:3.0.5")
+    testImplementation("org.glassfish.jersey.inject:jersey-hk2:3.0.5")
+    testImplementation("org.glassfish.jersey.core:jersey-common:3.0.5")
+
 }
 
 jar {


### PR DESCRIPTION
Jakarta EE 8 doesn't change functionality or package names, it only publishes the artifacts under new jakarta maven coordinates.

In theory our instrumentation should still compile and function properly when updated to use the jakarta 8 dependencies as the package names and code that we instrument haven't changed.

For existing instrumentation that has dependencies on the various javax.* packages we'll need to update them to use the Jakarta 8 EE version of the dependency and verify that the modules still compile and that all tests still pass.

 

jersey-client-2.26

Dependencies to use:
implementation("org.glassfish.jersey.core:jersey-client:3.0.5")
testImplementation("org.glassfish.jersey.inject:jersey-hk2:3.0.5")
testImplementation("org.glassfish.jersey.core:jersey-common:3.0.5")
https://projects.eclipse.org/projects/ee4j.jersey

https://mvnrepository.com/artifact/org.glassfish.jersey