### PR TITLE
retries on failed instrumentation test

### DIFF
--- a/.github/workflows/Java-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-Instrumentation-Tests.yml
@@ -143,7 +143,6 @@ jobs:
         id: run_tests_1
         continue-on-error: true
         env:
-
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
           timeout 35m ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue

--- a/.github/workflows/Java-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-Instrumentation-Tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         jre: [8, 11, 17, 19]
     name: Java ${{ matrix.jre }} Instrumentation Tests
-    timeout-minutes: 60
+    timeout-minutes: 120
     # needs: install-all-java
     runs-on: ubuntu-20.04
     env:
@@ -146,7 +146,7 @@ jobs:
 
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
-          ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
+          timeout 35m ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
 
       - name: Run instrumentation tests for Java ${{ matrix.jre }} w/o GE (attempt 2)
         id: run_tests_2
@@ -155,14 +155,14 @@ jobs:
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
-          ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
+          timeout 35m ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
 
       - name: Run instrumentation tests for Java ${{ matrix.jre }} w/o GE (attempt 3)
         if: steps.run_tests_2.outcome == 'failure'
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
-          ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
+          timeout 35m ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
 
       # Capture HTML build result in artifacts
       - name: Capture build reports

--- a/.github/workflows/Java-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-Instrumentation-Tests.yml
@@ -139,7 +139,26 @@ jobs:
           rm gradle.properties
           mv gradle.properties.gha gradle.properties
 
-      - name: Run instrumentation tests for Java ${{ matrix.jre }} w/o GE
+      - name: Run instrumentation tests for Java ${{ matrix.jre }} w/o GE (attempt 1)
+        id: run_tests_1
+        continue-on-error: true
+        env:
+
+          JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
+        run: |
+          ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
+
+      - name: Run instrumentation tests for Java ${{ matrix.jre }} w/o GE (attempt 2)
+        id: run_tests_2
+        continue-on-error: true
+        if: steps.run_tests_1.outcome == 'failure'
+        env:
+          JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
+        run: |
+          ./gradlew $GRADLE_OPTIONS --console=plain :instrumentation:test -Ptest${{ matrix.jre }} --continue
+
+      - name: Run instrumentation tests for Java ${{ matrix.jre }} w/o GE (attempt 3)
+        if: steps.run_tests_2.outcome == 'failure'
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |


### PR DESCRIPTION
### Overview
Reduce developer toil.  We often have to repeatedly re-run tests by observing a failure, logging onto github. triggering a re-run.  Often, this rerun has to happen multiple times. This will retry up to 2 times if the first test, and subsequently the 2nd retry fails. This should reduce the number of times a developer has to manually trigger the job significantly.  Even if the 3 tries doesn't get past a false failure, then a second manual run still nets up to 6 runs.  
This also gives someone a good opportunity to intervene and make sure the failure is not a legit failure before manually kicking off the job after the 1st 3 tries.

*Note, this does not restart a workflow in the case where it is cancelled due to a timeout or some other cancelled condition. It only reruns if there is a test failure.  There's not a direct way to rerun a cancelled workflow.

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
