### PR TITLE
Capping r2dbc-mssql version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.prokod.gradle-crossbuild' version '0.12.1' apply false
-    id "org.jetbrains.kotlin.jvm" version "1.3.31" apply false
+    id "org.jetbrains.kotlin.jvm" version "1.6.20" apply false
     id "com.newrelic.gradle-verify-instrumentation-plugin" version "3.2" apply false
     id "com.newrelic.gradle-compatibility-doc-plugin" version "1.1" apply false
 }

--- a/instrumentation/r2dbc-mssql/build.gradle
+++ b/instrumentation/r2dbc-mssql/build.gradle
@@ -9,7 +9,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.r2dbc:r2dbc-mssql:[0.8.0,)'
+    passesOnly 'io.r2dbc:r2dbc-mssql:[0.8.0,1.0.0.RC1)'
 }
 
 site {

--- a/instrumentation/spring-3.0.0/build.gradle
+++ b/instrumentation/spring-3.0.0/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation("org.springframework:spring-context:3.0.0.RELEASE")
     implementation("org.springframework:spring-web:3.0.0.RELEASE")
-    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.31")
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.20")
 }
 
 jar {

--- a/instrumentation/spring-4.0.0/build.gradle
+++ b/instrumentation/spring-4.0.0/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation("org.springframework:spring-context:4.0.0.RELEASE")
     implementation("org.springframework:spring-web:4.0.0.RELEASE")
-    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.31")
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.20")
 }
 
 jar {

--- a/instrumentation/spring-4.2.0/build.gradle
+++ b/instrumentation/spring-4.2.0/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation("org.springframework:spring-context:4.2.0.RELEASE")
     implementation("org.springframework:spring-web:4.2.0.RELEASE")
-    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.31")
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.20")
 }
 
 jar {

--- a/instrumentation/spring-4.3.0/build.gradle
+++ b/instrumentation/spring-4.3.0/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation("org.springframework:spring-context:4.3.0.RELEASE")
     implementation("org.springframework:spring-web:4.3.0.RELEASE")
-    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.31")
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.20")
 }
 
 jar {


### PR DESCRIPTION
### Overview
r2dbc-mssql stopped applying with the new RC just released. Capping the version to prevent future errors in verify instrumentation.
