### PR TITLE
Gracefully shutdown the agent if it encounters issues on startup

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/DelegatingInstrumentation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/DelegatingInstrumentation.java
@@ -1,0 +1,90 @@
+package com.newrelic.agent.util;
+
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.util.jar.JarFile;
+
+public class DelegatingInstrumentation implements Instrumentation {
+    protected final Instrumentation delegate;
+
+    public DelegatingInstrumentation(Instrumentation instrumentation) {
+        this.delegate = instrumentation;
+    }
+
+    @Override
+    public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        delegate.addTransformer(transformer, canRetransform);
+    }
+
+    @Override
+    public void addTransformer(ClassFileTransformer transformer) {
+        delegate.addTransformer(transformer);
+    }
+
+    @Override
+    public boolean removeTransformer(ClassFileTransformer transformer) {
+        return delegate.removeTransformer(transformer);
+    }
+
+    @Override
+    public boolean isRetransformClassesSupported() {
+        return delegate.isRetransformClassesSupported();
+    }
+
+    @Override
+    public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
+        delegate.retransformClasses(classes);
+    }
+
+    @Override
+    public boolean isRedefineClassesSupported() {
+        return delegate.isRedefineClassesSupported();
+    }
+
+    @Override
+    public void redefineClasses(ClassDefinition... definitions) throws ClassNotFoundException, UnmodifiableClassException {
+        delegate.redefineClasses(definitions);
+    }
+
+    @Override
+    public boolean isModifiableClass(Class<?> theClass) {
+        return delegate.isModifiableClass(theClass);
+    }
+
+    @Override
+    public Class[] getAllLoadedClasses() {
+        return delegate.getAllLoadedClasses();
+    }
+
+    @Override
+    public Class[] getInitiatedClasses(ClassLoader loader) {
+        return delegate.getInitiatedClasses(loader);
+    }
+
+    @Override
+    public long getObjectSize(Object objectToSize) {
+        return delegate.getObjectSize(objectToSize);
+    }
+
+    @Override
+    public void appendToBootstrapClassLoaderSearch(JarFile jarfile) {
+        delegate.appendToBootstrapClassLoaderSearch(jarfile);
+    }
+
+    @Override
+    public void appendToSystemClassLoaderSearch(JarFile jarfile) {
+        delegate.appendToSystemClassLoaderSearch(jarfile);
+    }
+
+    @Override
+    public boolean isNativeMethodPrefixSupported() {
+        return delegate.isNativeMethodPrefixSupported();
+    }
+
+    @Override
+    public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
+        delegate.setNativeMethodPrefix(transformer, prefix);
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/InstrumentationWrapper.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/InstrumentationWrapper.java
@@ -19,30 +19,13 @@ import com.newrelic.agent.Agent;
 /**
  * This delegating wrapper of an {@link Instrumentation} instance.
  */
-public class InstrumentationWrapper implements Instrumentation {
-    protected final Instrumentation delegate;
+public class InstrumentationWrapper extends DelegatingInstrumentation {
 
     public InstrumentationWrapper(Instrumentation delegate) {
-        super();
-        this.delegate = delegate;
+        super(delegate);
     }
 
-    public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
-        delegate.addTransformer(transformer, canRetransform);
-    }
-
-    public void addTransformer(ClassFileTransformer transformer) {
-        delegate.addTransformer(transformer);
-    }
-
-    public boolean removeTransformer(ClassFileTransformer transformer) {
-        return delegate.removeTransformer(transformer);
-    }
-
-    public boolean isRetransformClassesSupported() {
-        return delegate.isRetransformClassesSupported();
-    }
-
+    @Override
     public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
         if (Agent.LOG.isFinestEnabled()) {
             StringBuilder sb = new StringBuilder("Classes about to be retransformed: ");
@@ -51,13 +34,10 @@ public class InstrumentationWrapper implements Instrumentation {
             }
             Agent.LOG.log(Level.FINEST, sb.toString());
         }
-        delegate.retransformClasses(classes);
+        super.retransformClasses(classes);
     }
 
