### PR TITLE
Updating verify instrumentation to run tests with Java 17

### DIFF
--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -63,13 +63,14 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       # Rewrite gradle.properties
       - name: set gradle.properties
         run: |
           sed -i -e "s|jdk8=8|jdk8=${JAVA_HOME_8_x64}|
-          s|jdk11=11|jdk11=${JAVA_HOME_11_x64}|" gradle.properties.gha
+          s|jdk11=11|jdk11=${JAVA_HOME_11_x64}|
+          s|jdk17=17|jdk17=${JAVA_HOME_17_x64}|" gradle.properties.gha
           mv gradle.properties.gha gradle.properties
 
       - name: Setup Gradle options


### PR DESCRIPTION
### Overview
Spring 6 is only compatible with Java 17+. So verify instrumentation needs to be run with at least that version of Java.
