### PR TITLE
Capping jdbc-ojdbc-tns instrumentation

### DIFF
--- a/instrumentation/jdbc-ojdbc-tns/build.gradle
+++ b/instrumentation/jdbc-ojdbc-tns/build.gradle
@@ -9,7 +9,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passes("com.oracle.database.jdbc:ojdbc8:[0,)")
+    passes("com.oracle.database.jdbc:ojdbc8:[0,23.2.0.0)")
     passes("com.oracle.database.jdbc:ojdbc6:[0,)")
     passes("com.oracle.database.jdbc:ojdbc5:[0,)")
 }


### PR DESCRIPTION
### Overview
A new version of ojdbc8 no longer works with the jdbc-ojdbc-tns instrumentation module.