### PR TITLE
Instrument methods with dispatcher=true when they invoke token.link() outside of a transaction 

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/Instrumentation.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/Instrumentation.java
@@ -11,6 +11,8 @@ import java.io.Closeable;
 import java.lang.reflect.Method;
 
 import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
 
 public interface Instrumentation {
 
@@ -95,10 +97,19 @@ public interface Instrumentation {
      * Add instrumentation for a given method of a given class only if no @InstrumentedMethod annotation is present.
      * Does not instrument native, abstract, or interface methods. Calls retransform if necessary.
      * 
-     * @param methodToInstrument - exact method name along with it's associated declared class to instrument.
+     * @param methodToInstrument - exact method name along with its associated declared class to instrument.
      * @param metricPrefix
      */
     void instrument(Method methodToInstrument, String metricPrefix);
+
+    /**
+     * Trace with transactions enabled (dispatcher=true) the first non-New Relic stack element on the current stack.
+     * Often customers will call APIs like {@link Token#link()}, which need to be called within a transaction,
+     * without having instrumented code to start a transaction.  We can detect that case and instrument the calling
+     * method.
+     * This will be rate limited to reduce the overhead.
+     */
+    void instrument();
 
     /**
      * Re-transform a class if it hasn't already been instrumented (Annotated with @InstrumentedClass). Classes that

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/Instrumentation.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/Instrumentation.java
@@ -103,11 +103,12 @@ public interface Instrumentation {
     void instrument(Method methodToInstrument, String metricPrefix);
 
     /**
-     * Trace with transactions enabled (dispatcher=true) the first non-New Relic stack element on the current stack.
+     * Trace with transaction activity enabled (async=true) the first non-New Relic stack element on the current stack.
      * Often customers will call APIs like {@link Token#link()}, which need to be called within a transaction,
      * without having instrumented code to start a transaction.  We can detect that case and instrument the calling
      * method.
-     * This will be rate limited to reduce the overhead.
+     * This will be rate limited to reduce the overhead, controlled by
+     * the config class_transformer:auto_async_link_rate_limit
      */
     void instrument();
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpInstrumentation.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpInstrumentation.java
@@ -30,6 +30,10 @@ public class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
+    public void instrument() {
+    }
+
+    @Override
     public void retransformUninstrumentedClass(Class<?> classToRetransform) {
     }
 

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/NoOpClassTransformerService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/NoOpClassTransformerService.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.instrumentation.classmatchers.ClassAndMethodMatcher;
 import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.instrumentation.context.InstrumentationContextManager;
 import com.newrelic.agent.instrumentation.custom.ClassRetransformer;
+import com.newrelic.agent.instrumentation.tracing.TraceDetails;
 import com.newrelic.agent.logging.IAgentLogger;
 
 import java.lang.instrument.Instrumentation;
@@ -102,6 +103,11 @@ class NoOpClassTransformerService implements ClassTransformerService {
 
     @Override
     public boolean addTraceMatcher(ClassAndMethodMatcher matcher, String metricPrefix) {
+        return false;
+    }
+
+    @Override
+    public boolean addTraceMatcher(ClassAndMethodMatcher matcher, TraceDetails traceDetails) {
         return false;
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -125,9 +125,9 @@ public class Transaction {
     static final ClassMethodSignature REQUEST_INITIALIZED_CLASS_SIGNATURE = new ClassMethodSignature(
             "javax.servlet.ServletRequestListener", "requestInitialized", "(Ljavax/servlet/ServletRequestEvent;)V");
     static final int REQUEST_INITIALIZED_CLASS_SIGNATURE_ID = ClassMethodSignatures.get().add(REQUEST_INITIALIZED_CLASS_SIGNATURE);
-  static final ClassMethodSignature SCALA_API_TXN_CLASS_SIGNATURE = new ClassMethodSignature(
+    static final ClassMethodSignature SCALA_API_TXN_CLASS_SIGNATURE = new ClassMethodSignature(
     "newrelic.scala.api.TraceOps$", "txn", null);
-  public static final int SCALA_API_TXN_CLASS_SIGNATURE_ID =
+    public static final int SCALA_API_TXN_CLASS_SIGNATURE_ID =
     ClassMethodSignatures.get().add(SCALA_API_TXN_CLASS_SIGNATURE);
     private static final String THREAD_ASSERTION_FAILURE = "Thread assertion failed!";
 
@@ -1415,6 +1415,7 @@ public class Transaction {
         synchronized (newTx.lock) {
             if (!newTx.isInProgress()) {
                 Agent.LOG.log(Level.FINER, "Transaction {0}: ignoring link call because transaction not in progress.", newTx);
+                AgentBridge.instrumentation.instrument();
                 return false;
             } else if (!token.isActive()) {
                 Agent.LOG.log(Level.FINER, "Transaction {0}: ignoring link call because token is no longer active {1}.", newTx, token);
@@ -1423,6 +1424,7 @@ public class Transaction {
                 TransactionActivity oldTxa = TransactionActivity.get();
                 if (oldTxa == null || !oldTxa.isStarted()) {
                     Agent.LOG.log(Level.FINER, "Transaction {0}: ignoring link call because there is no started txa to link to: {1}.", newTx, oldTxa);
+                    AgentBridge.instrumentation.instrument();
                     return false;
                 } else {
                     // don't worry about a race with expire, if tracer is not null we're fine because tracer is

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
@@ -90,6 +90,11 @@ public interface ClassTransformerConfig extends Config {
      */
     boolean isGrantPackageAccess();
 
+    /**
+     * Returns the auto async-link rate limit in millis.
+     */
+    long getAutoAsyncLinkRateLimit();
+
     Config getInstrumentationConfig(String implementationTitle);
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
@@ -97,6 +97,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     private final boolean defaultMethodTracingEnabled;
     private final boolean isBuiltinExtensionEnabled;
     private final boolean litemode;
+    private final long autoAsyncLinkRateLimit;
 
     public ClassTransformerConfigImpl(Map<String, Object> props, boolean customTracingEnabled, boolean litemode) {
         super(props, SYSTEM_PROPERTY_ROOT);
@@ -117,6 +118,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
         preValidateWeavePackages = getProperty(PREVALIDATE_WEAVE_PACKAGES, DEFAULT_PREVALIDATE_WEAVE_PACKAGES);
         preMatchWeaveMethods = getProperty(PREMATCH_WEAVE_METHODS, DEFAULT_PREMATCH_WEAVE_METHODS);
         defaultMethodTracingEnabled = getProperty("default_method_tracing_enabled", true);
+        autoAsyncLinkRateLimit = getProperty("auto_async_link_rate_limit", TimeUnit.SECONDS.toMillis(1));
 
         this.traceAnnotationMatcher = customTracingEnabled ? initializeTraceAnnotationMatcher(props) : new NoMatchAnnotationMatcher();
         this.ignoreTransactionAnnotationMatcher = new ClassNameAnnotationMatcher(AnnotationNames.NEW_RELIC_IGNORE_TRANSACTION, false);
@@ -302,6 +304,11 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     @Override
     public boolean preMatchWeaveMethods() {
         return preMatchWeaveMethods;
+    }
+
+    @Override
+    public long getAutoAsyncLinkRateLimit() {
+        return autoAsyncLinkRateLimit;
     }
 
     public static final String JDBC_STATEMENTS_PROPERTY = "jdbc_statements";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerService.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.instrumentation.classmatchers.ClassAndMethodMatcher;
 import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.instrumentation.context.InstrumentationContextManager;
 import com.newrelic.agent.instrumentation.custom.ClassRetransformer;
+import com.newrelic.agent.instrumentation.tracing.TraceDetails;
 import com.newrelic.agent.service.Service;
 
 public interface ClassTransformerService extends Service {
@@ -34,6 +35,13 @@ public interface ClassTransformerService extends Service {
      * @return true if the matcher was not previously added
      */
     boolean addTraceMatcher(ClassAndMethodMatcher matcher, String metricPrefix);
+
+    /**
+     * Add a matcher that will match class/methods which should be traced.
+     *
+     * @return true if the matcher was not previously added
+     */
+    boolean addTraceMatcher(ClassAndMethodMatcher matcher, TraceDetails traceDetails);
 
     /**
      * Queues the retransformation of loaded classes that match the given class matchers.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
@@ -75,7 +75,7 @@ public class ClassTransformerServiceImpl extends AbstractService implements Clas
         // pick up
         extensionInstrumentation = new ExtensionInstrumentation(instrumentationProxy);
 
-        instrumentation = new InstrumentationImpl(logger);
+        instrumentation = new InstrumentationImpl(logger, classTransformerConfig);
         AgentBridge.instrumentation = instrumentation;
 
         ThreadFactory factory = new DefaultThreadFactory("New Relic Retransformer", true);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/InstrumentationImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/InstrumentationImplTest.java
@@ -19,6 +19,7 @@ import com.newrelic.agent.instrumentation.classmatchers.ClassAndMethodMatcher;
 import com.newrelic.agent.instrumentation.tracing.TraceDetails;
 import com.newrelic.agent.samplers.SamplerService;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.api.agent.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -31,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -97,6 +99,21 @@ public class InstrumentationImplTest {
         assertEquals(1, classes.size());
         Mockito.verify(mockCoreService, times(1)).getInstrumentation();
         Mockito.verify(instrumentation, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void testDisableAuto() {
+        ClassTransformerConfig config = mock(ClassTransformerConfig.class);
+        when(config.getAutoAsyncLinkRateLimit()).thenReturn(0L);
+        InstrumentationImpl instrumentation = new InstrumentationImpl(mock(Logger.class), config);
+        assertFalse(instrumentation.autoInstrumentCheck.get());
+    }
+
+    @Test
+    public void getAutoAsyncLinkRateLimitInSeconds() {
+        ClassTransformerConfig config = mock(ClassTransformerConfig.class);
+        when(config.getAutoAsyncLinkRateLimit()).thenReturn(500L);
+        assertEquals(0.5f, InstrumentationImpl.getAutoAsyncLinkRateLimitInSeconds(config), 0.001);
     }
 
     @Test


### PR DESCRIPTION

### Overview
There are cases for async transactions in which customers call `Token.link()` outside of a transaction, which causes linking to fail.  We can detect this happening and re-transforming the class so that the method is traced with transactions enabled.

To determine the calling class/method, we generate an exception and use the stack trace elements.  Because we're doing this automatically, I added rate limiting so that we only try this once per second.  We could make that time configurable, and we could add a config switch to completely disable this behavior.

### Related Github Issue
https://issues.newrelic.com/browse/NR-74916

### Testing
The referenced ticket contains an application which can be used to reproduce the issue and verify the fix.

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
