### PR TITLE
NR-23881 - change the method used to get the MDC

### DIFF
--- a/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
+++ b/instrumentation/apache-log4j-2/src/main/java/com/nr/agent/instrumentation/log4j2/AgentUtil.java
@@ -44,7 +44,7 @@ public class AgentUtil {
             Throwable throwable = event.getThrown();
 
             if (shouldCreateLogEvent(message, throwable)) {
-                ReadOnlyStringMap contextData = event.getContextData();
+                Map<String, String> contextData = event.getContextMap();
                 Map<LogAttributeKey, Object> logEventMap = new HashMap<>(calculateInitialMapSize(contextData));
                 if (message != null) {
                     String formattedMessage = message.getFormattedMessage();
@@ -55,7 +55,7 @@ public class AgentUtil {
                 logEventMap.put(TIMESTAMP, event.getTimeMillis());
 
                 if (AppLoggingUtils.isAppLoggingContextDataEnabled() && contextData != null) {
-                    for (Map.Entry<String, String> entry : contextData.toMap().entrySet()) {
+                    for (Map.Entry<String, String> entry : contextData.entrySet()) {
                         String key = entry.getKey();
                         String value = entry.getValue();
                         LogAttributeKey logAttrKey = new LogAttributeKey(key, LogAttributeType.CONTEXT);
@@ -121,7 +121,7 @@ public class AgentUtil {
         return (message != null) || !ExceptionUtil.isThrowableNull(throwable);
     }
 
-    private static int calculateInitialMapSize(ReadOnlyStringMap mdcPropertyMap) {
+    private static int calculateInitialMapSize(Map<String, String> mdcPropertyMap) {
         return AppLoggingUtils.isAppLoggingContextDataEnabled() && mdcPropertyMap != null
                 ? mdcPropertyMap.size() + DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES
                 : DEFAULT_NUM_OF_LOG_EVENT_ATTRIBUTES;


### PR DESCRIPTION
### Overview
The method used in the first PR for this feature in Log4J was introduced in version 2.7.
But the instrumentation module supports version 2.6.

So this is changing the method used to the existing in 2.6.