### PR TITLE
retry scala instrumentation

### DIFF
--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Build newrelicJar w/o GE
+      - name: Build newrelicJar
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
@@ -111,30 +111,26 @@ jobs:
       - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} (attempt 1)
         id: run_tests_1
         continue-on-error: true
+        timeout-minutes: 25
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
-        timeout-minutes: 25
 
       - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} (attempt 2)
         id: run_tests_2
         if: steps.run_tests_1.outcome == 'failure'
         continue-on-error: true
+        timeout-minutes: 25
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
-        run: |
-          sleep 60
-          ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
-        timeout-minutes: 25
+        run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
 
       - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} (attempt 3)
         if: steps.run_tests_2.outcome == 'failure'
+        timeout-minutes: 25
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
-        run: |
-          sleep 60
-          ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
-        timeout-minutes: 25
+        run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
 
       - name: Capture build reports
         if: ${{ failure() }}

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -23,7 +23,6 @@ jobs:
       default-branch: "main"
       # we use this in env var for conditionals (secrets can't be used in conditionals)
       AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      GRADLE_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
     strategy:
       ##max-parallel: 1 ## used to force sequential
       fail-fast: false
@@ -37,7 +36,6 @@ jobs:
             scala: 2.11
     steps:
       - uses: actions/checkout@v3
-      #- uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Set up Java 8
         # https://github.com/actions/setup-java
@@ -92,27 +90,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Build newrelicJar
-        if: ${{ env.GRADLE_KEY != '' }}        
-        env:
-          CI: GHA
-          JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: 34.229.76.228=${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_CACHE_USER: gha
-          GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-          JRE: jre${{ matrix.java-version }}
-          LANGUAGE: scala
-          SCALA_VERSION: scala${{ matrix.scala }}
-          TEST_TYPE: instrumentation
-        run: |
-          # echo "JAVA_HOME=${ORG_GRADLE_PROJECT_jdk8}" >> $GITHUB_ENV
-          echo "REVIEW ANY NEW ITEMS IN WORKSPACE"
-          ls -la
-          ./gradlew clean jar --parallel
-          ls -la newrelic-agent/build/
-
       - name: Build newrelicJar w/o GE
-        if: ${{ env.GRADLE_KEY == '' }}
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: |
@@ -130,25 +108,33 @@ jobs:
           rm gradle.properties
           mv gradle.properties.gha gradle.properties
 
-      - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }}
-        if: ${{ env.GRADLE_KEY != '' }}
-        env:
-          CI: GHA
-          JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: 34.229.76.228=${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_CACHE_USER: gha
-          GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-          JRE: jre${{ matrix.java-version }}
-          LANGUAGE: scala
-          SCALA_VERSION: scala${{ matrix.scala }}
-          TEST_TYPE: instrumentation
-        run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue --scan -Dscan.uploadInBackground=false --build-cache
-
-      - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} w/o GE
-        if: ${{ env.GRADLE_KEY == '' }}
+      - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} (attempt 1)
+        id: run_tests_1
+        continue-on-error: true
         env:
           JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
         run: ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
+        timeout-minutes: 25
+
+      - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} (attempt 2)
+        id: run_tests_2
+        if: steps.run_tests_1.outcome == 'failure'
+        continue-on-error: true
+        env:
+          JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
+        run: |
+          sleep 60
+          ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
+        timeout-minutes: 25
+
+      - name: Run instrumentation tests for Java ${{ matrix.java-version }} and scala ${{ matrix.scala }} (attempt 3)
+        if: steps.run_tests_2.outcome == 'failure'
+        env:
+          JAVA_HOME: ${{ env.ORG_GRADLE_PROJECT_jdk8 }}
+        run: |
+          sleep 60
+          ./gradlew --console=plain --parallel :instrumentation:test -Ptest${{ matrix.java-version }} -PnoInstrumentation -Pscala-${{ matrix.scala }} --continue
+        timeout-minutes: 25
 
       - name: Capture build reports
         if: ${{ failure() }}


### PR DESCRIPTION
### Overview
This PR adds retry logic to the scala instrumentation GHA workflows.  It is essentially the same as what was added to the Java Instrumentation workflows. Timeouts are slightly different because the number of jobs and average finish times.

*This also removes the old github enterprise portion of the workflow.


Example run where first job failed and the retry succeeds. 
https://github.com/newrelic/newrelic-java-agent/actions/runs/4751877319/jobs/8441538352


