### PR TITLE
Kafka Streams: Include missing numeric metrics

### DIFF
--- a/instrumentation/kafka-streams-metrics-1.0.0/src/main/java/com/nr/instrumentation/kafka/streams/MetricsScheduler.java
+++ b/instrumentation/kafka-streams-metrics-1.0.0/src/main/java/com/nr/instrumentation/kafka/streams/MetricsScheduler.java
@@ -64,8 +64,8 @@ public class MetricsScheduler {
                 Map<String, Object> eventData = new HashMap<>();
                 for (final Map.Entry<String, KafkaMetric> metric : nrMetricsReporter.getMetrics().entrySet()) {
                     Object metricValue = metric.getValue().metricValue();
-                    if (metricValue instanceof Double) {
-                        final float value = ((Double) metricValue).floatValue();
+                    if (metricValue instanceof Number) {
+                        final float value = ((Number) metricValue).floatValue();
                         if (KAFKA_METRICS_DEBUG) {
                             AgentBridge.getAgent().getLogger().log(Level.FINEST, "getMetric: {0} = {1}", metric.getKey(), value);
                         }


### PR DESCRIPTION
### Overview
Some numeric metrics from Kafka Streams are not recorded. This fix is here to include them.
