### PR TITLE
NEWRELIC-4936 - Fix invalid ClassCastException in graphql 16/17

### DIFF
--- a/instrumentation/graphql-java-16.2/build.gradle
+++ b/instrumentation/graphql-java-16.2/build.gradle
@@ -5,9 +5,12 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.2'}
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.2'
+}
 
 repositories {
     mavenCentral()

--- a/instrumentation/graphql-java-17.0/build.gradle
+++ b/instrumentation/graphql-java-17.0/build.gradle
@@ -5,6 +5,8 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.2'}

--- a/instrumentation/graphql-java-17.0/src/test/java/com/nr/instrumentation/graphql/GraphQLSpanUtilTest.java
+++ b/instrumentation/graphql-java-17.0/src/test/java/com/nr/instrumentation/graphql/GraphQLSpanUtilTest.java
@@ -11,10 +11,16 @@ import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.PrivateApi;
 import com.nr.instrumentation.graphql.helper.GraphQLTestHelper;
 import com.nr.instrumentation.graphql.helper.PrivateApiStub;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ExecutionStrategyParameters;
+import graphql.execution.MergedField;
+import graphql.execution.ResultPath;
 import graphql.language.Definition;
 import graphql.language.Document;
+import graphql.schema.GraphQLNonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -25,6 +31,9 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class GraphQLSpanUtilTest {
 
@@ -79,5 +88,43 @@ public class GraphQLSpanUtilTest {
         assertEquals(expectedType, privateApiStub.getTracerParameterFor("graphql.operation.type"));
         assertEquals(expectedName, privateApiStub.getTracerParameterFor("graphql.operation.name"));
         assertEquals(expectedQuery, privateApiStub.getTracerParameterFor("graphql.operation.query"));
+    }
+
+    // This test verifies https://issues.newrelic.com/browse/NEWRELIC-4936 no longer exists
+    @Test
+    public void testInvalidClassExceptionFix() {
+        // given execution parameters with execution step info type that is NOT GraphQLNamedSchemaElement
+        String expectedFieldPath = "fieldPath";
+        String expectedFieldName = "fieldName";
+        ExecutionStrategyParameters parameters =
+                mockExecutionStrategyParametersForInvalidClassCastExceptionTest(expectedFieldPath, expectedFieldName);
+
+        // when (this had ClassCastException)
+        GraphQLSpanUtil.setResolverAttributes(parameters);
+
+        // then tracer parameters set correctly without exception
+        assertEquals(expectedFieldPath, privateApiStub.getTracerParameterFor("graphql.field.path"));
+        assertEquals(expectedFieldName, privateApiStub.getTracerParameterFor("graphql.field.name"));
+
+        // and 'graphql.field.parentType' is not set
+        assertNull(privateApiStub.getTracerParameterFor("graphql.field.parentType"),
+                "'graphql.field.parentType' is not required and should be null here");
+    }
+
+    private static ExecutionStrategyParameters mockExecutionStrategyParametersForInvalidClassCastExceptionTest(String graphqlFieldPath, String graphqlFieldName) {
+        ExecutionStrategyParameters parameters = mock(ExecutionStrategyParameters.class);
+        ResultPath resultPath = mock(ResultPath.class);
+        MergedField mergedField = mock(MergedField.class);
+        ExecutionStepInfo executionStepInfo = mock(ExecutionStepInfo.class);
+        GraphQLNonNull notGraphQLNamedSchemaElement = mock(GraphQLNonNull.class);
+
+        when(resultPath.getSegmentName()).thenReturn(graphqlFieldPath);
+        when(mergedField.getName()).thenReturn(graphqlFieldName);
+        when(parameters.getPath()).thenReturn(resultPath);
+        when(parameters.getField()).thenReturn(mergedField);
+        when(parameters.getExecutionStepInfo()).thenReturn(executionStepInfo);
+        when(executionStepInfo.getType()).thenReturn(notGraphQLNamedSchemaElement);
+
+        return parameters;
     }
 }


### PR DESCRIPTION
* Unsafe cast to GraphQLObjectType
* https://github.com/newrelic/newrelic-java-agent/issues/1064
* https://issues.newrelic.com/browse/NEWRELIC-4936 (internal)