### PR TITLE
Use Pattern.compile in Netty RequestWrapper

### DIFF
--- a/instrumentation/netty-3.4/src/main/java/com/agent/instrumentation/netty34/RequestWrapper.java
+++ b/instrumentation/netty-3.4/src/main/java/com/agent/instrumentation/netty34/RequestWrapper.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 public class RequestWrapper extends ExtendedRequest {
+    private static final Pattern URL_REPLACEMENT_PATTERN = Pattern.compile("(?i)%(?![\\da-f]{2})");
     private static CookieDecoder cookieDecoder = new CookieDecoder();
     private final HttpRequest request;
     private final Set<Cookie> cookies;
@@ -51,7 +53,7 @@ public class RequestWrapper extends ExtendedRequest {
         Map<String, List<String>> params;
         try {
             String uri = request.getUri();
-            uri = uri.replaceAll("(?i)%(?![\\da-f]{2})", "%25"); // Escape any percent signs in the URI
+            uri = URL_REPLACEMENT_PATTERN.matcher(uri).replaceAll("%25"); // Escape any percent signs in the URI
             QueryStringDecoder decoderQuery = new QueryStringDecoder(uri);
             params = decoderQuery.getParameters();
         } catch (Exception e) {

--- a/instrumentation/netty-3.4/src/test/java/netty34/RequestWrapperTest.java
+++ b/instrumentation/netty-3.4/src/test/java/netty34/RequestWrapperTest.java
@@ -1,0 +1,33 @@
+package netty34;
+
+import com.agent.instrumentation.netty34.RequestWrapper;
+import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestWrapperTest {
+
+    @Test
+    public void testPercentageEscaping() {
+        Map<String, String> inputExpectedMap = new HashMap<>();
+        inputExpectedMap.put("http://example.com?asdf=%qwer", "%qwer");
+        inputExpectedMap.put("http://example.com?asdf=%20", " ");
+        inputExpectedMap.put("http://example.com?asdf=%2b", "+");
+        inputExpectedMap.put("http://example.com?asdf=qwer", "qwer");
+
+        for (Map.Entry<String, String> inputExpectedEntry : inputExpectedMap.entrySet()) {
+            String input = inputExpectedEntry.getKey();
+            String expected = inputExpectedEntry.getValue();
+            DefaultHttpRequest request = mock(DefaultHttpRequest.class);
+            when(request.getUri()).thenReturn(input);
+            RequestWrapper requestWrapper = new RequestWrapper(request);
+            Assert.assertEquals(expected, requestWrapper.getParameterValues("asdf")[0]);
+        }
+    }
+}

--- a/instrumentation/netty-3.8/src/main/java/com/agent/instrumentation/netty38/RequestWrapper.java
+++ b/instrumentation/netty-3.8/src/main/java/com/agent/instrumentation/netty38/RequestWrapper.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 public class RequestWrapper extends ExtendedRequest {
+    private static final Pattern URL_REPLACEMENT_PATTERN = Pattern.compile("(?i)%(?![\\da-f]{2})");
     private static CookieDecoder cookieDecoder = new CookieDecoder();
     private final HttpRequest request;
     private final Set<Cookie> cookies;
@@ -51,7 +53,7 @@ public class RequestWrapper extends ExtendedRequest {
         Map<String, List<String>> params;
         try {
             String uri = request.getUri();
-            uri = uri.replaceAll("(?i)%(?![\\da-f]{2})", "%25"); // Escape any percent signs in the URI
+            uri = URL_REPLACEMENT_PATTERN.matcher(uri).replaceAll("%25"); // Escape any percent signs in the URI
             QueryStringDecoder decoderQuery = new QueryStringDecoder(uri);
             params = decoderQuery.getParameters();
         } catch (Exception e) {

--- a/instrumentation/netty-3.8/src/test/java/netty38/RequestWrapperTest.java
+++ b/instrumentation/netty-3.8/src/test/java/netty38/RequestWrapperTest.java
@@ -1,0 +1,35 @@
+package netty38;
+
+import com.agent.instrumentation.netty38.RequestWrapper;
+import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestWrapperTest {
+
+    @Test
+    public void testPercentageEscaping() {
+        Map<String, String> inputExpectedMap = new HashMap<>();
+        inputExpectedMap.put("http://example.com?asdf=%qwer", "%qwer");
+        inputExpectedMap.put("http://example.com?asdf=%20", " ");
+        inputExpectedMap.put("http://example.com?asdf=%2b", "+");
+        inputExpectedMap.put("http://example.com?asdf=qwer", "qwer");
+
+        for (Map.Entry<String, String> inputExpectedEntry : inputExpectedMap.entrySet()) {
+            String input = inputExpectedEntry.getKey();
+            String expected = inputExpectedEntry.getValue();
+            DefaultHttpRequest request = mock(DefaultHttpRequest.class);
+            when(request.headers()).thenReturn(HttpHeaders.EMPTY_HEADERS);
+            when(request.getUri()).thenReturn(input);
+            RequestWrapper requestWrapper = new RequestWrapper(request);
+            Assert.assertEquals(expected, requestWrapper.getParameterValues("asdf")[0]);
+        }
+    }
+}

--- a/instrumentation/netty-4.0.0/src/main/java/com/agent/instrumentation/netty40/RequestWrapper.java
+++ b/instrumentation/netty-4.0.0/src/main/java/com/agent/instrumentation/netty40/RequestWrapper.java
@@ -24,8 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 public class RequestWrapper extends ExtendedRequest {
+    private static final Pattern URL_REPLACEMENT_PATTERN = Pattern.compile("(?i)%(?![\\da-f]{2})");
     private final HttpRequest request;
     private final Set<Cookie> cookies;
     private final Map<String, List<String>> parameters;
@@ -49,7 +51,7 @@ public class RequestWrapper extends ExtendedRequest {
         Map<String, List<String>> params;
         try {
             String uri = request.getUri();
-            uri = uri.replaceAll("(?i)%(?![\\da-f]{2})", "%25"); // Escape any percent signs in the URI
+            uri = URL_REPLACEMENT_PATTERN.matcher(uri).replaceAll("%25"); // Escape any percent signs in the URI
             QueryStringDecoder decoderQuery = new QueryStringDecoder(uri);
             params = decoderQuery.parameters();
         } catch (Exception e) {

--- a/instrumentation/netty-4.0.0/src/test/java/netty40/RequestWrapperTest.java
+++ b/instrumentation/netty-4.0.0/src/test/java/netty40/RequestWrapperTest.java
@@ -1,0 +1,35 @@
+package netty40;
+
+import com.agent.instrumentation.netty40.RequestWrapper;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestWrapperTest {
+
+    @Test
+    public void testPercentageEscaping() {
+        Map<String, String> inputExpectedMap = new HashMap<>();
+        inputExpectedMap.put("http://example.com?asdf=%qwer", "%qwer");
+        inputExpectedMap.put("http://example.com?asdf=%20", " ");
+        inputExpectedMap.put("http://example.com?asdf=%2b", "+");
+        inputExpectedMap.put("http://example.com?asdf=qwer", "qwer");
+
+        for (Map.Entry<String, String> inputExpectedEntry : inputExpectedMap.entrySet()) {
+            String input = inputExpectedEntry.getKey();
+            String expected = inputExpectedEntry.getValue();
+            DefaultHttpRequest request = mock(DefaultHttpRequest.class);
+            when(request.headers()).thenReturn(HttpHeaders.EMPTY_HEADERS);
+            when(request.getUri()).thenReturn(input);
+            RequestWrapper requestWrapper = new RequestWrapper(request);
+            Assert.assertEquals(expected, requestWrapper.getParameterValues("asdf")[0]);
+        }
+    }
+}

--- a/instrumentation/netty-4.0.8/src/main/java/com/agent/instrumentation/netty40/RequestWrapper.java
+++ b/instrumentation/netty-4.0.8/src/main/java/com/agent/instrumentation/netty40/RequestWrapper.java
@@ -23,8 +23,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 public class RequestWrapper extends ExtendedRequest {
+    private static final Pattern URL_REPLACEMENT_PATTERN = Pattern.compile("(?i)%(?![\\da-f]{2})");
     private final HttpRequest request;
     private final Set<Cookie> cookies;
     private final Map<String, List<String>> parameters;
@@ -48,7 +50,7 @@ public class RequestWrapper extends ExtendedRequest {
         Map<String, List<String>> params;
         try {
             String uri = request.getUri();
-            uri = uri.replaceAll("(?i)%(?![\\da-f]{2})", "%25"); // Escape any percent signs in the URI
+            uri = URL_REPLACEMENT_PATTERN.matcher(uri).replaceAll("%25"); // Escape any percent signs in the URI
             QueryStringDecoder decoderQuery = new QueryStringDecoder(uri);
             params = decoderQuery.parameters();
         } catch (Exception e) {

--- a/instrumentation/netty-4.0.8/src/test/java/netty408/RequestWrapperTest.java
+++ b/instrumentation/netty-4.0.8/src/test/java/netty408/RequestWrapperTest.java
@@ -1,0 +1,35 @@
+package netty408;
+
+import com.agent.instrumentation.netty40.RequestWrapper;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestWrapperTest {
+
+    @Test
+    public void testPercentageEscaping() {
+        Map<String, String> inputExpectedMap = new HashMap<>();
+        inputExpectedMap.put("http://example.com?asdf=%qwer", "%qwer");
+        inputExpectedMap.put("http://example.com?asdf=%20", " ");
+        inputExpectedMap.put("http://example.com?asdf=%2b", "+");
+        inputExpectedMap.put("http://example.com?asdf=qwer", "qwer");
+
+        for (Map.Entry<String, String> inputExpectedEntry : inputExpectedMap.entrySet()) {
+            String input = inputExpectedEntry.getKey();
+            String expected = inputExpectedEntry.getValue();
+            HttpRequest request = mock(HttpRequest.class);
+            when(request.headers()).thenReturn(HttpHeaders.EMPTY_HEADERS);
+            when(request.getUri()).thenReturn(input);
+            RequestWrapper requestWrapper = new RequestWrapper(request);
+            Assert.assertEquals(expected, requestWrapper.getParameterValues("asdf")[0]);
+        }
+    }
+}


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
This makes the RequestWrapper more efficient since it does not have to compile the pattern each time.

### Related Github Issue
N/A

### Testing
The CI testing suite should pass.

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
