### PR TITLE
NR-00000 - Improve verify instrumentation

### DIFF
--- a/.github/workflows/Create-Custom-Jar.yml
+++ b/.github/workflows/Create-Custom-Jar.yml
@@ -46,7 +46,7 @@ jobs:
           mv gradle.properties.gha gradle.properties
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -69,7 +69,7 @@ jobs:
       # secrets are available in the interface, but may NOT be edited.
       - name: Configure AWS Credentials
         if: ${{ env.AWS_KEY != '' }}        
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/Java-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-Instrumentation-Tests.yml
@@ -93,7 +93,7 @@ jobs:
       ## AWS jars - plan to cache
       - name: Configure AWS Credentials
         if: ${{ env.AWS_KEY != '' }}
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}

--- a/.github/workflows/Release-CopyToS3-prod.yml
+++ b/.github/workflows/Release-CopyToS3-prod.yml
@@ -18,7 +18,7 @@ jobs:
         # This always checkouts main. So the script will be run from main.
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEFAULT }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEFAULT }}

--- a/.github/workflows/Release-CopyToS3-staging.yml
+++ b/.github/workflows/Release-CopyToS3-staging.yml
@@ -22,7 +22,7 @@ jobs:
         # This always checkouts main. So the script will be run from main.
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}

--- a/.github/workflows/VerifyInstrumentation-Single.yml
+++ b/.github/workflows/VerifyInstrumentation-Single.yml
@@ -65,7 +65,7 @@ jobs:
       ## AWS jars - plan to cache
       - name: Configure AWS Credentials
         if: ${{ env.AWS_KEY != '' }}
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}

--- a/.github/workflows/VerifyInstrumentation.yml
+++ b/.github/workflows/VerifyInstrumentation.yml
@@ -84,7 +84,7 @@ jobs:
     needs: build-agent
     uses: ./.github/workflows/X-Reusable-VerifyInstrumentation.yml
     with:
-      page: 1/10
+      page: 1/2
       ref: ${{ github.event.inputs.ref || 'main' }}
     secrets: inherit
 
@@ -93,6 +93,6 @@ jobs:
     needs: build-agent
     uses: ./.github/workflows/X-Reusable-VerifyInstrumentation.yml
     with:
-      page: 2/10
+      page: 2/2
       ref: ${{ github.event.inputs.ref || 'main' }}
     secrets: inherit

--- a/.github/workflows/VerifyInstrumentation.yml
+++ b/.github/workflows/VerifyInstrumentation.yml
@@ -47,7 +47,7 @@ jobs:
       ## AWS jars - plan to cache
       - name: Configure AWS Credentials
         if: ${{ env.AWS_KEY != '' }}
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/VerifyInstrumentation.yml
+++ b/.github/workflows/VerifyInstrumentation.yml
@@ -11,12 +11,86 @@ on:
   schedule:
     - cron: '0 8 * * *'
 
-# GHA Matrix strategy only allows 255 entries.
-# So 2 pages should be good until we have around 500 instrumentation modules
-# When we grow to more than that, we'll need to create a third job here and have pages 1/3, 2/3 and 3/3
 jobs:
