### PR TITLE
Retransform classes using Trace annotation on attach

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerService.java
@@ -51,4 +51,6 @@ public interface ClassTransformerService extends Service {
      * agent.
      */
     Instrumentation getExtensionInstrumentation();
+
+    default void retransformForAttach() {}
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.ClassTransformerConfig;
+import com.newrelic.agent.instrumentation.annotationmatchers.AnnotationMatcher;
 import com.newrelic.agent.instrumentation.classmatchers.ClassAndMethodMatcher;
 import com.newrelic.agent.instrumentation.classmatchers.OptimizedClassMatcher.Match;
 import com.newrelic.agent.instrumentation.classmatchers.OptimizedClassMatcherBuilder;
@@ -26,7 +27,6 @@ import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.util.DefaultThreadFactory;
 import com.newrelic.agent.util.asm.Utils;
-import com.newrelic.api.agent.Trace;
 import org.objectweb.asm.commons.Method;
 
 import java.lang.instrument.ClassFileTransformer;
@@ -288,7 +288,9 @@ public class ClassTransformerServiceImpl extends AbstractService implements Clas
 
     @Override
     public void retransformForAttach() {
-        final Predicate<Class> traceMatcher = Utils.getAnnotationsMatcher(Trace.class);
+        final AnnotationMatcher traceAnnotationMatcher = ServiceFactory.getConfigService().getDefaultAgentConfig()
+                .getClassTransformerConfig().getTraceAnnotationMatcher();
+        final Predicate<Class> traceMatcher = Utils.getAnnotationsMatcher(traceAnnotationMatcher);
         final List<Class> classesToRejit = Arrays.asList(getExtensionInstrumentation().getAllLoadedClasses())
                 .stream().filter(traceMatcher)
                 .collect(Collectors.toList());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/asm/UtilsTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/asm/UtilsTest.java
@@ -17,16 +17,29 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
 
 import javax.sql.PooledConnection;
 import javax.swing.ListCellRenderer;
 
+import com.newrelic.agent.bridge.AgentBridge;
 import org.junit.Assert;
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class UtilsTest {
+
+    @Test
+    public void getAnnotationsMatcher() {
+        Predicate<Class> annotationsMatcher = Utils.getAnnotationsMatcher(Test.class);
+        assertTrue(annotationsMatcher.test(UtilsTest.class));
+        assertFalse(annotationsMatcher.test(AgentBridge.class));
+        assertFalse(annotationsMatcher.test(Runnable.class));
+    }
 
     @Test
     public void readClassThroughLoader() throws IOException {
@@ -63,8 +76,8 @@ public class UtilsTest {
     }
 
     private void assertClass(ClassReader classReader) {
-        Assert.assertTrue(Arrays.asList(classReader.getInterfaces()).contains(Type.getInternalName(Map.class)));
-        Assert.assertTrue(Arrays.asList(classReader.getInterfaces()).contains(
+        assertTrue(Arrays.asList(classReader.getInterfaces()).contains(Type.getInternalName(Map.class)));
+        assertTrue(Arrays.asList(classReader.getInterfaces()).contains(
                 Type.getInternalName(ListCellRenderer.class)));
         Assert.assertEquals(Type.getInternalName(LinkedHashMap.class), classReader.getSuperName());
     }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/asm/UtilsTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/asm/UtilsTest.java
@@ -35,7 +35,7 @@ public class UtilsTest {
 
     @Test
     public void getAnnotationsMatcher() {
-        Predicate<Class> annotationsMatcher = Utils.getAnnotationsMatcher(Test.class);
+        Predicate<Class> annotationsMatcher = Utils.getAnnotationsMatcher(Type.getDescriptor(Test.class)::equals);
         assertTrue(annotationsMatcher.test(UtilsTest.class));
         assertFalse(annotationsMatcher.test(AgentBridge.class));
         assertFalse(annotationsMatcher.test(Runnable.class));


### PR DESCRIPTION
### Overview

@toddwest pointed out that when using attach (calling `agent main`) the agent does not re-instrument classes using custom instrumentation (the `@Trace`) annotation.  This fixes that.

### Testing
Please reach out to me for a test application.  I have an internal application I can share.

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
