### PR TITLE
Update gradle version to 7.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.prokod.gradle-crossbuild' version '0.12.1' apply false
+    id 'com.github.prokod.gradle-crossbuild' version '0.14.1' apply false
     id "org.jetbrains.kotlin.jvm" version "1.6.20" apply false
     id "com.newrelic.gradle-verify-instrumentation-plugin" version "3.2" apply false
     id "com.newrelic.gradle-compatibility-doc-plugin" version "1.1" apply false

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
-    compile "com.googlecode.json-simple:json-simple:1.1"
-    compile "com.google.guava:guava:28.2-android"
+    implementation("com.googlecode.json-simple:json-simple:1.1")
+    implementation("com.google.guava:guava:28.2-android")
 }

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: 'scala'
 
 configurations {
     includeInJar
@@ -6,6 +7,7 @@ configurations {
 
 dependencies {
     configurations.implementation.extendsFrom(configurations.includeInJar)
+
 }
 
 jar {

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -250,4 +250,3 @@ dependencies {
     testImplementation("org.hamcrest:hamcrest-library:1.3")
     testImplementation(project(":test-annotations"))
 }
-

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -251,14 +251,3 @@ dependencies {
     testImplementation(project(":test-annotations"))
 }
 
-// Make ScalaCompile tasks cacheable.  This is a workaround for a defect fixed in Gradle 7.1.0.
-tasks.withType(ScalaCompile).configureEach {
-    options.getForkOptions().setExecutable(null)
-    def launcher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
-    inputs.property("javaLauncherVersion", launcher.map { it.metadata.languageVersion })
-    doFirst {
-        options.getForkOptions().setExecutable(launcher.get().getExecutablePath().asFile.absolutePath)
-    }
-}

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -5,7 +5,7 @@ configurations {
 }
 
 dependencies {
-    configurations.compile.extendsFrom(configurations.includeInJar)
+    configurations.implementation.extendsFrom(configurations.includeInJar)
 }
 
 jar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -10,9 +10,7 @@ isScalaProjectEnabled(project, "scala-2.12")
 // resolution fails for this module. It succeeds when gradle tasks are isolated to this module, but _may_
 // fail when gradle tasks span multiple scala modules with different versions. Its not deterministic and
 // quite mysterious.
-//configurations.zinc {
-//    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
-//}
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.2.0' }

--- a/instrumentation/akka-http-core-10.2.0/build.gradle
+++ b/instrumentation/akka-http-core-10.2.0/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'scala'
 
+scala.zincVersion = "1.7.1"
+
 isScalaProjectEnabled(project, "scala-2.12")
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is
@@ -8,9 +10,9 @@ isScalaProjectEnabled(project, "scala-2.12")
 // resolution fails for this module. It succeeds when gradle tasks are isolated to this module, but _may_
 // fail when gradle tasks span multiple scala modules with different versions. Its not deterministic and
 // quite mysterious.
-configurations.zinc {
-    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
-}
+//configurations.zinc {
+//    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+//}
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-10.2.0' }

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -2,6 +2,9 @@ plugins{
     id 'scala'
 }
 
+scala {
+    zincVersion = "1.7.1"
+}
 isScalaProjectEnabled(project, "scala-2.13")
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is
@@ -10,9 +13,9 @@ isScalaProjectEnabled(project, "scala-2.13")
 // resolution fails for this module. It succeeds when gradle tasks are isolated to this module, but _may_
 // fail when gradle tasks span multiple scala modules with different versions. Its not deterministic and
 // quite mysterious.
-configurations.zinc {
-    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
-}
+//configurations.zinc {
+//    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
+//}
 
 
 jar {

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -13,9 +13,7 @@ isScalaProjectEnabled(project, "scala-2.13")
 // resolution fails for this module. It succeeds when gradle tasks are isolated to this module, but _may_
 // fail when gradle tasks span multiple scala modules with different versions. Its not deterministic and
 // quite mysterious.
-//configurations.zinc {
-//    resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
-//}
+
 
 
 jar {

--- a/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
+++ b/instrumentation/akka-http-core-2.13_10.1.8/build.gradle
@@ -1,16 +1,19 @@
-apply plugin: 'scala'
+plugins{
+    id 'scala'
+}
 
 isScalaProjectEnabled(project, "scala-2.13")
 
 // The scala plugin uses zinc for incremental compiling. Zinc itself relies on scala, and while gradle is
 // normally able to resolve the correct version of scala for zinc (even if that version is different than
-// the version of scala required for the module), it certain circumstances the zinc scala version
+// the version of scala required for the module), in certain circumstances the zinc scala version
 // resolution fails for this module. It succeeds when gradle tasks are isolated to this module, but _may_
 // fail when gradle tasks span multiple scala modules with different versions. Its not deterministic and
 // quite mysterious.
 configurations.zinc {
     resolutionStrategy.force "org.scala-lang:scala-library:2.12.12"
 }
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.akka-http-core-2.13_10.1.8' }

--- a/instrumentation/aws-java-sdk-s3-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-s3-2.0/build.gradle
@@ -2,7 +2,7 @@ jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-java-sdk-s3-2.0' }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/aws-java-sdk-sns-1.11.12/build.gradle
+++ b/instrumentation/aws-java-sdk-sns-1.11.12/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-sns:1.11.676")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest {

--- a/instrumentation/aws-java-sdk-sns-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-sns-2.0/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     implementation("software.amazon.awssdk:sns:2.10.19")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest {

--- a/instrumentation/aws-java-sdk-sqs-1.10.44/build.gradle
+++ b/instrumentation/aws-java-sdk-sqs-1.10.44/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     testImplementation("org.elasticmq:elasticmq-rest-sqs_2.13:0.15.3")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-java-sdk-sqs-1.10.44' }

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     testImplementation("org.elasticmq:elasticmq-rest-sqs_2.13:0.15.3")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 test {
     onlyIf {

--- a/instrumentation/grpc-1.30.0/build.gradle
+++ b/instrumentation/grpc-1.30.0/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 }
 apply plugin: 'com.google.protobuf'
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/grpc-1.40.0/build.gradle
+++ b/instrumentation/grpc-1.40.0/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 }
 apply plugin: 'com.google.protobuf'
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/java.completable-future-jdk8/build.gradle
+++ b/instrumentation/java.completable-future-jdk8/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 }
 
 // This instrumentation module should not use the bootstrap classpath
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.java.completable-future-jdk8' }

--- a/instrumentation/java.completable-future-jdk8u40/build.gradle
+++ b/instrumentation/java.completable-future-jdk8u40/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 }
 
 // This instrumentation module should not use the bootstrap classpath
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.java.completable-future-jdk8u40' }

--- a/instrumentation/java.logging-jdk8/build.gradle
+++ b/instrumentation/java.logging-jdk8/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 }
 
 // This instrumentation module should not use the bootstrap classpath
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.java.logging-jdk8' }

--- a/instrumentation/javax.xml/build.gradle
+++ b/instrumentation/javax.xml/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 }
 
 // This instrumentation module should not use the bootstrap classpath
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.javax.xml' }

--- a/instrumentation/jdbc-postgresql-8.0-312.jdbc3/build.gradle
+++ b/instrumentation/jdbc-postgresql-8.0-312.jdbc3/build.gradle
@@ -4,7 +4,7 @@ configurations {
     shadowIntoJar
 }
 
-configurations.compile.extendsFrom(configurations.shadowIntoJar)
+configurations.implementation.extendsFrom(configurations.shadowIntoJar)
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/jdbc-postgresql-9.4.1207/build.gradle
+++ b/instrumentation/jdbc-postgresql-9.4.1207/build.gradle
@@ -4,7 +4,7 @@ configurations {
     shadowIntoJar
 }
 
-configurations.compile.extendsFrom(configurations.shadowIntoJar)
+configurations.implementation.extendsFrom(configurations.shadowIntoJar)
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/jdbc-postgresql-9.4.1208/build.gradle
+++ b/instrumentation/jdbc-postgresql-9.4.1208/build.gradle
@@ -4,7 +4,7 @@ configurations {
     shadowIntoJar
 }
 
-configurations.compile.extendsFrom(configurations.shadowIntoJar)
+configurations.implementation.extendsFrom(configurations.shadowIntoJar)
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/kafka-clients-metrics-2.0.0/build.gradle
+++ b/instrumentation/kafka-clients-metrics-2.0.0/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation("org.apache.kafka:kafka-clients:2.0.0")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-clients-metrics-2.0.0',

--- a/instrumentation/kafka-clients-metrics-3.0.0/build.gradle
+++ b/instrumentation/kafka-clients-metrics-3.0.0/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation("org.testcontainers:kafka:1.16.3")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-clients-metrics-3.0.0',

--- a/instrumentation/netty-reactor-0.7.0/build.gradle
+++ b/instrumentation/netty-reactor-0.7.0/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     implementation("io.projectreactor.ipc:reactor-netty:0.7.0.RELEASE")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.netty-reactor-0.7.0' }

--- a/instrumentation/netty-reactor-0.8.0/build.gradle
+++ b/instrumentation/netty-reactor-0.8.0/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     implementation("io.projectreactor.netty:reactor-netty:0.8.0.RELEASE")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.netty-reactor-0.8.0' }

--- a/instrumentation/netty-reactor-0.9.0/build.gradle
+++ b/instrumentation/netty-reactor-0.9.0/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     implementation("io.projectreactor.netty:reactor-netty:0.9.0.RELEASE")
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.netty-reactor-0.9.0' }

--- a/instrumentation/newrelic-scala-monix-api/build.gradle
+++ b/instrumentation/newrelic-scala-monix-api/build.gradle
@@ -1,5 +1,9 @@
-apply plugin: 'scala'
+plugins{
+    id 'scala'
+}
+
 scala.zincVersion = "1.2.5"
+
 
 isScalaProjectEnabled(project, "scala-2.13")
 

--- a/instrumentation/newrelic-scala-monix-api/build.gradle
+++ b/instrumentation/newrelic-scala-monix-api/build.gradle
@@ -8,7 +8,7 @@ scala.zincVersion = "1.7.1"
 isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
-    zinc("org.scala-sbt:zinc_2.12:1.7.1")
+    zinc("org.scala-sbt:zinc_2.13:1.7.1")
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation(project(":newrelic-weaver-scala-api"))

--- a/instrumentation/newrelic-scala-monix-api/build.gradle
+++ b/instrumentation/newrelic-scala-monix-api/build.gradle
@@ -2,13 +2,13 @@ plugins{
     id 'scala'
 }
 
-scala.zincVersion = "1.2.5"
+scala.zincVersion = "1.7.1"
 
 
 isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
-    zinc("org.scala-sbt:zinc_2.12:1.2.5")
+    zinc("org.scala-sbt:zinc_2.12:1.7.1")
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation(project(":newrelic-weaver-scala-api"))

--- a/instrumentation/play-2.5/build.gradle
+++ b/instrumentation/play-2.5/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.11")
 

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -4,7 +4,8 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.11")
 

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -4,7 +4,7 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.11")
 

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 sourceSets.test.scala.srcDir "src/test/java"
 sourceSets.test.java.srcDirs = []
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":newrelic-api"))

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -4,7 +4,8 @@ import play.routes.compiler.RoutesCompiler$
 import scala.collection.JavaConversions
 
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.11")
 

