### PR TITLE
Infinite Tracing payload compression and batching

### DIFF
--- a/infinite-tracing/build.gradle.kts
+++ b/infinite-tracing/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":newrelic-api"))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
     testImplementation("org.mockito:mockito-junit-jupiter:3.3.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
 }

--- a/infinite-tracing/src/main/java/com/newrelic/ChannelManager.java
+++ b/infinite-tracing/src/main/java/com/newrelic/ChannelManager.java
@@ -119,8 +119,8 @@ class ChannelManager {
     @VisibleForTesting
     IngestServiceStub buildStub(ManagedChannel managedChannel) {
         IngestServiceStub ingestServiceStub = IngestServiceGrpc.newStub(managedChannel);
-        if (config.getCompression() != null) {
-            ingestServiceStub = ingestServiceStub.withCompression(config.getCompression());
+        if (config.getUseCompression()) {
+            ingestServiceStub = ingestServiceStub.withCompression("gzip");
         }
         return ingestServiceStub;
     }

--- a/infinite-tracing/src/main/java/com/newrelic/ChannelManager.java
+++ b/infinite-tracing/src/main/java/com/newrelic/ChannelManager.java
@@ -29,7 +29,7 @@ class ChannelManager {
     @GuardedBy("lock") private CountDownLatch backoffLatch;
     @GuardedBy("lock") private ManagedChannel managedChannel;
     @GuardedBy("lock") private boolean recreateSpanObserver = true;
-    @GuardedBy("lock") private ClientCallStreamObserver<V1.Span> spanObserver;
+    @GuardedBy("lock") private Observer observer;
     @GuardedBy("lock") private String agentRunToken;
     @GuardedBy("lock") private Map<String, String> requestMetadata;
 
@@ -62,7 +62,7 @@ class ChannelManager {
      *
      * @return a span observer
      */
-    ClientCallStreamObserver<V1.Span> getSpanObserver() {
+    Observer getObserver() {
         // Obtain the lock, and await the backoff if in progress
         CountDownLatch latch;
         synchronized (lock) {
@@ -88,23 +88,41 @@ class ChannelManager {
                 managedChannel = buildChannel();
             }
             if (recreateSpanObserver) {
-                if (spanObserver != null) {
+                if (observer != null) {
                     logger.log(Level.FINE, "Cancelling and recreating gRPC span observer.");
-                    spanObserver.cancel("CLOSING_CONNECTION", new ChannelClosingException());
+                    observer.cancel("CLOSING_CONNECTION", new ChannelClosingException());
                 }
                 IngestServiceStub ingestServiceStub = buildStub(managedChannel);
                 ResponseObserver responseObserver = buildResponseObserver();
-                spanObserver = (ClientCallStreamObserver<V1.Span>) ingestServiceStub.recordSpan(responseObserver);
+                if (config.getUseBatching()) {
+                    observer = buildSpanBatchObserver((ClientCallStreamObserver<V1.SpanBatch>) ingestServiceStub.recordSpanBatch(responseObserver));
+                } else {
+                    observer = buildSpanObserver((ClientCallStreamObserver<V1.Span>) ingestServiceStub.recordSpan(responseObserver));
+                }
                 aggregator.incrementCounter("Supportability/InfiniteTracing/Connect");
                 recreateSpanObserver = false;
             }
-            return spanObserver;
+            return observer;
         }
     }
 
     @VisibleForTesting
+    Observer buildSpanObserver(ClientCallStreamObserver<V1.Span> observer) {
+        return new SpanObserver(observer);
+    }
+
+    @VisibleForTesting
+    Observer buildSpanBatchObserver(ClientCallStreamObserver<V1.SpanBatch> observer) {
+        return new SpanBatchObserver(observer);
+    }
+
+    @VisibleForTesting
     IngestServiceStub buildStub(ManagedChannel managedChannel) {
-        return IngestServiceGrpc.newStub(managedChannel);
+        IngestServiceStub ingestServiceStub = IngestServiceGrpc.newStub(managedChannel);
+        if (config.getCompression() != null) {
+            ingestServiceStub = ingestServiceStub.withCompression(config.getCompression());
+        }
+        return ingestServiceStub;
     }
 
     @VisibleForTesting
@@ -113,7 +131,7 @@ class ChannelManager {
     }
 
     /**
-     * Mark that the span observer should be canceled and recreated the next time {@link #getSpanObserver()} is called.
+     * Mark that the span observer should be canceled and recreated the next time {@link #getObserver()} is called.
      */
     void recreateSpanObserver() {
         synchronized (lock) {
@@ -122,7 +140,7 @@ class ChannelManager {
     }
 
     /**
-     * Shutdown the channel, cancel the span observer, and backoff. The next time {@link #getSpanObserver()}
+     * Shutdown the channel, cancel the span observer, and backoff. The next time {@link #getObserver()}
      * is called, it will await the backoff and the channel will be recreated.
      *
      * @param backoffSeconds the number of seconds to await before the channel can be recreated
@@ -160,7 +178,7 @@ class ChannelManager {
     }
 
     /**
-     * Shutdown the channel and do not recreate it. The next time {@link #getSpanObserver()} is called
+     * Shutdown the channel and do not recreate it. The next time {@link #getObserver()} is called
      * an exception will be thrown.
      */
     void shutdownChannelForever() {

--- a/infinite-tracing/src/main/java/com/newrelic/InfiniteTracing.java
+++ b/infinite-tracing/src/main/java/com/newrelic/InfiniteTracing.java
@@ -48,6 +48,10 @@ public class InfiniteTracing implements Consumer<SpanEvent> {
      */
     public void start(String agentRunToken, Map<String, String> requestMetadata) {
         synchronized (lock) {
+            // Record supportability metrics related to Infinite Tracing configuration settings
+            aggregator.incrementCounter("Supportability/InfiniteTracing/gRPC/Compression/" + (config.getUseCompression() ? "enabled" : "disabled"));
+            aggregator.incrementCounter("Supportability/InfiniteTracing/gRPC/Batching/" + (config.getUseBatching() ? "enabled" : "disabled"));
+
             if (spanEventSenderFuture != null) {
                 channelManager.updateMetadata(agentRunToken, requestMetadata);
                 channelManager.shutdownChannelAndBackoff(0);

--- a/infinite-tracing/src/main/java/com/newrelic/InfiniteTracingConfig.java
+++ b/infinite-tracing/src/main/java/com/newrelic/InfiniteTracingConfig.java
@@ -13,10 +13,8 @@ public class InfiniteTracingConfig {
     private final Double flakyPercentage;
     private final Long flakyCode;
     private final boolean usePlaintext;
-    private final String compression;
+    private final boolean useCompression;
     private final boolean useBatching;
-    private final int maxBatchSize;
-    private final int lingerMs;
 
     public InfiniteTracingConfig(Builder builder) {
         this.licenseKey = builder.licenseKey;
@@ -27,10 +25,8 @@ public class InfiniteTracingConfig {
         this.flakyPercentage = builder.flakyPercentage;
         this.flakyCode = builder.flakyCode;
         this.usePlaintext = builder.usePlaintext;
-        this.compression = builder.compression;
+        this.useCompression = builder.useCompression;
         this.useBatching = builder.useBatching;
-        this.maxBatchSize = builder.maxBatchSize;
-        this.lingerMs = builder.lingerMs;
     }
 
     public static Builder builder() {
@@ -69,20 +65,12 @@ public class InfiniteTracingConfig {
         return usePlaintext;
     }
 
-    public String getCompression() {
-        return compression;
+    public boolean getUseCompression() {
+        return useCompression;
     }
 
     public boolean getUseBatching() {
         return useBatching;
-    }
-
-    public int getMaxBatchSize() {
-        return maxBatchSize;
-    }
-
-    public int getLingerMs() {
-        return lingerMs;
     }
 
     public static class Builder {
@@ -94,10 +82,8 @@ public class InfiniteTracingConfig {
         private Double flakyPercentage;
         private Long flakyCode;
         private boolean usePlaintext;
-        private String compression;
+        private boolean useCompression;
         private boolean useBatching;
-        private int maxBatchSize;
-        private int lingerMs;
 
         /**
          * The New Relic APM license key configured for the application.
@@ -173,12 +159,12 @@ public class InfiniteTracingConfig {
         }
 
         /**
-         * The optional compression type to use when sending to the Trace Observer.
+         * The optional boolean to use compression when sending to the Trace Observer.
          *
-         * @param compression The compression type to use. Available options are "gzip" or "none".
+         * @param useCompression true to use compression, false otherwise
          */
-        public Builder compression(String compression) {
-            this.compression = compression;
+        public Builder useCompression(boolean useCompression) {
+            this.useCompression = useCompression;
             return this;
         }
 
@@ -189,23 +175,6 @@ public class InfiniteTracingConfig {
          */
         public Builder useBatching(boolean useBatching) {
             this.useBatching = useBatching;
-            return this;
-        }
-
-        /**
-         * Sets the maximum batch size when batching is enabled.
-         */
-        public Builder maxBatchSize(int maxBatchSize) {
-            this.maxBatchSize = maxBatchSize;
-            return this;
-        }
-
-        /**
-         * Sets the maximum amount of time to wait for a span batch
-         * to fill before sending if below the {@link #maxBatchSize}
-         */
-        public Builder lingerMs(int lingerMs) {
-            this.lingerMs = lingerMs;
             return this;
         }
 

--- a/infinite-tracing/src/main/java/com/newrelic/InfiniteTracingConfig.java
+++ b/infinite-tracing/src/main/java/com/newrelic/InfiniteTracingConfig.java
@@ -13,6 +13,10 @@ public class InfiniteTracingConfig {
     private final Double flakyPercentage;
     private final Long flakyCode;
     private final boolean usePlaintext;
+    private final String compression;
+    private final boolean useBatching;
+    private final int maxBatchSize;
+    private final int lingerMs;
 
     public InfiniteTracingConfig(Builder builder) {
         this.licenseKey = builder.licenseKey;
@@ -23,6 +27,10 @@ public class InfiniteTracingConfig {
         this.flakyPercentage = builder.flakyPercentage;
         this.flakyCode = builder.flakyCode;
         this.usePlaintext = builder.usePlaintext;
+        this.compression = builder.compression;
+        this.useBatching = builder.useBatching;
+        this.maxBatchSize = builder.maxBatchSize;
+        this.lingerMs = builder.lingerMs;
     }
 
     public static Builder builder() {
@@ -61,6 +69,22 @@ public class InfiniteTracingConfig {
         return usePlaintext;
     }
 
+    public String getCompression() {
+        return compression;
+    }
+
+    public boolean getUseBatching() {
+        return useBatching;
+    }
+
+    public int getMaxBatchSize() {
+        return maxBatchSize;
+    }
+
+    public int getLingerMs() {
+        return lingerMs;
+    }
+
     public static class Builder {
         public int maxQueueSize;
         public Logger logger;
@@ -70,6 +94,10 @@ public class InfiniteTracingConfig {
         private Double flakyPercentage;
         private Long flakyCode;
         private boolean usePlaintext;
+        private String compression;
+        private boolean useBatching;
+        private int maxBatchSize;
+        private int lingerMs;
 
         /**
          * The New Relic APM license key configured for the application.
@@ -137,10 +165,47 @@ public class InfiniteTracingConfig {
         /**
          * The optional boolean connect using plaintext
          *
-         * @param usePlaintext
+         * @param usePlaintext true to use plaintext, false otherwise
          */
         public Builder usePlaintext(boolean usePlaintext) {
             this.usePlaintext = usePlaintext;
+            return this;
+        }
+
+        /**
+         * The optional compression type to use when sending to the Trace Observer.
+         *
+         * @param compression The compression type to use. Available options are "gzip" or "none".
+         */
+        public Builder compression(String compression) {
+            this.compression = compression;
+            return this;
+        }
+
+        /**
+         * The optional boolean to use batching when sending to the Trace Observer.
+         *
+         * @param useBatching true to use batching, false otherwise
+         */
+        public Builder useBatching(boolean useBatching) {
+            this.useBatching = useBatching;
+            return this;
+        }
+
+        /**
+         * Sets the maximum batch size when batching is enabled.
+         */
+        public Builder maxBatchSize(int maxBatchSize) {
+            this.maxBatchSize = maxBatchSize;
+            return this;
+        }
+
+        /**
+         * Sets the maximum amount of time to wait for a span batch
+         * to fill before sending if below the {@link #maxBatchSize}
+         */
+        public Builder lingerMs(int lingerMs) {
+            this.lingerMs = lingerMs;
             return this;
         }
 

--- a/infinite-tracing/src/main/java/com/newrelic/Observer.java
+++ b/infinite-tracing/src/main/java/com/newrelic/Observer.java
@@ -1,0 +1,32 @@
+package com.newrelic;
+
+import com.newrelic.trace.v1.V1;
+
+import javax.annotation.Nullable;
+
+/**
+ * Shared interface between batching and non-batching trace observer implementations
+ */
+public interface Observer {
+
+    /**
+     * Sends a single span to the observer
+     */
+    void onNext(V1.Span span);
+
+    /**
+     * Sends a batch of spans to the observer.
+     */
+    void onNext(V1.SpanBatch spanBatch);
+
+    /**
+     * Whether the observer is in a ready state to accept spans
+     */
+    boolean isReady();
+
+    /**
+     * Cancel the connection to the observer
+     */
+    void cancel(@Nullable String message, @Nullable Throwable cause);
+
+}

--- a/infinite-tracing/src/main/java/com/newrelic/SpanBatchObserver.java
+++ b/infinite-tracing/src/main/java/com/newrelic/SpanBatchObserver.java
@@ -1,0 +1,36 @@
+package com.newrelic;
+
+import com.newrelic.trace.v1.V1;
+import io.grpc.stub.ClientCallStreamObserver;
+
+import javax.annotation.Nullable;
+
+public class SpanBatchObserver implements Observer {
+
+    private final ClientCallStreamObserver<V1.SpanBatch> observer;
+
+    public SpanBatchObserver(ClientCallStreamObserver<V1.SpanBatch> observer) {
+        this.observer = observer;
+    }
+
+    @Override
+    public void onNext(V1.Span span) {
+        // This should only be used by the SpanObserver
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onNext(V1.SpanBatch spanBatch) {
+        observer.onNext(spanBatch);
+    }
+
+    @Override
+    public boolean isReady() {
+        return observer.isReady();
+    }
+
+    @Override
+    public void cancel(@Nullable String message, @Nullable Throwable cause) {
+        observer.cancel(message, cause);
+    }
+}

--- a/infinite-tracing/src/main/java/com/newrelic/SpanConverter.java
+++ b/infinite-tracing/src/main/java/com/newrelic/SpanConverter.java
@@ -3,8 +3,10 @@ package com.newrelic;
 import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.trace.v1.V1;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 class SpanConverter {
 
@@ -29,6 +31,18 @@ class SpanConverter {
                 .putAllIntrinsics(intrinsicAttributes)
                 .putAllAgentAttributes(agentAttributes)
                 .putAllUserAttributes(userAttributes)
+                .build();
+    }
+
+    /**
+     * Convert the batch of span events to the equivalent gRPC spans.
+     *
+     * @param spanEvents the span event batch
+     * @return the gRPC span batch
+     */
+    static V1.SpanBatch convert(Collection<SpanEvent> spanEvents) {
+        return V1.SpanBatch.newBuilder()
+                .addAllSpans(spanEvents.stream().map(SpanConverter::convert).collect(Collectors.toList()))
                 .build();
     }
 

--- a/infinite-tracing/src/main/java/com/newrelic/SpanEventSender.java
+++ b/infinite-tracing/src/main/java/com/newrelic/SpanEventSender.java
@@ -5,8 +5,9 @@ import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.MetricAggregator;
 import com.newrelic.trace.v1.V1;
-import io.grpc.stub.ClientCallStreamObserver;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -14,6 +15,7 @@ import java.util.logging.Level;
 class SpanEventSender implements Runnable {
 
     private final Logger logger;
+    private final InfiniteTracingConfig config;
     private final BlockingQueue<SpanEvent> queue;
     private final MetricAggregator aggregator;
     private final ChannelManager channelManager;
@@ -22,6 +24,7 @@ class SpanEventSender implements Runnable {
 
     SpanEventSender(InfiniteTracingConfig config, BlockingQueue<SpanEvent> queue, MetricAggregator aggregator, ChannelManager channelManager) {
         this.logger = config.getLogger();
+        this.config = config;
         this.queue = queue;
         this.aggregator = aggregator;
         this.channelManager = channelManager;
@@ -47,26 +50,22 @@ class SpanEventSender implements Runnable {
     @VisibleForTesting
     void pollAndWrite() {
         // Get stream observer
-        ClientCallStreamObserver<V1.Span> observer = channelManager.getSpanObserver();
+        Observer observer = channelManager.getObserver();
 
         // Confirm the observer is ready
         if (!awaitReadyObserver(observer)) {
             return;
         }
 
-        // Poll queue for span
-        SpanEvent span = pollSafely();
-        if (span == null) {
-            return;
+        if (config.getUseBatching()) {
+            drainAndSendBatchWhenReady(observer);
+        } else {
+            pollAndSendSpan(observer);
         }
-
-        // Convert span and write to observer
-        V1.Span convertedSpan = SpanConverter.convert(span);
-        writeToObserver(observer, convertedSpan);
     }
 
     @VisibleForTesting
-    boolean awaitReadyObserver(ClientCallStreamObserver<V1.Span> observer) {
+    boolean awaitReadyObserver(Observer observer) {
         if (observer.isReady()) {
             return true;
         }
@@ -82,6 +81,55 @@ class SpanEventSender implements Runnable {
     }
 
     @VisibleForTesting
+    void drainAndSendBatchWhenReady(Observer observer) {
+        // If our queue is larger than our max batch size we will send the batch right away,
+        // otherwise we will pause for the linger time to wait for the batch to fill first.
+        if (queue.size() < config.getMaxBatchSize()) {
+            try {
+                if (queue.isEmpty()) {
+                    // Prevent a busy-wait loop when we have no data flowing through
+                    Thread.sleep(250);
+                } else {
+                    Thread.sleep(config.getLingerMs());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Thread interrupted while waiting for span batch to fill.");
+            }
+        }
+
+        Collection<SpanEvent> spanEvents = drainSpanBatch();
+        if (spanEvents.isEmpty()) {
+            return;
+        }
+
+        // Convert and send the batch to the trace observer
+        V1.SpanBatch convertedSpanBatch = SpanConverter.convert(spanEvents);
+        writeToObserver(observer, convertedSpanBatch);
+    }
+
+    @VisibleForTesting
+    Collection<SpanEvent> drainSpanBatch() {
+        // Drain up to the max batch size
+        Collection<SpanEvent> spanEvents = new LinkedList<>();
+        queue.drainTo(spanEvents, config.getMaxBatchSize());
+        return spanEvents;
+    }
+
+    @VisibleForTesting
+    void pollAndSendSpan(Observer observer) {
+        // Poll queue for span
+        SpanEvent span = pollSafely();
+        if (span == null) {
+            return;
+        }
+
+        // Convert single span and write to observer
+        V1.Span convertedSpan = SpanConverter.convert(span);
+        writeToObserver(observer, convertedSpan);
+    }
+
+    @VisibleForTesting
     SpanEvent pollSafely() {
         try {
             return queue.poll(250, TimeUnit.MILLISECONDS);
@@ -92,7 +140,7 @@ class SpanEventSender implements Runnable {
     }
 
     @VisibleForTesting
-    void writeToObserver(ClientCallStreamObserver<V1.Span> observer, V1.Span span) {
+    void writeToObserver(Observer observer, V1.Span span) {
         try {
             observer.onNext(span);
         } catch (Throwable t) {
@@ -102,4 +150,14 @@ class SpanEventSender implements Runnable {
         aggregator.incrementCounter("Supportability/InfiniteTracing/Span/Sent");
     }
 
+    @VisibleForTesting
+    void writeToObserver(Observer observer, V1.SpanBatch spanBatch) {
+        try {
+            observer.onNext(spanBatch);
+        } catch (Throwable t) {
+            logger.log(Level.SEVERE, t, "Unable to send span batch.");
+            throw t;
+        }
+        aggregator.incrementCounter("Supportability/InfiniteTracing/Span/Sent", spanBatch.getSpansCount());
+    }
 }

--- a/infinite-tracing/src/main/java/com/newrelic/SpanObserver.java
+++ b/infinite-tracing/src/main/java/com/newrelic/SpanObserver.java
@@ -1,0 +1,36 @@
+package com.newrelic;
+
+import com.newrelic.trace.v1.V1;
+import io.grpc.stub.ClientCallStreamObserver;
+
+import javax.annotation.Nullable;
+
+public class SpanObserver implements Observer {
+
+    private final ClientCallStreamObserver<V1.Span> observer;
+
+    public SpanObserver(ClientCallStreamObserver<V1.Span> observer) {
+        this.observer = observer;
+    }
+
+    @Override
+    public void onNext(V1.Span span) {
+        observer.onNext(span);
+    }
+
+    @Override
+    public void onNext(V1.SpanBatch spanBatch) {
+        // This should only be used by the SpanBatchObserver
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isReady() {
+        return observer.isReady();
+    }
+
+    @Override
+    public void cancel(@Nullable String message, @Nullable Throwable cause) {
+        observer.cancel(message, cause);
+    }
+}

--- a/infinite-tracing/src/test/java/com/newrelic/InfiniteTracingConfigTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/InfiniteTracingConfigTest.java
@@ -30,19 +30,19 @@ class InfiniteTracingConfigTest {
     }
 
     @Test
-    void testGzipCompression() {
+    void testEnableCompression() {
         InfiniteTracingConfig config = InfiniteTracingConfig.builder()
-                .compression("gzip")
+                .useCompression(true)
                 .build();
-        assertEquals("gzip", config.getCompression());
+        assertTrue(config.getUseCompression());
     }
 
     @Test
     void testDisableCompression() {
         InfiniteTracingConfig config = InfiniteTracingConfig.builder()
-                .compression(null)
+                .useCompression(false)
                 .build();
-        assertNull(config.getCompression());
+        assertFalse(config.getUseCompression());
     }
 
     @Test
@@ -51,13 +51,5 @@ class InfiniteTracingConfigTest {
                 .useBatching(true)
                 .build();
         assertTrue(config.getUseBatching());
-    }
-
-    @Test
-    void testLingerMs() {
-        InfiniteTracingConfig config = InfiniteTracingConfig.builder()
-                .lingerMs(100)
-                .build();
-        assertEquals(100, config.getLingerMs());
     }
 }

--- a/infinite-tracing/src/test/java/com/newrelic/InfiniteTracingConfigTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/InfiniteTracingConfigTest.java
@@ -2,7 +2,10 @@ package com.newrelic;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InfiniteTracingConfigTest {
 
@@ -26,4 +29,35 @@ class InfiniteTracingConfigTest {
         assertFalse(config.getUsePlaintext());
     }
 
+    @Test
+    void testGzipCompression() {
+        InfiniteTracingConfig config = InfiniteTracingConfig.builder()
+                .compression("gzip")
+                .build();
+        assertEquals("gzip", config.getCompression());
+    }
+
+    @Test
+    void testDisableCompression() {
+        InfiniteTracingConfig config = InfiniteTracingConfig.builder()
+                .compression(null)
+                .build();
+        assertNull(config.getCompression());
+    }
+
+    @Test
+    void testEnableBatching() {
+        InfiniteTracingConfig config = InfiniteTracingConfig.builder()
+                .useBatching(true)
+                .build();
+        assertTrue(config.getUseBatching());
+    }
+
+    @Test
+    void testLingerMs() {
+        InfiniteTracingConfig config = InfiniteTracingConfig.builder()
+                .lingerMs(100)
+                .build();
+        assertEquals(100, config.getLingerMs());
+    }
 }

--- a/infinite-tracing/src/test/java/com/newrelic/SpanBatchObserverTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/SpanBatchObserverTest.java
@@ -1,0 +1,65 @@
+package com.newrelic;
+
+import com.newrelic.trace.v1.V1;
+import io.grpc.stub.ClientCallStreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class SpanBatchObserverTest {
+
+    @Mock
+    private ClientCallStreamObserver<V1.SpanBatch> observer;
+
+    private SpanBatchObserver target;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+        target = spy(new SpanBatchObserver(observer));
+    }
+
+    @Test
+    void cancel_invokesObserver() {
+        String message = "message";
+        Throwable cause = new RuntimeException("error");
+
+        target.cancel(message, cause);
+
+        verify(observer).cancel(message, cause);
+    }
+
+    @Test
+    void isReady_invokesObserver() {
+        target.isReady();
+        verify(observer).isReady();
+    }
+
+    @Test
+    void onNext_spanThrowsException() {
+        assertThrows(UnsupportedOperationException.class, new Executable() {
+            @Override
+            public void execute() {
+                target.onNext(V1.Span.newBuilder().build());
+            }
+        });
+
+        verify(observer, never()).onNext(ArgumentMatchers.any());
+    }
+
+    @Test
+    void onNext_spanBatchInvokesObserver() {
+        V1.SpanBatch spanBatch = V1.SpanBatch.newBuilder().build();
+        target.onNext(spanBatch);
+
+        verify(observer).onNext(spanBatch);
+    }
+}

--- a/infinite-tracing/src/test/java/com/newrelic/SpanEventSenderTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/SpanEventSenderTest.java
@@ -4,7 +4,6 @@ import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.MetricAggregator;
 import com.newrelic.trace.v1.V1;
-import io.grpc.stub.ClientCallStreamObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -13,16 +12,21 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.newrelic.SpanConverterTest.buildSpanEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -45,7 +49,7 @@ class SpanEventSenderTest {
     @Mock
     private ChannelManager channelManager;
     @Mock
-    private ClientCallStreamObserver<V1.Span> observer;
+    private Observer observer;
 
     private SpanEventSender target;
 
@@ -53,7 +57,7 @@ class SpanEventSenderTest {
     void setup() {
         MockitoAnnotations.initMocks(this);
         when(config.getLogger()).thenReturn(logger);
-        when(channelManager.getSpanObserver()).thenReturn(observer);
+        when(channelManager.getObserver()).thenReturn(observer);
         target = spy(new SpanEventSender(config, queue, aggregator, channelManager));
     }
 
@@ -76,7 +80,8 @@ class SpanEventSenderTest {
         target.pollAndWrite();
 
         verify(target, never()).pollSafely();
-        verify(target, never()).writeToObserver(ArgumentMatchers.<ClientCallStreamObserver<V1.Span>>any(), ArgumentMatchers.<V1.Span>any());
+        verify(target, never()).writeToObserver(ArgumentMatchers.<Observer>any(), ArgumentMatchers.<V1.Span>any());
+        verify(target, never()).writeToObserver(ArgumentMatchers.<Observer>any(), ArgumentMatchers.<V1.SpanBatch>any());
     }
 
     @Test
@@ -86,7 +91,21 @@ class SpanEventSenderTest {
 
         target.pollAndWrite();
 
-        verify(target, never()).writeToObserver(ArgumentMatchers.<ClientCallStreamObserver<V1.Span>>any(), ArgumentMatchers.<V1.Span>any());
+        verify(target, never()).writeToObserver(ArgumentMatchers.<Observer>any(), ArgumentMatchers.<V1.Span>any());
+        verify(target, never()).writeToObserver(ArgumentMatchers.<Observer>any(), ArgumentMatchers.<V1.SpanBatch>any());
+    }
+
+    @Test
+    void pollAndWrite_EmptyQueueDoesNotWriteBatch() {
+        doReturn(10).when(config).getMaxBatchSize();
+        doReturn(true).when(config).getUseBatching();
+        doReturn(true).when(queue).isEmpty();
+        doReturn(true).when(target).awaitReadyObserver(observer);
+
+        target.pollAndWrite();
+
+        verify(target, never()).writeToObserver(ArgumentMatchers.<Observer>any(), ArgumentMatchers.<V1.Span>any());
+        verify(target, never()).writeToObserver(ArgumentMatchers.<Observer>any(), ArgumentMatchers.<V1.SpanBatch>any());
     }
 
     @Test
@@ -98,6 +117,19 @@ class SpanEventSenderTest {
         target.pollAndWrite();
 
         verify(target).writeToObserver(observer, SpanConverter.convert(spanEvent));
+    }
+
+    @Test
+    void pollAndWrite_ObserverReadySpanBatchAvailableWrites() {
+        Collection<SpanEvent> spanEvents = IntStream.range(0, 5).mapToObj(i -> buildSpanEvent()).collect(Collectors.toList());
+        doReturn(10).when(config).getMaxBatchSize();
+        doReturn(true).when(config).getUseBatching();
+        doReturn(true).when(target).awaitReadyObserver(observer);
+        doReturn(spanEvents).when(target).drainSpanBatch();
+
+        target.pollAndWrite();
+
+        verify(target).writeToObserver(observer, SpanConverter.convert(spanEvents));
     }
 
     @Test
@@ -139,6 +171,17 @@ class SpanEventSenderTest {
     }
 
     @Test
+    void drainSpanBatch_DrainsUpToMaxBatchSize() {
+        int maxBatchSize = 3;
+        doReturn(maxBatchSize).when(config).getMaxBatchSize();
+        doReturn(true).when(config).getUseBatching();
+
+        target.drainSpanBatch();
+
+        verify(queue).drainTo(any(), eq(maxBatchSize));
+    }
+
+    @Test
     void writeToObserver_RethrowsException() {
         doThrow(new RuntimeException("Error!")).when(observer).onNext(ArgumentMatchers.<V1.Span>any());
 
@@ -152,10 +195,33 @@ class SpanEventSenderTest {
     }
 
     @Test
+    void writeToBatchObserver_RethrowsException() {
+        doThrow(new RuntimeException("Error!")).when(observer).onNext(ArgumentMatchers.<V1.SpanBatch>any());
+
+        assertThrows(RuntimeException.class, new Executable() {
+            @Override
+            public void execute() {
+                target.writeToObserver(observer, V1.SpanBatch.newBuilder().build());
+            }
+        });
+        verify(aggregator, never()).incrementCounter(anyString());
+    }
+
+    @Test
     void writeToObserver_NoExceptionIncrementsCounter() {
         target.writeToObserver(observer, V1.Span.newBuilder().build());
 
         verify(aggregator).incrementCounter("Supportability/InfiniteTracing/Span/Sent");
     }
 
+    @Test
+    void writeToBatchObserver_NoExceptionIncrementsCounterByBatchSize() {
+        target.writeToObserver(observer, V1.SpanBatch.newBuilder()
+                .addSpans(V1.Span.newBuilder().build())
+                .addSpans(V1.Span.newBuilder().build())
+                .addSpans(V1.Span.newBuilder().build())
+                .build());
+
+        verify(aggregator).incrementCounter("Supportability/InfiniteTracing/Span/Sent", 3);
+    }
 }

--- a/infinite-tracing/src/test/java/com/newrelic/SpanEventSenderTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/SpanEventSenderTest.java
@@ -97,7 +97,6 @@ class SpanEventSenderTest {
 
     @Test
     void pollAndWrite_EmptyQueueDoesNotWriteBatch() {
-        doReturn(10).when(config).getMaxBatchSize();
         doReturn(true).when(config).getUseBatching();
         doReturn(true).when(queue).isEmpty();
         doReturn(true).when(target).awaitReadyObserver(observer);
@@ -122,7 +121,6 @@ class SpanEventSenderTest {
     @Test
     void pollAndWrite_ObserverReadySpanBatchAvailableWrites() {
         Collection<SpanEvent> spanEvents = IntStream.range(0, 5).mapToObj(i -> buildSpanEvent()).collect(Collectors.toList());
-        doReturn(10).when(config).getMaxBatchSize();
         doReturn(true).when(config).getUseBatching();
         doReturn(true).when(target).awaitReadyObserver(observer);
         doReturn(spanEvents).when(target).drainSpanBatch();
@@ -172,8 +170,7 @@ class SpanEventSenderTest {
 
     @Test
     void drainSpanBatch_DrainsUpToMaxBatchSize() {
-        int maxBatchSize = 3;
-        doReturn(maxBatchSize).when(config).getMaxBatchSize();
+        int maxBatchSize = 100;
         doReturn(true).when(config).getUseBatching();
 
         target.drainSpanBatch();

--- a/infinite-tracing/src/test/java/com/newrelic/SpanObserverTest.java
+++ b/infinite-tracing/src/test/java/com/newrelic/SpanObserverTest.java
@@ -1,0 +1,65 @@
+package com.newrelic;
+
+import com.newrelic.trace.v1.V1;
+import io.grpc.stub.ClientCallStreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class SpanObserverTest {
+
+    @Mock
+    private ClientCallStreamObserver<V1.Span> observer;
+
+    private SpanObserver target;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+        target = spy(new SpanObserver(observer));
+    }
+
+    @Test
+    void cancel_invokesObserver() {
+        String message = "message";
+        Throwable cause = new RuntimeException("error");
+
+        target.cancel(message, cause);
+
+        verify(observer).cancel(message, cause);
+    }
+
+    @Test
+    void isReady_invokesObserver() {
+        target.isReady();
+        verify(observer).isReady();
+    }
+
+    @Test
+    void onNext_spanInvokesObserver() {
+        V1.Span span = V1.Span.newBuilder().build();
+        target.onNext(span);
+
+        verify(observer).onNext(span);
+    }
+
+    @Test
+    void onNext_spanBatchThrowsException() {
+        assertThrows(UnsupportedOperationException.class, new Executable() {
+            @Override
+            public void execute() {
+                target.onNext(V1.SpanBatch.newBuilder().build());
+            }
+        });
+
+        verify(observer, never()).onNext(ArgumentMatchers.any());
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfig.java
@@ -20,13 +20,9 @@ public interface InfiniteTracingConfig {
 
     boolean getUsePlaintext();
 
-    String getCompression();
+    boolean getUseCompression();
 
     boolean getUseBatching();
-
-    int getMaxBatchSize();
-
-    int getLingerMs();
 
     boolean isEnabled();
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfig.java
@@ -20,6 +20,14 @@ public interface InfiniteTracingConfig {
 
     boolean getUsePlaintext();
 
+    String getCompression();
+
+    boolean getUseBatching();
+
+    int getMaxBatchSize();
+
+    int getLingerMs();
+
     boolean isEnabled();
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfigImpl.java
@@ -22,6 +22,14 @@ public class InfiniteTracingConfigImpl extends BaseConfig implements InfiniteTra
     public static final String FLAKY_CODE = "_flakyCode";
     public static final String USE_PLAINTEXT = "plaintext";
     public static final boolean DEFAULT_USE_PLAINTEXT = false;
+    public static final String COMPRESSION = "compression";
+    public static final String DEFAULT_COMPRESSION = "gzip";
+    public static final String USE_BATCHING = "batching";
+    public static final boolean DEFAULT_USE_BATCHING = true;
+    public static final String MAX_BATCH_SIZE = "max_batch_size";
+    public static final int DEFAULT_MAX_BATCH_SIZE = 100;
+    public static final String LINGER_MS = "linger_ms";
+    public static final int DEFAULT_LINGER_MS = 10;
 
     static final String SYSTEM_PROPERTY_ROOT = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + ROOT + ".";
 
@@ -81,6 +89,26 @@ public class InfiniteTracingConfigImpl extends BaseConfig implements InfiniteTra
     @Override
     public boolean getUsePlaintext() {
         return getProperty(USE_PLAINTEXT, DEFAULT_USE_PLAINTEXT);
+    }
+
+    @Override
+    public String getCompression() {
+        return getProperty(COMPRESSION, DEFAULT_COMPRESSION);
+    }
+
+    @Override
+    public boolean getUseBatching() {
+        return getProperty(USE_BATCHING, DEFAULT_USE_BATCHING);
+    }
+
+    @Override
+    public int getMaxBatchSize() {
+        return getProperty(MAX_BATCH_SIZE, DEFAULT_MAX_BATCH_SIZE);
+    }
+
+    @Override
+    public int getLingerMs() {
+        return getProperty(LINGER_MS, DEFAULT_LINGER_MS);
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/InfiniteTracingConfigImpl.java
@@ -22,14 +22,10 @@ public class InfiniteTracingConfigImpl extends BaseConfig implements InfiniteTra
     public static final String FLAKY_CODE = "_flakyCode";
     public static final String USE_PLAINTEXT = "plaintext";
     public static final boolean DEFAULT_USE_PLAINTEXT = false;
-    public static final String COMPRESSION = "compression";
-    public static final String DEFAULT_COMPRESSION = "gzip";
+    public static final String USE_COMPRESSION = "compression";
+    public static final boolean DEFAULT_USE_COMPRESSION = true;
     public static final String USE_BATCHING = "batching";
     public static final boolean DEFAULT_USE_BATCHING = true;
-    public static final String MAX_BATCH_SIZE = "max_batch_size";
-    public static final int DEFAULT_MAX_BATCH_SIZE = 100;
-    public static final String LINGER_MS = "linger_ms";
-    public static final int DEFAULT_LINGER_MS = 10;
 
     static final String SYSTEM_PROPERTY_ROOT = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + ROOT + ".";
 
@@ -92,23 +88,13 @@ public class InfiniteTracingConfigImpl extends BaseConfig implements InfiniteTra
     }
 
     @Override
-    public String getCompression() {
-        return getProperty(COMPRESSION, DEFAULT_COMPRESSION);
+    public boolean getUseCompression() {
+        return getProperty(USE_COMPRESSION, DEFAULT_USE_COMPRESSION);
     }
 
     @Override
     public boolean getUseBatching() {
         return getProperty(USE_BATCHING, DEFAULT_USE_BATCHING);
-    }
-
-    @Override
-    public int getMaxBatchSize() {
-        return getProperty(MAX_BATCH_SIZE, DEFAULT_MAX_BATCH_SIZE);
-    }
-
-    @Override
-    public int getLingerMs() {
-        return getProperty(LINGER_MS, DEFAULT_LINGER_MS);
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -332,10 +332,8 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
                 .flakyPercentage(config.getFlakyPercentage())
                 .flakyCode(config.getFlakyCode())
                 .usePlaintext(config.getUsePlaintext())
-                .compression(config.getCompression())
+                .useCompression(config.getUseCompression())
                 .useBatching(config.getUseBatching())
-                .maxBatchSize(config.getMaxBatchSize())
-                .lingerMs(config.getLingerMs())
                 .build();
 
         return InfiniteTracing.initialize(infiniteTracingConfig, NewRelic.getAgent().getMetricAggregator());

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -332,6 +332,10 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
                 .flakyPercentage(config.getFlakyPercentage())
                 .flakyCode(config.getFlakyCode())
                 .usePlaintext(config.getUsePlaintext())
+                .compression(config.getCompression())
+                .useBatching(config.getUseBatching())
+                .maxBatchSize(config.getMaxBatchSize())
+                .lingerMs(config.getLingerMs())
                 .build();
 
         return InfiniteTracing.initialize(infiniteTracingConfig, NewRelic.getAgent().getMetricAggregator());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/InfiniteTracingConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/InfiniteTracingConfigImplTest.java
@@ -68,21 +68,9 @@ public class InfiniteTracingConfigImplTest {
     }
 
     @Test
-    public void testGzipCompressionByDefault() {
+    public void testUseCompressionByDefault() {
         InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
-        assertEquals("gzip", config.getCompression());
-    }
-
-    @Test
-    public void testMaxBatchSizeDefault() {
-        InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
-        assertEquals(100, config.getMaxBatchSize());
-    }
-
-    @Test
-    public void testLingerMsDefault() {
-        InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
-        assertEquals(10, config.getLingerMs());
+        assertTrue(config.getUseCompression());
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/InfiniteTracingConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/InfiniteTracingConfigImplTest.java
@@ -8,7 +8,6 @@
 package com.newrelic.agent.config;
 
 import com.newrelic.agent.SaveSystemPropertyProviderRule;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,6 +59,30 @@ public class InfiniteTracingConfigImplTest {
         localProps.put(FLAKY_PERCENTAGE, 50.0);
         InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
         assertEquals(50.0, config.getFlakyPercentage(), 0.0);
+    }
+
+    @Test
+    public void testUseBatchingByDefault() {
+        InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
+        assertTrue(config.getUseBatching());
+    }
+
+    @Test
+    public void testGzipCompressionByDefault() {
+        InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
+        assertEquals("gzip", config.getCompression());
+    }
+
+    @Test
+    public void testMaxBatchSizeDefault() {
+        InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
+        assertEquals(100, config.getMaxBatchSize());
+    }
+
+    @Test
+    public void testLingerMsDefault() {
+        InfiniteTracingConfigImpl config = new InfiniteTracingConfigImpl(localProps);
+        assertEquals(10, config.getLingerMs());
     }
 
     @Test


### PR DESCRIPTION
### Overview

This PR adds support for Infinite Tracing payloads to be both compressed and batched by default. The following changes are included as part of this work:

- Implements support for compressing infinite tracing payloads
- `gzip` compression is enabled by default for batching **and** non-batching configurations
- Implements support for batching spans within infinite tracing payloads
- Defaults for batching are:
  - Batching `enabled` by default
  - Up to `100` spans bundled per batch
  - Waiting (linger) for up to `5s` to fill up the batch before sending

The span data is still streaming over HTTP/2 using gRPC but utilizing compression and batching will significantly reduce payload sizes and bytes over the wire, resulting in significantly lower network transfer costs for customers. 


### Testing

All new functionality has been covered with unit tests where possible.

### Checks

- Are your contributions backwards compatible with relevant frameworks and APIs?
  - Yes

- Does your code contain any breaking changes?
  - No (although infinite tracing defaults are changing)

- Does your code introduce any new dependencies?
  - Only a `testImplementation` dependency for parameterized tests
