### PR TITLE
fixed compile deps for jax-rs

### DIFF
--- a/instrumentation/jax-rs-1.0/build.gradle
+++ b/instrumentation/jax-rs-1.0/build.gradle
@@ -2,9 +2,9 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
 
-    testImplementation("org.glassfish.jersey.containers:jersey-container-servlet:2.16")
-    testImplementation("org.glassfish.jersey.test-framework:jersey-test-framework-core:2.16")
-    testImplementation("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:2.16")
+    testImplementation("org.glassfish.jersey.containers:jersey-container-servlet:3.0.5")
+    testImplementation("org.glassfish.jersey.test-framework:jersey-test-framework-core:3.0.5")
+    testImplementation("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:3.0.5")
     testImplementation(project(":instrumentation:jersey-2"))
 }
 


### PR DESCRIPTION
Jakarta EE 8 doesn't change functionality or package names, it only publishes the artifacts under new jakarta maven coordinates.

In theory our instrumentation should still compile and function properly when updated to use the jakarta 8 dependencies as the package names and code that we instrument haven't changed.

For existing instrumentation that has dependencies on the various {*}javax.{*}* packages we'll need to update them to use the Jakarta 8 EE version of the dependency and verify that the modules still compile and that all tests still pass.

 https://issues.newrelic.com/browse/NR-28393