### PR TITLE
Add error and thread attributes to log4j2 and logback1.2 logs

### DIFF
--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AgentUtil {
-    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 7;
+    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 10;
     // Log message attributes
     public static final String MESSAGE = "message";
     public static final String TIMESTAMP = "timestamp";
@@ -29,6 +29,9 @@ public class AgentUtil {
     public static final String ERROR_CLASS = "error.class";
     public static final String ERROR_STACK = "error.stack";
     public static final String THREAD_NAME = "thread.name";
+    public static final String THREAD_ID = "thread.id";
+    public static final String LOGGER_NAME = "logger.name";
+    public static final String LOGGER_FQCN = "logger.fqcn";
     public static final String UNKNOWN = "UNKNOWN";
 
     // Linking metadata attributes used in blob
@@ -90,6 +93,18 @@ public class AgentUtil {
                     String threadName = event.getThreadName();
                     if (threadName != null) {
                         logEventMap.put(THREAD_NAME, threadName);
+                    }
+
+                    logEventMap.put(THREAD_ID, event.getThreadId());
+
+                    String loggerName = event.getLoggerName();
+                    if (loggerName != null) {
+                        logEventMap.put(LOGGER_NAME, loggerName);
+                    }
+
+                    String loggerFqcn = event.getLoggerFqcn();
+                    if (loggerFqcn != null) {
+                        logEventMap.put(LOGGER_FQCN, loggerFqcn);
                     }
 
                     AgentBridge.getAgent().getLogSender().recordLogEvent(logEventMap);

--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
@@ -56,61 +56,74 @@ public class AgentUtil {
     public static void recordNewRelicLogEvent(LogEvent event) {
         if (event != null) {
             Message message = event.getMessage();
-            if (message != null) {
-                String formattedMessage = message.getFormattedMessage();
-                // Bail out and don't create a LogEvent if log message is empty
-                if (formattedMessage != null && !formattedMessage.isEmpty()) {
-                    HashMap<String, Object> logEventMap = new HashMap<>(DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES);
-                    logEventMap.put(MESSAGE, formattedMessage);
-                    logEventMap.put(TIMESTAMP, event.getTimeMillis());
+            Throwable throwable = event.getThrown();
 
-                    Level level = event.getLevel();
-                    if (level != null) {
-                        String levelName = level.name();
-                        if (levelName.isEmpty()) {
-                            logEventMap.put(LEVEL, UNKNOWN);
-                        } else {
-                            logEventMap.put(LEVEL, levelName);
-                        }
+            if (shouldCreateLogEvent(message, throwable)) {
+                HashMap<String, Object> logEventMap = new HashMap<>(DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES);
+                if (message != null) {
+                    String formattedMessage = message.getFormattedMessage();
+                    if (formattedMessage != null && !formattedMessage.isEmpty()) {
+                        logEventMap.put(MESSAGE, formattedMessage);
                     }
-
-                    Throwable throwable = event.getThrown();
-                    String errorStack = ExceptionUtil.getErrorStack(throwable);
-                    if (errorStack != null) {
-                        logEventMap.put(ERROR_STACK, errorStack);
-                    }
-
-                    String errorMessage = ExceptionUtil.getErrorMessage(throwable);
-                    if (errorMessage != null) {
-                        logEventMap.put(ERROR_MESSAGE, errorMessage);
-                    }
-
-                    String errorClass = ExceptionUtil.getErrorClass(throwable);
-                    if (errorClass != null) {
-                        logEventMap.put(ERROR_CLASS, errorClass);
-                    }
-
-                    String threadName = event.getThreadName();
-                    if (threadName != null) {
-                        logEventMap.put(THREAD_NAME, threadName);
-                    }
-
-                    logEventMap.put(THREAD_ID, event.getThreadId());
-
-                    String loggerName = event.getLoggerName();
-                    if (loggerName != null) {
-                        logEventMap.put(LOGGER_NAME, loggerName);
-                    }
-
-                    String loggerFqcn = event.getLoggerFqcn();
-                    if (loggerFqcn != null) {
-                        logEventMap.put(LOGGER_FQCN, loggerFqcn);
-                    }
-
-                    AgentBridge.getAgent().getLogSender().recordLogEvent(logEventMap);
                 }
+                logEventMap.put(TIMESTAMP, event.getTimeMillis());
+
+                Level level = event.getLevel();
+                if (level != null) {
+                    String levelName = level.name();
+                    if (levelName.isEmpty()) {
+                        logEventMap.put(LEVEL, UNKNOWN);
+                    } else {
+                        logEventMap.put(LEVEL, levelName);
+                    }
+                }
+
+                String errorStack = ExceptionUtil.getErrorStack(throwable);
+                if (errorStack != null) {
+                    logEventMap.put(ERROR_STACK, errorStack);
+                }
+
+                String errorMessage = ExceptionUtil.getErrorMessage(throwable);
+                if (errorMessage != null) {
+                    logEventMap.put(ERROR_MESSAGE, errorMessage);
+                }
+
+                String errorClass = ExceptionUtil.getErrorClass(throwable);
+                if (errorClass != null) {
+                    logEventMap.put(ERROR_CLASS, errorClass);
+                }
+
+                String threadName = event.getThreadName();
+                if (threadName != null) {
+                    logEventMap.put(THREAD_NAME, threadName);
+                }
+
+                logEventMap.put(THREAD_ID, event.getThreadId());
+
+                String loggerName = event.getLoggerName();
+                if (loggerName != null) {
+                    logEventMap.put(LOGGER_NAME, loggerName);
+                }
+
+                String loggerFqcn = event.getLoggerFqcn();
+                if (loggerFqcn != null) {
+                    logEventMap.put(LOGGER_FQCN, loggerFqcn);
+                }
+
+                AgentBridge.getAgent().getLogSender().recordLogEvent(logEventMap);
             }
         }
+    }
+
+    /**
+     * A LogEvent MUST NOT be reported if neither a log message nor an error is logged. If either is present report the LogEvent.
+     *
+     * @param message   Message to validate
+     * @param throwable Throwable to validate
+     * @return true if a LogEvent should be created, otherwise false
+     */
+    private static boolean shouldCreateLogEvent(Message message, Throwable throwable) {
+        return (message != null) || !ExceptionUtil.isThrowableNull(throwable);
     }
 
     /**

--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/ExceptionUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/ExceptionUtil.java
@@ -1,0 +1,48 @@
+package com.nr.agent.instrumentation.log4j2;
+
+public class ExceptionUtil {
+    public static final int MAX_STACK_SIZE = 500;
+
+    public static boolean isThrowableNull(Throwable throwable) {
+        return throwable == null;
+    }
+
+    public static String getErrorStack(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+
+        StackTraceElement[] stack = throwable.getStackTrace();
+        return getErrorStack(stack);
+    }
+
+    public static String getErrorStack(StackTraceElement[] stack) {
+        return getErrorStack(stack, MAX_STACK_SIZE);
+    }
+
+    public static String getErrorStack(StackTraceElement[] stack, Integer maxStackSize) {
+        if (stack == null || stack.length == 0) {
+            return null;
+        }
+
+        StringBuilder stackBuilder = new StringBuilder();
+        for (int i = 0; i < Math.min(maxStackSize, stack.length); i++) {
+            stackBuilder.append("  at ").append(stack[i].toString()).append("\n");
+        }
+        return stackBuilder.toString();
+    }
+
+    public static String getErrorMessage(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+        return throwable.getMessage();
+    }
+
+    public static String getErrorClass(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+        return throwable.getClass().getName();
+    }
+}

--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/ExceptionUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/ExceptionUtil.java
@@ -1,7 +1,7 @@
 package com.nr.agent.instrumentation.log4j2;
 
 public class ExceptionUtil {
-    public static final int MAX_STACK_SIZE = 500;
+    public static final int MAX_STACK_SIZE = 300;
 
     public static boolean isThrowableNull(Throwable throwable) {
         return throwable == null;

--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/ExceptionUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/ExceptionUtil.java
@@ -26,7 +26,8 @@ public class ExceptionUtil {
         }
 
         StringBuilder stackBuilder = new StringBuilder();
-        for (int i = 0; i < Math.min(maxStackSize, stack.length); i++) {
+        int stackSizeLimit = Math.min(maxStackSize, stack.length);
+        for (int i = 0; i < stackSizeLimit; i++) {
             stackBuilder.append("  at ").append(stack[i].toString()).append("\n");
         }
         return stackBuilder.toString();

--- a/instrumentation/apache-log4j-2/src/test/java/com/nr/agent/instrumentation/log4j2/ExceptionUtilTest.java
+++ b/instrumentation/apache-log4j-2/src/test/java/com/nr/agent/instrumentation/log4j2/ExceptionUtilTest.java
@@ -1,0 +1,61 @@
+package com.nr.agent.instrumentation.log4j2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExceptionUtilTest {
+
+    @Test
+    public void testIsThrowableNull() {
+        Throwable nullThrowable = null;
+        Throwable nonNullThrowable = new Throwable("Hi");
+
+        assertTrue(ExceptionUtil.isThrowableNull(nullThrowable));
+        assertFalse(ExceptionUtil.isThrowableNull(nonNullThrowable));
+    }
+
+    @Test
+    public void testGetErrorStack() {
+        int maxStackSize = 3;
+        StackTraceElement stackTraceElement1 = new StackTraceElement("Class1", "method1", "File1", 1);
+        StackTraceElement stackTraceElement2 = new StackTraceElement("Class2", "method2", "File2", 2);
+        StackTraceElement stackTraceElement3 = new StackTraceElement("Class3", "method3", "File3", 3);
+        StackTraceElement stackTraceElement4 = new StackTraceElement("Class4", "method4", "File4", 4);
+        StackTraceElement stackTraceElement5 = new StackTraceElement("Class5", "method5", "File5", 5);
+        StackTraceElement[] stack = new StackTraceElement[] { stackTraceElement1, stackTraceElement2, stackTraceElement3, stackTraceElement4,
+                stackTraceElement5 };
+        String errorStack = ExceptionUtil.getErrorStack(stack, maxStackSize);
+
+        // Processed stack should be limited to only the first three lines
+        assertTrue(errorStack.contains(stackTraceElement1.toString()));
+        assertTrue(errorStack.contains(stackTraceElement2.toString()));
+        assertTrue(errorStack.contains(stackTraceElement3.toString()));
+        // Processed stack should omit the last two lines
+        assertFalse(errorStack.contains(stackTraceElement4.toString()));
+        assertFalse(errorStack.contains(stackTraceElement5.toString()));
+    }
+
+    @Test
+    public void testGetErrorMessage() {
+        String expectedMessage = "Hi";
+        Throwable nullThrowable = null;
+        Throwable nonNullThrowable = new Throwable(expectedMessage);
+
+        assertNull(ExceptionUtil.getErrorMessage(nullThrowable));
+        assertEquals(expectedMessage, ExceptionUtil.getErrorMessage(nonNullThrowable));
+    }
+
+    @Test
+    public void testGetErrorClass() {
+        String expectedExceptionClass = "java.lang.RuntimeException";
+        Throwable nullThrowable = null;
+        RuntimeException runtimeException = new RuntimeException("Hi");
+
+        assertNull(ExceptionUtil.getErrorClass(nullThrowable));
+        assertEquals(expectedExceptionClass, ExceptionUtil.getErrorClass(runtimeException));
+    }
+}

--- a/instrumentation/logback-classic-1.2/src/main/java/ch/qos/logback/classic/spi/LoggingEvent_Instrumentation.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/ch/qos/logback/classic/spi/LoggingEvent_Instrumentation.java
@@ -64,10 +64,11 @@ public class LoggingEvent_Instrumentation {
         }
 
         timeStamp = System.currentTimeMillis();
+        String currentThreadName = (Thread.currentThread()).getName();
 
         if (applicationLoggingEnabled && isApplicationLoggingForwardingEnabled()) {
             // Record and send LogEvent to New Relic
-            recordNewRelicLogEvent(getFormattedMessage(), timeStamp, level);
+            recordNewRelicLogEvent(getFormattedMessage(), timeStamp, level, throwable, currentThreadName);
         }
     }
 

--- a/instrumentation/logback-classic-1.2/src/main/java/ch/qos/logback/classic/spi/LoggingEvent_Instrumentation.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/ch/qos/logback/classic/spi/LoggingEvent_Instrumentation.java
@@ -64,11 +64,14 @@ public class LoggingEvent_Instrumentation {
         }
 
         timeStamp = System.currentTimeMillis();
-        String currentThreadName = (Thread.currentThread()).getName();
+
+        Thread thread = Thread.currentThread();
+        String threadName = thread.getName();
+        long threadId = thread.getId();
 
         if (applicationLoggingEnabled && isApplicationLoggingForwardingEnabled()) {
             // Record and send LogEvent to New Relic
-            recordNewRelicLogEvent(getFormattedMessage(), timeStamp, level, throwable, currentThreadName);
+            recordNewRelicLogEvent(getFormattedMessage(), timeStamp, level, throwable, threadName, threadId, loggerName, fqnOfLoggerClass);
         }
     }
 

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AgentUtil {
-    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 7;
+    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 10;
     // Log message attributes
     public static final String MESSAGE = "message";
     public static final String TIMESTAMP = "timestamp";
@@ -27,6 +27,9 @@ public class AgentUtil {
     public static final String ERROR_CLASS = "error.class";
     public static final String ERROR_STACK = "error.stack";
     public static final String THREAD_NAME = "thread.name";
+    public static final String THREAD_ID = "thread.id";
+    public static final String LOGGER_NAME = "logger.name";
+    public static final String LOGGER_FQCN = "logger.fqcn";
     public static final String UNKNOWN = "UNKNOWN";
 
     // Linking metadata attributes used in blob
@@ -50,7 +53,8 @@ public class AgentUtil {
      * @param timeStampMillis log timestamp
      * @param level           log level
      */
-    public static void recordNewRelicLogEvent(String message, long timeStampMillis, Level level, Throwable throwable, String threadName) {
+    public static void recordNewRelicLogEvent(String message, long timeStampMillis, Level level, Throwable throwable, String threadName, long threadId,
+            String loggerName, String fqcnLoggerName) {
         // Bail out and don't create a LogEvent if log message is empty
         if (!message.isEmpty()) {
             HashMap<String, Object> logEventMap = new HashMap<>(DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES);
@@ -80,6 +84,16 @@ public class AgentUtil {
 
             if (threadName != null) {
                 logEventMap.put(THREAD_NAME, threadName);
+            }
+
+            logEventMap.put(THREAD_ID, threadId);
+
+            if (loggerName != null) {
+                logEventMap.put(LOGGER_NAME, loggerName);
+            }
+
+            if (fqcnLoggerName != null) {
+                logEventMap.put(LOGGER_FQCN, fqcnLoggerName);
             }
 
             AgentBridge.getAgent().getLogSender().recordLogEvent(logEventMap);

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/AgentUtil.java
@@ -18,12 +18,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AgentUtil {
-    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 3;
+    public static final int DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES = 7;
     // Log message attributes
     public static final String MESSAGE = "message";
     public static final String TIMESTAMP = "timestamp";
     public static final String LEVEL = "level";
+    public static final String ERROR_MESSAGE = "error.message";
+    public static final String ERROR_CLASS = "error.class";
+    public static final String ERROR_STACK = "error.stack";
+    public static final String THREAD_NAME = "thread.name";
     public static final String UNKNOWN = "UNKNOWN";
+
     // Linking metadata attributes used in blob
     private static final String BLOB_PREFIX = "NR-LINKING";
     private static final String BLOB_DELIMITER = "|";
@@ -45,7 +50,7 @@ public class AgentUtil {
      * @param timeStampMillis log timestamp
      * @param level           log level
      */
-    public static void recordNewRelicLogEvent(String message, long timeStampMillis, Level level) {
+    public static void recordNewRelicLogEvent(String message, long timeStampMillis, Level level, Throwable throwable, String threadName) {
         // Bail out and don't create a LogEvent if log message is empty
         if (!message.isEmpty()) {
             HashMap<String, Object> logEventMap = new HashMap<>(DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES);
@@ -56,6 +61,25 @@ public class AgentUtil {
                 logEventMap.put(LEVEL, UNKNOWN);
             } else {
                 logEventMap.put(LEVEL, level);
+            }
+
+            String errorStack = ExceptionUtil.getErrorStack(throwable);
+            if (errorStack != null) {
+                logEventMap.put(ERROR_STACK, errorStack);
+            }
+
+            String errorMessage = ExceptionUtil.getErrorMessage(throwable);
+            if (errorMessage != null) {
+                logEventMap.put(ERROR_MESSAGE, errorMessage);
+            }
+
+            String errorClass = ExceptionUtil.getErrorClass(throwable);
+            if (errorClass != null) {
+                logEventMap.put(ERROR_CLASS, errorClass);
+            }
+
+            if (threadName != null) {
+                logEventMap.put(THREAD_NAME, threadName);
             }
 
             AgentBridge.getAgent().getLogSender().recordLogEvent(logEventMap);
@@ -102,7 +126,9 @@ public class AgentUtil {
                 value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
             }
         } catch (UnsupportedEncodingException e) {
-            NewRelic.getAgent().getLogger().log(java.util.logging.Level.WARNING, "Unable to URL encode entity.name for application_logging.local_decorating", e);
+            NewRelic.getAgent()
+                    .getLogger()
+                    .log(java.util.logging.Level.WARNING, "Unable to URL encode entity.name for application_logging.local_decorating", e);
         }
         return value;
     }

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtil.java
@@ -1,0 +1,48 @@
+package com.nr.agent.instrumentation.logbackclassic12;
+
+public class ExceptionUtil {
+    public static final int MAX_STACK_SIZE = 500;
+
+    public static boolean isThrowableNull(Throwable throwable) {
+        return throwable == null;
+    }
+
+    public static String getErrorStack(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+
+        StackTraceElement[] stack = throwable.getStackTrace();
+        return getErrorStack(stack);
+    }
+
+    public static String getErrorStack(StackTraceElement[] stack) {
+        return getErrorStack(stack, MAX_STACK_SIZE);
+    }
+
+    public static String getErrorStack(StackTraceElement[] stack, Integer maxStackSize) {
+        if (stack == null || stack.length == 0) {
+            return null;
+        }
+
+        StringBuilder stackBuilder = new StringBuilder();
+        for (int i = 0; i < Math.min(maxStackSize, stack.length); i++) {
+            stackBuilder.append("  at ").append(stack[i].toString()).append("\n");
+        }
+        return stackBuilder.toString();
+    }
+
+    public static String getErrorMessage(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+        return throwable.getMessage();
+    }
+
+    public static String getErrorClass(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+        return throwable.getClass().getName();
+    }
+}

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtil.java
@@ -26,7 +26,8 @@ public class ExceptionUtil {
         }
 
         StringBuilder stackBuilder = new StringBuilder();
-        for (int i = 0; i < Math.min(maxStackSize, stack.length); i++) {
+        int stackSizeLimit = Math.min(maxStackSize, stack.length);
+        for (int i = 0; i < stackSizeLimit; i++) {
             stackBuilder.append("  at ").append(stack[i].toString()).append("\n");
         }
         return stackBuilder.toString();

--- a/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtil.java
+++ b/instrumentation/logback-classic-1.2/src/main/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtil.java
@@ -1,7 +1,7 @@
 package com.nr.agent.instrumentation.logbackclassic12;
 
 public class ExceptionUtil {
-    public static final int MAX_STACK_SIZE = 500;
+    public static final int MAX_STACK_SIZE = 300;
 
     public static boolean isThrowableNull(Throwable throwable) {
         return throwable == null;

--- a/instrumentation/logback-classic-1.2/src/test/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtilTest.java
+++ b/instrumentation/logback-classic-1.2/src/test/java/com/nr/agent/instrumentation/logbackclassic12/ExceptionUtilTest.java
@@ -1,0 +1,61 @@
+package com.nr.agent.instrumentation.logbackclassic12;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExceptionUtilTest {
+
+    @Test
+    public void testIsThrowableNull() {
+        Throwable nullThrowable = null;
+        Throwable nonNullThrowable = new Throwable("Hi");
+
+        assertTrue(ExceptionUtil.isThrowableNull(nullThrowable));
+        assertFalse(ExceptionUtil.isThrowableNull(nonNullThrowable));
+    }
+
+    @Test
+    public void testGetErrorStack() {
+        int maxStackSize = 3;
+        StackTraceElement stackTraceElement1 = new StackTraceElement("Class1", "method1", "File1", 1);
+        StackTraceElement stackTraceElement2 = new StackTraceElement("Class2", "method2", "File2", 2);
+        StackTraceElement stackTraceElement3 = new StackTraceElement("Class3", "method3", "File3", 3);
+        StackTraceElement stackTraceElement4 = new StackTraceElement("Class4", "method4", "File4", 4);
+        StackTraceElement stackTraceElement5 = new StackTraceElement("Class5", "method5", "File5", 5);
+        StackTraceElement[] stack = new StackTraceElement[] { stackTraceElement1, stackTraceElement2, stackTraceElement3, stackTraceElement4,
+                stackTraceElement5 };
+        String errorStack = ExceptionUtil.getErrorStack(stack, maxStackSize);
+
+        // Processed stack should be limited to only the first three lines
+        assertTrue(errorStack.contains(stackTraceElement1.toString()));
+        assertTrue(errorStack.contains(stackTraceElement2.toString()));
+        assertTrue(errorStack.contains(stackTraceElement3.toString()));
+        // Processed stack should omit the last two lines
+        assertFalse(errorStack.contains(stackTraceElement4.toString()));
+        assertFalse(errorStack.contains(stackTraceElement5.toString()));
+    }
+
+    @Test
+    public void testGetErrorMessage() {
+        String expectedMessage = "Hi";
+        Throwable nullThrowable = null;
+        Throwable nonNullThrowable = new Throwable(expectedMessage);
+
+        assertNull(ExceptionUtil.getErrorMessage(nullThrowable));
+        assertEquals(expectedMessage, ExceptionUtil.getErrorMessage(nonNullThrowable));
+    }
+
+    @Test
+    public void testGetErrorClass() {
+        String expectedExceptionClass = "java.lang.RuntimeException";
+        Throwable nullThrowable = null;
+        RuntimeException runtimeException = new RuntimeException("Hi");
+
+        assertNull(ExceptionUtil.getErrorClass(nullThrowable));
+        assertEquals(expectedExceptionClass, ExceptionUtil.getErrorClass(runtimeException));
+    }
+}


### PR DESCRIPTION
Custom jar with these changes can be downloaded here: https://github.com/newrelic/newrelic-java-agent/actions/runs/2800301113

Waiting on approval of this proposal to update agent specs with these changes: https://source.datanerd.us/agents/agent-specs/pull/579

---

Addresses https://github.com/newrelic/newrelic-java-agent/issues/802

This PR adds the `thread.name`, `thread.id`,  `logger.name`,  `logger.fqcn`, `error.class`, `error.stack`, and `error.message` attributes to log events for the `logback-classic-1.2` and `apache-log4j-2` instrumentation.

Screenshot showing the new log event attributes that this PR adds:

<img width="1349" alt="enhanced-logs" src="https://user-images.githubusercontent.com/3496648/182475333-3fa282ca-3516-46f3-b900-23f1c26197a2.png">
 
This is the result of calling the following Spring controller:

```
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
import org.springframework.stereotype.Controller;
import org.springframework.web.bind.annotation.GetMapping;

import java.util.Arrays;

@Controller
class CrashController {

	private static final Logger LOGGER = LoggerFactory.getLogger(CrashController.class);

	@GetMapping("/oups")
	public String triggerException() {
		RuntimeException runtimeException = new RuntimeException(
			"Expected: controller used to showcase what happens when an exception is thrown");
		LOGGER.error("OH NO!!!!!", runtimeException);
		throw runtimeException;
	}

}
```