### PR TITLE
Support Java 17-compiled instrumentation modules

### DIFF
--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
@@ -182,7 +182,9 @@ public final class WeaveUtils {
     private static int getRuntimeMaxSupportedClassVersion() {
         try {
             double jvmSpecVersion = Double.valueOf(System.getProperty("java.specification.version"));
-            if (jvmSpecVersion >=11) {
+            if (jvmSpecVersion >= 17) {
+                return 61;
+            else if (jvmSpecVersion >= 11) {
                 return 55;
             } else if (jvmSpecVersion >= 1.8) {
                 return 52;

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
@@ -184,7 +184,7 @@ public final class WeaveUtils {
             double jvmSpecVersion = Double.valueOf(System.getProperty("java.specification.version"));
             if (jvmSpecVersion >= 17) {
                 return 61;
-            else if (jvmSpecVersion >= 11) {
+            } else if (jvmSpecVersion >= 11) {
                 return 55;
             } else if (jvmSpecVersion >= 1.8) {
                 return 52;


### PR DESCRIPTION
I want to use an instrumentation module I compiled with Java 17, and this is preventing me from doing so.

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
Minor change to support specifications of Java 17 and later

### Related Github Issue
none

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
n/a Does your code contain any breaking changes? Please describe. 
n/a Does your code introduce any new dependencies? Please describe.