--- a/instrumentation/play-ws-2.13_2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.13_2.6.0/build.gradle
@@ -1,10 +1,11 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.13")
 
 dependencies {
-    zinc("org.scala-sbt:zinc_2.12:1.2.5")
+    zinc("org.scala-sbt:zinc_2.13:1.7.1")
     implementation(project(":newrelic-api"))
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -3,7 +3,7 @@ scala.zincVersion = "1.2.5"
 
 isScalaProjectEnabled(project, "scala-2.11")
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/play-ws-2.6.0/build.gradle
+++ b/instrumentation/play-ws-2.6.0/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.11")
 

--- a/instrumentation/slick-2.11_3.2.0/build.gradle
+++ b/instrumentation/slick-2.11_3.2.0/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.11")
 

--- a/instrumentation/slick-2.12_3.2.0/build.gradle
+++ b/instrumentation/slick-2.12_3.2.0/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.12")
 

--- a/instrumentation/slick-3.0.0/build.gradle
+++ b/instrumentation/slick-3.0.0/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'scala'
-scala.zincVersion = "1.2.5"
+
+scala.zincVersion = "1.7.1"
 
 isScalaProjectEnabled(project, "scala-2.10")
 

--- a/instrumentation/spring-webclient-5.0/build.gradle
+++ b/instrumentation/spring-webclient-5.0/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spring-webclient-5.0' }

--- a/instrumentation/spring-webflux-5.0.0/build.gradle
+++ b/instrumentation/spring-webflux-5.0.0/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation(project(":instrumentation:spring-webclient-5.0"))
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spring-webflux-5.0.0'}

--- a/instrumentation/spring-webflux-5.1.0/build.gradle
+++ b/instrumentation/spring-webflux-5.1.0/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation(project(":instrumentation:spring-webclient-5.0"))
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spring-webflux-5.1.0'}

--- a/instrumentation/spring-webflux-5.3.0/build.gradle
+++ b/instrumentation/spring-webflux-5.3.0/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation(project(":instrumentation:spring-webclient-5.0"))
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spring-webflux-5.3.0'}

--- a/instrumentation/vertx-core-3.3.0/build.gradle
+++ b/instrumentation/vertx-core-3.3.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-core-3.3.3/build.gradle
+++ b/instrumentation/vertx-core-3.3.3/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-core-3.4.1/build.gradle
+++ b/instrumentation/vertx-core-3.4.1/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-core-3.6.0/build.gradle
+++ b/instrumentation/vertx-core-3.6.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-core-3.8.0/build.gradle
+++ b/instrumentation/vertx-core-3.8.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-core-3.9.0/build.gradle
+++ b/instrumentation/vertx-core-3.9.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.2.0/build.gradle
+++ b/instrumentation/vertx-web-3.2.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.3.0/build.gradle
+++ b/instrumentation/vertx-web-3.3.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.5.0/build.gradle
+++ b/instrumentation/vertx-web-3.5.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.5.1/build.gradle
+++ b/instrumentation/vertx-web-3.5.1/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.5.2/build.gradle
+++ b/instrumentation/vertx-web-3.5.2/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.6.0/build.gradle
+++ b/instrumentation/vertx-web-3.6.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.8.0/build.gradle
+++ b/instrumentation/vertx-web-3.8.0/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/instrumentation/vertx-web-3.8.3/build.gradle
+++ b/instrumentation/vertx-web-3.8.3/build.gradle
@@ -4,7 +4,7 @@ jar {
     }
 }
 
