### PR TITLE
Fix DT headers not being added on requests made with HttpUrlConnection

### DIFF
--- a/functional_test/src/test/java/com/newrelic/agent/instrumentation/pointcuts/net/HttpURLConnectionTest.java
+++ b/functional_test/src/test/java/com/newrelic/agent/instrumentation/pointcuts/net/HttpURLConnectionTest.java
@@ -255,7 +255,7 @@ public class HttpURLConnectionTest {
         String testClass = "com.newrelic.agent.instrumentation.pointcuts.net.HttpURLConnectionTest";
         String scope = format("OtherTransaction/Custom/{0}/run3", testClass);
 
-        verifyMetrics("example.com", scope, 2, 0, 0, 1);
+        verifyMetrics("example.com", scope, 3, 0, 0, 1);
     }
 
     @Trace(dispatcher = true)
@@ -363,7 +363,7 @@ public class HttpURLConnectionTest {
         String testClass = "com.newrelic.agent.instrumentation.pointcuts.net.HttpURLConnectionTest";
         String scope = format("OtherTransaction/Custom/{0}/run7", testClass);
 
-        verifyMetrics("example.com", scope, 2, 0, 0, 1);
+        verifyMetrics("example.com", scope, 3, 0, 0, 1);
     }
 
     @Trace(dispatcher = true)
@@ -393,7 +393,7 @@ public class HttpURLConnectionTest {
         String testClass = "com.newrelic.agent.instrumentation.pointcuts.net.HttpURLConnectionTest";
         String scope = format("OtherTransaction/Custom/{0}/run8", testClass);
 
-        verifyMetrics("example.com", scope, 2, 0, 0, 1);
+        verifyMetrics("example.com", scope, 3, 0, 0, 1);
     }
 
     @Trace(dispatcher = true)
@@ -422,7 +422,7 @@ public class HttpURLConnectionTest {
         String testClass = "com.newrelic.agent.instrumentation.pointcuts.net.HttpURLConnectionTest";
         String scope = format("OtherTransaction/Custom/{0}/run9", testClass);
 
-        verifyMetrics("example.com", scope, 1, 0, 0, 1);
+        verifyMetrics("example.com", scope, 2, 0, 0, 1);
     }
 
     @Trace(dispatcher = true)

--- a/functional_test/src/test/java/test/newrelic/test/agent/HttpCommonsTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/HttpCommonsTest.java
@@ -65,13 +65,13 @@ public class HttpCommonsTest {
         httpURLConnectionTx();
 
         Set<String> metrics = AgentHelper.getMetrics();
-        assertTrue(metrics.toString(), metrics.contains("External/" + HOST + "/HttpURLConnection/getResponseCode"));
+        assertTrue(metrics.toString(), metrics.contains("External/" + HOST + "/HttpURLConnection"));
 
         Map<String, Integer> metricCounts = getMetricCounts(
-                MetricName.create("External/" + HOST + "/HttpURLConnection/getResponseCode",
+                MetricName.create("External/" + HOST + "/HttpURLConnection",
                         "OtherTransaction/Custom/test.newrelic.test.agent.HttpCommonsTest/httpURLConnectionTx"));
 
-        assertEquals(1, (int) metricCounts.get("External/" + HOST + "/HttpURLConnection/getResponseCode"));
+        assertEquals(1, (int) metricCounts.get("External/" + HOST + "/HttpURLConnection"));
     }
 
     @Trace(dispatcher = true)

--- a/instrumentation/httpurlconnection/src/main/java/java/net/HttpURLConnection.java
+++ b/instrumentation/httpurlconnection/src/main/java/java/net/HttpURLConnection.java
@@ -73,7 +73,7 @@ public abstract class HttpURLConnection extends URLConnection {
         return inputStream;
     }
 
-    @Trace(leaf = true)
+    @Trace
     public int getResponseCode() throws Exception {
         MetricState metricState = lazyGetMetricState();
         TracedMethod method = AgentBridge.getAgent().getTracedMethod();


### PR DESCRIPTION
### Overview
A customer was having trouble linking two applications using HttpUrlConnection on a RSClient created by JAXRSClientFactory.
The problem was that the client calls `getResponseCode` on the `HttpUrlConnection` which in turn calls `getInputStream`.
Our instrumentation instruments both methods, and both have `@Trace(leaf = true)`.

The part of the instrumentation that would add the headers in this case is in `getInputStream`. But before adding the headers, it check if the tracer is metric producer. In this case, since the tracer in `getResponseCode` is a leaf, `getInputStream` will get a `NoOpTracer` (which is not a metric producer). And thus the headers will not be added.

### Related Issue
NR-19683
