### PR TITLE
test platform classloader path for all supported versions

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
@@ -266,9 +266,15 @@ public class ClassLoaderClassTransformer implements ClassMatchVisitorFactory, Co
 
         // Avoid the IBM jvm crasher. See JAVA-1206.
         if (ServiceFactory.getConfigService().getDefaultAgentConfig().getIbmWorkaroundEnabled()) {
-            Agent.LOG.log(Level.FINE,
-                    "ClassLoaderClassTransformer: skipping redefine of {0}. IBM SR {1}. java.runtime.version {2}",
-                    ClassLoader.class.getName(), IBMUtils.getIbmSRNumber(), System.getProperty("java.runtime.version"));
+//            Agent.LOG.log(Level.FINE,
+//                    "ClassLoaderClassTransformer: skipping redefine of {0}. IBM SR {1}. java.runtime.version {2}",
+//                    ClassLoader.class.getName(), IBMUtils.getIbmSRNumber(), System.getProperty("java.runtime.version"));
+            try {
+                Agent.LOG.log(Level.FINER, "IBM WORKAROUND PATH: ClassLoaderClassTransformer: Attempting to redefine {0}", ClassLoader.class);
+                InstrumentationProxy.forceRedefinition(instrumentation, ClassLoader.class);
+            } catch (Exception e) {
+                Agent.LOG.log(Level.FINEST, e, "ClassLoaderClassTransformer: Error redefining {0}", ClassLoader.class.getName());
+            }
         } else {
             try {
                 Agent.LOG.log(Level.FINER, "ClassLoaderClassTransformer: Attempting to redefine {0}", ClassLoader.class);

--- a/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
@@ -165,6 +165,12 @@ public class BootstrapAgent {
             if (System.getProperty("ibm_iv25688_workaround") != null) {
                 ibmWorkaround = Boolean.parseBoolean(System.getProperty("ibm_iv25688_workaround"));
             }
+            //Do not go through IBM workaround and always go through the platform classloader path in order to test against current JVM test suites.
+            //The system class loader path was done in order to workaround some bugs. Those bugs were on IBM jdk versions 6 and 7. The agent no longer supports
+            //6 and 7 obsolete code and we can open up suppport for Openj9 and Semeru
+            //When we go through the System Classloader code path, we never add the AgentBridge...datastore jar to the class path
+            //This causes the RecordSql NoClassDefFound exception
+            ibmWorkaround = false;
 
             ClassLoader classLoader;
             if (ibmWorkaround) {


### PR DESCRIPTION
DO NOT MERGE!!!!!
Create pull request for ease of running tests.


Hypothesis:
            When we go through the System Classloader code path, we never add the AgentBridge...datastore jar to the class path. 
            This causes the RecordSql NoClassDefFound exception
             I believe this was done because of some conflict with java.sql classloader on certain versions(but not fully confirmed).  Regardless, because of current JDK classloaders, I believe this is a completely obsolete workaround. JDK 9+ should be fine to always use platform classloader to add our agent and agent-bridge-datastore classes to the classpath.
JDK will use the bootstrap loader, which is fine. <8  jdks are obsolete anyway.
 
    Do not go through IBM workaround and always go through the platform classloader path in order to test against current JVM test suites.
   The system classloader path was done in order to workaround some bugs. Those bugs were on IBM jdk versions 6 and 7. The agent no longer supports
    6 and 7 obsolete code and we can open up suppport for Openj9 and Semeru