-compileJava.options.bootstrapClasspath = null
+
 
 dependencies {
     implementation(project(":agent-bridge"))

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -29,8 +29,8 @@ configurations {
     finalArtifact
 }
 
-configurations.compile.extendsFrom(configurations.shadowIntoJar)
-configurations.compile.extendsFrom(configurations.jarIntoJar)
+configurations.implementation.extendsFrom(configurations.shadowIntoJar)
+configurations.implementation.extendsFrom(configurations.jarIntoJar)
 
 project.ext {
     instrumentProjects = {

--- a/newrelic-cats-effect3-api/build.gradle.kts
+++ b/newrelic-cats-effect3-api/build.gradle.kts
@@ -2,8 +2,9 @@ import com.nr.builder.publish.PublishConfig
 
 plugins {
     `maven-publish`
-    `signing`
-    id("com.github.prokod.gradle-crossbuild-scala")
+    signing
+    id("com.github.prokod.gradle-crossbuild-scala" )
+
 }
 evaluationDependsOn(":newrelic-api")
 

--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -23,7 +23,7 @@ java {
 }
 
 dependencies {
-    zinc("org.scala-sbt:zinc_2.12:1.2.5")
+    zinc("org.scala-sbt:zinc_2.13:1.7.1")
     implementation("org.scala-lang:scala-library:2.13.7")
     implementation(project(":newrelic-api"))
     testImplementation(project(":instrumentation-test"))

--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -2,8 +2,9 @@ import com.nr.builder.publish.PublishConfig
 
 plugins {
     `maven-publish`
-    `signing`
-    id("com.github.prokod.gradle-crossbuild-scala")
+    signing
+    id("com.github.prokod.gradle-crossbuild-scala" )
+
 }
 evaluationDependsOn(":newrelic-api")
 

--- a/newrelic-scala-cats-api/build.gradle.kts
+++ b/newrelic-scala-cats-api/build.gradle.kts
@@ -3,7 +3,7 @@ import com.nr.builder.publish.PublishConfig
 plugins {
     `maven-publish`
     `signing`
-    id("com.github.prokod.gradle-crossbuild-scala")
+    id("com.github.prokod.gradle-crossbuild-scala" )
 }
 evaluationDependsOn(":newrelic-api")
 

--- a/newrelic-scala-monix-api/build.gradle.kts
+++ b/newrelic-scala-monix-api/build.gradle.kts
@@ -5,13 +5,16 @@ plugins {
     signing
     id("com.github.prokod.gradle-crossbuild-scala" )
 }
+
 evaluationDependsOn(":newrelic-api")
+
 
 crossBuild {
     scalaVersionsCatalog = mapOf("2.11" to "2.11.12", "2.12" to "2.12.13", "2.13" to "2.13.5")
     builds {
         register("scala") {
             scalaVersions = setOf("2.11", "2.12", "2.13")
+
         }
     }
 }
@@ -22,7 +25,7 @@ java {
 }
 
 dependencies {
-    zinc("org.scala-sbt:zinc_2.12:1.2.5")
+    zinc("org.scala-sbt:zinc_2.13:1.7.1")
     implementation("org.scala-lang:scala-library:2.13.5")
     implementation("io.monix:monix-eval_2.13:3.3.0")
     implementation("io.monix:monix-reactive_2.13:3.3.0")

--- a/newrelic-scala-monix-api/build.gradle.kts
+++ b/newrelic-scala-monix-api/build.gradle.kts
@@ -3,7 +3,7 @@ import com.nr.builder.publish.PublishConfig
 plugins {
     `maven-publish`
     signing
-    id("com.github.prokod.gradle-crossbuild-scala")
+    id("com.github.prokod.gradle-crossbuild-scala" )
 }
 evaluationDependsOn(":newrelic-api")
 

--- a/newrelic-scala-zio-api/build.gradle.kts
+++ b/newrelic-scala-zio-api/build.gradle.kts
@@ -3,7 +3,7 @@ import com.nr.builder.publish.PublishConfig
 plugins {
     `maven-publish`
     `signing`
-    id("com.github.prokod.gradle-crossbuild-scala")
+    id("com.github.prokod.gradle-crossbuild-scala" )
 }
 evaluationDependsOn(":newrelic-api")
 

--- a/newrelic-scala-zio-api/build.gradle.kts
+++ b/newrelic-scala-zio-api/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `signing`
     id("com.github.prokod.gradle-crossbuild-scala" )
 }
+
 evaluationDependsOn(":newrelic-api")
 
 crossBuild {
@@ -22,7 +23,7 @@ java {
 }
 
 dependencies {
-    zinc("org.scala-sbt:zinc_2.12:1.2.5")
+    zinc("org.scala-sbt:zinc_2.13:1.7.1")
     implementation("org.scala-lang:scala-library:2.13.5")
     implementation("dev.zio:zio_2.13:1.0.9")
     implementation(project(":newrelic-api"))

--- a/newrelic-weaver/build.gradle
+++ b/newrelic-weaver/build.gradle
@@ -1,6 +1,6 @@
 configurations {
     testClasses {
-        extendsFrom(testRuntime)
+        extendsFrom(testRuntimeOnly)
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@ pluginManagement {
 plugins {
     id "com.gradle.enterprise" version "3.7.1"
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.1'
+
 }
 
 buildCache {


### PR DESCRIPTION
This upgrades us to 7.5.1 so we can do more of the new things. 
Removes several deprecated and removed features.  Replaces them with the new things.
Also, there was a workaround for compileScala jobs that is no longer needed as of Gradle Version 7.1. 