### PR TITLE
Fix jdk11 http client so that segments don't time out

### DIFF
--- a/instrumentation/httpclient-jdk11/src/main/java/com.nr.agent.instrumentation.httpclient/Java11HttpClientUtil.java
+++ b/instrumentation/httpclient-jdk11/src/main/java/com.nr.agent.instrumentation.httpclient/Java11HttpClientUtil.java
@@ -68,6 +68,7 @@ public class Java11HttpClientUtil {
                 reportUnknownHostExternal(segment);
             } else {
                 NewRelic.noticeError(e);
+                segment.end();
             }
         }
     }


### PR DESCRIPTION
Fixes a bug that would cause a segment timeout in the JDK 11 HTTP client instrumentation. The bug would occur whenever the synchronous `HttpClient.send(...)` method was invoked and any exception other than a `ConnectException` was thrown.

If an exception occurred here we would call `handleConnectException`:

```
    @Trace
    public <T> HttpResponse<T> send(HttpRequest req, HttpResponse.BodyHandler<T> responseHandler)
            throws IOException, InterruptedException {
        URI uri = req.uri();
        Segment segment = startSegment(uri);
        HttpResponse<T> response;
        try {
            response = Weaver.callOriginal();
            if (segment == null) {
                return response;
            }
        } catch (Exception e) {
            handleConnectException(e, req, segment);
            throw e;
        }
        processResponse(response, segment);
        return response;
    }
```

If the exception was a `ConnectException` we would properly report it and end the segment but if it was any other exception type it only gets reported without actually ending the segment. 

```
    public static void handleConnectException(Exception e, HttpRequest request, Segment segment){
        if (request.uri() != null) {
            if (throwableIsConnectException(e)) {
                reportUnknownHostExternal(segment);
            } else {
                NewRelic.noticeError(e);
                // FIXME we should be calling segment.end() in this case as well
            }
        }
    }
```

This would result in a segment for the external call hitting the 10 minute segment timeout limit and being truncated:
<img width="694" alt="Screen Shot 2022-10-21 at 3 55 05 PM" src="https://user-images.githubusercontent.com/3496648/197302559-2e297bab-d60f-4cc3-9afc-e8685026e077.png">

After expiring the segment properly the segment completes in milliseconds and is no longer truncated:
<img width="709" alt="Screen Shot 2022-10-21 at 3 56 12 PM" src="https://user-images.githubusercontent.com/3496648/197302664-928e5275-c495-413f-b290-6133715e4bbc.png">