### PR TITLE
NR-00000 - Moving dependencies from JCenter to Maven Central

### DIFF
--- a/instrumentation/play-2.6.13/build.gradle
+++ b/instrumentation/play-2.6.13/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation(project(":newrelic-weaver-scala-api"))
-    implementation("org.scala-lang:scala-library:2.11.+")
+    implementation("org.scala-lang:scala-library:2.11.12")
     implementation("com.typesafe.play:play-server_2.11:2.6.13")
     testImplementation("com.typesafe.play:play-test_2.11:2.6.13")
     testImplementation("com.typesafe.play:play-java_2.11:2.6.13")

--- a/instrumentation/play-2.6/build.gradle
+++ b/instrumentation/play-2.6/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation(project(":newrelic-weaver-scala-api"))
-    implementation("org.scala-lang:scala-library:2.11.+")
+    implementation("org.scala-lang:scala-library:2.11.12")
     implementation("com.typesafe.play:play-server_2.11:2.6.0")
     testImplementation("com.typesafe.play:play-test_2.11:2.6.0")
     testImplementation("com.typesafe.play:play-java_2.11:2.6.0")

--- a/instrumentation/play-2.7/build.gradle
+++ b/instrumentation/play-2.7/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
     implementation(project(":newrelic-weaver-scala-api"))
-    implementation("org.scala-lang:scala-library:2.11.+")
+    implementation("org.scala-lang:scala-library:2.11.12")
     implementation("com.typesafe.play:play-server_2.11:2.7.0-M2")
     testImplementation("com.typesafe.play:play-test_2.11:2.7.0-M2")
     testImplementation("com.typesafe.play:play-java_2.11:2.7.0-M2")

--- a/instrumentation/spring-aop-2/build.gradle
+++ b/instrumentation/spring-aop-2/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
     implementation(project(":agent-bridge"))
-    implementation("org.springframework:spring-aop:3.2.+")
+    implementation("org.springframework:spring-aop:3.2.18.RELEASE")
     //     implementation("org.springframework:spring:2.0.3") // First version to have MethodMatchers.matches()
 
 }


### PR DESCRIPTION
### Overview
Some artifacts used by the agent used a syntax for version (1.0.+) to get the latest patch version.
This works well in JCenter, but not on Maven Central. So when JCenter have problems we are not able to build the agent.

Specifying the version for these artifacts allows us to download them from Maven Central.

It is unlikely that we'd get any new patch version for these artifacts since their last version are from 2017.