-    public boolean isRedefineClassesSupported() {
-        return delegate.isRedefineClassesSupported();
-    }
-
+    @Override
     public void redefineClasses(ClassDefinition... definitions) throws ClassNotFoundException,
             UnmodifiableClassException {
         if (Agent.LOG.isFinestEnabled()) {
@@ -69,39 +49,4 @@ public class InstrumentationWrapper implements Instrumentation {
         }
         delegate.redefineClasses(definitions);
     }
-
-    public boolean isModifiableClass(Class<?> theClass) {
-        return delegate.isModifiableClass(theClass);
-    }
-
-    @SuppressWarnings("rawtypes")
-    public Class[] getAllLoadedClasses() {
-        return delegate.getAllLoadedClasses();
-    }
-
-    @SuppressWarnings("rawtypes")
-    public Class[] getInitiatedClasses(ClassLoader loader) {
-        return delegate.getInitiatedClasses(loader);
-    }
-
-    public long getObjectSize(Object objectToSize) {
-        return delegate.getObjectSize(objectToSize);
-    }
-
-    public void appendToBootstrapClassLoaderSearch(JarFile jarfile) {
-        delegate.appendToBootstrapClassLoaderSearch(jarfile);
-    }
-
-    public void appendToSystemClassLoaderSearch(JarFile jarfile) {
-        delegate.appendToSystemClassLoaderSearch(jarfile);
-    }
-
-    public boolean isNativeMethodPrefixSupported() {
-        return delegate.isNativeMethodPrefixSupported();
-    }
-
-    public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
-        delegate.setNativeMethodPrefix(transformer, prefix);
-    }
-
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/UnwindableInstrumentation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/UnwindableInstrumentation.java
@@ -1,0 +1,12 @@
+package com.newrelic.agent.util;
+
+import java.lang.instrument.Instrumentation;
+
+public interface UnwindableInstrumentation extends Instrumentation {
+    /**
+     * Remove all New Relic class transformers and rejit any classes they have modified
+     */
+    void unwind();
+
+    void started();
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/UnwindableInstrumentationImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/UnwindableInstrumentationImpl.java
@@ -1,0 +1,230 @@
+package com.newrelic.agent.util;
+
+import org.objectweb.asm.Type;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+public class UnwindableInstrumentationImpl extends DelegatingInstrumentation implements UnwindableInstrumentation {
+    final Map<ClassFileTransformer, ClassFileTransformer> classFileTransformerMap =
+            new ConcurrentHashMap<>();
+    final Set<Class<?>> modifiedClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    final Set<ClassInfo> modifiedClassInfo = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final AtomicBoolean wrap = new AtomicBoolean(true);
+
+    UnwindableInstrumentationImpl(Instrumentation instrumentation) {
+        super(instrumentation);
+    }
+
+    @Override
+    public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        if (wrap.get() && isNewRelic(transformer)) {
+            super.addTransformer(wrap(transformer), canRetransform);
+        } else {
+            super.addTransformer(transformer, canRetransform);
+        }
+    }
+
+    @Override
+    public void addTransformer(ClassFileTransformer transformer) {
+        if (wrap.get() && isNewRelic(transformer)) {
+            super.addTransformer(wrap(transformer));
+        } else {
+            super.addTransformer(transformer);
+        }
+    }
+
+    @Override
+    public boolean removeTransformer(ClassFileTransformer transformer) {
+        if (wrap.get() && isNewRelic(transformer)) {
+            ClassFileTransformer wrapper = classFileTransformerMap.get(transformer);
+            if (wrapper != null) {
+                return super.removeTransformer(wrapper);
+            } else {
+                return super.removeTransformer(transformer);
+            }
+        } else {
+            return super.removeTransformer(transformer);
+        }
+    }
+
+    private ClassFileTransformer wrap(ClassFileTransformer transformer) {
+        ClassFileTransformer wrapper = new ClassFileTransformer() {
+            @Override
+            public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+                final byte[] modifiedBytes = transformer.transform(loader, className, classBeingRedefined, protectionDomain, classfileBuffer);
+                if (wrap.get()) {
+                    if (modifiedBytes != null && modifiedBytes.length != classfileBuffer.length) {
+                        if (classBeingRedefined == null) {
+                            modifiedClassInfo.add(new ClassInfo(loader, className));
+                        } else {
+                            modifiedClasses.add(classBeingRedefined);
+                        }
+                    }
+                }
+                return modifiedBytes;
+            }
+        };
+        classFileTransformerMap.put(transformer, wrapper);
+        return wrapper;
+    }
+
+    private static boolean isNewRelic(ClassFileTransformer transformer) {
+        return transformer.getClass().getName().contains("newrelic");
+    }
+
+    @Override
+    public void started() {
+        wrap.set(false);
+        modifiedClasses.clear();
+        modifiedClassInfo.clear();
+    }
+
+    @Override
+    public void unwind() {
+        wrap.set(false);
+        classFileTransformerMap.values().forEach(super::removeTransformer);
+        classFileTransformerMap.clear();
+
+        modifiedClassInfo.forEach(classInfo -> {
+            try {
+                modifiedClasses.add(classInfo.loadClass());
+            } catch (ClassNotFoundException e) {
+                // ignore
+            }
+        });
+
+        modifiedClassInfo.clear();
+        if (!modifiedClasses.isEmpty()) {
+            try {
+                super.retransformClasses(modifiedClasses.toArray(new Class[0]));
+            } catch (UnmodifiableClassException e) {
+            }
+        }
+
+        modifiedClasses.clear();
+    }
+
+    /**
+     * Wrap instrumentation so that we can unwind our instrumentation if necessary.
+     */
+    public static Instrumentation wrapInstrumentation(final Instrumentation instrumentation) {
+        final List<MethodDesc> missingInterfaceMethods = getMissingInterfaceMethods();
+
+        final UnwindableInstrumentationImpl unwindableInstrumentation = new UnwindableInstrumentationImpl(instrumentation);
+        if (missingInterfaceMethods.isEmpty()) {
+            return unwindableInstrumentation;
+        } else {
+            return createProxyInstance(unwindableInstrumentation, instrumentation, missingInterfaceMethods);
+        }
+    }
+
+    /**
+     * Returns an UnwindableInstrumentation proxy instance that invokes the new java 9 Instrumentation methods
+     * on the instrumentation instance, otherwise invoking using the unwindableInstrumentation instance.
+     */
+    static Instrumentation createProxyInstance(final UnwindableInstrumentation unwindableInstrumentation,
+                                                       final Instrumentation instrumentation,
+                                                       final List<MethodDesc> missingInterfaceMethods) {
+        final Set<MethodDesc> missingMethods = new HashSet<>(missingInterfaceMethods);
+        final InvocationHandler invocationHandler = (proxy, method, args) -> {
+            if (missingMethods.contains(new MethodDesc(method))) {
+                return method.invoke(instrumentation, args);
+            } else {
+                return method.invoke(unwindableInstrumentation, args);
+            }
+        };
+
+        return (Instrumentation) Proxy.newProxyInstance(UnwindableInstrumentation.class.getClassLoader(),
+                new Class[] { UnwindableInstrumentation.class}, invocationHandler);
+    }
+
+    /**
+     * Return the 2 methods added to Instrumentation in java 9 that are missing from our implementation (if running
+     * in 9+).
+     */
+    static List<MethodDesc> getMissingInterfaceMethods() {
+        final List<MethodDesc> interfaceMethods = Arrays.asList(Instrumentation.class.getMethods())
+                .stream()
+                .map(MethodDesc::new)
+                .collect(Collectors.toList());
+
+        Arrays.asList(DelegatingInstrumentation.class.getDeclaredMethods())
+                .stream()
+                .map(MethodDesc::new)
+                .forEach(interfaceMethods::remove);
+
+        return interfaceMethods;
+    }
+
+    static class MethodDesc {
+        private final String name;
+        private final String desc;
+
+        public MethodDesc(String name, String desc) {
+            this.name = name;
+            this.desc = desc;
+        }
+
+        public MethodDesc(Method method) {
+            this(method.getName(), Type.getMethodDescriptor(method));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MethodDesc that = (MethodDesc) o;
+            return name.equals(that.name) && desc.equals(that.desc);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, desc);
+        }
+    }
+
+    private static class ClassInfo {
+        private final ClassLoader classLoader;
+        private final String className;
+
+        public ClassInfo(ClassLoader classLoader, String className) {
+            this.classLoader = classLoader;
+            this.className = className;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ClassInfo classInfo = (ClassInfo) o;
+            return Objects.equals(classLoader, classInfo.classLoader) && className.equals(classInfo.className);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(classLoader, className);
+        }
+
+        public Class<?> loadClass() throws ClassNotFoundException {
+            ClassLoader classLoader = this.classLoader == null ? ClassLoader.getSystemClassLoader() : this.classLoader;
+            return classLoader.loadClass(className);
+        }
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/UnwindableInstrumentationImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/UnwindableInstrumentationImplTest.java
@@ -9,9 +9,9 @@ import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +26,7 @@ public class UnwindableInstrumentationImplTest {
     @Test
     public void getMissingInterfaceMethods() {
         List<UnwindableInstrumentationImpl.MethodDesc> missingInterfaceMethods = UnwindableInstrumentationImpl.getMissingInterfaceMethods();
-        Optional<Method> redefineModule = Arrays.asList(Instrumentation.class.getDeclaredMethods()).stream()
+        Optional<Method> redefineModule = Arrays.stream(Instrumentation.class.getDeclaredMethods())
                 .filter(method -> "redefineModule".equals(method.getName()))
                 .findFirst();
         // if we find the redefineModule method, we're running in java9+ and missing methods should contain it
@@ -38,7 +38,7 @@ public class UnwindableInstrumentationImplTest {
         Instrumentation inst = Mockito.mock(Instrumentation.class);
         UnwindableInstrumentationImpl unwindableInstrumentation = Mockito.mock(UnwindableInstrumentationImpl.class);
         Instrumentation proxy = UnwindableInstrumentationImpl.createProxyInstance(unwindableInstrumentation, inst,
-                Arrays.asList(new UnwindableInstrumentationImpl.MethodDesc("isRetransformClassesSupported", "()Z")));
+                Collections.singletonList(new UnwindableInstrumentationImpl.MethodDesc("isRetransformClassesSupported", "()Z")));
         assertTrue(proxy instanceof UnwindableInstrumentation);
 
         ClassFileTransformer transformer = Mockito.mock(ClassFileTransformer.class);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/UnwindableInstrumentationImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/UnwindableInstrumentationImplTest.java
@@ -1,0 +1,138 @@
+package com.newrelic.agent.util;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UnwindableInstrumentationImplTest {
+    @Test
+    public void wrapInstrumentation() {
+        Instrumentation inst = UnwindableInstrumentationImpl.wrapInstrumentation(Mockito.mock(Instrumentation.class));
+        assertTrue(inst instanceof UnwindableInstrumentation);
+    }
+
+    @Test
+    public void getMissingInterfaceMethods() {
+        List<UnwindableInstrumentationImpl.MethodDesc> missingInterfaceMethods = UnwindableInstrumentationImpl.getMissingInterfaceMethods();
+        assertEquals(0, missingInterfaceMethods.size());
+    }
+
+    @Test
+    public void createProxyInstance() {
+        Instrumentation inst = Mockito.mock(Instrumentation.class);
+        UnwindableInstrumentationImpl unwindableInstrumentation = Mockito.mock(UnwindableInstrumentationImpl.class);
+        Instrumentation proxy = UnwindableInstrumentationImpl.createProxyInstance(unwindableInstrumentation, inst,
+                Arrays.asList(new UnwindableInstrumentationImpl.MethodDesc("isRetransformClassesSupported", "()Z")));
+        assertTrue(proxy instanceof UnwindableInstrumentation);
+
+        ClassFileTransformer transformer = Mockito.mock(ClassFileTransformer.class);
+        proxy.addTransformer(transformer);
+        Mockito.verify(inst, Mockito.times(0)).addTransformer(transformer);
+        Mockito.verify(unwindableInstrumentation, Mockito.times(1)).addTransformer(transformer);
+
+        proxy.isRetransformClassesSupported();
+        Mockito.verify(inst, Mockito.times(1)).isRetransformClassesSupported();
+        Mockito.verify(unwindableInstrumentation, Mockito.times(0)).isRetransformClassesSupported();
+    }
+
+    @Test
+    public void addTransformersAndUnwind() {
+        final List<ClassFileTransformer> transformers = new ArrayList<>();
+        Instrumentation instrumentation = new DelegatingInstrumentation(Mockito.mock(Instrumentation.class)) {
+            @Override
+            public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+                transformers.add(transformer);
+            }
+            @Override
+            public void addTransformer(ClassFileTransformer transformer) {
+                transformers.add(transformer);
+            }
+
+            @Override
+            public boolean removeTransformer(ClassFileTransformer transformer) {
+                return transformers.remove(transformer);
+            }
+        };
+        UnwindableInstrumentationImpl impl = new UnwindableInstrumentationImpl(instrumentation);
+        ClassFileTransformer transformer = Mockito.mock(ClassFileTransformer.class);
+        impl.addTransformer(transformer);
+        impl.addTransformer(transformer, true);
+
+        assertEquals(0, impl.classFileTransformerMap.size());
+        assertEquals(2, transformers.size());
+
+        ClassFileTransformer nrTransformer = new ClassFileTransformer() {
+            @Override
+            public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                                    ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+                return null;
+            }
+        };
+        impl.addTransformer(nrTransformer);
+        assertEquals(3, transformers.size());
+
+        assertEquals(1, impl.classFileTransformerMap.size());
+        impl.unwind();
+        assertEquals(0, impl.classFileTransformerMap.size());
+        assertEquals(2, transformers.size());
+
+        impl.addTransformer(nrTransformer);
+        assertEquals(0, impl.classFileTransformerMap.size());
+        assertEquals(3, transformers.size());
+    }
+
+    @Test
+    public void transformClass() throws Exception {
+        final List<ClassFileTransformer> transformers = new ArrayList<>();
+        final List<Class<?>> retransformed = new ArrayList<>();
+        Instrumentation instrumentation = new DelegatingInstrumentation(Mockito.mock(Instrumentation.class)) {
+            @Override
+            public void addTransformer(ClassFileTransformer transformer) {
+                transformers.add(transformer);
+            }
+
+            @Override
+            public void retransformClasses(Class<?>... classes) {
+                retransformed.addAll(Arrays.asList(classes));
+            }
+        };
+        UnwindableInstrumentationImpl impl = new UnwindableInstrumentationImpl(instrumentation);
+
+        ClassFileTransformer nrTransformer = new ClassFileTransformer() {
+            @Override
+            public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                                    ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+                return new byte[] { 0xB, 0xE, 0xE, 0xF };
+            }
+        };
+        impl.addTransformer(nrTransformer);
+
+        assertEquals(1, impl.classFileTransformerMap.size());
+        assertEquals(1, transformers.size());
+
+        transformers.get(0).transform(null, UnwindableInstrumentation.class.getName(),
+                null, null, new byte[0]);
+        transformers.get(0).transform(null, UnwindableInstrumentationImpl.class.getName(),
+                UnwindableInstrumentationImpl.class, null, new byte[0]);
+        assertEquals(1, impl.modifiedClassInfo.size());
+        assertEquals(1, impl.modifiedClasses.size());
+
+        impl.unwind();
+
+        assertEquals(0, impl.modifiedClassInfo.size());
+        assertEquals(0, impl.modifiedClasses.size());
+
+        assertEquals(2, retransformed.size());
+        assertTrue(retransformed.contains(UnwindableInstrumentation.class));
+        assertTrue(retransformed.contains(UnwindableInstrumentationImpl.class));
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/UnwindableInstrumentationImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/UnwindableInstrumentationImplTest.java
@@ -5,10 +5,13 @@ import org.mockito.Mockito;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -23,7 +26,11 @@ public class UnwindableInstrumentationImplTest {
     @Test
     public void getMissingInterfaceMethods() {
         List<UnwindableInstrumentationImpl.MethodDesc> missingInterfaceMethods = UnwindableInstrumentationImpl.getMissingInterfaceMethods();
-        assertEquals(0, missingInterfaceMethods.size());
+        Optional<Method> redefineModule = Arrays.asList(Instrumentation.class.getDeclaredMethods()).stream()
+                .filter(method -> "redefineModule".equals(method.getName()))
+                .findFirst();
+        // if we find the redefineModule method, we're running in java9+ and missing methods should contain it
+        assertEquals(redefineModule.isPresent(), !missingInterfaceMethods.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
If the java agent encounters a serious issue on startup, it calls `System.exit`.  It would be better if it gracefully shutdown.  This is a particularly troublesome quality when connecting to running applications.

I have a demo that connects to a Spring Petclinic app and uses the nri-lsi-java tool to connect the agent.  It's causing the app to exit.  Here's the repo: https://source.datanerd.us/saxon/java-agent-crash

### Overview

This wraps the `Instrumentation` instance so that we can remove class transformers and shutdown the agent if there's an exception.  We only do this for the attach (`agentmain`) case.  `premain` works as it does today.  When everyone is comfortable with this change it'd be nice to use it for premain as well.

### Related Github Issue
https://issues.newrelic.com/browse/NR-84187

### Testing
I've referenced a test repo to fully reproduce the issue.  There are some unit tests for changes.

### Checks

[] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
