### PR TITLE
NEWRELIC-3498 fix Vfs.Dir scala dir

### DIFF
--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'scala'
 
 configurations {
     includeInJar


### PR DESCRIPTION
Fixes build issue.
We (I) added the apply scala plugin to the java.gradle script, which meant we were expecting scala classes in each module. Our build task however did not expect that so was appropriately throwing an exception when the directories for scala classes weren't available in modules that did not in fact compile any scala.
### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
