### PR TITLE
Adding stack trace to when logging CLM data retrieval error

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -304,7 +304,7 @@ public class DefaultTracer extends AbstractTracer {
             } catch (Throwable t) {
                 String msg = "An error occurred saving the clm attributes: " + t;
                 Agent.LOG.severe(msg);
-                Agent.LOG.log(Level.FINER, msg);
+                Agent.LOG.log(Level.FINER, msg, t);
             }
 
             try {


### PR DESCRIPTION
### Overview
When an error occurs while retrieving CLM data, a log message is written, but it is missing the stack trace on finer log levels.

This adds the stack trace, as other errors in the same class.