### PR TITLE
bump scala 2.13 to latest point release 2.13.10

### DIFF
--- a/newrelic-cats-effect3-api/build.gradle.kts
+++ b/newrelic-cats-effect3-api/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 evaluationDependsOn(":newrelic-api")
 
 crossBuild {
-    scalaVersionsCatalog = mapOf("2.12" to "2.12.13", "2.13" to "2.13.5")
+    scalaVersionsCatalog = mapOf("2.12" to "2.12.13", "2.13" to "2.13.10")
     builds {
         register("scala") {
             scalaVersions = setOf("2.12", "2.13")
@@ -23,7 +23,7 @@ java {
 }
 
 dependencies {
-    implementation("org.scala-lang:scala-library:2.13.5")
+    implementation("org.scala-lang:scala-library:2.13.10")
     implementation("org.typelevel:cats-effect_2.13:3.3.5")
     implementation(project(":newrelic-api"))
     testImplementation(project(":instrumentation-test"))

--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 evaluationDependsOn(":newrelic-api")
 
 crossBuild {
-    scalaVersionsCatalog = mapOf("2.10" to "2.10.7", "2.11" to "2.11.12", "2.12" to "2.12.13", "2.13" to "2.13.5")
+    scalaVersionsCatalog = mapOf("2.10" to "2.10.7", "2.11" to "2.11.12", "2.12" to "2.12.13", "2.13" to "2.13.10")
     builds {
         register("scala") {
             scalaVersions = setOf("2.10", "2.11", "2.12", "2.13")
@@ -24,7 +24,7 @@ java {
 
 dependencies {
     zinc("org.scala-sbt:zinc_2.13:1.7.1")
-    implementation("org.scala-lang:scala-library:2.13.7")
+    implementation("org.scala-lang:scala-library:2.13.10")
     implementation(project(":newrelic-api"))
     testImplementation(project(":instrumentation-test"))
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))

--- a/newrelic-scala-cats-api/build.gradle.kts
+++ b/newrelic-scala-cats-api/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 evaluationDependsOn(":newrelic-api")
 
 crossBuild {
-    scalaVersionsCatalog = mapOf("2.12" to "2.12.13", "2.13" to "2.13.5")
+    scalaVersionsCatalog = mapOf("2.12" to "2.12.13", "2.13" to "2.13.10")
     builds {
         register("scala") {
             scalaVersions = setOf("2.12", "2.13")
@@ -22,7 +22,7 @@ java {
 }
 
 dependencies {
-    implementation("org.scala-lang:scala-library:2.13.5")
+    implementation("org.scala-lang:scala-library:2.13.10")
     implementation("org.typelevel:cats-effect_2.13:2.5.1")
     implementation(project(":newrelic-api"))
     testImplementation(project(":instrumentation-test"))

--- a/newrelic-scala-monix-api/build.gradle.kts
+++ b/newrelic-scala-monix-api/build.gradle.kts
@@ -10,7 +10,7 @@ evaluationDependsOn(":newrelic-api")
 
 
 crossBuild {
-    scalaVersionsCatalog = mapOf("2.11" to "2.11.12", "2.12" to "2.12.13", "2.13" to "2.13.5")
+    scalaVersionsCatalog = mapOf("2.11" to "2.11.12", "2.12" to "2.12.13", "2.13" to "2.13.10")
     builds {
         register("scala") {
             scalaVersions = setOf("2.11", "2.12", "2.13")
@@ -26,7 +26,7 @@ java {
 
 dependencies {
     zinc("org.scala-sbt:zinc_2.13:1.7.1")
-    implementation("org.scala-lang:scala-library:2.13.5")
+    implementation("org.scala-lang:scala-library:2.13.10")
     implementation("io.monix:monix-eval_2.13:3.3.0")
     implementation("io.monix:monix-reactive_2.13:3.3.0")
     implementation(project(":newrelic-api"))

--- a/newrelic-scala-zio-api/build.gradle.kts
+++ b/newrelic-scala-zio-api/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 evaluationDependsOn(":newrelic-api")
 
 crossBuild {
-    scalaVersionsCatalog = mapOf("2.11" to "2.11.12", "2.12" to "2.12.13", "2.13" to "2.13.5")
+    scalaVersionsCatalog = mapOf("2.11" to "2.11.12", "2.12" to "2.12.13", "2.13" to "2.13.10")
     builds {
         register("scala") {
             scalaVersions = setOf("2.11", "2.12", "2.13")
@@ -24,7 +24,7 @@ java {
 
 dependencies {
     zinc("org.scala-sbt:zinc_2.13:1.7.1")
-    implementation("org.scala-lang:scala-library:2.13.5")
+    implementation("org.scala-lang:scala-library:2.13.10")
     implementation("dev.zio:zio_2.13:1.0.9")
     implementation(project(":newrelic-api"))
     testImplementation(project(":instrumentation-test"))


### PR DESCRIPTION
Latest point release for scala 2.13.x APIs.
bumps to 2.13.10

### Overview
Describe the changes present in the pull request

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
