### PR TITLE
NEWRELIC-658 check expected error config for noticeError api

### DIFF
--- a/functional_test/src/test/java/test/newrelic/test/agent/ExpectedErrorsTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/ExpectedErrorsTest.java
@@ -306,7 +306,7 @@ public class ExpectedErrorsTest {
             assertEquals(0, statsEngine.getStats("Errors/all").getCallCount());
             assertEquals(1, statsEngine.getStats("ErrorsExpected/all").getCallCount());
 
-            verifyExpectedErrorSupportabilityApiCalls(statsEngine, 0, 0, 1, 0);
+            verifyExpectedErrorSupportabilityApiCalls(statsEngine, 0, 1, 1, 0);
             verifyIgnoreErrorSupportabilityApiCalls(statsEngine, 0, 0, 0);
         } finally {
             holder.close();

--- a/functional_test/src/test/resources/configs/expected_errors_test.yml
+++ b/functional_test/src/test/resources/configs/expected_errors_test.yml
@@ -15,6 +15,19 @@ expected_error_test:
       -
         class_name: "test.newrelic.test.agent.ExpectedError"
 
+expected_error_config_api_test:
+
+  error_collector:
+
+    expected_classes:
+      -
+        class_name: "test.newrelic.test.agent.ExpectedError"
+      -
+        class_name: "java.lang.RuntimeException"
+        message: "I should be expected by my message"
+
+
+
 
 expected_error_bad_message_test:
 


### PR DESCRIPTION

### Overview
The changes here force the noticeError API to check the expected error configuration when using APIs that do not explicitly set the expected boolean. 
Previously, we just passed false all the way through and the expected boolean only gets set if the caller uses the API that includes the boolean.



### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
Tested with local apps and config.
This will add new tests.

### Checks

[ yes] Are your contributions backwards compatible with relevant frameworks and APIs?
[ no] Does your code contain any breaking changes? Please describe. 
[ no] Does your code introduce any new dependencies? Please describe.
