### PR TITLE
NR-92387 Add toggle "newrelic.jdbchelper.vanilla_map" to revert map impl

### DIFF
--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/ExpiringValueMap.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/ExpiringValueMap.java
@@ -2,11 +2,8 @@ package com.newrelic.agent.bridge.datastore;
 
 import com.newrelic.agent.bridge.AgentBridge;
 
-import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -21,7 +18,7 @@ import java.util.logging.Level;
  * @param <K> the class type of the cache key
  * @param <V> the class type of the value object
  */
-public class ExpiringValueCache<K, V> {
+public class ExpiringValueMap<K, V> extends AbstractMap<K, V>{
 
     private final ConcurrentHashMap<K, TimestampedMapValue<V>> wrappedMap;
 
@@ -49,7 +46,7 @@ public class ExpiringValueCache<K, V> {
      * @param expireLogicFunction the {@link ExpiringValueLogicFunction} lambda that contains the
      *                            logic to determine if an entry should be removed from the map
      */
-    public ExpiringValueCache(String taskName, long timerIntervalMilli, ExpiringValueLogicFunction expireLogicFunction) {
+    public ExpiringValueMap(String taskName, long timerIntervalMilli, ExpiringValueLogicFunction expireLogicFunction) {
         wrappedMap = new ConcurrentHashMap<>();
 
         Runnable task = () -> {
@@ -76,7 +73,7 @@ public class ExpiringValueCache<K, V> {
      * @param key the key for the target value
      * @return the target value
      */
-    public V get(K key) {
+    public V get(Object key) {
         TimestampedMapValue<V> testValue = wrappedMap.get(key);
         return testValue == null ? null : testValue.getValue();
     }
@@ -95,7 +92,12 @@ public class ExpiringValueCache<K, V> {
         return value;
     }
 
-    public boolean containsKey(K key) {
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        throw new UnsupportedOperationException("entrySet not supported");
+    }
+
+    public boolean containsKey(Object key) {
         return wrappedMap.containsKey(key);
     }
 

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/JdbcHelper.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/JdbcHelper.java
@@ -8,12 +8,12 @@
 package com.newrelic.agent.bridge.datastore;
 
 import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.NewRelic;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Statement;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,26 +42,41 @@ public class JdbcHelper {
 
     /**
      * Any values in the urlToFactory or urlToDatabaseName Maps older than this value will
-     * be evicted from the cache when the {@link ExpiringValueCache} timer fires. This
+     * be evicted from the cache when the {@link ExpiringValueMap} timer fires. This
      * will also be used as the timer interval value.
      */
     private static final long CACHE_EXPIRATION_AGE_MILLI = Duration.ofHours(8).toMillis();
 
-    private static final ExpiringValueCache.ExpiringValueLogicFunction EXPIRE_FUNC =
+    private static final ExpiringValueMap.ExpiringValueLogicFunction EXPIRE_FUNC =
             (timeCreated, timeLastAccessed) -> timeLastAccessed < (System.currentTimeMillis() - CACHE_EXPIRATION_AGE_MILLI);
 
     // This will contain every vendor type that we detected on the client system
     private static final Map<String, DatabaseVendor> typeToVendorLookup = new ConcurrentHashMap<>(10);
     private static final Map<Class<?>, DatabaseVendor> classToVendorLookup = AgentBridge.collectionFactory.createConcurrentWeakKeyedMap();
-    private static final ExpiringValueCache<String, ConnectionFactory> urlToFactory =
-            new ExpiringValueCache<>("urlToFactoryCache", CACHE_EXPIRATION_AGE_MILLI, EXPIRE_FUNC);
-
-    private static final ExpiringValueCache<String, String> urlToDatabaseName =
-            new ExpiringValueCache<>("urlToDatabaseNameCache", CACHE_EXPIRATION_AGE_MILLI, EXPIRE_FUNC);
     private static final Map<Statement, String> statementToSql = AgentBridge.collectionFactory.createConcurrentWeakKeyedMap();
     private static final Map<Connection, String> connectionToIdentifier = AgentBridge.collectionFactory.createConcurrentWeakKeyedMap();
     private static final Map<Connection, String> connectionToURL = AgentBridge.collectionFactory.createConcurrentWeakKeyedMap();
     public static final String UNKNOWN = "unknown";
+
+    // Config to toggle the use of the ExpiringValueCache Map implementation or vanilla ConcurrentHashMap implementation
+    // for the urlToFactory and urlToDatabaseName maps. The default is to use the ExpiringValueCache. Set a Java System
+    // property of newrelic.jdbchelper.vanilla_map=true to revert to the ConcurrentHashMap implementation.
+    private static final Map<String, ConnectionFactory> urlToFactory;
+    private static final Map<String, String> urlToDatabaseName;
+    static {
+        boolean useVanillaMap = Boolean.getBoolean("newrelic.jdbchelper.vanilla_map");
+        if (useVanillaMap) {
+            urlToFactory = new ConcurrentHashMap<>(10);
+            urlToDatabaseName = new ConcurrentHashMap<>(10);
+        } else {
+            urlToFactory =
+                    new ExpiringValueMap<>("urlToFactoryCache", CACHE_EXPIRATION_AGE_MILLI, EXPIRE_FUNC);
+            urlToDatabaseName =
+                    new ExpiringValueMap<>("urlToDatabaseNameCache", CACHE_EXPIRATION_AGE_MILLI, EXPIRE_FUNC);
+        }
+        NewRelic.getAgent().getLogger().log(Level.FINEST, "JdbcHelper using map implementation: {0} " +
+                "for urlToFactory and urlToDatabaseName maps", useVanillaMap ? "ConcurrentHashMap" : "ExpiringValueMap");
+    }
 
     public static void putVendor(Class<?> driverOrDatastoreClass, DatabaseVendor databaseVendor) {
         classToVendorLookup.put(driverOrDatastoreClass, databaseVendor);

--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/ExpiringValueMapTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/ExpiringValueMapTest.java
@@ -8,13 +8,13 @@ import org.junit.Test;
 
 import java.time.Duration;
 
-public class ExpiringValueCacheTest {
+public class ExpiringValueMapTest {
 
     private static final String VALUE_PREFIX = "val";
 
     @Test
     public void constructor_WithNoOpLambda_RemovesNoItems() {
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
         int mapSize = testMap.size();
 
         //Let the timer fire a few times and make sure the map doesn't change during that time
@@ -26,10 +26,10 @@ public class ExpiringValueCacheTest {
 
     @Test
     public void timer_WithValidLambda_ExpiresTargetRecords() {
-        ExpiringValueCache.ExpiringValueLogicFunction func =
+        ExpiringValueMap.ExpiringValueLogicFunction func =
                 (createdTime, timeLastAccessed) -> timeLastAccessed < System.currentTimeMillis() + 10000;
 
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(1000, func);
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(1000, func);
 
         await()
                 .atMost(3, SECONDS)
@@ -38,9 +38,9 @@ public class ExpiringValueCacheTest {
 
     @Test
     public void timer_WithValidLambda_LeavesMapUnmodified() {
-        ExpiringValueCache.ExpiringValueLogicFunction func =
+        ExpiringValueMap.ExpiringValueLogicFunction func =
                 (createdTime, timeLastAccessed) -> timeLastAccessed < System.currentTimeMillis() - 10000;
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(1000, func);
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(1000, func);
         int mapSize = testMap.size();
 
         await()
@@ -51,13 +51,13 @@ public class ExpiringValueCacheTest {
 
     @Test
     public void containsKey_WithValidKey_ReturnsTrue() {
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
         assertTrue(testMap.containsKey("1"));
     }
 
     @Test
     public void size_ReturnsProperValue() {
-        ExpiringValueCache<String, String> testMap = new ExpiringValueCache<>("testTimer", 1000, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = new ExpiringValueMap<>("testTimer", 1000, noOpLogicFunction());
         assertEquals(0, testMap.size());
 
         testMap.put("1", "Borderlands");
@@ -67,19 +67,19 @@ public class ExpiringValueCacheTest {
 
     @Test
     public void getValue_WithValidKey_ReturnsProperValue() {
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
         assertEquals(VALUE_PREFIX + "1", testMap.get("1"));
     }
 
     @Test
     public void getValue_WithInvalidKey_ReturnsNull() {
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
         assertNull(testMap.get("zzzzzzz"));
     }
 
     @Test
     public void putValue_WithValidKeyAndValue_AddsSuccessfully() {
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
         int beforeMapSize = testMap.size();
         testMap.put("222", "Borderlands");
 
@@ -88,20 +88,20 @@ public class ExpiringValueCacheTest {
 
     @Test(expected = NullPointerException.class)
     public void putValue_WithNullKey_ThrowsException() {
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
         testMap.put(null, "Borderlands");
     }
 
     @Test(expected = NullPointerException.class)
     public void putValue_WithNullValue_ThrowsException() {
-        ExpiringValueCache<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
+        ExpiringValueMap<String, String> testMap = generateNewHashMap(500, noOpLogicFunction());
         testMap.put("222", null);
     }
 
-    private ExpiringValueCache<String, String> generateNewHashMap(
-            long timerInterval, ExpiringValueCache.ExpiringValueLogicFunction func) {
+    private ExpiringValueMap<String, String> generateNewHashMap(
+            long timerInterval, ExpiringValueMap.ExpiringValueLogicFunction func) {
 
-        ExpiringValueCache<String, String> testMap = new ExpiringValueCache<>("testTimer", timerInterval, func);
+        ExpiringValueMap<String, String> testMap = new ExpiringValueMap<>("testTimer", timerInterval, func);
         for(int i=0; i< 20; i++) {
             testMap.put(Integer.toString(i), VALUE_PREFIX + i);
         }
@@ -109,7 +109,7 @@ public class ExpiringValueCacheTest {
         return testMap;
     }
 
-    private ExpiringValueCache.ExpiringValueLogicFunction noOpLogicFunction() {
+    private ExpiringValueMap.ExpiringValueLogicFunction noOpLogicFunction() {
         return (created, accessed) -> false;
     }
 

--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcHelperTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcHelperTest.java
@@ -132,4 +132,57 @@ public class JdbcHelperTest {
         Assert.assertEquals("connectionString", JdbcHelper.getConnectionURL(connection));
     }
 
+    @Test
+    public void putAndGetConnectionFactory_withValidFactory_isSuccessful() throws SQLException {
+        final Connection connection = Mockito.mock(Connection.class);
+        final DatabaseMetaData metaData = Mockito.mock(DatabaseMetaData.class);
+        Mockito.when(connection.getMetaData()).thenReturn(metaData);
+        Mockito.when(metaData.getURL()).thenReturn("connUrl1");
+        final ConnectionFactory factory = Mockito.mock(ConnectionFactory.class);
+
+        Assert.assertNull(JdbcHelper.getConnectionFactory(connection));
+        JdbcHelper.putConnectionFactory("connUrl1", factory);
+        Assert.assertEquals(factory, JdbcHelper.getConnectionFactory(connection));
+    }
+
+    @Test
+    public void putAndGetDatabaseName_withValidName_isSuccessful() throws SQLException {
+        final Connection connection = Mockito.mock(Connection.class);
+        final DatabaseMetaData metaData = Mockito.mock(DatabaseMetaData.class);
+        Mockito.when(connection.getMetaData()).thenReturn(metaData);
+        Mockito.when(metaData.getURL()).thenReturn("connUrl3");
+        final ConnectionFactory factory = Mockito.mock(ConnectionFactory.class);
+
+        Assert.assertNull(JdbcHelper.getCachedDatabaseName(connection));
+        JdbcHelper.putDatabaseName("connUrl3", "dbName1");
+        Assert.assertEquals("dbName1", JdbcHelper.getCachedDatabaseName(connection));
+    }
+
+    @Test
+    public void vanillaMap_putAndGetConnectionFactory_withValidFactory_isSuccessful() throws SQLException {
+        System.setProperty("newrelic.jdbchelper.vanilla_map", "true");
+        final Connection connection = Mockito.mock(Connection.class);
+        final DatabaseMetaData metaData = Mockito.mock(DatabaseMetaData.class);
+        Mockito.when(connection.getMetaData()).thenReturn(metaData);
+        Mockito.when(metaData.getURL()).thenReturn("connUrl3");
+        final ConnectionFactory factory = Mockito.mock(ConnectionFactory.class);
+
+        Assert.assertNull(JdbcHelper.getConnectionFactory(connection));
+        JdbcHelper.putConnectionFactory("connUrl3", factory);
+        Assert.assertEquals(factory, JdbcHelper.getConnectionFactory(connection));
+        System.setProperty("newrelic.jdbchelper.vanilla_map", "false");
+    }
+
+    @Test
+    public void vanillaMap_putAndGetDatabaseName_withValidName_isSuccessful() throws SQLException {
+        final Connection connection = Mockito.mock(Connection.class);
+        final DatabaseMetaData metaData = Mockito.mock(DatabaseMetaData.class);
+        Mockito.when(connection.getMetaData()).thenReturn(metaData);
+        Mockito.when(metaData.getURL()).thenReturn("connUrl4");
+        final ConnectionFactory factory = Mockito.mock(ConnectionFactory.class);
+
+        Assert.assertNull(JdbcHelper.getCachedDatabaseName(connection));
+        JdbcHelper.putDatabaseName("connUrl4", "dbName2");
+        Assert.assertEquals("dbName2", JdbcHelper.getCachedDatabaseName(connection));
+    }
 }

--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcHelperTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcHelperTest.java
@@ -175,6 +175,7 @@ public class JdbcHelperTest {
 
     @Test
     public void vanillaMap_putAndGetDatabaseName_withValidName_isSuccessful() throws SQLException {
+        System.setProperty("newrelic.jdbchelper.vanilla_map", "true");
         final Connection connection = Mockito.mock(Connection.class);
         final DatabaseMetaData metaData = Mockito.mock(DatabaseMetaData.class);
         Mockito.when(connection.getMetaData()).thenReturn(metaData);
@@ -184,5 +185,6 @@ public class JdbcHelperTest {
         Assert.assertNull(JdbcHelper.getCachedDatabaseName(connection));
         JdbcHelper.putDatabaseName("connUrl4", "dbName2");
         Assert.assertEquals("dbName2", JdbcHelper.getCachedDatabaseName(connection));
+        System.setProperty("newrelic.jdbchelper.vanilla_map", "false");
     }
 }


### PR DESCRIPTION
Temporary configuration option that will allow the agent to use a `ConcurrentHashMap` implementation rather than the `ExpiringValueMap` implementation for the urlToFactory and urlToDatabaseName maps. To revert to the `ConcurrentHashMap`, set a Java system property of `newrelic.jdbchelper.vanilla_map`.

Also renamed `ExpiringValueCache` to `ExpiringValueMap`.

This config option will be removed in a future Agent release.