### PR TITLE
Updating glassfish-6 verification range

### DIFF
--- a/instrumentation/glassfish-6/build.gradle
+++ b/instrumentation/glassfish-6/build.gradle
@@ -11,7 +11,9 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.glassfish.main.web:web-core:[6.0.0-RC1,7.0.0-M3)'
+    passesOnly 'org.glassfish.main.web:web-core:[6.0.0-RC1,)'
+    exclude 'org.glassfish.main.web:web-core:7.0.0-M3'
+    exclude 'org.glassfish.main.web:web-core:7.0.0-M4'
     exclude 'org.glassfish.main.web:web-core:7.0.0-M10'
 }
 


### PR DESCRIPTION
### Overview
The glassfish-6 instrumentation module stopped applying to version 7.0.0-M3, but it is applying to 7.0.0.
This PR fixes the verification range
