### PR TITLE
cap spring version verification

### DIFF
--- a/instrumentation/spring-jms-2/build.gradle
+++ b/instrumentation/spring-jms-2/build.gradle
@@ -10,7 +10,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.springframework:spring-jms:[0,)'
+    passesOnly 'org.springframework:spring-jms:[0,6.0.0)'
     exclude 'org.springframework:spring-jms:3.2.0.BUILD'
     // This is a bad artifact on artifactory
     excludeRegex 'org.springframework:spring-jms:5.0.0.(RC)[0-9]*$'

--- a/instrumentation/spring-webflux-5.3.0/build.gradle
+++ b/instrumentation/spring-webflux-5.3.0/build.gradle
@@ -15,7 +15,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly('org.springframework:spring-webflux:[5.3.0,)')
+    passesOnly('org.springframework:spring-webflux:[5.3.0,6.0.0)')
     excludeRegex '.*.M[0-9]'
     excludeRegex '.*.RC[0-9]'
 }


### PR DESCRIPTION
Spring 6.0.0 GA revealed that new modules will be needed for spring-jms and spring-webflux. This pr caps the verification to the passing range.