### PR TITLE
Newrelic-3822 Bug fix for when Spring Webclient times out and emits a ReadTimeoutException, the transaction fails to link

### DIFF
--- a/instrumentation/netty-4.0.0/src/main/java/io/netty/channel/ChannelHandler_Instrumentation.java
+++ b/instrumentation/netty-4.0.0/src/main/java/io/netty/channel/ChannelHandler_Instrumentation.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package io.netty.channel;
+
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(type = MatchType.Interface, originalName = "io.netty.channel.ChannelHandler")
+public class ChannelHandler_Instrumentation {
+
+    /*
+     * This is to solve a bug where the transaction is lost when spring webclient times out and throws an error
+     * using the io.netty.handler.timeout.ReadTimeoutHandler class from netty.
+     *
+     * Any extra handlers used by netty will now link a transaction if available.
+     *
+     * */
+    @Trace(async = true, excludeFromTransactionTrace = true)
+    public void exceptionCaught(ChannelHandlerContext_Instrumentation ctx, Throwable cause) throws Exception {
+        if (ctx != null &&
+                ctx.pipeline().token != null && ctx.pipeline().token.isActive()) {
+            ctx.pipeline().token.link();
+        }
+
+        Weaver.callOriginal();
+    }
+
+}

--- a/instrumentation/netty-4.0.8/src/main/java/io/netty/channel/ChannelHandler_Instrumentation.java
+++ b/instrumentation/netty-4.0.8/src/main/java/io/netty/channel/ChannelHandler_Instrumentation.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package io.netty.channel;
+
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(type = MatchType.Interface, originalName = "io.netty.channel.ChannelHandler")
+public class ChannelHandler_Instrumentation {
+
+    /*
+    * This is to solve a bug where the transaction is lost when spring webclient times out and throws an error
+    * using the io.netty.handler.timeout.ReadTimeoutHandler class from netty.
+    *
+    * Any extra handlers used by netty will now link a transaction if available.
+    *
+    * -----------------------------------
+    * WARNING
+    * -----------------------------------
+    *
+    * Netty has marked this method as deprecated since 4.1
+    *
+    * If instrumentation verification fails for because of this class,
+    * then in the new instrumentation module try instrumenting the class:
+    *
+    * io.netty.channel.AbstractChannelHandlerContext
+    *
+    * and its method:
+    *
+    * static void invokeExceptionCaught(final AbstractChannelHandlerContext next, final Throwable cause)
+    *
+    * */
+    @Trace(async = true, excludeFromTransactionTrace = true)
+    public void exceptionCaught(ChannelHandlerContext_Instrumentation ctx, Throwable cause) throws Exception {
+        if (ctx != null &&
+                ctx.pipeline().token != null && ctx.pipeline().token.isActive()) {
+            ctx.pipeline().token.link();
+        }
+
+        Weaver.callOriginal();
+    }
+
+}

--- a/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
@@ -25,7 +25,8 @@ final class HttpClientConnect_Instrumentation {
 
         @Trace(async = true, excludeFromTransactionTrace = true)
         public void onUncaughtException(Connection connection, Throwable error) {
-            Token token = currentContext().getOrDefault("newrelic-token", null);
+            Context ctx = currentContext();
+            Token token = ctx != null ? ctx.getOrDefault("newrelic-token", null) : null;
             if (token != null && token.isActive()) {
                 token.link();
             }

--- a/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
@@ -1,0 +1,29 @@
+package reactor.netty.http.client;
+
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import reactor.netty.Connection;
+import reactor.util.context.Context;
+
+@Weave(originalName = "reactor.netty.http.client.HttpClientConnect")
+final class HttpClientConnect_Instrumentation {
+
+    @Weave(originalName = "reactor.netty.http.client.HttpClientConnect$HttpObserver")
+    static final class HttpObserver_Instrumentation {
+
+        public Context currentContext() {
+            return Weaver.callOriginal();
+        }
+
+        @Trace(async = true, excludeFromTransactionTrace = true)
+        public void onUncaughtException(Connection connection, Throwable error) {
+            Token token = currentContext().getOrDefault("newrelic-token", null);
+            if (token != null && token.isActive()) {
+                token.link();
+            }
+            Weaver.callOriginal();
+        }
+    }
+}

--- a/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.8.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
@@ -1,3 +1,9 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package reactor.netty.http.client;
 
 import com.newrelic.api.agent.Token;

--- a/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
@@ -25,7 +25,8 @@ final class HttpClientConnect_Instrumentation {
 
         @Trace(async = true, excludeFromTransactionTrace = true)
         public void onUncaughtException(Connection connection, Throwable error) {
-            Token token = currentContext().getOrDefault("newrelic-token", null);
+            Context ctx = currentContext();
+            Token token = ctx != null ? ctx.getOrDefault("newrelic-token", null) : null;
             if (token != null && token.isActive()) {
                 token.link();
             }

--- a/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
@@ -1,0 +1,29 @@
+package reactor.netty.http.client;
+
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import reactor.netty.Connection;
+import reactor.util.context.Context;
+
+@Weave(originalName = "reactor.netty.http.client.HttpClientConnect")
+final class HttpClientConnect_Instrumentation {
+
+    @Weave(originalName = "reactor.netty.http.client.HttpClientConnect$HttpObserver")
+    static final class HttpObserver_Instrumentation {
+
+        public Context currentContext() {
+            return Weaver.callOriginal();
+        }
+
+        @Trace(async = true, excludeFromTransactionTrace = true)
+        public void onUncaughtException(Connection connection, Throwable error) {
+            Token token = currentContext().getOrDefault("newrelic-token", null);
+            if (token != null && token.isActive()) {
+                token.link();
+            }
+            Weaver.callOriginal();
+        }
+    }
+}

--- a/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
+++ b/instrumentation/netty-reactor-0.9.0/src/main/java/reactor/netty/http/client/HttpClientConnect_Instrumentation.java
@@ -1,3 +1,9 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package reactor.netty.http.client;
 
 import com.newrelic.api.agent.Token;


### PR DESCRIPTION
When Spring WebClient emits a `io.netty.handler.timeout.ReadTimeoutException` due to a timeout, the transaction trace was originally lost. This PR fixes the bug.

[Related Github Issue link](https://github.com/newrelic/newrelic-java-agent/issues/242)