### PR TITLE
Fix weavedmethod constructor

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/instrumentation/InstrumentedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/instrumentation/InstrumentedMethod.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 /**
  * Marks an instrumented method.
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface InstrumentedMethod {
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/instrumentation/WeavedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/instrumentation/WeavedMethod.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 /**
  * Marks a weaved method.
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WeavedMethod {
     /**


### PR DESCRIPTION
### Overview
The InstrumentedMethod and WeavedMethod are added, in runtime, to methods that are instrumented by the agent.

They are also added to instrumented constructors, even though their target does not list constructors.

This usually does not pose a problem, but may cause failures if that class is validated during runtime.

### Related Github Issue
Fixes #1153