### PR TITLE
NR-00000 - Removing "bad" glassfish version from verifier

### DIFF
--- a/instrumentation/glassfish-6/build.gradle
+++ b/instrumentation/glassfish-6/build.gradle
@@ -12,6 +12,7 @@ jar {
 
 verifyInstrumentation {
     passesOnly 'org.glassfish.main.web:web-core:[6.0.0-RC1,7.0.0-M3)'
+    exclude 'org.glassfish.main.web:web-core:7.0.0-M10'
 }
 
 site {


### PR DESCRIPTION
### Overview
The glassfish-6 instrumentation shouldn't apply to Glassfish 7, but it did apply to 7.0.0-M10.

Disabling that version for now.