### PR TITLE
NR-64061 Add user tracking to transactions and errors

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
@@ -75,6 +75,11 @@ class NoOpPublicApi implements PublicApi {
     }
 
     @Override
+    public void setUserIdParam(String userId) {
+
+    }
+
+    @Override
     public void setTransactionName(String category, String name) {
 
     }

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
@@ -75,7 +75,7 @@ class NoOpPublicApi implements PublicApi {
     }
 
     @Override
-    public void setUserIdParam(String userId) {
+    public void setUserId(String userId) {
 
     }
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
@@ -157,6 +157,13 @@ public interface PublicApi {
     void addCustomParameters(Map<String, Object> params);
 
     /**
+     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     *
+     * @param userId The user ID to report.
+     */
+    void setUserIdParam(String userId);
+
+    /**
      * Set the name of the current transaction.
      *
      * @param category Metric category. If the input is null, then the default will be used.

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
@@ -157,11 +157,11 @@ public interface PublicApi {
     void addCustomParameters(Map<String, Object> params);
 
     /**
-     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     * Sets the user ID for the current transaction by adding the "enduser.id" attribute. It is reported in errors and transaction traces.
      *
      * @param userId The user ID to report.
      */
-    void setUserIdParam(String userId);
+    void setUserId(String userId);
 
     /**
      * Set the name of the current transaction.

--- a/agent-bridge/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/agent-bridge/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -220,12 +220,12 @@ public final class NewRelic {
 
 
     /**
-     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     * Sets the user ID for the current transaction by adding the "enduser.id" attribute. It is reported in errors and transaction traces.
      *
      * @param userId The user ID to report.
      */
-    public static void setUserIdParam(String userId) {
-        AgentBridge.publicApi.setUserIdParam(userId);
+    public static void setUserId(String userId) {
+        AgentBridge.publicApi.setUserId(userId);
     }
 
     /**

--- a/agent-bridge/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/agent-bridge/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -218,6 +218,16 @@ public final class NewRelic {
         AgentBridge.publicApi.addCustomParameters(params);
     }
 
+
+    /**
+     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     *
+     * @param userId The user ID to report.
+     */
+    public static void setUserIdParam(String userId) {
+        AgentBridge.publicApi.setUserIdParam(userId);
+    }
+
     /**
      * Set the name of the current transaction.
      * 

--- a/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
@@ -794,7 +794,11 @@ public class ApiTest implements TransactionListener {
 
 
     @Trace(dispatcher = true)
-    private void runTestSetUserId() throws Exception {
+    private void runTestSetUserId() {
+        NewRelic.setUserId("");
+        Assert.assertFalse(Transaction.getTransaction().getAgentAttributes().containsKey("enduser.id"));
+        NewRelic.setUserId(null);
+        Assert.assertFalse(Transaction.getTransaction().getAgentAttributes().containsKey("enduser.id"));
         NewRelic.setUserId("hello");
         Assert.assertEquals("hello", Transaction.getTransaction().getAgentAttributes().get("enduser.id"));
     }

--- a/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
@@ -790,14 +790,13 @@ public class ApiTest implements TransactionListener {
         } finally {
             Transaction.clearTransaction();
         }
-        ErrorService errorService = ServiceFactory.getRPMService().getErrorService();
     }
 
 
     @Trace(dispatcher = true)
     private void runTestSetUserIdParam() throws Exception {
         NewRelic.setUserIdParam("hello");
-        Assert.assertEquals("hello", Transaction.getTransaction().getUserAttributes().get("userId"));
+        Assert.assertEquals("hello", Transaction.getTransaction().getAgentAttributes().get("userId"));
     }
 
     @Test

--- a/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
@@ -776,6 +776,7 @@ public class ApiTest implements TransactionListener {
             Transaction.clearTransaction();
         }
     }
+
     @Trace(dispatcher = true)
     private void runTestAddCustomBoolParameter() {
         NewRelic.addCustomParameter("bool", true);

--- a/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
@@ -776,11 +776,28 @@ public class ApiTest implements TransactionListener {
             Transaction.clearTransaction();
         }
     }
-
     @Trace(dispatcher = true)
     private void runTestAddCustomBoolParameter() {
         NewRelic.addCustomParameter("bool", true);
         Assert.assertEquals(true, Transaction.getTransaction().getUserAttributes().get("bool"));
+    }
+
+
+    @Test
+    public void testSetUserIdParam() throws Exception {
+        try {
+            runTestSetUserIdParam();
+        } finally {
+            Transaction.clearTransaction();
+        }
+        ErrorService errorService = ServiceFactory.getRPMService().getErrorService();
+    }
+
+
+    @Trace(dispatcher = true)
+    private void runTestSetUserIdParam() throws Exception {
+        NewRelic.setUserIdParam("hello");
+        Assert.assertEquals("hello", Transaction.getTransaction().getUserAttributes().get("userId"));
     }
 
     @Test

--- a/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/api/ApiTest.java
@@ -784,9 +784,9 @@ public class ApiTest implements TransactionListener {
 
 
     @Test
-    public void testSetUserIdParam() throws Exception {
+    public void testSetUserId() throws Exception {
         try {
-            runTestSetUserIdParam();
+            runTestSetUserId();
         } finally {
             Transaction.clearTransaction();
         }
@@ -794,9 +794,9 @@ public class ApiTest implements TransactionListener {
 
 
     @Trace(dispatcher = true)
-    private void runTestSetUserIdParam() throws Exception {
-        NewRelic.setUserIdParam("hello");
-        Assert.assertEquals("hello", Transaction.getTransaction().getAgentAttributes().get("userId"));
+    private void runTestSetUserId() throws Exception {
+        NewRelic.setUserId("hello");
+        Assert.assertEquals("hello", Transaction.getTransaction().getAgentAttributes().get("enduser.id"));
     }
 
     @Test

--- a/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Filter.java
+++ b/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Filter.java
@@ -9,6 +9,7 @@ package jakarta.servlet;
 
 import java.security.Principal;
 
+import com.newrelic.api.agent.NewRelic;
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.newrelic.agent.bridge.AgentBridge;
@@ -27,6 +28,7 @@ public abstract class Filter {
             Principal principal = ((HttpServletRequest) request).getUserPrincipal();
             if (principal != null) {
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
+                NewRelic.setUserId(principal.getName());
             }
         }
 

--- a/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
+++ b/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
@@ -8,8 +8,11 @@
 package jakarta.servlet;
 
 import java.security.Principal;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.weaver.NewField;
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.newrelic.agent.bridge.AgentBridge;
@@ -21,6 +24,9 @@ import com.newrelic.api.agent.weaver.Weaver;
 @Weave(type = MatchType.Interface)
 public abstract class Servlet {
 
+    @NewField
+    private final AtomicBoolean logNrUserDeprecation = new AtomicBoolean(true);
+
     @Trace(dispatcher = true)
     public void service(ServletRequest request, ServletResponse response) {
 
@@ -29,6 +35,10 @@ public abstract class Servlet {
             if (principal != null) {
                 // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
+                if (logNrUserDeprecation.get()) {
+                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'userId' attribute instead.");
+                    logNrUserDeprecation.set(false);
+                }
                 NewRelic.setUserIdParam(principal.getName());
             }
         }

--- a/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
+++ b/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
@@ -24,21 +24,13 @@ import com.newrelic.api.agent.weaver.Weaver;
 @Weave(type = MatchType.Interface)
 public abstract class Servlet {
 
-    @NewField
-    private final AtomicBoolean logNrUserDeprecation = new AtomicBoolean(true);
-
     @Trace(dispatcher = true)
     public void service(ServletRequest request, ServletResponse response) {
 
         if (request instanceof HttpServletRequest) {
             Principal principal = ((HttpServletRequest) request).getUserPrincipal();
             if (principal != null) {
-                // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
-                if (logNrUserDeprecation.get()) {
-                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'enduser.id' attribute instead.");
-                    logNrUserDeprecation.set(false);
-                }
                 NewRelic.setUserId(principal.getName());
             }
         }

--- a/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
+++ b/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
@@ -9,6 +9,7 @@ package jakarta.servlet;
 
 import java.security.Principal;
 
+import com.newrelic.api.agent.NewRelic;
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.newrelic.agent.bridge.AgentBridge;
@@ -26,7 +27,9 @@ public abstract class Servlet {
         if (request instanceof HttpServletRequest) {
             Principal principal = ((HttpServletRequest) request).getUserPrincipal();
             if (principal != null) {
+                // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
+                NewRelic.setUserIdParam(principal.getName());
             }
         }
 

--- a/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
+++ b/instrumentation/servlet-user-5.0/src/main/java/jakarta/servlet/Servlet.java
@@ -36,10 +36,10 @@ public abstract class Servlet {
                 // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
                 if (logNrUserDeprecation.get()) {
-                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'userId' attribute instead.");
+                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'enduser.id' attribute instead.");
                     logNrUserDeprecation.set(false);
                 }
-                NewRelic.setUserIdParam(principal.getName());
+                NewRelic.setUserId(principal.getName());
             }
         }
 

--- a/instrumentation/servlet-user/src/main/java/javax/servlet/Filter.java
+++ b/instrumentation/servlet-user/src/main/java/javax/servlet/Filter.java
@@ -12,6 +12,7 @@ import java.security.Principal;
 import javax.servlet.http.HttpServletRequest;
 
 import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
@@ -27,6 +28,7 @@ public abstract class Filter {
             Principal principal = ((HttpServletRequest) request).getUserPrincipal();
             if (principal != null) {
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
+                NewRelic.setUserId(principal.getName());
             }
         }
 

--- a/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
+++ b/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
@@ -7,25 +7,18 @@
 
 package javax.servlet;
 
-import java.security.Principal;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-
-import javax.servlet.http.HttpServletRequest;
-
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.weaver.MatchType;
-import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 
+import javax.servlet.http.HttpServletRequest;
+import java.security.Principal;
+
 @Weave(type = MatchType.Interface)
 public abstract class Servlet {
-
-    @NewField
-    private final AtomicBoolean logNrUserDeprecation = new AtomicBoolean(true);
 
     @Trace(dispatcher = true)
     public void service(ServletRequest request, ServletResponse response) {
@@ -33,12 +26,7 @@ public abstract class Servlet {
         if (request instanceof HttpServletRequest) {
             Principal principal = ((HttpServletRequest) request).getUserPrincipal();
             if (principal != null) {
-                // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
-                if (logNrUserDeprecation.get()) {
-                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'enduser.id' attribute instead.");
-                    logNrUserDeprecation.set(false);
-                }
                 NewRelic.setUserId(principal.getName());
             }
         }

--- a/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
+++ b/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
@@ -12,6 +12,7 @@ import java.security.Principal;
 import javax.servlet.http.HttpServletRequest;
 
 import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
@@ -26,7 +27,9 @@ public abstract class Servlet {
         if (request instanceof HttpServletRequest) {
             Principal principal = ((HttpServletRequest) request).getUserPrincipal();
             if (principal != null) {
+                // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
+                NewRelic.setUserIdParam(principal.getName());
             }
         }
 

--- a/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
+++ b/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
@@ -8,6 +8,8 @@
 package javax.servlet;
 
 import java.security.Principal;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -15,11 +17,15 @@ import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 
 @Weave(type = MatchType.Interface)
 public abstract class Servlet {
+
+    @NewField
+    private final AtomicBoolean logNrUserDeprecation = new AtomicBoolean(true);
 
     @Trace(dispatcher = true)
     public void service(ServletRequest request, ServletResponse response) {
@@ -29,6 +35,10 @@ public abstract class Servlet {
             if (principal != null) {
                 // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
+                if (logNrUserDeprecation.get()) {
+                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'userId' attribute instead.");
+                    logNrUserDeprecation.set(false);
+                }
                 NewRelic.setUserIdParam(principal.getName());
             }
         }

--- a/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
+++ b/instrumentation/servlet-user/src/main/java/javax/servlet/Servlet.java
@@ -36,10 +36,10 @@ public abstract class Servlet {
                 // The user attribute is deprecated, the userId is going to be used instead
                 AgentBridge.getAgent().getTransaction().getAgentAttributes().put("user", principal.getName());
                 if (logNrUserDeprecation.get()) {
-                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'userId' attribute instead.");
+                    NewRelic.getAgent().getLogger().log(Level.INFO, "The 'user' attribute for transactions is deprecated, use the 'enduser.id' attribute instead.");
                     logNrUserDeprecation.set(false);
                 }
-                NewRelic.setUserIdParam(principal.getName());
+                NewRelic.setUserId(principal.getName());
             }
         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -129,7 +129,6 @@ public class Transaction {
     "newrelic.scala.api.TraceOps$", "txn", null);
     public static final int SCALA_API_TXN_CLASS_SIGNATURE_ID =
     ClassMethodSignatures.get().add(SCALA_API_TXN_CLASS_SIGNATURE);
-
     private static final String THREAD_ASSERTION_FAILURE = "Thread assertion failed!";
 
     private static final ThreadLocal<Transaction> transactionHolder = new ThreadLocal<>();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -129,6 +129,8 @@ public class Transaction {
     "newrelic.scala.api.TraceOps$", "txn", null);
     public static final int SCALA_API_TXN_CLASS_SIGNATURE_ID =
     ClassMethodSignatures.get().add(SCALA_API_TXN_CLASS_SIGNATURE);
+
+    public static final String USER_ID_ATTRIBUTE = "userId";
     private static final String THREAD_ASSERTION_FAILURE = "Thread assertion failed!";
 
     private static final ThreadLocal<Transaction> transactionHolder = new ThreadLocal<>();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -130,7 +130,6 @@ public class Transaction {
     public static final int SCALA_API_TXN_CLASS_SIGNATURE_ID =
     ClassMethodSignatures.get().add(SCALA_API_TXN_CLASS_SIGNATURE);
 
-    public static final String USER_ID_ATTRIBUTE = "enduser.id";
     private static final String THREAD_ASSERTION_FAILURE = "Thread assertion failed!";
 
     private static final ThreadLocal<Transaction> transactionHolder = new ThreadLocal<>();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -130,7 +130,7 @@ public class Transaction {
     public static final int SCALA_API_TXN_CLASS_SIGNATURE_ID =
     ClassMethodSignatures.get().add(SCALA_API_TXN_CLASS_SIGNATURE);
 
-    public static final String USER_ID_ATTRIBUTE = "userId";
+    public static final String USER_ID_ATTRIBUTE = "enduser.id";
     private static final String THREAD_ASSERTION_FAILURE = "Thread assertion failed!";
 
     private static final ThreadLocal<Transaction> transactionHolder = new ThreadLocal<>();

--- a/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
@@ -286,6 +286,16 @@ public class NewRelicApiImplementation implements PublicApi {
     }
 
     /**
+     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     *
+     * @param userId The user ID to report.
+     */
+    @Override
+    public void setUserIdParam(String userId) {
+        attributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setReportedUserIdParameter");
+    }
+
+    /**
      * Set the name of the current transaction.
      *
      * @param category

--- a/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
@@ -296,7 +296,14 @@ public class NewRelicApiImplementation implements PublicApi {
      */
     @Override
     public void setUserId(String userId) {
-        agentAttributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setUserId");
+        final String attributeKey = "enduser.id";
+        final String methodCalled = "setUserId";
+        // Ignore null and empty strings
+        if (userId == null || userId.trim().isEmpty()) {
+            Agent.LOG.log(Level.FINER, "Unable to add {0} attribute because {1} was invoked with a null or blank value", attributeKey, methodCalled);
+            return;
+        }
+        agentAttributeSender.addAttribute(attributeKey, userId, methodCalled);
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
@@ -10,6 +10,7 @@ package com.newrelic.api.agent;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.Transaction;
+import com.newrelic.agent.attributes.AgentAttributeSender;
 import com.newrelic.agent.attributes.AttributeSender;
 import com.newrelic.agent.attributes.CustomAttributeSender;
 import com.newrelic.agent.bridge.AgentBridge;
@@ -36,14 +37,17 @@ import java.util.logging.Level;
  * DO NOT INVOKE THIS CLASS DIRECTLY. Use {@link com.newrelic.api.agent.NewRelic}.
  */
 public class NewRelicApiImplementation implements PublicApi {
-    private final AttributeSender attributeSender;
+    private final AttributeSender customAttributeSender;
 
-    public NewRelicApiImplementation(AttributeSender sender) {
-        attributeSender = sender;
+    private final AttributeSender agentAttributeSender;
+
+    public NewRelicApiImplementation(AttributeSender customSender, AttributeSender agentSender) {
+        customAttributeSender = customSender;
+        agentAttributeSender = agentSender;
     }
 
     public NewRelicApiImplementation() {
-        this(new CustomAttributeSender());
+        this(new CustomAttributeSender(), new AgentAttributeSender());
     }
 
     // ************************** Error collector ***********************************//
@@ -109,7 +113,7 @@ public class NewRelicApiImplementation implements PublicApi {
 
     public void noticeError(Throwable throwable, Map<String, ?> params, boolean expected) {
         try {
-            ServiceFactory.getRPMService().getErrorService().reportException(throwable, filterErrorAtts(params, attributeSender), expected);
+            ServiceFactory.getRPMService().getErrorService().reportException(throwable, filterErrorAtts(params, customAttributeSender), expected);
 
             MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_NOTICE_ERROR);
             //SUPPORTABILITY_API_EXPECTED_ERROR_API_THROWABLE metric is intended to be recorded independent of whether
@@ -132,7 +136,7 @@ public class NewRelicApiImplementation implements PublicApi {
     @Override
     public void noticeError(String message, Map<String, ?> params, boolean expected) {
         try {
-            ServiceFactory.getRPMService().getErrorService().reportError(message, filterErrorAtts(params, attributeSender), expected);
+            ServiceFactory.getRPMService().getErrorService().reportError(message, filterErrorAtts(params, customAttributeSender), expected);
 
             MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_NOTICE_ERROR);
             if (expected) {
@@ -250,7 +254,7 @@ public class NewRelicApiImplementation implements PublicApi {
      */
     @Override
     public void addCustomParameter(String key, String value) {
-        attributeSender.addAttribute(key, value, "addCustomParameter");
+        customAttributeSender.addAttribute(key, value, "addCustomParameter");
     }
 
     /**
@@ -261,7 +265,7 @@ public class NewRelicApiImplementation implements PublicApi {
      */
     @Override
     public void addCustomParameter(String key, Number value) {
-        attributeSender.addAttribute(key, value, "addCustomParameter");
+        customAttributeSender.addAttribute(key, value, "addCustomParameter");
     }
 
     /**
@@ -272,7 +276,7 @@ public class NewRelicApiImplementation implements PublicApi {
      */
     @Override
     public void addCustomParameter(String key, boolean value) {
-        attributeSender.addAttribute(key, value, "addCustomParameter");
+        customAttributeSender.addAttribute(key, value, "addCustomParameter");
     }
 
     /**
@@ -282,7 +286,7 @@ public class NewRelicApiImplementation implements PublicApi {
      */
     @Override
     public void addCustomParameters(Map<String, Object> params) {
-        attributeSender.addAttributes(params, "addCustomParameters");
+        customAttributeSender.addAttributes(params, "addCustomParameters");
     }
 
     /**
@@ -292,7 +296,7 @@ public class NewRelicApiImplementation implements PublicApi {
      */
     @Override
     public void setUserIdParam(String userId) {
-        attributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setUserIdParam");
+        agentAttributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setUserIdParam");
     }
 
     /**
@@ -540,7 +544,7 @@ public class NewRelicApiImplementation implements PublicApi {
             Agent.LOG.finer(msg);
         }
         MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_SET_USER_NAME);
-        attributeSender.addAttribute("user", name, "setUserName");
+        customAttributeSender.addAttribute("user", name, "setUserName");
     }
 
     /**
@@ -563,7 +567,7 @@ public class NewRelicApiImplementation implements PublicApi {
                 String msg = MessageFormat.format("Attempting to set account name to \"{0}\" in NewRelic API", name);
                 Agent.LOG.finer(msg);
             }
-            attributeSender.addAttribute("account", name, "setAccountName");
+            customAttributeSender.addAttribute("account", name, "setAccountName");
             MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_SET_ACCOUNT_NAME);
         }
     }
@@ -589,7 +593,7 @@ public class NewRelicApiImplementation implements PublicApi {
                 Agent.LOG.finer(msg);
             }
             MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_SET_PRODUCT_NAME);
-            attributeSender.addAttribute("product", name, "setProductName");
+            customAttributeSender.addAttribute("product", name, "setProductName");
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
@@ -290,13 +290,13 @@ public class NewRelicApiImplementation implements PublicApi {
     }
 
     /**
-     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     * Sets the user ID for the current transaction by adding the "enduser.id" attribute. It is reported in errors and transaction traces.
      *
      * @param userId The user ID to report.
      */
     @Override
-    public void setUserIdParam(String userId) {
-        agentAttributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setUserIdParam");
+    public void setUserId(String userId) {
+        agentAttributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setUserId");
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
@@ -292,7 +292,7 @@ public class NewRelicApiImplementation implements PublicApi {
      */
     @Override
     public void setUserIdParam(String userId) {
-        attributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setReportedUserIdParameter");
+        attributeSender.addAttribute(Transaction.USER_ID_ATTRIBUTE, userId, "setUserIdParam");
     }
 
     /**

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -265,11 +265,11 @@ public final class NewRelic {
     }
 
     /**
-     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     * Sets the user ID for the current transaction by adding the "enduser.id" attribute. It is reported in errors and transaction traces.
      *
      * @param userId The user ID to report.
      */
-    public static void setUserIdParam(String userId) {
+    public static void setUserId(String userId) {
     }
 
     /**

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -265,6 +265,14 @@ public final class NewRelic {
     }
 
     /**
+     * Add the userId parameter to the current transaction. It is reported in errors and transaction traces.
+     *
+     * @param userId The user ID to report.
+     */
+    public static void setUserIdParam(String userId) {
+    }
+
+    /**
      * Set the name of the current transaction.
      *
      * @param category Metric category. If the input is null, then the default will be used.


### PR DESCRIPTION
### Overview
This PR adds user tracking to transactions and errors in a way that will be consistent to other APM agents. 

A new method in our public API was added called `NewRelic.setUserId(String userId)` that sets an enduser.id attribute to a transaction. It in turns passes that attribute into errors linked to that transaction.

In addition, the servler-user and servlet-user-5.0 instrumentation was modified to also set the enduser.id attribute using the name of a provided principle in a Servlet / Filter.
