### PR TITLE
Make sure TokenAndRefCount.token is never null

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/AgentBridge.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/AgentBridge.java
@@ -118,8 +118,8 @@ public final class AgentBridge {
         public AtomicInteger refCount;
 
         public TokenAndRefCount(com.newrelic.agent.bridge.Token token, TracedMethod tracedMethod, AtomicInteger refCount) {
-            this.token = token;
-            this.tracedMethod = new AtomicReference<Object>(tracedMethod);
+            this.token = token == null ? NoOpToken.INSTANCE : token;
+            this.tracedMethod = new AtomicReference<>(tracedMethod);
             this.refCount = refCount;
         }
 


### PR DESCRIPTION

### Overview

Code such as this expect that `TokenAndRefCount.token` is never null:

https://github.com/newrelic/newrelic-java-agent/blob/main/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java#L1403

This sets the `token` to the no-op implementation if a null token is passed in.  We could add some logging when the token is null since ignoring this case could mask an issue, but I'll leave that as a future enhancement.

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
