### PR TITLE
exclude alphas on jedis

### DIFF
--- a/instrumentation/jedis-4.0.0/build.gradle
+++ b/instrumentation/jedis-4.0.0/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 verifyInstrumentation {
     passes 'redis.clients:jedis:[4.0.0,)'
     fails 'redis.clients:jedis:[1.4.0,3.8.0]'
-    excludeRegex 'redis.clients:jedis:.*-(m|rc|RC|beta)[0-9]*'
+    excludeRegex 'redis.clients:jedis:.*-(m|rc|RC|alpha|beta)[0-9]*'
     exclude 'redis.clients:jedis:3.6.2'
 
 }


### PR DESCRIPTION
exclude alphas on jedis
Jedis added a 5.0.0-alpha1. Our verifyInstrumentation didn't exclude alphas. Added that to the test config.
https://mvnrepository.com/artifact/redis.clients/jedis