### PR TITLE
NR-2447 Add log forwarding and tests for JUL.

### DIFF
--- a/functional_test/src/test/java/test/newrelic/test/agent/JavaUtilLoggerTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/JavaUtilLoggerTest.java
@@ -1,30 +1,425 @@
 package test.newrelic.test.agent;
 
 import com.newrelic.agent.Transaction;
+import com.newrelic.agent.model.LogEvent;
+import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.service.analytics.DistributedSamplingPriorityQueue;
+import com.newrelic.agent.service.logging.LogSenderServiceImpl;
 import com.newrelic.agent.stats.SimpleStatsEngine;
 import com.newrelic.agent.stats.TransactionStats;
 import com.newrelic.api.agent.Trace;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test for com.newrelic.instrumentation.java.logging-jdk8 instrumentation
  */
 public class JavaUtilLoggerTest {
-
     private static final String CAPTURED = "This log message should be captured";
     private static final String NOT_CAPTURED = "This message should NOT be captured";
+    private final String applicationName = ServiceFactory.getConfigService().getDefaultAgentConfig().getApplicationName();
+    private final LogSenderServiceImpl logSenderService = (LogSenderServiceImpl) ServiceFactory.getServiceManager().getLogSenderService();
+    private final DistributedSamplingPriorityQueue<LogEvent> logReservoir = logSenderService.getReservoir(applicationName);
 
     @Before
     public void setup() {
         Transaction.clearTransaction();
+        // Clear LogEvent reservoir between tests
+        logSenderService.clearReservoir(applicationName);
+    }
+
+    @Test
+    public void testLogEventsAllLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.ALL);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 2;
+        logger.warning(CAPTURED);
+        logger.warning(CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 3;
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 4;
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 5;
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 6;
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 7;
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsOffLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.OFF);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 0;
+        logger.severe(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 0;
+        logger.warning(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 0;
+        logger.info(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 0;
+        logger.config(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 0;
+        logger.fine(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 0;
+        logger.finer(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 0;
+        logger.finest(NOT_CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsSevereLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.SEVERE);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 0;
+        logger.warning(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 0;
+        logger.info(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 0;
+        logger.config(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 0;
+        logger.fine(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 0;
+        logger.finer(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 0;
+        logger.finest(NOT_CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsWarningLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.WARNING);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 2;
+        logger.warning(CAPTURED);
+        logger.warning(CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 0;
+        logger.info(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 0;
+        logger.config(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 0;
+        logger.fine(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 0;
+        logger.finer(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 0;
+        logger.finest(NOT_CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsInfoLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.INFO);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 2;
+        logger.warning(CAPTURED);
+        logger.warning(CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 3;
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 0;
+        logger.config(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 0;
+        logger.fine(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 0;
+        logger.finer(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 0;
+        logger.finest(NOT_CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsConfigLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.CONFIG);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 2;
+        logger.warning(CAPTURED);
+        logger.warning(CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 3;
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 4;
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 0;
+        logger.fine(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 0;
+        logger.finer(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 0;
+        logger.finest(NOT_CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsFineLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.FINE);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 2;
+        logger.warning(CAPTURED);
+        logger.warning(CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 3;
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 4;
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 5;
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 0;
+        logger.finer(NOT_CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 0;
+        logger.finest(NOT_CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsFinerLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.FINER);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 2;
+        logger.warning(CAPTURED);
+        logger.warning(CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 3;
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 4;
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 5;
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 6;
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 0;
+        logger.finest(NOT_CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
+    }
+
+    @Test
+    public void testLogEventsFinestLevel() {
+        // Given
+        final Logger logger = Logger.getLogger(JavaUtilLoggerTest.class.getName());
+        logger.setLevel(Level.FINEST);
+
+        // When
+        int expectedTotalEventsCapturedAtSevere = 1;
+        logger.severe(CAPTURED);
+
+        int expectedTotalEventsCapturedAtWarning = 2;
+        logger.warning(CAPTURED);
+        logger.warning(CAPTURED);
+
+        int expectedTotalEventsCapturedAtInfo = 3;
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+        logger.info(CAPTURED);
+
+        int expectedTotalEventsCapturedAtConfig = 4;
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+        logger.config(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFine = 5;
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+        logger.fine(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFiner = 6;
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+        logger.finer(CAPTURED);
+
+        int expectedTotalEventsCapturedAtFinest = 7;
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+        logger.finest(CAPTURED);
+
+        // Then
+        doAssertions(expectedTotalEventsCapturedAtSevere, expectedTotalEventsCapturedAtWarning, expectedTotalEventsCapturedAtInfo,
+                expectedTotalEventsCapturedAtConfig, expectedTotalEventsCapturedAtFine, expectedTotalEventsCapturedAtFiner,
+                expectedTotalEventsCapturedAtFinest);
     }
 
     @Trace(dispatcher = true)
@@ -50,14 +445,14 @@ public class JavaUtilLoggerTest {
 
         // Then
         Map<String, Integer> metrics = getLogMetricsCounts();
-        Assert.assertEquals(8, (int) metrics.get("Logging/lines"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/FINEST"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/FINER"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/FINE"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/CONFIG"));
-        Assert.assertEquals(3, (int) metrics.get("Logging/lines/INFO"));
-        Assert.assertEquals(4, (int) metrics.get("Logging/lines/WARNING"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/SEVERE"));
+        assertEquals(8, (int) metrics.get("Logging/lines"));
+        assertEquals(0, (int) metrics.get("Logging/lines/FINEST"));
+        assertEquals(0, (int) metrics.get("Logging/lines/FINER"));
+        assertEquals(0, (int) metrics.get("Logging/lines/FINE"));
+        assertEquals(0, (int) metrics.get("Logging/lines/CONFIG"));
+        assertEquals(3, (int) metrics.get("Logging/lines/INFO"));
+        assertEquals(4, (int) metrics.get("Logging/lines/WARNING"));
+        assertEquals(1, (int) metrics.get("Logging/lines/SEVERE"));
     }
 
     @Trace(dispatcher = true)
@@ -78,14 +473,14 @@ public class JavaUtilLoggerTest {
 
         // Then
         Map<String, Integer> metrics = getLogMetricsCounts();
-        Assert.assertEquals(7, (int) metrics.get("Logging/lines"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/FINEST"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/FINER"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/FINE"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/CONFIG"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/INFO"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/WARNING"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/SEVERE"));
+        assertEquals(7, (int) metrics.get("Logging/lines"));
+        assertEquals(1, (int) metrics.get("Logging/lines/FINEST"));
+        assertEquals(1, (int) metrics.get("Logging/lines/FINER"));
+        assertEquals(1, (int) metrics.get("Logging/lines/FINE"));
+        assertEquals(1, (int) metrics.get("Logging/lines/CONFIG"));
+        assertEquals(1, (int) metrics.get("Logging/lines/INFO"));
+        assertEquals(1, (int) metrics.get("Logging/lines/WARNING"));
+        assertEquals(1, (int) metrics.get("Logging/lines/SEVERE"));
     }
 
     @Trace(dispatcher = true)
@@ -111,14 +506,14 @@ public class JavaUtilLoggerTest {
 
         // Then
         Map<String, Integer> metrics = getLogMetricsCounts();
-        Assert.assertEquals(8, (int) metrics.get("Logging/lines"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/FINEST"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/FINER"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/FINE"));
-        Assert.assertEquals(0, (int) metrics.get("Logging/lines/CONFIG"));
-        Assert.assertEquals(3, (int) metrics.get("Logging/lines/INFO"));
-        Assert.assertEquals(4, (int) metrics.get("Logging/lines/WARNING"));
-        Assert.assertEquals(1, (int) metrics.get("Logging/lines/SEVERE"));
+        assertEquals(8, (int) metrics.get("Logging/lines"));
+        assertEquals(0, (int) metrics.get("Logging/lines/FINEST"));
+        assertEquals(0, (int) metrics.get("Logging/lines/FINER"));
+        assertEquals(0, (int) metrics.get("Logging/lines/FINE"));
+        assertEquals(0, (int) metrics.get("Logging/lines/CONFIG"));
+        assertEquals(3, (int) metrics.get("Logging/lines/INFO"));
+        assertEquals(4, (int) metrics.get("Logging/lines/WARNING"));
+        assertEquals(1, (int) metrics.get("Logging/lines/SEVERE"));
     }
 
     private Map<String, Integer> getLogMetricsCounts() {
@@ -135,5 +530,73 @@ public class JavaUtilLoggerTest {
         metrics.put("Logging/lines/WARNING", engine.getStats("Logging/lines/WARNING").getCallCount());
         metrics.put("Logging/lines/SEVERE", engine.getStats("Logging/lines/SEVERE").getCallCount());
         return metrics;
+    }
+
+    private List<LogEvent> getFinestLevelLogEvents(Collection<LogEvent> logEvents) {
+        return logEvents.stream()
+                .filter(logEvent -> logEvent.getUserAttributesCopy().containsValue(Level.FINEST.toString()))
+                .collect(Collectors.toList());
+    }
+
+    private List<LogEvent> getFinerLevelLogEvents(Collection<LogEvent> logEvents) {
+        return logEvents.stream()
+                .filter(logEvent -> logEvent.getUserAttributesCopy().containsValue(Level.FINER.toString()))
+                .collect(Collectors.toList());
+    }
+
+    private List<LogEvent> getFineLevelLogEvents(Collection<LogEvent> logEvents) {
+        return logEvents.stream()
+                .filter(logEvent -> logEvent.getUserAttributesCopy().containsValue(Level.FINE.toString()))
+                .collect(Collectors.toList());
+    }
+
+    private List<LogEvent> getConfigLevelLogEvents(Collection<LogEvent> logEvents) {
+        return logEvents.stream()
+                .filter(logEvent -> logEvent.getUserAttributesCopy().containsValue(Level.CONFIG.toString()))
+                .collect(Collectors.toList());
+    }
+
+    private List<LogEvent> getInfoLevelLogEvents(Collection<LogEvent> logEvents) {
+        return logEvents.stream()
+                .filter(logEvent -> logEvent.getUserAttributesCopy().containsValue(Level.INFO.toString()))
+                .collect(Collectors.toList());
+    }
+
+    private List<LogEvent> getWarningLevelLogEvents(Collection<LogEvent> logEvents) {
+        return logEvents.stream()
+                .filter(logEvent -> logEvent.getUserAttributesCopy().containsValue(Level.WARNING.toString()))
+                .collect(Collectors.toList());
+    }
+
+    private List<LogEvent> getSevereLevelLogEvents(List<LogEvent> logEvents) {
+        return logEvents.stream()
+                .filter(logEvent -> logEvent.getUserAttributesCopy().containsValue(Level.SEVERE.toString()))
+                .collect(Collectors.toList());
+    }
+
+    private void doAssertions(int expectedTotalEventsCapturedAtSevere, int expectedTotalEventsCapturedAtWarning, int expectedTotalEventsCapturedAtInfo,
+            int expectedTotalEventsCapturedAtConfig, int expectedTotalEventsCapturedAtFine, int expectedTotalEventsCapturedAtFiner,
+            int expectedTotalEventsCapturedAtFinest) {
+        int expectedTotalEventsCaptured = expectedTotalEventsCapturedAtSevere +
+                expectedTotalEventsCapturedAtWarning + expectedTotalEventsCapturedAtInfo +
+                expectedTotalEventsCapturedAtConfig + expectedTotalEventsCapturedAtFine +
+                expectedTotalEventsCapturedAtFiner + expectedTotalEventsCapturedAtFinest;
+
+        List<LogEvent> severeLevelLogEvents = getSevereLevelLogEvents(logReservoir.asList());
+        List<LogEvent> warningLevelLogEvents = getWarningLevelLogEvents(logReservoir.asList());
+        List<LogEvent> infoLevelLogEvents = getInfoLevelLogEvents(logReservoir.asList());
+        List<LogEvent> configLevelLogEvents = getConfigLevelLogEvents(logReservoir.asList());
+        List<LogEvent> fineLevelLogEvents = getFineLevelLogEvents(logReservoir.asList());
+        List<LogEvent> finerLevelLogEvents = getFinerLevelLogEvents(logReservoir.asList());
+        List<LogEvent> finestLevelLogEvents = getFinestLevelLogEvents(logReservoir.asList());
+
+        assertEquals(expectedTotalEventsCaptured, logReservoir.size());
+        assertEquals(expectedTotalEventsCapturedAtSevere, severeLevelLogEvents.size());
+        assertEquals(expectedTotalEventsCapturedAtWarning, warningLevelLogEvents.size());
+        assertEquals(expectedTotalEventsCapturedAtInfo, infoLevelLogEvents.size());
+        assertEquals(expectedTotalEventsCapturedAtConfig, configLevelLogEvents.size());
+        assertEquals(expectedTotalEventsCapturedAtFine, fineLevelLogEvents.size());
+        assertEquals(expectedTotalEventsCapturedAtFiner, finerLevelLogEvents.size());
+        assertEquals(expectedTotalEventsCapturedAtFinest, finestLevelLogEvents.size());
     }
 }

--- a/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/ExceptionUtil.java
+++ b/instrumentation/java.logging-jdk8/src/main/java/com/nr/instrumentation/jul/ExceptionUtil.java
@@ -1,0 +1,49 @@
+package com.nr.instrumentation.jul;
+
+public class ExceptionUtil {
+    public static final int MAX_STACK_SIZE = 300;
+
+    public static boolean isThrowableNull(Throwable throwable) {
+        return throwable == null;
+    }
+
+    public static String getErrorStack(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+
+        StackTraceElement[] stack = throwable.getStackTrace();
+        return getErrorStack(stack);
+    }
+
+    public static String getErrorStack(StackTraceElement[] stack) {
+        return getErrorStack(stack, MAX_STACK_SIZE);
+    }
+
+    public static String getErrorStack(StackTraceElement[] stack, Integer maxStackSize) {
+        if (stack == null || stack.length == 0) {
+            return null;
+        }
+
+        StringBuilder stackBuilder = new StringBuilder();
+        int stackSizeLimit = Math.min(maxStackSize, stack.length);
+        for (int i = 0; i < stackSizeLimit; i++) {
+            stackBuilder.append("  at ").append(stack[i].toString()).append("\n");
+        }
+        return stackBuilder.toString();
+    }
+
+    public static String getErrorMessage(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+        return throwable.getMessage();
+    }
+
+    public static String getErrorClass(Throwable throwable) {
+        if (isThrowableNull(throwable)) {
+            return null;
+        }
+        return throwable.getClass().getName();
+    }
+}

--- a/instrumentation/java.logging-jdk8/src/main/java/java/util/logging/LogRecord_Instrumentation.java
+++ b/instrumentation/java.logging-jdk8/src/main/java/java/util/logging/LogRecord_Instrumentation.java
@@ -1,0 +1,22 @@
+package java.util.logging;
+
+import com.newrelic.api.agent.weaver.Weave;
+
+import static com.nr.instrumentation.jul.AgentUtil.getLinkingMetadataBlob;
+import static com.nr.instrumentation.jul.AgentUtil.isApplicationLoggingEnabled;
+import static com.nr.instrumentation.jul.AgentUtil.isApplicationLoggingLocalDecoratingEnabled;
+
+@Weave(originalName = "java.util.logging.LogRecord")
+public class LogRecord_Instrumentation {
+    private String message;
+
+    public String getMessage() {
+        if (isApplicationLoggingEnabled() && isApplicationLoggingLocalDecoratingEnabled()) {
+            // Append New Relic linking metadata from agent to log message
+            return message + getLinkingMetadataBlob();
+        } else {
+            return message;
+        }
+    }
+
+}

--- a/instrumentation/java.logging-jdk8/src/main/java/java/util/logging/Logger_Instrumentation.java
+++ b/instrumentation/java.logging-jdk8/src/main/java/java/util/logging/Logger_Instrumentation.java
@@ -8,19 +8,38 @@
 package java.util.logging;
 
 import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.WeaveAllConstructors;
 import com.newrelic.api.agent.weaver.Weaver;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static com.nr.instrumentation.jul.AgentUtil.isApplicationLoggingEnabled;
+import static com.nr.instrumentation.jul.AgentUtil.isApplicationLoggingForwardingEnabled;
 import static com.nr.instrumentation.jul.AgentUtil.isApplicationLoggingMetricsEnabled;
+import static com.nr.instrumentation.jul.AgentUtil.recordNewRelicLogEvent;
 
 @Weave(originalName = "java.util.logging.Logger")
 public class Logger_Instrumentation {
+    @NewField
+    public static AtomicBoolean instrumented = new AtomicBoolean(false);
 
+    @WeaveAllConstructors
+    Logger_Instrumentation() {
+        // Generate the instrumentation module supportability metric only once
+        if (!instrumented.getAndSet(true)) {
+            NewRelic.incrementCounter("Supportability/Logging/Java/JavaUtilLogging/enabled");
+        }
+    }
+
+    // Get the current filter for this Logger.
     public Filter getFilter() {
         return Weaver.callOriginal();
     }
 
+    // Check if a message of the given level would actually be logged by this logger.
+    // This check is based on the Loggers effective level, which may be inherited from its parent.
     public boolean isLoggable(Level level) {
         return Boolean.TRUE.equals(Weaver.callOriginal());
     }
@@ -28,12 +47,15 @@ public class Logger_Instrumentation {
     public void log(LogRecord record) {
         // Do nothing if application_logging.enabled: false
         if (isApplicationLoggingEnabled()) {
-            if (isApplicationLoggingMetricsEnabled()) {
-                if (isLoggable(record.getLevel()) && getFilter() == null || getFilter().isLoggable(record)) {
-                    // Generate log level metrics
-                    NewRelic.incrementCounter("Logging/lines");
-                    NewRelic.incrementCounter("Logging/lines/" + record.getLevel().toString());
-                }
+            boolean shouldLog = isLoggable(record.getLevel()) && getFilter() == null || getFilter().isLoggable(record);
+            if (isApplicationLoggingMetricsEnabled() && shouldLog) {
+                // Generate log level metrics
+                NewRelic.incrementCounter("Logging/lines");
+                NewRelic.incrementCounter("Logging/lines/" + record.getLevel().toString());
+            }
+            if (isApplicationLoggingForwardingEnabled() && shouldLog) {
+                // Record and send LogEvent to New Relic
+                recordNewRelicLogEvent(record);
             }
         }
         Weaver.callOriginal();

--- a/instrumentation/java.logging-jdk8/src/test/README.md
+++ b/instrumentation/java.logging-jdk8/src/test/README.md
@@ -1,0 +1,3 @@
+The instrumentation test framework cannot test instrumentation modules that weave core JDK classes. 
+
+In such cases use functional tests instead: `newrelic-java-agent/functional_test/src/test/java/test/newrelic/test/agent/JavaUtilLoggerTest.java`

--- a/instrumentation/java.logging-jdk8/src/test/java/com/nr/instrumentation/jul/ExceptionUtilTest.java
+++ b/instrumentation/java.logging-jdk8/src/test/java/com/nr/instrumentation/jul/ExceptionUtilTest.java
@@ -1,0 +1,61 @@
+package com.nr.instrumentation.jul;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExceptionUtilTest {
+
+    @Test
+    public void testIsThrowableNull() {
+        Throwable nullThrowable = null;
+        Throwable nonNullThrowable = new Throwable("Hi");
+
+        assertTrue(ExceptionUtil.isThrowableNull(nullThrowable));
+        assertFalse(ExceptionUtil.isThrowableNull(nonNullThrowable));
+    }
+
+    @Test
+    public void testGetErrorStack() {
+        int maxStackSize = 3;
+        StackTraceElement stackTraceElement1 = new StackTraceElement("Class1", "method1", "File1", 1);
+        StackTraceElement stackTraceElement2 = new StackTraceElement("Class2", "method2", "File2", 2);
+        StackTraceElement stackTraceElement3 = new StackTraceElement("Class3", "method3", "File3", 3);
+        StackTraceElement stackTraceElement4 = new StackTraceElement("Class4", "method4", "File4", 4);
+        StackTraceElement stackTraceElement5 = new StackTraceElement("Class5", "method5", "File5", 5);
+        StackTraceElement[] stack = new StackTraceElement[] { stackTraceElement1, stackTraceElement2, stackTraceElement3, stackTraceElement4,
+                stackTraceElement5 };
+        String errorStack = ExceptionUtil.getErrorStack(stack, maxStackSize);
+
+        // Processed stack should be limited to only the first three lines
+        assertTrue(errorStack.contains(stackTraceElement1.toString()));
+        assertTrue(errorStack.contains(stackTraceElement2.toString()));
+        assertTrue(errorStack.contains(stackTraceElement3.toString()));
+        // Processed stack should omit the last two lines
+        assertFalse(errorStack.contains(stackTraceElement4.toString()));
+        assertFalse(errorStack.contains(stackTraceElement5.toString()));
+    }
+
+    @Test
+    public void testGetErrorMessage() {
+        String expectedMessage = "Hi";
+        Throwable nullThrowable = null;
+        Throwable nonNullThrowable = new Throwable(expectedMessage);
+
+        assertNull(ExceptionUtil.getErrorMessage(nullThrowable));
+        assertEquals(expectedMessage, ExceptionUtil.getErrorMessage(nonNullThrowable));
+    }
+
+    @Test
+    public void testGetErrorClass() {
+        String expectedExceptionClass = "java.lang.RuntimeException";
+        Throwable nullThrowable = null;
+        RuntimeException runtimeException = new RuntimeException("Hi");
+
+        assertNull(ExceptionUtil.getErrorClass(nullThrowable));
+        assertEquals(expectedExceptionClass, ExceptionUtil.getErrorClass(runtimeException));
+    }
+}

--- a/instrumentation/java.logging-jdk8/src/test/resources/application_logging_enabled.yml
+++ b/instrumentation/java.logging-jdk8/src/test/resources/application_logging_enabled.yml
@@ -1,0 +1,10 @@
+common: &default_settings
+  application_logging:
+    enabled: true
+    forwarding:
+      enabled: true
+      max_samples_stored: 10000
+    metrics:
+      enabled: true
+    local_decorating:
+      enabled: false


### PR DESCRIPTION
Adds instrumentation for creating and forwarding `LogEvent`s logged by the `java.util.logging` library.

<img width="1106" alt="JUL logs" src="https://user-images.githubusercontent.com/3496648/194967217-f427c206-870c-4fc9-a61a-d4f0cd7db258.png">

AITs for this PR: https://github.com/newrelic/java-agent-integration-tests/pull/120