### PR TITLE
Update to jfr-daemon 1.9.0

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         transitive = false
     }
     shadowIntoJar("com.newrelic.agent.java:newrelic-module-util-java:2.1")
-    shadowIntoJar("com.newrelic:jfr-daemon:1.8.0")
+    shadowIntoJar("com.newrelic:jfr-daemon:1.9.0")
     shadowIntoJar "org.ow2.asm:asm:$asmVersion"
     shadowIntoJar "org.ow2.asm:asm-tree:$asmVersion"
     shadowIntoJar "org.ow2.asm:asm-commons:$asmVersion"


### PR DESCRIPTION
Pulls in the following improvements from the underlying telemetry-sdk:
* Update to telemetry-sdk 0.15.0 to address [CVE-2020-29582](https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/273) with kotlin lib dependencies of okhttp
* Also includes telemetry-sdk 0.14.0 improvement to decrease CPU utilization: [Replace UUID.randomUUID() with a faster implementation](https://github.com/newrelic/newrelic-telemetry-sdk-java/pull/292)