### PR TITLE
jakarta.xml

### DIFF
--- a/functional_test/build.gradle
+++ b/functional_test/build.gradle
@@ -62,8 +62,7 @@ dependencies {
     testImplementation("com.sun.jersey:jersey-core:1.9.1")
     testImplementation("javax.xml:jaxrpc-api:1.1")
 
-    // Removed from the JDK starting in Java 11
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("org.apache.derby:derby:10.10.1.1")
     testImplementation("org.apache.struts:struts-core:1.3.5")

--- a/instrumentation/akka-http-2.11_2.4.5/build.gradle
+++ b/instrumentation/akka-http-2.11_2.4.5/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation(project(":instrumentation:akka-2.2")) { transitive = false }
     testImplementation(project(":instrumentation:scala-2.9.3")) { transitive = false }
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 }
 
 verifyInstrumentation {

--- a/instrumentation/akka-http-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-2.13_10.1.8/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation(project(":instrumentation:akka-2.2")) { transitive = false }
     testImplementation(project(":instrumentation:scala-2.13.0")) { transitive = false }
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 }
 
 verifyInstrumentation {

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testImplementation("com.typesafe.play:play-test_2.11:2.6.13")
     testImplementation("com.typesafe.play:play-java_2.11:2.6.13")
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 }
 
 jar {

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testImplementation("com.typesafe.play:play-test_2.11:2.6.0")
     testImplementation("com.typesafe.play:play-java_2.11:2.6.0")
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 }
 
 jar {

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testImplementation("com.typesafe.play:play-test_2.11:2.7.0-M2")
     testImplementation("com.typesafe.play:play-java_2.11:2.7.0-M2")
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 }
 
 jar {

--- a/instrumentation/spray-http-1.3.1/build.gradle
+++ b/instrumentation/spray-http-1.3.1/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation(project(":instrumentation:akka-2.2")) { transitive = false }
     testImplementation(project(":instrumentation:scala-2.9.3")) { transitive = false }
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
     testImplementation("io.spray:spray-can_2.10:1.3.3")
 
 }

--- a/instrumentation/vertx-web-3.2.0/build.gradle
+++ b/instrumentation/vertx-web-3.2.0/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation("io.vertx:vertx-sql-common:3.2.0")
     testImplementation("io.vertx:vertx-jdbc-client:3.2.0")
     testImplementation("org.hsqldb:hsqldb:2.3.4")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 }
 
 verifyInstrumentation {

--- a/instrumentation/vertx-web-3.3.0/build.gradle
+++ b/instrumentation/vertx-web-3.3.0/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.vertx:vertx-web:3.3.0")
 
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("io.vertx:vertx-web:3.4.2")
     testImplementation("io.vertx:vertx-sql-common:3.4.2")

--- a/instrumentation/vertx-web-3.5.0/build.gradle
+++ b/instrumentation/vertx-web-3.5.0/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.vertx:vertx-web:3.5.0")
 
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("io.vertx:vertx-web:3.5.0")
     testImplementation("io.vertx:vertx-sql-common:3.5.0")

--- a/instrumentation/vertx-web-3.5.1/build.gradle
+++ b/instrumentation/vertx-web-3.5.1/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.vertx:vertx-web:3.5.1")
 
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("io.vertx:vertx-web:3.5.1")
     testImplementation("io.vertx:vertx-sql-common:3.5.1")

--- a/instrumentation/vertx-web-3.5.2/build.gradle
+++ b/instrumentation/vertx-web-3.5.2/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.vertx:vertx-web:3.5.2")
 
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("io.vertx:vertx-web:3.5.2")
     testImplementation("io.vertx:vertx-sql-common:3.5.2")

--- a/instrumentation/vertx-web-3.6.0/build.gradle
+++ b/instrumentation/vertx-web-3.6.0/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.vertx:vertx-web:3.6.0")
 
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("io.vertx:vertx-web:3.7.0")
     testImplementation("io.vertx:vertx-sql-common:3.7.0")

--- a/instrumentation/vertx-web-3.8.0/build.gradle
+++ b/instrumentation/vertx-web-3.8.0/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.vertx:vertx-web:3.8.0")
 
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("io.vertx:vertx-web:3.8.0")
     testImplementation("io.vertx:vertx-sql-common:3.8.0")

--- a/instrumentation/vertx-web-3.8.3/build.gradle
+++ b/instrumentation/vertx-web-3.8.3/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.vertx:vertx-web:3.8.3")
 
     testImplementation("com.jayway.restassured:rest-assured:2.7.0")
-    testImplementation("javax.xml.bind:jaxb-api:2.3.0")
+    testImplementation("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
 
     testImplementation("io.vertx:vertx-web:3.8.3")
     testImplementation("io.vertx:vertx-sql-common:3.8.3")


### PR DESCRIPTION
For existing instrumentation that has dependencies on the various javax.* packages we'll need to update them to use the Jakarta 8 EE version of the dependency and verify that the modules still compile and that all tests still pass.

 

java.xml

Dependencies to use:
https://mvnrepository.com/artifact/jakarta.xml.ws/jakarta.xml.ws-api/2.3.3

This dependency was scattered throughout many different modules.