### PR TITLE
fix slick instrumentation on scala 2.13

### DIFF
--- a/instrumentation/slick-2.12_3.2.0/src/main/scala/slick/util/AsyncExecutor.scala
+++ b/instrumentation/slick-2.12_3.2.0/src/main/scala/slick/util/AsyncExecutor.scala
@@ -79,7 +79,7 @@ class NewRelicExecutionContext(delegatee :ExecutionContext) extends ExecutionCon
   }
 }
 
-class NewRelicRunnable(runnable :Runnable) extends Runnable {
+class NewRelicRunnable(var runnable :Runnable) extends Runnable {
   @Trace(async = true)
   override def run() {
     try {


### PR DESCRIPTION

### Overview
Describe the changes present in the pull request

Since agent version 7.9, Slick (and possibly other) modules stopped working using scala 2.13. 

While I found what causes the issue as outlined in the linked issue, I have no time to come up with a fix other than avoiding the problematic code path by marking the runnable a `var` such that the `FinalTraitTransformer` doesn't pick up `NewRelicRunnable` and therefor skips that transformation. Tested this locally and it seems to fix the problem , allowing us to use the agent while a real fix can be developed.  


### Related Github Issue
[Issue](https://github.com/newrelic/newrelic-java-agent/issues/1000)

### Testing
Apart from the existing (and ignored?) tests, I did run the agent built from this branch and verified that the slick instrumentation works.

### Checks

[ x] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
