### PR TITLE
NEWRELIC-3836 remove obsolete ibm workaround - support Semeru/OpenJ9 versions

### DIFF
--- a/functional_test/src/test/java/com/newrelic/agent/instrumentation/ClassLoaderTest.java
+++ b/functional_test/src/test/java/com/newrelic/agent/instrumentation/ClassLoaderTest.java
@@ -10,6 +10,7 @@ package com.newrelic.agent.instrumentation;
 import com.newrelic.agent.Transaction;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
+import com.newrelic.test.marker.IBMJ9IncompatibleTest;
 import com.newrelic.test.marker.Java17IncompatibleTest;
 import com.newrelic.test.marker.Java19IncompatibleTest;
 import org.junit.Assert;
@@ -67,7 +68,7 @@ public class ClassLoaderTest {
 
     // Java 12 no longer lets us access the declared field
     @Test
-    @Category({ Java17IncompatibleTest.class, Java19IncompatibleTest.class })
+    @Category({ IBMJ9IncompatibleTest.class, Java17IncompatibleTest.class, Java19IncompatibleTest.class })
     public void testSetSystemClassLoader() throws Exception {
 
         final ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();

--- a/functional_test/src/test/java/test/newrelic/test/agent/spans/SpanErrorsTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/spans/SpanErrorsTest.java
@@ -11,9 +11,12 @@ import com.google.common.collect.ImmutableMap;
 import com.newrelic.agent.interfaces.SamplingPriorityQueue;
 import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.test.marker.IBMJ9IncompatibleTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Categories;
+import org.junit.experimental.categories.Category;
 import test.newrelic.EnvironmentHolderSettingsGenerator;
 import test.newrelic.test.agent.EnvironmentHolder;
 
@@ -98,6 +101,7 @@ public class SpanErrorsTest {
         ));
     }
 
