### PR TITLE
Tracer debug logging

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
@@ -338,7 +338,9 @@ public class TransactionActivity {
         } else {
             if (tracer.getParentTracer() != null) {
                 lastTracer = tracer;
-                Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer set to {0}", tracer);
+                if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
+                    Agent.LOG.log(Level.FINEST, "Tracer Debug: lastTracer set to {0}", tracer);
+                }
                 addTracer(tracer);
             } else {
                 if (Agent.LOG.isFinestEnabled()) {
@@ -356,7 +358,9 @@ public class TransactionActivity {
      */
     public void tracerFinished(Tracer tracer, int opcode) {
         if (tracer instanceof SkipTracer) {
-            Agent.LOG.log(Level.INFO, "Tracer Debug: SkipTracer tracer = {0}", tracer);
+            if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
+                Agent.LOG.log(Level.INFO, "Tracer Debug: SkipTracer tracer = {0}", tracer);
+            }
             return;
         }
         if (tracer != lastTracer) {
@@ -365,7 +369,9 @@ public class TransactionActivity {
             finished(rootTracer, opcode);
         } else {
             lastTracer = tracer.getParentTracer();
-            Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
+            if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
+                Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
+            }
         }
     }
 
@@ -465,7 +471,9 @@ public class TransactionActivity {
     private void setRootTracer(Tracer tracer) {
         rootTracer = tracer;
         lastTracer = tracer;
-        Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer and rootTracer set to {0}", tracer);
+        if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
+            Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer and rootTracer set to {0}", tracer);
+        }
 
         if (tracer instanceof DefaultTracer) {
             DefaultTracer dt = (DefaultTracer) tracer;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
@@ -339,7 +339,7 @@ public class TransactionActivity {
             if (tracer.getParentTracer() != null) {
                 lastTracer = tracer;
                 if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                    Agent.LOG.log(Level.FINEST, "Tracer Debug: lastTracer set to {0}", tracer);
+                    Agent.LOG.log(Level.FINEST, "Tracer Debug: called addTracerToStack, lastTracer set to {0}", tracer);
                 }
                 addTracer(tracer);
             } else {
@@ -359,7 +359,7 @@ public class TransactionActivity {
     public void tracerFinished(Tracer tracer, int opcode) {
         if (tracer instanceof SkipTracer) {
             if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                Agent.LOG.log(Level.FINEST, "Tracer Debug: SkipTracer tracer = {0}", tracer);
+                Agent.LOG.log(Level.FINEST, "Tracer Debug: called tracerFinished to pop tracer off stack, SkipTracer tracer = {0}", tracer);
             }
             return;
         }
@@ -370,7 +370,7 @@ public class TransactionActivity {
         } else {
             lastTracer = tracer.getParentTracer();
             if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                Agent.LOG.log(Level.FINEST, "Tracer Debug: lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
+                Agent.LOG.log(Level.FINEST, "Tracer Debug: called tracerFinished to pop tracer off stack, lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
             }
         }
     }
@@ -472,7 +472,7 @@ public class TransactionActivity {
         rootTracer = tracer;
         lastTracer = tracer;
         if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-            Agent.LOG.log(Level.FINEST, "Tracer Debug: lastTracer and rootTracer set to {0}", tracer);
+            Agent.LOG.log(Level.FINEST, "Tracer Debug: called setRootTracer, lastTracer and rootTracer set to {0}", tracer);
         }
 
         if (tracer instanceof DefaultTracer) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
@@ -338,6 +338,7 @@ public class TransactionActivity {
         } else {
             if (tracer.getParentTracer() != null) {
                 lastTracer = tracer;
+                Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer set to {0}", tracer);
                 addTracer(tracer);
             } else {
                 if (Agent.LOG.isFinestEnabled()) {
@@ -355,6 +356,7 @@ public class TransactionActivity {
      */
     public void tracerFinished(Tracer tracer, int opcode) {
         if (tracer instanceof SkipTracer) {
+            Agent.LOG.log(Level.INFO, "Tracer Debug: SkipTracer tracer = {0}", tracer);
             return;
         }
         if (tracer != lastTracer) {
@@ -363,6 +365,7 @@ public class TransactionActivity {
             finished(rootTracer, opcode);
         } else {
             lastTracer = tracer.getParentTracer();
+            Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
         }
     }
 
@@ -462,6 +465,7 @@ public class TransactionActivity {
     private void setRootTracer(Tracer tracer) {
         rootTracer = tracer;
         lastTracer = tracer;
+        Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer and rootTracer set to {0}", tracer);
 
         if (tracer instanceof DefaultTracer) {
             DefaultTracer dt = (DefaultTracer) tracer;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
@@ -339,7 +339,7 @@ public class TransactionActivity {
             if (tracer.getParentTracer() != null) {
                 lastTracer = tracer;
                 if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                    Agent.LOG.log(Level.FINEST, "Tracer Debug: called addTracerToStack, lastTracer set to {0}", tracer);
+                    Agent.LOG.log(Level.FINEST, "Tracer Debug: called addTracerToStack, lastTracer (pointer to top of stack) set to {0}", tracer);
                 }
                 addTracer(tracer);
             } else {
@@ -359,7 +359,7 @@ public class TransactionActivity {
     public void tracerFinished(Tracer tracer, int opcode) {
         if (tracer instanceof SkipTracer) {
             if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                Agent.LOG.log(Level.FINEST, "Tracer Debug: called tracerFinished to pop tracer off stack, SkipTracer tracer = {0}", tracer);
+                Agent.LOG.log(Level.FINEST, "Tracer Debug: called tracerFinished to pop tracer off stack, ignoring SkipTracer tracer = {0}", tracer);
             }
             return;
         }
@@ -370,7 +370,7 @@ public class TransactionActivity {
         } else {
             lastTracer = tracer.getParentTracer();
             if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                Agent.LOG.log(Level.FINEST, "Tracer Debug: called tracerFinished to pop tracer off stack, lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
+                Agent.LOG.log(Level.FINEST, "Tracer Debug: called tracerFinished to pop tracer off stack, lastTracer (pointer to top of stack) set to {0}, tracer (actual tracer popped off stack) = {1}", lastTracer, tracer);
             }
         }
     }
@@ -382,7 +382,7 @@ public class TransactionActivity {
      * @param opcode
      */
     private void failedDueToInconsistentTracerState(Tracer tracer, int opcode) {
-        Agent.LOG.log(Level.SEVERE, "Inconsistent state!  tracer != last tracer for {0} ({1} != {2})", this, tracer,
+        Agent.LOG.log(Level.SEVERE, "Tracer Debug: Inconsistent state! tracer (actual tracer popped off stack) != lastTracer (pointer to top of stack) for {0} ({1} != {2})", this, tracer,
                 lastTracer);
         try {
             transaction.activityFailedOrIgnored(this, opcode);
@@ -472,7 +472,7 @@ public class TransactionActivity {
         rootTracer = tracer;
         lastTracer = tracer;
         if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-            Agent.LOG.log(Level.FINEST, "Tracer Debug: called setRootTracer, lastTracer and rootTracer set to {0}", tracer);
+            Agent.LOG.log(Level.FINEST, "Tracer Debug: called setRootTracer, lastTracer (pointer to top of stack) and rootTracer set to {0}", tracer);
         }
 
         if (tracer instanceof DefaultTracer) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionActivity.java
@@ -359,7 +359,7 @@ public class TransactionActivity {
     public void tracerFinished(Tracer tracer, int opcode) {
         if (tracer instanceof SkipTracer) {
             if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                Agent.LOG.log(Level.INFO, "Tracer Debug: SkipTracer tracer = {0}", tracer);
+                Agent.LOG.log(Level.FINEST, "Tracer Debug: SkipTracer tracer = {0}", tracer);
             }
             return;
         }
@@ -370,7 +370,7 @@ public class TransactionActivity {
         } else {
             lastTracer = tracer.getParentTracer();
             if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-                Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
+                Agent.LOG.log(Level.FINEST, "Tracer Debug: lastTracer set to {0}, tracer = {1}", lastTracer, tracer);
             }
         }
     }
@@ -472,7 +472,7 @@ public class TransactionActivity {
         rootTracer = tracer;
         lastTracer = tracer;
         if (Agent.isDebugEnabled() && Agent.LOG.isFinestEnabled()) {
-            Agent.LOG.log(Level.INFO, "Tracer Debug: lastTracer and rootTracer set to {0}", tracer);
+            Agent.LOG.log(Level.FINEST, "Tracer Debug: lastTracer and rootTracer set to {0}", tracer);
         }
 
         if (tracer instanceof DefaultTracer) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -313,11 +313,11 @@ public class DefaultTracer extends AbstractTracer {
                 }
             } catch (Throwable t) {
                 String msg = MessageFormat.format(
-                        "Tracer Debug: An error occurred calling Transaction.tracerFinished() for class {0} : {1} : this Tracer = {2}",
+                        "An error occurred calling Transaction.tracerFinished() for class {0} : {1} : this Tracer = {2}",
                         classMethodSignature.getClassName(), t.toString(), this);
 
                 Agent.LOG.severe(msg);
-                Agent.LOG.log(Level.INFO, msg, t);
+                Agent.LOG.log(Level.FINER, msg, t);
             }
             reset();
         } finally {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -313,10 +313,11 @@ public class DefaultTracer extends AbstractTracer {
                 }
             } catch (Throwable t) {
                 String msg = MessageFormat.format(
-                        "An error occurred calling Transaction.tracerFinished() for class {0} : {1}",
-                        classMethodSignature.getClassName(), t.toString());
+                        "Tracer Debug: An error occurred calling Transaction.tracerFinished() for class {0} : {1} : this Tracer = {2}",
+                        classMethodSignature.getClassName(), t.toString(), this);
+
                 Agent.LOG.severe(msg);
-                Agent.LOG.log(Level.FINER, msg, t);
+                Agent.LOG.log(Level.INFO, msg, t);
             }
             reset();
         } finally {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -313,7 +313,7 @@ public class DefaultTracer extends AbstractTracer {
                 }
             } catch (Throwable t) {
                 String msg = MessageFormat.format(
-                        "An error occurred calling Transaction.tracerFinished() for class {0} : {1} : this Tracer = {2}",
+                        "Tracer Debug: An error occurred calling Transaction.tracerFinished() for class {0} : {1} : this Tracer = {2}",
                         classMethodSignature.getClassName(), t.toString(), this);
 
                 Agent.LOG.severe(msg);


### PR DESCRIPTION
Adds some additional logging to help troubleshoot `Inconsistent state! tracer != last tracer` errors. 

Additional logging will appear when the following is set:

```
-Dnewrelic.config.log_level=finest 
-Dnewrelic.debug=true
```

Grep'ing the agent logs for `Tracer Debug:` should produce all of the debug log messages related to this issue, which shows how tracers are being created and processed.

For context, this issue occurs when the agent is handling some async activity and is adding tracers for each method call and popping tracers off the stack as each method call completes. The agent tracks what the first tracer (root tracer) is when the async activity started and by the end we would expect that that last tracer we pop off should be the root, but in this case it isn't, which means that the agent has lost track of the correct call stack into this async code. When the pointer to the tracer object at the top of the stack differs from the actual tracer object that gets popped off then the agent is in an inconsistent state. If this happens the agent discards the async information it was attempting to record and logs the inconsistent state error.

It could potentially be caused by an internal error in some instrumented code that causes the agent to exit early without properly handling it or if the agent loses track of the active transaction.