### PR TITLE
NEWRELIC-4831 Clean up deprecated attributes

### DIFF
--- a/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
+++ b/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
@@ -1650,7 +1650,7 @@ public class AkkaHttpRoutesTest {
         Assert.assertNotNull(transactionEvents);
         Assert.assertEquals(expectedSize, transactionEvents.size());
         for (TransactionEvent transactionEvent : transactionEvents) {
-            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("httpResponseCode"));
+            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("http.statusCode"));
             Assert.assertNotNull(httpResponseCode);
             Assert.assertEquals(expectedResponseCode, httpResponseCode);
         }

--- a/instrumentation/akka-http-2.13_10.1.8/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
+++ b/instrumentation/akka-http-2.13_10.1.8/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
@@ -1646,7 +1646,7 @@ public class AkkaHttpRoutesTest {
         Assert.assertNotNull(transactionEvents);
         Assert.assertEquals(expectedSize, transactionEvents.size());
         for (TransactionEvent transactionEvent : transactionEvents) {
-            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("httpResponseCode"));
+            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("http.statusCode"));
             Assert.assertNotNull(httpResponseCode);
             Assert.assertEquals(expectedResponseCode, httpResponseCode);
         }

--- a/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,7 +39,6 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
 
@@ -70,7 +69,6 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {

--- a/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
@@ -68,7 +68,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
@@ -86,7 +85,6 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
-        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(0, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
@@ -127,7 +125,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(status, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
@@ -136,7 +133,6 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
-        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(status, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }

--- a/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,7 +39,6 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
 
@@ -70,7 +69,6 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {

--- a/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
@@ -68,7 +68,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
@@ -86,7 +85,6 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
-        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(0, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
@@ -127,7 +125,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(status, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
@@ -136,7 +133,6 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
-        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(status, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }

--- a/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,7 +39,6 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
@@ -69,7 +68,6 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {

--- a/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
@@ -69,7 +69,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
@@ -87,7 +86,6 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
-        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(0, serverTxEvent.getAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
@@ -128,7 +126,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(status, rootSegment.getTracerAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
@@ -137,7 +134,6 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
-        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(status, serverTxEvent.getAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }

--- a/instrumentation/grpc-1.40.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcUtil.java
+++ b/instrumentation/grpc-1.40.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcUtil.java
@@ -34,14 +34,14 @@ public class GrpcUtil {
     }
 
     /**
-     * Set the response.status attribute and error cause (if applicable) on the transaction
+     * Set the http.statusCode attribute and error cause (if applicable) on the transaction
      * when the ServerStream is closed or cancelled.
      *
      * @param status The {@link Status} of the completed/cancelled operation
      */
     public static void setServerStreamResponseStatus(Status status) {
         if (status != null) {
-            NewRelic.addCustomParameter("response.status", status.getCode().value());
+            NewRelic.addCustomParameter("http.statusCode", status.getCode().value());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.40.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.40.0/src/test/java/ValidationHelper.java
@@ -60,7 +60,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -76,7 +75,6 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
-        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 
@@ -116,7 +114,6 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
-        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -124,7 +121,6 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
-        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
@@ -28,10 +28,6 @@ public final class AttributeNames {
     public static final String TIMEOUT_CAUSE = "nr.timeoutCause";
     public static final String ERROR_EXPECTED = "error.expected";
 
-    // transaction attributes - modifiable by agent
-    public static final String HTTP_STATUS = "httpResponseCode";
-    public static final String HTTP_STATUS_MESSAGE = "httpResponseMessage";
-
     public static final String HTTP_STATUS_CODE = "http.statusCode";
     public static final String HTTP_STATUS_TEXT = "http.statusText";
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfigImpl.java
@@ -22,8 +22,6 @@ public class AttributesConfigImpl extends BaseConfig implements AttributesConfig
     public static final String[] DEFAULT_BROWSER_EXCLUDES = new String[] {
             AttributeNames.DISPLAY_HOST,
             AttributeNames.HTTP_REQUEST_STAR,
-            AttributeNames.HTTP_STATUS_MESSAGE,
-            AttributeNames.HTTP_STATUS,
             AttributeNames.INSTANCE_NAME,
             AttributeNames.JVM_STAR,
             AttributeNames.MESSAGE_REQUEST_STAR,
@@ -39,7 +37,6 @@ public class AttributesConfigImpl extends BaseConfig implements AttributesConfig
 
     public static final String[] DEFAULT_TRANSACTION_EVENTS_EXCLUDES = new String[] {
             AttributeNames.HTTP_REQUEST_STAR,
-            AttributeNames.HTTP_STATUS_MESSAGE,
             AttributeNames.JVM_STAR,
             AttributeNames.MESSAGE_REQUEST_STAR,
             AttributeNames.SOLR_STAR

--- a/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
@@ -120,14 +120,11 @@ public class WebRequestDispatcher extends DefaultDispatcher implements WebRespon
                 storeResponseContentType();
 
                 if (getStatus() > 0) {
-                    // http status is now being recorded as a string
-                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS, String.valueOf(getStatus()));
                     // http.statusCode is supposed to be an int
                     getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_CODE, getStatus());
                 }
 
                 if (getStatusMessage() != null) {
-                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_MESSAGE, getStatusMessage());
                     getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_TEXT, getStatusMessage());
                 }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -208,9 +208,6 @@ public class SpanEventFactory {
         if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_CODE)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS_CODE, statusCode);
         }
-        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS)) {
-            builder.putAgentAttribute(AttributeNames.HTTP_STATUS, statusCode);
-        }
         return this;
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/TracerToSpanEventTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/TracerToSpanEventTest.java
@@ -36,8 +36,6 @@ import java.util.function.Supplier;
 
 import static com.newrelic.agent.MetricNames.QUEUE_TIME;
 import static com.newrelic.agent.attributes.AttributeNames.HTTP_REQUEST_PREFIX;
-import static com.newrelic.agent.attributes.AttributeNames.HTTP_STATUS;
-import static com.newrelic.agent.attributes.AttributeNames.HTTP_STATUS_MESSAGE;
 import static com.newrelic.agent.attributes.AttributeNames.MESSAGE_REQUEST_PREFIX;
 import static com.newrelic.agent.attributes.AttributeNames.PORT;
 import static com.newrelic.agent.attributes.AttributeNames.QUEUE_DURATION;
@@ -337,14 +335,10 @@ public class TracerToSpanEventTest {
         int httpResponseCode = 404;
         String httpResponseMessage = "I cannot find that page, silly";
         String contentType = "application/vnd.ms-powerpoint ";
-        expectedAgentAttributes.put("httpResponseCode", httpResponseCode);
-        expectedAgentAttributes.put("httpResponseMessage", httpResponseMessage);
         expectedAgentAttributes.put(RESPONSE_CONTENT_TYPE_PARAMETER_NAME, contentType);
 
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
-        transactionAgentAttributes.put(HTTP_STATUS, httpResponseCode);
-        transactionAgentAttributes.put(HTTP_STATUS_MESSAGE, httpResponseMessage);
         transactionAgentAttributes.put(RESPONSE_CONTENT_TYPE_PARAMETER_NAME, contentType);
 
         when(txnData.getAgentAttributes()).thenReturn(transactionAgentAttributes);


### PR DESCRIPTION


### Overview
Remove deprecated attributes: `httpResponseCode`, `httpResponseMessage`

### Checks

[Y] Are your contributions backwards compatible with relevant frameworks and APIs?
[N] Does your code contain any breaking changes? Please describe. 
[N] Does your code introduce any new dependencies? Please describe.
