### PR TITLE
Fix bug with log4j2 metrics not getting disabled

### DIFF
--- a/instrumentation/apache-log4j-2/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig_Instrumentation.java
+++ b/instrumentation/apache-log4j-2/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig_Instrumentation.java
@@ -37,17 +37,19 @@ public class LoggerConfig_Instrumentation {
 
     protected void callAppenders(LogEvent event) {
         // Do nothing if application_logging.enabled: false
-        // Do nothing if logger has parents and isAdditive is set to true to avoid duplicated counters and logs
-        if (isApplicationLoggingEnabled() && getParent() == null || !isAdditive()) {
-            if (isApplicationLoggingMetricsEnabled()) {
-                // Generate log level metrics
-                NewRelic.incrementCounter("Logging/lines");
-                NewRelic.incrementCounter("Logging/lines/" + event.getLevel().toString());
-            }
+        if (isApplicationLoggingEnabled()) {
+            // Do nothing if logger has parents and isAdditive is set to true to avoid duplicated counters and logs
+            if (getParent() == null || !isAdditive()) {
+                if (isApplicationLoggingMetricsEnabled()) {
+                    // Generate log level metrics
+                    NewRelic.incrementCounter("Logging/lines");
+                    NewRelic.incrementCounter("Logging/lines/" + event.getLevel().toString());
+                }
 
-            if (isApplicationLoggingForwardingEnabled()) {
-                // Record and send LogEvent to New Relic
-                recordNewRelicLogEvent(event);
+                if (isApplicationLoggingForwardingEnabled()) {
+                    // Record and send LogEvent to New Relic
+                    recordNewRelicLogEvent(event);
+                }
             }
         }
         Weaver.callOriginal();


### PR DESCRIPTION
Fixes a bug where the below logic could evaluate to `true` even if application logging was disabled at the top level (i.e. `application_logging.enabled: false`):

```
        if (isApplicationLoggingEnabled() && getParent() == null || !isAdditive()) {...}
```

If the entire `application_logging` stanza is disabled at the top level it should result in all related features being disabled regardless of how they are set.

In this case, where the `metrics` feature is still enabled, the code would make it past the above logic and still generate logging metrics.

```
  application_logging:
    enabled: false
    forwarding:
      enabled: true
      max_samples_stored: 10000
    local_decorating:
      enabled: true
    metrics:
      enabled: true
```