### PR TITLE
bring infinite-tracing into regular tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ subprojects {
             'instrumentation',  // is a parent project
             'instrumentation-build', // is a build utility
             'newrelic-java', // this is a project used exclusively for bundling the zip file.
-            'infinite-tracing', // has its own plans
     ].contains(project.name)
     if (isJavaProject) {
         project.ext.javaProject = true

--- a/infinite-tracing/build.gradle.kts
+++ b/infinite-tracing/build.gradle.kts
@@ -26,12 +26,13 @@ java {
     }
 }
 
-tasks.test {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     testLogging {
         events("failed")
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.SHORT
     }
+
 }
 
 tasks.withType<GenerateModuleMetadata> {


### PR DESCRIPTION
This change brings the infinite-tracing module in line with how most of our other projects run tests:
tasks.withType<Test> {
}
is better than the test block because it is lazily evaluated
It also allows us to gain the jacoco config from the java.gradle build without any extra work to get the plugin to work in this format, which was proving problematic.
This separate PR is just to keep this change separated from the jacoco and codecov work since it is kind of a standalone change and improvement otherwise.

