### PR TITLE
NR-84187 Fix ClassCircularityError when agent attaches

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
@@ -72,6 +72,8 @@ public class BootstrapAgent {
             throw new IllegalArgumentException("Unable to attach. The license key was not specified");
         }
         System.out.println("Attaching the New Relic java agent");
+        // force this formatter to load early to avoid a java.lang.ClassCircularityError
+        MessageFormat.format("{0}", 1.0);
         try {
             agentArgs = decodeAndDecompressAgentArguments(agentArgs);
         } catch (IOException e) {


### PR DESCRIPTION
### Overview
I have an app that crashes when using nri-lsi-java to attach the java agent.  Here's how to reproduce this: https://source.datanerd.us/saxon/java-agent-crash

Here's the exception:

```New Relic support.java.lang.ClassCircularityError: java/text/FieldPosition$Delegate
at java.base/java.text.FieldPosition.getFieldDelegate(FieldPosition.java:215)at java.base/java.text.DecimalFormat.format(DecimalFormat.java:714)at java.base/java.text.DecimalFormat.format(DecimalFormat.java:507)at ```

We can avoid the error by loading `FieldPosition$Delegate` before we modify class loaders.

### Related Github Issue
[Include a link to the related GitHub issue, if applicable](https://issues.newrelic.com/browse/NR-84187)

### Testing
You can verify the fix with https://source.datanerd.us/saxon/java-agent-crash

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