+  # build the agent and saves Gradle's cache so all modules can use the cache
+  build-agent:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Save JAVA_HOME as JDK11 for later usage
+        run: |
+          echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
+      - name: Save JAVA_HOME as JDK8 for later usage
+        run: |
+          echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+
+      # Rewrite gradle.properties
+      - name: set gradle.properties
+        run: |
+          sed -i -e "s|jdk8=8|jdk8=${JDK8}|
+          s|jdk11=11|jdk11=${JDK11}|" gradle.properties.gha
+          mv gradle.properties.gha gradle.properties
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Setup Gradle options
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JDK11" >> $GITHUB_ENV
+
+      ## AWS jars - plan to cache
+      - name: Configure AWS Credentials
+        if: ${{ env.AWS_KEY != '' }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-region: us-east-2
+
+      - name: Download S3 instrumentation jar zip
+        if: ${{ env.AWS_KEY != '' }}
+        run: aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20220805.zip proprietary-jars.zip  ## Updated 2022
+
+      - name: Unzip the instrumentation jars
+        if: ${{ env.AWS_KEY != '' }}
+        run: unzip proprietary-jars.zip
+
+      - name: Log jars are in target libs
+        if: ${{ env.AWS_KEY != '' }}
+        run: find instrumentation -name "*.jar"
+      ## End AWS jars - plan to cache (check for cache, restore if required)
+
+      - name: Build agent
+        run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
+
+      - name: Cache agent
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          key: ${{ github.run_id }}
+
+  # GHA Matrix strategy only allows 255 entries.
+  # So 2 pages should be good until we have around 500 instrumentation modules
+  # When we grow to more than that, we'll need to create a third job here and have pages 1/3, 2/3 and 3/3
+
   verify-instrumentation-1:
     name: Page 1/2
+    needs: build-agent
     uses: ./.github/workflows/X-Reusable-VerifyInstrumentation.yml
     with:
       page: 1/2
@@ -27,6 +101,7 @@ jobs:
 
   verify-instrumentation-2:
     name: Page 2/2
+    needs: build-agent
     uses: ./.github/workflows/X-Reusable-VerifyInstrumentation.yml
     with:
       page: 2/2

--- a/.github/workflows/VerifyInstrumentation.yml
+++ b/.github/workflows/VerifyInstrumentation.yml
@@ -15,51 +15,42 @@ jobs:
   # build the agent and saves Gradle's cache so all modules can use the cache
   build-agent:
     runs-on: ubuntu-20.04
+    env:
+      # we use this in env var for conditionals (secrets can't be used in conditionals)
+      AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Set up Java 11
+      - name: Set up Javas
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Save JAVA_HOME as JDK11 for later usage
-        run: |
-          echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV
-
-      - name: Set up Java 8
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 8
-
-      - name: Save JAVA_HOME as JDK8 for later usage
-        run: |
-          echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+          java-version: |
+            11
+            8
 
       # Rewrite gradle.properties
       - name: set gradle.properties
         run: |
-          sed -i -e "s|jdk8=8|jdk8=${JDK8}|
-          s|jdk11=11|jdk11=${JDK11}|" gradle.properties.gha
+          sed -i -e "s|jdk8=8|jdk8=${JAVA_HOME_8_x64}|
+          s|jdk11=11|jdk11=${JAVA_HOME_11_x64}|" gradle.properties.gha
           mv gradle.properties.gha gradle.properties
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
       - name: Setup Gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JDK11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JAVA_HOME_11_x64" >> $GITHUB_ENV
 
       ## AWS jars - plan to cache
       - name: Configure AWS Credentials
         if: ${{ env.AWS_KEY != '' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
       - name: Download S3 instrumentation jar zip
@@ -93,19 +84,15 @@ jobs:
     needs: build-agent
     uses: ./.github/workflows/X-Reusable-VerifyInstrumentation.yml
     with:
-      page: 1/2
+      page: 1/10
       ref: ${{ github.event.inputs.ref || 'main' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    secrets: inherit
 
   verify-instrumentation-2:
     name: Page 2/2
     needs: build-agent
     uses: ./.github/workflows/X-Reusable-VerifyInstrumentation.yml
     with:
-      page: 2/2
+      page: 2/10
       ref: ${{ github.event.inputs.ref || 'main' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    secrets: inherit

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -118,10 +118,14 @@ jobs:
       - name: Build agent
         run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
 
+      - run: |
+          pwd
+          find . -iname "newrelic.jar"
+
       - name: Cache agent
         uses: actions/cache@v3
         with:
-          path: ~/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: /home/runner/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
   verify-module:
@@ -197,7 +201,7 @@ jobs:
         id: retrieve-agent
         uses: actions/cache@v3
         with:
-          path: ~/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: /home/runner/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
       - if: ${{ steps.retrieve-agent.outputs.cache-hit != 'true' }}

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Cache agent
         uses: actions/cache@v3
         with:
-          path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: ~/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
   verify-module:
@@ -130,7 +130,7 @@ jobs:
     needs: [read-modules, build-agent]
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 5
       # GHA's IDE think the line below is broken. It is not.
       matrix: ${{ fromJson(needs.read-modules.outputs.modules) }}
     steps:
@@ -200,7 +200,7 @@ jobs:
         id: retrieve-agent
         uses: actions/cache@v3
         with:
-          path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: ~/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
       - if: ${{ steps.retrieve-agent.outputs.cache-hit != 'true' }}

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -120,8 +120,9 @@ jobs:
 
       - name: Cache agent
         uses: actions/cache@v3
-        path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
-        key: ${{ github.run_id }}
+        with:
+          path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          key: ${{ github.run_id }}
 
   verify-module:
     name: ${{ matrix.modules }}
@@ -198,8 +199,9 @@ jobs:
       - name: Retrieve agent from cache
         id: retrieve-agent
         uses: actions/cache@v3
-        path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
-        key: ${{ github.run_id }}
+        with:
+          path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          key: ${{ github.run_id }}
 
       - if: ${{ steps.retrieve-agent.outputs.cache-hit != 'true' }}
         name: Build agent

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Cache agent
         uses: actions/cache@v3
         with:
-          path: ~/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: ~/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
   verify-module:
@@ -165,11 +165,8 @@ jobs:
           s|jdk11=11|jdk11=${JDK11}|" gradle.properties.gha
           mv gradle.properties.gha gradle.properties
 
-      # The verify task should not save to the cache. It will only use the cache from the build-agent job.
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: true
 
       - name: Setup Gradle options
         run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JDK11" >> $GITHUB_ENV
@@ -200,7 +197,7 @@ jobs:
         id: retrieve-agent
         uses: actions/cache@v3
         with:
-          path: ~/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: ~/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
       - if: ${{ steps.retrieve-agent.outputs.cache-hit != 'true' }}

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -21,7 +21,6 @@ on:
         required: false
 
 jobs:
-
   # this job reads the directories in newrelic-java-agent/instrumentation and creates a JSON with the list of the modules
   # this list is paginated and will be used in the verify-module job.
   read-modules:
@@ -32,7 +31,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-
 
       - id: set-modules
         name: get instrumentation modules as json
@@ -50,87 +48,13 @@ jobs:
           # save the output of the job
           echo "modules=$modules" >> $GITHUB_OUTPUT
 
-  # build the agent and saves Gradle's cache so all modules can use the cache
-  # At first, the agent jar was being cached, but this caused a problem with the caching mechanism and some
-  # later jobs were not able to retrieve the cached agent jar.
-  build-agent:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Save JAVA_HOME as JDK11 for later usage
-        run: |
-          echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV
-
-      - name: Set up Java 8
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 8
-
-      - name: Save JAVA_HOME as JDK8 for later usage
-        run: |
-          echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
-
-      # Rewrite gradle.properties
-      - name: set gradle.properties
-        run: |
-          sed -i -e "s|jdk8=8|jdk8=${JDK8}|
-          s|jdk11=11|jdk11=${JDK11}|" gradle.properties.gha
-          mv gradle.properties.gha gradle.properties
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Setup Gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JDK11" >> $GITHUB_ENV
-
-      ## AWS jars - plan to cache
-      - name: Configure AWS Credentials
-        if: ${{ env.AWS_KEY != '' }}
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-          aws-region: us-east-2
-
-      - name: Download S3 instrumentation jar zip
-        if: ${{ env.AWS_KEY != '' }}
-        run: aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20220805.zip proprietary-jars.zip  ## Updated 2022
-
-      - name: Unzip the instrumentation jars
-        if: ${{ env.AWS_KEY != '' }}
-        run: unzip proprietary-jars.zip
-
-      - name: Log jars are in target libs
-        if: ${{ env.AWS_KEY != '' }}
-        run: find instrumentation -name "*.jar"
-      ## End AWS jars - plan to cache (check for cache, restore if required)
-
-      - name: Build agent
-        run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
-
-      - name: Cache agent
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
-          key: ${{ github.run_id }}
-
   verify-module:
     name: ${{ matrix.modules }}
     runs-on: ubuntu-20.04
-    needs: [read-modules, build-agent]
+    needs: read-modules
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       # GHA's IDE think the line below is broken. It is not.
       matrix: ${{ fromJson(needs.read-modules.outputs.modules) }}
     steps:

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -118,12 +118,18 @@ jobs:
       - name: Build agent
         run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
 
+      - name: Cache agent
+        uses: actions/cache@v3
+        path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+        key: ${{ github.run_id }}
+
   verify-module:
     name: ${{ matrix.modules }}
     runs-on: ubuntu-20.04
     needs: [read-modules, build-agent]
     strategy:
       fail-fast: false
+      max-parallel: 10
       # GHA's IDE think the line below is broken. It is not.
       matrix: ${{ fromJson(needs.read-modules.outputs.modules) }}
     steps:
@@ -189,7 +195,14 @@ jobs:
         run: find instrumentation -name "*.jar"
       ## End AWS jars - plan to cache (check for cache, restore if required)
 
-      - name: Build agent
+      - name: Retrieve agent from cache
+        id: retrieve-agent
+        uses: actions/cache@v3
+        path: newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+        key: ${{ github.run_id }}
+
+      - if: ${{ steps.retrieve-agent.outputs.cache-hit != 'true' }}
+        name: Build agent
         run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
 
       # Setting up 11 again so tests are run with it. This is so libraries build with 11 can pass.

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -52,9 +52,11 @@ jobs:
     name: ${{ matrix.modules }}
     runs-on: ubuntu-20.04
     needs: read-modules
+    env:
+      # we use this in env var for conditionals (secrets can't be used in conditionals)
+      AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
     strategy:
       fail-fast: false
-      max-parallel: 15
       # GHA's IDE think the line below is broken. It is not.
       matrix: ${{ fromJson(needs.read-modules.outputs.modules) }}
     steps:
@@ -62,46 +64,39 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Set up Java 11
+      - name: Set up Javas
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Save JAVA_HOME as JDK11 for later usage
-        run: |
-          echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV
-
-      - name: Set up Java 8
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 8
-
-      - name: Save JAVA_HOME as JDK8 for later usage
-        run: |
-          echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+          java-version: |
+            11
+            8
 
       # Rewrite gradle.properties
       - name: set gradle.properties
         run: |
-          sed -i -e "s|jdk8=8|jdk8=${JDK8}|
-          s|jdk11=11|jdk11=${JDK11}|" gradle.properties.gha
+          sed -i -e "s|jdk8=8|jdk8=${JAVA_HOME_8_x64}|
+          s|jdk11=11|jdk11=${JAVA_HOME_11_x64}|" gradle.properties.gha
           mv gradle.properties.gha gradle.properties
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-excludes: |
+            caches
+            notifications
+            jdks
 
       - name: Setup Gradle options
-        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JDK11" >> $GITHUB_ENV
+        run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JAVA_HOME_11_x64,JAVA_HOME_8_x64" >> $GITHUB_ENV
 
       ## AWS jars - plan to cache
       - name: Configure AWS Credentials
         if: ${{ env.AWS_KEY != '' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
       - name: Download S3 instrumentation jar zip
@@ -111,10 +106,6 @@ jobs:
       - name: Unzip the instrumentation jars
         if: ${{ env.AWS_KEY != '' }}
         run: unzip proprietary-jars.zip
-
-      - name: Log jars are in target libs
-        if: ${{ env.AWS_KEY != '' }}
-        run: find instrumentation -name "*.jar"
       ## End AWS jars - plan to cache (check for cache, restore if required)
 
       - name: Retrieve agent from cache

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -17,11 +17,6 @@ on:
         default: main
         type: string
         description: 'The ref (branch, SHA, tag?) to run the tests on'
-    secrets:
-      aws-access-key-id:
-        required: false
-      aws-secret-access-key:
-        required: false
 
 jobs:
   # this job reads the directories in newrelic-java-agent/instrumentation and creates a JSON with the list of the modules
@@ -88,7 +83,7 @@ jobs:
       ## AWS jars - plan to cache
       - name: Configure AWS Credentials
         if: ${{ env.AWS_KEY != '' }}
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -1,6 +1,9 @@
 # Reusable workflow to run Verify Instrumentation on modules.
 # Only processes a fraction of the modules so the they fit into a GHA matrix (which is limited to 255 jobs).
 
+# This workflow does not use the setup-gradle action on purpose. That action retrieves over 1GB from the cache
+# and when many runners do that at the same time, the cache server returns 429s (Too many requests).
+
 name: X - Reusable Verify Instrumentation
 on:
   workflow_call:

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -54,7 +54,7 @@ jobs:
     needs: read-modules
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 15
       # GHA's IDE think the line below is broken. It is not.
       matrix: ${{ fromJson(needs.read-modules.outputs.modules) }}
     steps:

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -79,14 +79,6 @@ jobs:
           s|jdk11=11|jdk11=${JAVA_HOME_11_x64}|" gradle.properties.gha
           mv gradle.properties.gha gradle.properties
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-home-cache-excludes: |
-            caches
-            notifications
-            jdks
-
       - name: Setup Gradle options
         run: echo "GRADLE_OPTIONS=-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JAVA_HOME_11_x64,JAVA_HOME_8_x64" >> $GITHUB_ENV
 

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -118,14 +118,10 @@ jobs:
       - name: Build agent
         run: ./gradlew $GRADLE_OPTIONS clean jar --parallel
 
-      - run: |
-          pwd
-          find . -iname "newrelic.jar"
-
       - name: Cache agent
         uses: actions/cache@v3
         with:
-          path: /home/runner/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
   verify-module:
@@ -201,7 +197,7 @@ jobs:
         id: retrieve-agent
         uses: actions/cache@v3
         with:
-          path: /home/runner/work/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
+          path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
       - if: ${{ steps.retrieve-agent.outputs.cache-hit != 'true' }}

--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -58,7 +58,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
### Overview
This PR brings some fixes and updates to the Verify Instrumentation workflow.
It also decreases the total runtime from 2 days to 17 hours and the actual runtime from 30 ~ 40 minutes to 20 ~ 30 minutes.

Changes:
- Building the agent only once and caching;
- removing the gradle cache on the verify instrumentation job
  - this prevent flooding the cache server with requests
  - does not impair runtime since very little of that cache was useful to the job;
- fixes AWS credentials.