### PR TITLE
#NEWRELIC-6527 guard lettuce npe

### DIFF
--- a/instrumentation/lettuce-5.0/src/main/java/com/nr/lettuce5/instrumentation/NRHolder.java
+++ b/instrumentation/lettuce-5.0/src/main/java/com/nr/lettuce5/instrumentation/NRHolder.java
@@ -11,6 +11,8 @@ import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Token;
 
+import java.util.logging.Level;
+
 public class NRHolder {
     private String segmentName = null;
     private Segment segment = null;
@@ -45,7 +47,7 @@ public class NRHolder {
             token.linkAndExpire();
             token = null;
         }
-        if (segment != null) {
+        if (segment != null && params != null) {
             String operation = params.getOperation();
             if (operation.equalsIgnoreCase("expire")) {
                 segment.ignore();
@@ -56,9 +58,13 @@ public class NRHolder {
             params = null;
             segment = null;
         } else {
-            String operation = params.getOperation();
-            if (!operation.equalsIgnoreCase("expire")) {
-                NewRelic.getAgent().getTracedMethod().reportAsExternal(params);
+            if (params != null) {
+                String operation = params.getOperation();
+                if (!operation.equalsIgnoreCase("expire")) {
+                    NewRelic.getAgent().getTracedMethod().reportAsExternal(params);
+                }
+            } else {
+                NewRelic.getAgent().getLogger().log(Level.WARNING, "DatastoreParameters was null for Lettuce instrumentation. Unable to report as external.");
             }
         }
     }

--- a/instrumentation/lettuce-6.0/src/main/java/com/nr/lettuce6/instrumentation/NRHolder.java
+++ b/instrumentation/lettuce-6.0/src/main/java/com/nr/lettuce6/instrumentation/NRHolder.java
@@ -11,6 +11,8 @@ import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Token;
 
+import java.util.logging.Level;
+
 public class NRHolder {
     private String segmentName = null;
     private Segment segment = null;
@@ -45,7 +47,7 @@ public class NRHolder {
             token.linkAndExpire();
             token = null;
         }
-        if (segment != null) {
+        if (segment != null && params != null) {
             String operation = params.getOperation();
             if (operation.equalsIgnoreCase("expire")) {
                 segment.ignore();
@@ -56,9 +58,13 @@ public class NRHolder {
             params = null;
             segment = null;
         } else {
-            String operation = params.getOperation();
-            if (!operation.equalsIgnoreCase("expire")) {
-                NewRelic.getAgent().getTracedMethod().reportAsExternal(params);
+            if (params != null) {
+                String operation = params.getOperation();
+                if (!operation.equalsIgnoreCase("expire")) {
+                    NewRelic.getAgent().getTracedMethod().reportAsExternal(params);
+                }
+            } else {
+                NewRelic.getAgent().getLogger().log(Level.WARNING, "DatastoreParameters was null for Lettuce instrumentation. Unable to report as external");
             }
         }
     }


### PR DESCRIPTION
### Overview
Reported NPE on newrelic java agent 7.9 and 7.11 in the lettuce instrumentation

```
java.lang.NullPointerException
at com.nr.lettuce5.instrumentation.NRHolder.end(NRHolder.java:59)
at com.nr.lettuce5.instrumentation.NRSignalTypeConsumer.accept(NRSignalTypeConsumer.java:24)
at com.nr.lettuce5.instrumentation.NRSignalTypeConsumer.accept(NRSignalTypeConsumer.java:13)
}}{{at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.runFinally(FluxDoFinally.java:156)
}}{{at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:132)

```
### Related Github Issue
https://issues.newrelic.com/browse/NEWRELIC-6527

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
