### PR TITLE
Metric names should not start with a forward slash

### DIFF
--- a/instrumentation/jcache-1.0.0/src/main/java/javax/cache/Cache.java
+++ b/instrumentation/jcache-1.0.0/src/main/java/javax/cache/Cache.java
@@ -31,7 +31,7 @@ public abstract class Cache<K, V> {
     private static final String GET_AND_REPLACE = "getAndReplace";
 
     @NewField
-    private static final String METRIC_NAME = "/Java/JCACHE";
+    private static final String METRIC_NAME = "Java/JCACHE";
 
     @Trace(excludeFromTransactionTrace = true, metricName = METRIC_NAME + "/" + GET, leaf = true)
     public abstract V get(K key);


### PR DESCRIPTION

### Overview
This instrumentation creates metrics that start with `/Java`.  Metric names should not start with a forward slash.
As a matter of style, the `JCACHE` segment also stands out as a sore thumb but ¯\_(ツ)_/¯ 

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
