### PR TITLE
Capping spring-ws-2.0 versions

### DIFF
--- a/instrumentation/spring-ws-2.0/build.gradle
+++ b/instrumentation/spring-ws-2.0/build.gradle
@@ -12,7 +12,7 @@ jar {
 }
 
 verifyInstrumentation {
-  passesOnly('org.springframework.ws:spring-ws-core:[1.5.7,)'){
+  passesOnly('org.springframework.ws:spring-ws-core:[1.5.7,4.0.0)'){
     implementation("org.apache.ws.commons.axiom:axiom-api:1.4.0")
   }
   // version 3.1.0 fails but then 3.1.1 passes again


### PR DESCRIPTION
### Overview
Capping the versions the spring-ws-2.0 instrumentation module should apply to.
