### PR TITLE
NEWRELIC-3834 add embedded tomcat jmx instrumentation

### DIFF
--- a/instrumentation/tomcat-jmx/src/main/java/com/nr/agent/instrumentation/tomcat/TomcatUtils.java
+++ b/instrumentation/tomcat-jmx/src/main/java/com/nr/agent/instrumentation/tomcat/TomcatUtils.java
@@ -7,22 +7,50 @@
 
 package com.nr.agent.instrumentation.tomcat;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.api.agent.NewRelic;
+
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 public class TomcatUtils {
 
     private static final String JMX_PREFIX = "Catalina";
+    private static final String JMX_EMBEDDED_PREFIX = "Tomcat";
+    private static final String JMX_EMBEDDED_DATASOURCE_PREFIX = "org.apache.tomcat.jdbc.pool.jmx";
+
     private static final AtomicBoolean addedJmx = new AtomicBoolean(false);
 
     public static void addJmx() {
         if (System.getProperty("com.sun.aas.installRoot") == null) {
             if (!addedJmx.getAndSet(true)) {
-                AgentBridge.jmxApi.addJmxMBeanGroup(JMX_PREFIX);
-                NewRelic.getAgent().getLogger().log(Level.FINER, "Added JMX for Tomcat");
+                MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+                //The ObjectName is different if embedded tomcat is used. Checking that this object has been registered
+                //will let us know that we are in an embedded tomcat. The Set returned by queryNames will return size 0 if the ObjectName is not
+                //found
+                try {
+                    if (server.queryNames(new ObjectName("Tomcat:type=Server"), null).size() == 1) {
+                        AgentBridge.jmxApi.addJmxMBeanGroup(JMX_EMBEDDED_PREFIX);
+                        NewRelic.getAgent().getLogger().log(Level.FINER, "Added JMX for Tomcat");
+
+                    }
+                    if(server.queryNames(new ObjectName("org.apache.tomcat.jdbc.pool.jmx:name=dataSourceMBean,type=ConnectionPool"), null)
+                            .size() == 1){
+                        AgentBridge.jmxApi.addJmxMBeanGroup(JMX_EMBEDDED_DATASOURCE_PREFIX);
+                        NewRelic.getAgent().getLogger().log(Level.FINER, "Added JMX for Tomcat dataSourceMbean ConnectionPool");
+
+                    } else {
+                        // It is safe to assume we are in a non embedded Tomcat (Catalina) which uses Catalina for the ObjectName, no need to query.
+                        AgentBridge.jmxApi.addJmxMBeanGroup(JMX_PREFIX);
+                        NewRelic.getAgent().getLogger().log(Level.FINER, "Added JMX for Catalina");
+                    }
+                } catch (MalformedObjectNameException e) {
+                    NewRelic.getAgent().getLogger().log(Level.FINEST, e, e.getMessage());
+                }
             }
         }
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxApiImpl.java
@@ -10,6 +10,8 @@ package com.newrelic.agent.jmx;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.bridge.JmxApi;
 import com.newrelic.agent.jmx.metrics.JmxFrameworkValues;
+import com.newrelic.agent.jmx.values.EmbeddedTomcatDataSourceJmxValues;
+import com.newrelic.agent.jmx.values.EmbeddedTomcatJmxValues;
 import com.newrelic.agent.jmx.values.GlassfishJmxValues;
 import com.newrelic.agent.jmx.values.Jboss7UpJmxValues;
 import com.newrelic.agent.jmx.values.JettyJmxMetrics;
@@ -71,6 +73,10 @@ public class JmxApiImpl implements JmxApi {
                     return new WebsphereLibertyJmxValues();
                 case TomcatJmxValues.PREFIX:
                     return new TomcatJmxValues();
+                case EmbeddedTomcatJmxValues.PREFIX:
+                    return new EmbeddedTomcatJmxValues();
+                case EmbeddedTomcatDataSourceJmxValues.PREFIX:
+                    return new EmbeddedTomcatDataSourceJmxValues();
                 case JettyJmxMetrics.PREFIX:
                     return new JettyJmxMetrics();
                 case Jboss7UpJmxValues.PREFIX:

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/EmbeddedTomcatDataSourceJmxValues.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/EmbeddedTomcatDataSourceJmxValues.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.jmx.values;
+
+import com.newrelic.agent.MetricNames;
+import com.newrelic.agent.jmx.metrics.BaseJmxValue;
+import com.newrelic.agent.jmx.metrics.DataSourceJmxMetricGenerator;
+import com.newrelic.agent.jmx.metrics.JmxFrameworkValues;
+import com.newrelic.agent.jmx.metrics.JmxMetric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EmbeddedTomcatDataSourceJmxValues extends JmxFrameworkValues {
+
+    /**
+     * The Mbean group namespaces are different between standalone Tomcat and Embedded Tomcat
+     * Standalone uses the prefix (aka type) Catalina for queries whereas embedded Tomcat uses the prefix (aka type) Tomcat.
+     * Our TomcatJmxValues instrumentation only queries MBeans with the Catalina prefix thus queries initiated by embedded Tomcat
+     * do not provide metrics. Additionally, datasource metrics
+     * were broken out into type: org.apache.tomcat.pool.jmx for embedded tomcat, hence this Class. See (@EmbeddedTomcatJmxValues)
+     */
+
+    public static final String PREFIX = "org.apache.tomcat.jdbc.pool.jmx";
+
+    private static final int METRIC_COUNT = 1;
+
+    private static final JmxMetric CONNECTIONS_ACTIVE = DataSourceJmxMetricGenerator.CONNECTIONS_ACTIVE.createMetric("NumActive");
+    private static final JmxMetric CONNECTIONS_IDLE = DataSourceJmxMetricGenerator.CONNECTIONS_IDLE.createMetric("NumIdle");
+    private static final JmxMetric CONNECTIONS_MAX = DataSourceJmxMetricGenerator.CONNECTIONS_MAX.createMetric("MaxActive");
+    private static final JmxMetric CONNECTIONS_CREATED = DataSourceJmxMetricGenerator.CONNECTIONS_CREATED.createMetric("CreatedCount");
+
+    private final List<BaseJmxValue> metrics = new ArrayList<>(METRIC_COUNT);
+
+    public EmbeddedTomcatDataSourceJmxValues() {
+        createMetrics("*");
+    }
+
+    public EmbeddedTomcatDataSourceJmxValues(String name) {
+        createMetrics(name);
+
+    }
+
+    private void createMetrics(String name) {
+
+        metrics.add(new BaseJmxValue("org.apache.tomcat.jdbc.pool.jmx:name=*,type=ConnectionPool", MetricNames.JMX_DATASOURCES + "{name}/",
+                new JmxMetric[] { CONNECTIONS_ACTIVE, CONNECTIONS_IDLE, CONNECTIONS_MAX, CONNECTIONS_CREATED }));
+    }
+
+    @Override
+    public List<BaseJmxValue> getFrameworkMetrics() {
+        return metrics;
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/EmbeddedTomcatJmxValues.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/EmbeddedTomcatJmxValues.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -10,7 +10,6 @@ package com.newrelic.agent.jmx.values;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.jmx.JmxType;
 import com.newrelic.agent.jmx.metrics.BaseJmxValue;
-import com.newrelic.agent.jmx.metrics.DataSourceJmxMetricGenerator;
 import com.newrelic.agent.jmx.metrics.JmxAction;
 import com.newrelic.agent.jmx.metrics.JmxFrameworkValues;
 import com.newrelic.agent.jmx.metrics.JmxMetric;
@@ -19,27 +18,25 @@ import com.newrelic.agent.jmx.metrics.ServerJmxMetricGenerator;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TomcatJmxValues extends JmxFrameworkValues {
+public class EmbeddedTomcatJmxValues extends JmxFrameworkValues {
 
     /**
-     * This is the main prefix for JMX metrics. However, the prefix can be changed by setting the name of the engine to
-     * something else.
+     * The Mbean group namespaces are different between standalone Tomcat and Embedded Tomcat
+     * Standalone uses the prefix (aka type) Catalina for queries whereas embedded Tomcat uses the prefix (aka type) Tomcat.
+     * Our TomcatJmxValues instrumentation only queries MBeans with the Catalina prefix thus queries initiated by embedded Tomcat
+     * do not provide metrics. Additionally, datasource metrics
+     * were broken out into type: org.apache.tomcat.pool.jmx for embedded tomcat. See (@EmbeddedTomcatDataSourceJmxValues)
      */
-    public static final String PREFIX = "Catalina";
 
-    private static final int METRIC_COUNT = 5;
+    public static final String PREFIX = "Tomcat";
 
-    // SESSION METRICS
+    private static final int METRIC_COUNT = 2;
+
+    // SESSION METRICS (Manager)
     private static final JmxMetric ACTIVE_SESSIONS = ServerJmxMetricGenerator.SESSION_ACTIVE_COUNT.createMetric("activeSessions");
     private static final JmxMetric EXPIRED_SESSIONS = ServerJmxMetricGenerator.SESSION_EXPIRED_COUNT.createMetric("expiredSessions");
     private static final JmxMetric REJECTED_SESSIONS = ServerJmxMetricGenerator.SESSION_REJECTED_COUNT.createMetric("rejectedSessions");
     private static final JmxMetric SESSION_ALIVE_TIME = ServerJmxMetricGenerator.SESSION_AVG_ALIVE_TIME.createMetric("sessionAverageAliveTime");
-
-    private static final JmxMetric CONNECTIONS_ACTIVE = DataSourceJmxMetricGenerator.CONNECTIONS_ACTIVE.createMetric("numActive");
-    private static final JmxMetric CONNECTIONS_IDLE = DataSourceJmxMetricGenerator.CONNECTIONS_IDLE.createMetric("numIdle");
-    private static final JmxMetric CONNECTIONS_MAX = DataSourceJmxMetricGenerator.CONNECTIONS_MAX.createMetric("maxActive");
-    private static final JmxMetric CONNECTIONS_MAX_TOMCAT_8 = DataSourceJmxMetricGenerator.CONNECTIONS_MAX.createMetric("maxTotal");
-
 
     // THREAD POOL METRICS
     private static final JmxMetric CURRENT_MAX_COUNT = ServerJmxMetricGenerator.MAX_THREAD_POOL_COUNT.createMetric("maxThreads");
@@ -49,18 +46,18 @@ public class TomcatJmxValues extends JmxFrameworkValues {
 
     private final List<BaseJmxValue> metrics = new ArrayList<>(METRIC_COUNT);
 
-    public TomcatJmxValues() {
+    public EmbeddedTomcatJmxValues() {
         createMetrics("*");
     }
 
-    public TomcatJmxValues(String name) {
+    public EmbeddedTomcatJmxValues(String name) {
         createMetrics(name);
 
     }
 
     private void createMetrics(String name) {
         /*
-         * Only used by 7.0. The manager bean provides information about sessions. sessionCounter is the total number of
+         * Only used by 7.0+. The manager bean provides information about sessions. sessionCounter is the total number of
          * sessions created by this manager. ActiveSessions is the number of active sessions at this moment.
          * expiredSesions is the number of sessions that have expired. RejectedSessions is the number of sessions
          * rejected due to maxActive being reached. SessionAverageAliveTime is the average time an expired session had
@@ -68,32 +65,10 @@ public class TomcatJmxValues extends JmxFrameworkValues {
          */
         metrics.add(new BaseJmxValue(name + ":type=Manager,context=*,host=*,*", MetricNames.JMX_SESSION + "{context}/",
                 new JmxMetric[] { ACTIVE_SESSIONS, EXPIRED_SESSIONS, REJECTED_SESSIONS, SESSION_ALIVE_TIME }));
-        /* This is for 6.0 and 5.5. */
-        metrics.add(new BaseJmxValue(name + ":type=Manager,path=*,host=*", MetricNames.JMX_SESSION + "{path}/",
-                new JmxMetric[] { ACTIVE_SESSIONS, EXPIRED_SESSIONS, REJECTED_SESSIONS, SESSION_ALIVE_TIME }));
-        /*
-         * Provides information about the thread pool. The current thread count and the current number of threads which
-         * are busy.
-         */
+
         metrics.add(new BaseJmxValue(name + ":type=ThreadPool,name=*", MetricNames.JMX_THREAD_POOL + "{name}/",
                 new JmxMetric[] { CURRENT_ACTIVE_COUNT, CURRENT_IDLE_COUNT, CURRENT_MAX_COUNT }));
-        
-        /*
-         * Provides information about the data source by finding the number of active and idle connections and the max connections. 
-         * In Tomcat 7, the number of max connections is represented by the maxActive attribute. In tomcat 8
-         * this was changed to maxTotal, hence the two CONNECTIONS_MAX metrics.
-         */
-        metrics.add(new BaseJmxValue(name + ":type=DataSource,context=*,host=*," +
-                "class=javax.sql.DataSource,name=*", MetricNames.JMX_DATASOURCES + "{name}/",
-                new JmxMetric[] { CONNECTIONS_ACTIVE, CONNECTIONS_IDLE, CONNECTIONS_MAX, CONNECTIONS_MAX_TOMCAT_8 }));
-        
-        /*
-         * Provides information about the data source when the customer is using JNDI GlobalNamingResources, which do 
-         * not have a context or a host.
-         */
-        metrics.add(new BaseJmxValue(name + ":type=DataSource," +
-                "class=javax.sql.DataSource,name=*", MetricNames.JMX_DATASOURCES + "{name}/",
-                new JmxMetric[] { CONNECTIONS_ACTIVE, CONNECTIONS_IDLE, CONNECTIONS_MAX, CONNECTIONS_MAX_TOMCAT_8 }));
+
     }
 
     @Override


### PR DESCRIPTION
Add instrumentation to cover embedded tomcat.
The agent doesn’t correctly query the following Tomcat JMX metrics when using embedded Tomcat with SpringBoot:

type=DataSource
type=ThreadPool
type=Manager

We add Tomcat JMX values for the above categories if the server was started via one of the following two methods:

```
org.apache.catalina.startup.HostConfig.start()
org.apache.catalina.core.StandardServer.startInternal()

```

It appears that when using embedded Tomcat with Spring Boot StandardServer does get instrumented properly:

```
Supportability/WeaveInstrumentation/WeaveClass/com.newrelic.instrumentation.tomcat-jmx/org/apache/catalina/core/StandardServer
Supportability/WeaveInstrumentation/WeaveClass/com.newrelic.instrumentation.tomcat-8.5.2/org/apache/catalina/core/StandardServer

```

By default, embedded Tomcat JMX is disabled by Spring Boot. In application.properties Tomcat mbeans need to be enabled by adding: server.tomcat.mbeanregistry.enabled=true

The problem though is that the Mbean group namespaces are different, standalone Tomcat uses the prefix Catalina for queries whereas embedded Tomcat uses the prefix Tomcat. Our tomcat-jmx instrumentation only queries MBeans with the Catalina prefix thus queries initiated by embedded Tomcat fail due to an incorrect group name.

Standalone Tomcat JMX:

Embedded Tomcat JMX

For now, the recommended workaround would be to utilize Custom JMX instrumentation by YAML and create a dashboard to view the metrics.

### Overview
Describe the changes present in the pull request

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
run local tests against embedded tomcat to confirm metrics are collected
### Checks


