### PR TITLE
Checks that there is a transaction prior to adding CLM attrs

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -290,7 +290,7 @@ public class DefaultTracer extends AbstractTracer {
             }
 
             try {
-                if (classMethodSignature != null &&
+                if (classMethodSignature != null && getTransaction() != null &&
                         ServiceFactory.getConfigService().getDefaultAgentConfig().getCodeLevelMetricsConfig().isEnabled()) {
                     String className = classMethodSignature.getClassName();
                     String methodName = classMethodSignature.getMethodName();


### PR DESCRIPTION
### Overview
When adding CLM attrs to an span, going thru the add attribute code, it tries to get a transaction.
But if the @Trace is someplace where there is no transaction, this causes an NPE.

This PR adds a guard to prevent that from happening.