+    @Category(IBMJ9IncompatibleTest.class)
     @Test
     public void testNoticedErrorOverridesThrownError() {
         runTransaction(new SpanErrorFlow.NoticeAndThrow());

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -142,16 +142,19 @@ test {
     if (project.hasProperty("test11")) {
         configureTest("jdk11") {
             useJUnit {
-                excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest'
+                excludeCategories 'com.newrelic.test.marker.Java11IncompatibleTest', 'com.newrelic.test.marker.IBMJ9IncompatibleTest'
             }
+
         }
     }
     if (project.hasProperty("test8")) {
         configureTest("jdk8") {
             useJUnit {
-                excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest'
+                excludeCategories 'com.newrelic.test.marker.Java8IncompatibleTest', 'com.newrelic.test.marker.IBMJ9IncompatibleTest'
             }
+
         }
+
     }
 
     // Alternate JDK distributions that we test against

--- a/instrumentation/cassandra-datastax-4.0.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraInstrumented.java
+++ b/instrumentation/cassandra-datastax-4.0.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraInstrumented.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
 import com.newrelic.agent.introspec.TraceSegment;
 import com.newrelic.agent.introspec.TransactionTrace;
+import com.newrelic.test.marker.IBMJ9IncompatibleTest;
 import com.newrelic.test.marker.Java11IncompatibleTest;
 import com.newrelic.test.marker.Java17IncompatibleTest;
 import com.newrelic.test.marker.Java19IncompatibleTest;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 // Issue when running cassandra unit on Java 9+ - https://github.com/jsevellec/cassandra-unit/issues/249
-@Category({ Java11IncompatibleTest.class, Java17IncompatibleTest.class, Java19IncompatibleTest.class })
+@Category({ IBMJ9IncompatibleTest.class, Java11IncompatibleTest.class, Java17IncompatibleTest.class, Java19IncompatibleTest.class })
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = { "com.datastax.oss.driver" })
 public class CassandraInstrumented {

--- a/instrumentation/cassandra-datastax-4.0.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraNoInstrumentation.java
+++ b/instrumentation/cassandra-datastax-4.0.0/src/test/java/com/nr/agent/instrumentation/cassandra/CassandraNoInstrumentation.java
@@ -12,6 +12,7 @@ import com.newrelic.agent.introspec.DatastoreHelper;
 import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
 import com.newrelic.agent.introspec.Introspector;
+import com.newrelic.test.marker.IBMJ9IncompatibleTest;
 import com.newrelic.test.marker.Java11IncompatibleTest;
 import com.newrelic.test.marker.Java17IncompatibleTest;
 import com.newrelic.test.marker.Java19IncompatibleTest;
@@ -25,7 +26,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertEquals;
 
 // Issue when running cassandra unit on Java 9+ - https://github.com/jsevellec/cassandra-unit/issues/249
-@Category({ Java11IncompatibleTest.class, Java17IncompatibleTest.class, Java19IncompatibleTest.class })
+@Category({ IBMJ9IncompatibleTest.class, Java11IncompatibleTest.class, Java17IncompatibleTest.class, Java19IncompatibleTest.class })
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = { "none" })
 public class CassandraNoInstrumentation {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfig.java
@@ -288,8 +288,6 @@ public interface AgentConfig extends com.newrelic.api.agent.Config, DataSenderCo
 
     boolean isHighSecurity();
 
-    boolean getIbmWorkaroundEnabled();
-
     /**
      * Get the agent's label configuration.
      *

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
@@ -56,7 +56,6 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     public static final String EXT_CONFIG_DIR = "extensions.dir";
     public static final String HIGH_SECURITY = "high_security";
     public static final String HOST = "host";
-    public static final String IBM_WORKAROUND = "ibm_iv25688_workaround";
     public static final String IGNORE_JARS = "ignore_jars";
     public static final String INSERT_API_KEY = "insert_api_key";
     public static final String JDBC_SUPPORT = "jdbc_support";
@@ -148,7 +147,6 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
      * host in newrelic.yml. This value makes the default behavior always work.
      */
     public static final String DEFAULT_HOST = "collector.newrelic.com";
-    public static final boolean DEFAULT_IBM_WORKAROUND = IBMUtils.getIbmWorkaroundDefault();
     public static final String DEFAULT_INSERT_API_KEY = "";
     // jdbc support
     public static final String GENERIC_JDBC_SUPPORT = "generic";
@@ -208,7 +206,6 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     private final boolean genericJdbcSupportEnabled;
     private final boolean highSecurity;
     private final String host;
-    private final boolean ibmWorkaroundEnabled;
     private final List<String> ignoreJars;
     private final String insertApiKey;
     private final boolean isApdexTSet;
@@ -328,7 +325,6 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
         caBundlePath = initSSLConfig();
         trimStats = getProperty(TRIM_STATS, DEFAULT_TRIM_STATS);
         platformInformationEnabled = getProperty(PLATFORM_INFORMATION_ENABLED, DEFAULT_PLATFORM_INFORMATION_ENABLED);
-        ibmWorkaroundEnabled = getProperty(IBM_WORKAROUND, DEFAULT_IBM_WORKAROUND);
         transactionNamingMode = parseTransactionNamingMode();
         maxStackTraceLines = getProperty(MAX_STACK_TRACE_LINES, DEFAULT_MAX_STACK_TRACE_LINES);
         String[] jdbcSupport = getProperty(JDBC_SUPPORT, DEFAULT_JDBC_SUPPORT).split(",");
@@ -1316,11 +1312,6 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     @Override
     public boolean isPutForDataSend() {
         return putForDataSend;
-    }
-
-    @Override
-    public boolean getIbmWorkaroundEnabled() {
-        return this.ibmWorkaroundEnabled;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/IBMUtils.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/IBMUtils.java
@@ -12,48 +12,9 @@ import java.util.regex.Pattern;
 
 public class IBMUtils {
     private static final String IBM_VENDOR = "IBM Corporation";
-    private static final Pattern srNumberPattern = Pattern.compile("\\(SR([0-9]+)[^()]*\\)\\s*$");
 
     public static boolean isIbmJVM() {
         return IBM_VENDOR.equals(System.getProperty("java.vendor"));
     }
 
-    /**
-     * See JAVA-1206.
-     *
-     * Default ibm workaround flag to true for known bad or unparsable ibm versions.
-     */
-    public static boolean getIbmWorkaroundDefault() {
-        try {
-            if (isIbmJVM()) {
-                String jvmVersion = System.getProperty("java.specification.version", "");
-                int srNum = getIbmSRNumber();
-
-                if ("1.7".equals(jvmVersion) && srNum >= 4) {
-                    // IBM Ticket says 7.SR3 is fixed, but no jvm can be found to test against
-                    return false;
-                }
-                return true;
-            }
-            return false;
-        } catch (Exception e) {
-            return true;
-        }
-    }
-
-    /**
-     * Parse the IBM Service Refresh patch version out of the system properties.
-     *
-     * @return the SR[0-9]* int, or -1 if no version can be found.
-     */
-    public static int getIbmSRNumber() {
-        if (isIbmJVM()) {
-            String runtimeVersion = System.getProperty("java.runtime.version", "");
-            Matcher matcher = srNumberPattern.matcher(runtimeVersion);
-            if (matcher.find()) {
-                return Integer.valueOf(matcher.group(1));
-            }
-        }
-        return -1;
-    }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextClassMatcherHelper.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextClassMatcherHelper.java
@@ -75,8 +75,11 @@ public class InstrumentationContextClassMatcherHelper {
     }
 
     // generated classes
-    if (className.contains("GeneratedConstructorAccessor") || className.contains("GeneratedMethodAccessor")
-        || className.contains("BoundMethodHandle$") || className.startsWith("jdk.jfr.internal.handlers.EventHandler")) {
+    if (className.contains("GeneratedConstructorAccessor") ||
+            className.contains("GeneratedMethodAccessor") ||
+            className.contains("GeneratedSerializationConstructor") ||
+            className.contains("BoundMethodHandle$") ||
+            className.startsWith("jdk.jfr.internal.handlers.EventHandler")) {
       return true;
     }
     return false;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassLoaderClassTransformer.java
@@ -12,7 +12,6 @@ import com.newrelic.agent.Agent;
 import com.newrelic.agent.InstrumentationProxy;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.config.ClassTransformerConfig;
-import com.newrelic.agent.config.IBMUtils;
 import com.newrelic.agent.instrumentation.ClassLoaderClassFinder;
 import com.newrelic.agent.instrumentation.builtin.AgentClassLoaderBaseInstrumentation;
 import com.newrelic.agent.instrumentation.builtin.AgentClassLoaderInstrumentation;
@@ -264,18 +263,11 @@ public class ClassLoaderClassTransformer implements ClassMatchVisitorFactory, Co
             }
         }
 
-        // Avoid the IBM jvm crasher. See JAVA-1206.
-        if (ServiceFactory.getConfigService().getDefaultAgentConfig().getIbmWorkaroundEnabled()) {
-            Agent.LOG.log(Level.FINE,
-                    "ClassLoaderClassTransformer: skipping redefine of {0}. IBM SR {1}. java.runtime.version {2}",
-                    ClassLoader.class.getName(), IBMUtils.getIbmSRNumber(), System.getProperty("java.runtime.version"));
-        } else {
-            try {
-                Agent.LOG.log(Level.FINER, "ClassLoaderClassTransformer: Attempting to redefine {0}", ClassLoader.class);
-                InstrumentationProxy.forceRedefinition(instrumentation, ClassLoader.class);
-            } catch (Exception e) {
-                Agent.LOG.log(Level.FINEST, e, "ClassLoaderClassTransformer: Error redefining {0}", ClassLoader.class.getName());
-            }
+        try {
+            Agent.LOG.log(Level.FINER, "ClassLoaderClassTransformer: Attempting to redefine {0}", ClassLoader.class);
+            InstrumentationProxy.forceRedefinition(instrumentation, ClassLoader.class);
+        } catch (Exception e) {
+            Agent.LOG.log(Level.FINEST, e, "ClassLoaderClassTransformer: Error redefining {0}", ClassLoader.class.getName());
         }
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -10,8 +10,10 @@ import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.jfr.ThreadNameNormalizer;
 import com.newrelic.jfr.daemon.DaemonConfig;
 import com.newrelic.jfr.daemon.JfrRecorderException;
+import com.newrelic.test.marker.IBMJ9IncompatibleTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -49,6 +51,7 @@ public class JfrServiceTest {
         when(agentConfig.getValue(eq(ThreadService.NAME_PATTERN_CFG_KEY), any(String.class)))
                 .thenReturn(ThreadNameNormalizer.DEFAULT_PATTERN);
     }
+
 
     @Test
     public void daemonConfigBuiltCorrect() {
@@ -94,7 +97,7 @@ public class JfrServiceTest {
         assertFalse(spyJfr.isEnabled());
         verify(spyJfr, times(0)).startJfrLoop();
     }
-
+    @Category( IBMJ9IncompatibleTest.class )
     @Test
     public void jfrLoopDoesStart() {
         JfrService jfrService = new JfrService(jfrConfig, agentConfig);

--- a/test-annotations/src/main/java/com/newrelic/test/marker/IBMJ9IncompatibleTest.java
+++ b/test-annotations/src/main/java/com/newrelic/test/marker/IBMJ9IncompatibleTest.java
@@ -1,0 +1,9 @@
+package com.newrelic.test.marker;
+
+
+/**
+ * Marker interface to denote a unit/functional/instrumentation test that is incompatible with IBM Semeru and other OpenJ9 runtimes.
+ */
+
+public interface IBMJ9IncompatibleTest {
+}


### PR DESCRIPTION
Issue explained in these comments:
We never add the agent-bridge-datastore.jar in the ibmWorkaround path.  However, even with that, there is still a bug in the IBM Workaround path where we fail to use the correct branch of logic for versions 8 and above.

```
         // Check for the IBM workaround
            boolean ibmWorkaround = IBMUtils.getIbmWorkaroundDefault();
            if (System.getProperty("ibm_iv25688_workaround") != null) {
                ibmWorkaround = Boolean.parseBoolean(System.getProperty("ibm_iv25688_workaround"));
            }

            ClassLoader classLoader;
            if (ibmWorkaround) {
                // For the IBM workaround lets just use the System ClassLoader
                //if you come down this path, we never end up
                //performing addBridgeJarToClassPath(inst, AGENT_BRIDGE_DATASTORE_JAR_NAME); hence NoClassDefFound for Record.Sql
                classLoader = ClassLoader.getSystemClassLoader();
            } else {
                ClassLoader agentClassLoaderParent = getPlatformClassLoaderOrNull();

                // Create a new URLClassLoader instance for the agent to use instead of relying on the System ClassLoader
                URL[] codeSource;
                if (isJavaSqlLoadedOnPlatformClassLoader(javaVersion)) {
                    //Semeru and other OpenJ9s for JDK 9+ are not getting to this path, and they should be.
                    //the logic in getIbmWorkaroundDefault() is faulty and causes anything above JDK 7 to not return false
                    URL url = BootstrapLoader.getDatastoreJarURL();
                    codeSource = new URL[] { getAgentJarUrl(), url };
                } else {
                    //If you get here, then the BootstrapLoader will have already
                    // performed addBridgeJarToClassPath(inst, AGENT_BRIDGE_DATASTORE_JAR_NAME); so, no problem (i.e. older JDKs did this).  
                    //IBM JDK 8 versions should have ended up here too, but did not because of the bug in  getIbmWorkaroundDefault() is faulty 
                  
                    codeSource = new URL[] { getAgentJarUrl() };
                }

                classLoader = new JVMAgentClassLoader(codeSource, agentClassLoaderParent);

                redefineJavaBaseModule(inst, classLoader);
                addReadUnnamedModuleToHttpModule(inst, agentClassLoaderParent);
            }
            
            
```



You can see in the if condition here that we only really check 1.7, so IBM JVMs 8 and above will always be true.  8 is above srNum 4.  Also, 9+ uses platform classloader, so this is all just uneccesary.  Had this check been correct, this issue probably wouldn't have come up. Still, best to rip this stuff out because it just is pointless complexity in the BootstrapAgent.

```
    public static boolean getIbmWorkaroundDefault() {
        try {
            if (isIbmJVM()) {
                String jvmVersion = System.getProperty("java.specification.version", "");
                int srNum = getIbmSRNumber();
                //We only set to false if 1.7 and above srNum
                //that means anything greater than jdk 7 will go through the true branch.
                if ("1.7".equals(jvmVersion) && srNum >= 4) {
                    // IBM Ticket says 7.SR3 is fixed, but no jvm can be found to test against
                    return false;
                }
                return true;
            }
            return false;
        } catch (Exception e) {
            return true;
        }
    }
```

This entire logic is obsolete anyway because the agent no longer supports Java 6 and 7. 

**Tests:**
We need to add OpenJ9 and/or Semeru runtimes to our AITs