### PR TITLE
NR-66564 JFR toggle Config Listener

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -485,6 +485,7 @@ public class MetricNames {
 
     // JFR Service
     public static final String SUPPORTABILITY_JFR_SERVICE_STARTED_SUCCESS = "Supportability/JfrService/Started/Success";
+    public static final String SUPPORTABILITY_JFR_SERVICE_STOPPED_SUCCESS = "Supportability/JfrService/Stopped/Success";
     public static final String SUPPORTABILITY_JFR_SERVICE_STARTED_FAIL = "Supportability/JfrService/Started/Fail";
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
@@ -17,6 +17,13 @@ public interface JfrConfig {
     boolean isEnabled();
 
     /**
+     * Set the JFR service enabled flag
+     *
+     * @param enabled the desired enabled flag value
+     */
+    void setEnabled(boolean enabled);
+
+    /**
      * Check if audit_logging is enabled for the JFR service.
      *
      * @return <code>true</code> is audit_logging is enabled for the JFR service is enabled, else <code>false</code>.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
@@ -19,7 +19,7 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     public static final Boolean AUDIT_LOGGING_DEFAULT = Boolean.FALSE;
     public static final Boolean USE_LICENSE_KEY_DEFAULT = Boolean.TRUE;
 
-    private final boolean isEnabled;
+    private boolean isEnabled;
 
     public JfrConfigImpl(Map<String, Object> pProps) {
         super(pProps, SYSTEM_PROPERTY_ROOT);
@@ -36,6 +36,11 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     @Override
     public boolean isEnabled() {
         return isEnabled;
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.isEnabled = enabled;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -96,6 +96,8 @@ public class JfrService extends AbstractService implements AgentConfigListener {
 
     @Override
     protected void doStop() {
+        NewRelic.getAgent().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_JFR_SERVICE_STOPPED_SUCCESS);
+
         if (jfrController != null) {
             jfrController.shutdown();
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -12,6 +12,7 @@ import com.newrelic.agent.Agent;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.AgentConfigListener;
 import com.newrelic.agent.config.JfrConfig;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
@@ -29,7 +30,7 @@ import static com.newrelic.jfr.daemon.AttributeNames.ENTITY_GUID;
 import static com.newrelic.jfr.daemon.SetupUtils.buildCommonAttributes;
 import static com.newrelic.jfr.daemon.SetupUtils.buildUploader;
 
-public class JfrService extends AbstractService {
+public class JfrService extends AbstractService implements AgentConfigListener {
 
     private final JfrConfig jfrConfig;
     private final AgentConfig defaultAgentConfig;
@@ -39,6 +40,7 @@ public class JfrService extends AbstractService {
         super(JfrService.class.getSimpleName());
         this.jfrConfig = jfrConfig;
         this.defaultAgentConfig = defaultAgentConfig;
+        ServiceFactory.getConfigService().addIAgentConfigListener(this);
     }
 
     @Override
@@ -127,5 +129,21 @@ public class JfrService extends AbstractService {
                 .proxyUser(defaultAgentConfig.getProxyUser())
                 .proxyPassword(defaultAgentConfig.getProxyPassword());
         return builder.build();
+    }
+
+    @Override
+    public void configChanged(String appName, AgentConfig agentConfig) {
+        boolean newJfrEnabledVal = agentConfig.getJfrConfig().isEnabled();
+
+        if (newJfrEnabledVal != jfrConfig.isEnabled()) {
+            Agent.LOG.log(Level.INFO, "JFR enabled flag changed to {0}", newJfrEnabledVal);
+            jfrConfig.setEnabled(newJfrEnabledVal);
+
+            if (newJfrEnabledVal) {
+                doStart();
+            } else {
+                doStop();
+            }
+        }
     }
 }


### PR DESCRIPTION
### Overview
- Implement the `AgentConfigListener` interface on the `JfrService` to allow the JFR to be toggled, real time, via the yml file
- Add `Supportability/JfrService/Stopped/Success` to track when JFR is toggled off
- Additional test

### Checks

[Y] Are your contributions backwards compatible with relevant frameworks and APIs?
[N] Does your code contain any breaking changes? Please describe. 
[N] Does your code introduce any new dependencies? Please describe.
