### PR TITLE
Add new Nodes metrics that include the consumed/produced topics

### DIFF
--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
@@ -77,15 +77,15 @@ public class MetricsScheduler {
                         }
                     }
                 }
-                if (METRICS_AS_EVENTS) {
-                    for (NewRelicMetricsReporter.NodeMetricName nodeMetricName : nrMetricsReporter.getNodes().values()) {
-                        eventData.put(nodeMetricName.asEventName(), 1f);
-                    }
-                } else {
-                    for (NewRelicMetricsReporter.NodeMetricName nodeMetricName : nrMetricsReporter.getNodes().values()) {
-                        NewRelic.recordMetric(nodeMetricName.getMetricName(), 1f);
+
+                for (NewRelicMetricsReporter.NodeMetricNames consumerNodeMetricNames : nrMetricsReporter.getNodes().values()) {
+                    if (METRICS_AS_EVENTS) {
+                        consumerNodeMetricNames.getEventNames().forEach(metricName -> eventData.put(metricName, 1f));
+                    } else {
+                        consumerNodeMetricNames.getMetricNames().forEach(metricName -> NewRelic.recordMetric(metricName, 1f));
                     }
                 }
+
                 if (METRICS_AS_EVENTS) {
                     NewRelic.getAgent().getInsights().recordCustomEvent(METRICS_EVENT_TYPE, eventData);
                 }

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
@@ -80,9 +80,13 @@ public class MetricsScheduler {
 
                 for (NewRelicMetricsReporter.NodeMetricNames consumerNodeMetricNames : nrMetricsReporter.getNodes().values()) {
                     if (METRICS_AS_EVENTS) {
-                        consumerNodeMetricNames.getEventNames().forEach(eventName -> eventData.put(eventName, 1f));
+                        for (String eventName : consumerNodeMetricNames.getEventNames()) {
+                            eventData.put(eventName, 1f);
+                        }
                     } else {
-                        consumerNodeMetricNames.getMetricNames().forEach(metricName -> NewRelic.recordMetric(metricName, 1f));
+                        for (String metricName : consumerNodeMetricNames.getMetricNames()) {
+                            NewRelic.recordMetric(metricName, 1f);
+                        }
                     }
                 }
 

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
@@ -80,7 +80,7 @@ public class MetricsScheduler {
 
                 for (NewRelicMetricsReporter.NodeMetricNames consumerNodeMetricNames : nrMetricsReporter.getNodes().values()) {
                     if (METRICS_AS_EVENTS) {
-                        consumerNodeMetricNames.getEventNames().forEach(metricName -> eventData.put(metricName, 1f));
+                        consumerNodeMetricNames.getEventNames().forEach(eventName -> eventData.put(eventName, 1f));
                     } else {
                         consumerNodeMetricNames.getMetricNames().forEach(metricName -> NewRelic.recordMetric(metricName, 1f));
                     }

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/NewRelicMetricsReporter.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/NewRelicMetricsReporter.java
@@ -90,7 +90,9 @@ public class NewRelicMetricsReporter implements MetricsReporter {
     }
 
     private void addTopicToNodeMetrics(String topic) {
-        nodes.values().forEach(nodeMetricNames -> nodeMetricNames.addMetricNameForTopic(topic));
+        for (NodeMetricNames nodeMetricNames : nodes.values()) {
+            nodeMetricNames.addMetricNameForTopic(topic);
+        }
     }
 
     @Override

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer_Instrumentation.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer_Instrumentation.java
@@ -7,9 +7,9 @@
 
 package org.apache.kafka.clients.consumer;
 
-import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
-import java.util.ArrayList;
+import java.util.Set;
 
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.common.errors.WakeupException;
@@ -41,11 +41,11 @@ public class KafkaConsumer_Instrumentation<K, V> {
     public KafkaConsumer_Instrumentation() {
         if (!initialized) {
             List<Node> nodes = metadata.fetch().nodes();
-            List<String> nodeNames = new ArrayList<>(nodes.size());
+            Set<String> nodeNames = new HashSet<>(nodes.size());
             for (Node node : nodes) {
                 nodeNames.add(node.host() + ":" + node.port());
             }
-            metrics.addReporter(new NewRelicMetricsReporter(nodeNames));
+            metrics.addReporter(new NewRelicMetricsReporter(nodeNames, NewRelicMetricsReporter.Mode.CONSUMER));
             initialized = true;
         }
     }

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
@@ -24,10 +24,11 @@ import com.nr.instrumentation.kafka.CallbackWrapper;
 import com.nr.instrumentation.kafka.NewRelicMetricsReporter;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.List;
-import java.util.ArrayList;
 
 @Weave(originalName = "org.apache.kafka.clients.producer.KafkaProducer")
 public class KafkaProducer_Instrumentation<K, V> {
@@ -43,11 +44,11 @@ public class KafkaProducer_Instrumentation<K, V> {
     public KafkaProducer_Instrumentation() {
         if (!initialized) {
             List<Node> nodes = metadata.fetch().nodes();
-            List<String> nodeNames = new ArrayList<>(nodes.size());
+            Set<String> nodeNames = new HashSet<>(nodes.size());
             for (Node node : nodes) {
                 nodeNames.add(node.host() + ":" + node.port());
             }
-            metrics.addReporter(new NewRelicMetricsReporter(nodeNames));
+            metrics.addReporter(new NewRelicMetricsReporter(nodeNames, NewRelicMetricsReporter.Mode.PRODUCER));
             initialized = true;
         }
     }


### PR DESCRIPTION
### Overview

These changes are a second iteration of [PR#1130](https://github.com/newrelic/newrelic-java-agent/pull/1130).
Since a service could have multiple Kafka consumers and producers, and each one could connect to different clusters, we want to introduce these new metrics to understand the relationship between consumers/producers, topics and nodes.

### Testing

Although `Kafka3MessageTest` is disabled because it's flaky on GHA, I added some more checks around the metrics I introduced and I checked that the tests pass locally.

### Checks

✅ Are your contributions backwards compatible with relevant frameworks and APIs? Yes
✅ Does your code contain any breaking changes? No
✅ Does your code introduce any new dependencies? No
