### PR TITLE
NR-23881 - Fixing typo in context data config

### DIFF
--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -106,7 +106,7 @@ common: &default_settings
       #max_samples_stored: 10000
 
       # Whether the log events should include context from loggers with support for that.
-      include_context_data:
+      context_data:
 
         # When true, application logs will contain context data.
         enabled: false


### PR DESCRIPTION
### Overview
The default config file had the wrong label for the context data stanza
