### PR TITLE
NullPointerException thrown when calling addCustomAttributes

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
@@ -8,7 +8,6 @@
 package com.newrelic.agent.tracers;
 
 import com.newrelic.agent.Agent;
-import com.newrelic.api.agent.AttributeHolder;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.Transaction;
 import com.newrelic.agent.TransactionActivity;
@@ -18,6 +17,7 @@ import com.newrelic.agent.bridge.TracedMethod;
 import com.newrelic.agent.bridge.TransactionNamePriority;
 import com.newrelic.agent.instrumentation.AgentWrapper;
 import com.newrelic.agent.util.Strings;
+import com.newrelic.api.agent.AttributeHolder;
 import com.newrelic.api.agent.ExternalParameters;
 import com.newrelic.api.agent.InboundHeaders;
 import com.newrelic.api.agent.OutboundHeaders;
@@ -342,7 +342,7 @@ public abstract class AbstractTracer implements Tracer, AttributeHolder {
     }
 
     private boolean shouldAddAttribute() {
-        return !getTransaction().getTransactionCounts().isOverTracerSegmentLimit();
+        return getTransaction() != null && !getTransaction().getTransactionCounts().isOverTracerSegmentLimit();
     }
 
     public void setAttribute(String key, Object value, boolean checkLimits, boolean isCustom) {


### PR DESCRIPTION
[_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._](https://issues.newrelic.com/browse/NEWRELIC-6338)

### Overview
null guards shouldAddAttribute
### Related Github Issue
Include a link to the related GitHub issue, if applicable


[NOTE]: # In a least one use case, a NullPointerExeception is thrown when calling any of the addCustomAttribute or addCustomAttributes method on TracedMethod. The exception is being thrown in the shouldAddAttribute() of AbstractTracer.

Description

If the following is true then a NullPointerExeception is thrown by the Agent, The async token is created but no transaction is started (No-op token created). If a method is called with the @Trace attribute async set to true and the token is linked then if you try to add an attribute to TracedMethod it results in a NullPointerExeception. This seems to happen because when the resulting TransactionActivity is created its Transaction object is set to null.
In some cases it results in the application not working properly.
### Testing
Testing against provided repro app

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
