### PR TITLE
Repolinter

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Test Default Branch
         id: default-branch
-        uses: actions/github-script@v2
+        uses: actions/github-script@v6
         with:
           script: |
             const data = await github.repos.get(context.repo)

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const data = await github.repos.get(context.repo)
+            const data = await github.rest.repos.get(context.repo)
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}


### PR DESCRIPTION
### Overview
The repolinter action used a version of github-script that ran in Node12.
Github is retiring Node12, so that action needs to be updated for the workflow to continue working.
