### PR TITLE
Log Cats Effect 2 instrumentation with Finest log level

### DIFF
--- a/instrumentation/cats-effect-2/src/main/scala/com/nr/agent/instrumentation/TokenAwareExecutionContext.scala
+++ b/instrumentation/cats-effect-2/src/main/scala/com/nr/agent/instrumentation/TokenAwareExecutionContext.scala
@@ -10,6 +10,7 @@ class TokenAwareExecutionContext(delegate: ExecutionContext) extends ExecutionCo
     AgentBridge.getAgent.getLogger.log(Level.FINEST, s"[${Thread.currentThread().getName}] Instrumenting IOShift " +
       s"ExecutionContext $delegate")
   }
+  
   override def execute(runnable: Runnable): Unit = {
     delegate.execute(new TokenAwareRunnable(runnable))
   }

--- a/instrumentation/cats-effect-2/src/main/scala/com/nr/agent/instrumentation/TokenAwareExecutionContext.scala
+++ b/instrumentation/cats-effect-2/src/main/scala/com/nr/agent/instrumentation/TokenAwareExecutionContext.scala
@@ -6,8 +6,10 @@ import java.util.logging.Level
 import scala.concurrent.ExecutionContext
 
 class TokenAwareExecutionContext(delegate: ExecutionContext) extends ExecutionContext  {
-  AgentBridge.getAgent.getLogger.log(Level.INFO, s"[${Thread.currentThread().getName}] Instrumenting IOShift " +
-    s"ExecutionContext $delegate")
+  if (AgentBridge.getAgent.getLogger.isLoggable(Level.FINEST)) {
+    AgentBridge.getAgent.getLogger.log(Level.FINEST, s"[${Thread.currentThread().getName}] Instrumenting IOShift " +
+      s"ExecutionContext $delegate")
+  }
   override def execute(runnable: Runnable): Unit = {
     delegate.execute(new TokenAwareRunnable(runnable))
   }

--- a/instrumentation/cats-effect-2/src/main/scala/com/nr/agent/instrumentation/TokenAwareExecutionContext.scala
+++ b/instrumentation/cats-effect-2/src/main/scala/com/nr/agent/instrumentation/TokenAwareExecutionContext.scala
@@ -10,7 +10,6 @@ class TokenAwareExecutionContext(delegate: ExecutionContext) extends ExecutionCo
     AgentBridge.getAgent.getLogger.log(Level.FINEST, s"[${Thread.currentThread().getName}] Instrumenting IOShift " +
       s"ExecutionContext $delegate")
   }
-  
   override def execute(runnable: Runnable): Unit = {
     delegate.execute(new TokenAwareRunnable(runnable))
   }


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
In one of previous PRs somebody introduced an info log in CE 2 instrumentation that was being logged on every instrumentation of IO.shift and it wasn't caught by neither `application_logging.enabled` property, nor `log_level`. This PR fixes it by making this log on Finest level only if it's applicable.

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
