### PR TITLE
move embedded datasource check inside

### DIFF
--- a/instrumentation/tomcat-jmx/src/main/java/com/nr/agent/instrumentation/tomcat/TomcatUtils.java
+++ b/instrumentation/tomcat-jmx/src/main/java/com/nr/agent/instrumentation/tomcat/TomcatUtils.java
@@ -37,11 +37,11 @@ public class TomcatUtils {
                         AgentBridge.jmxApi.addJmxMBeanGroup(JMX_EMBEDDED_PREFIX);
                         NewRelic.getAgent().getLogger().log(Level.FINER, "Added JMX for Tomcat");
 
-                    }
-                    if(server.queryNames(new ObjectName("org.apache.tomcat.jdbc.pool.jmx:name=dataSourceMBean,type=ConnectionPool"), null)
-                            .size() == 1){
-                        AgentBridge.jmxApi.addJmxMBeanGroup(JMX_EMBEDDED_DATASOURCE_PREFIX);
-                        NewRelic.getAgent().getLogger().log(Level.FINER, "Added JMX for Tomcat dataSourceMbean ConnectionPool");
+                        if (server.queryNames(new ObjectName("org.apache.tomcat.jdbc.pool.jmx:name=dataSourceMBean,type=ConnectionPool"), null)
+                                .size() == 1) {
+                            AgentBridge.jmxApi.addJmxMBeanGroup(JMX_EMBEDDED_DATASOURCE_PREFIX);
+                            NewRelic.getAgent().getLogger().log(Level.FINER, "Added JMX for Tomcat dataSourceMbean ConnectionPool");
+                        }
 
                     } else {
                         // It is safe to assume we are in a non embedded Tomcat (Catalina) which uses Catalina for the ObjectName, no need to query.


### PR DESCRIPTION
Fixes a bug that causes non embedded Tomcat (Catalina) to unnecessarily get queried for jmx when we know that embedded tomcat is running.

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
