### PR TITLE
Use some Java 7 and 8 utilities

### DIFF
--- a/functional_test/src/test/java/test/newrelic/test/agent/spans/SpanParentTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/spans/SpanParentTest.java
@@ -26,7 +26,6 @@ import com.newrelic.agent.service.analytics.TransactionEventsService;
 import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.agent.tracing.DistributedTracePayloadImpl;
 import com.newrelic.api.agent.*;
-import com.sun.jersey.core.util.Base64;
 import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -346,7 +345,7 @@ public class SpanParentTest {
     }
 
     private String findGuid(String headerValue) throws ParseException {
-        byte[] ar = Base64.decode(headerValue);
+        byte[] ar = Base64.getDecoder().decode(headerValue);
         String s = new String(ar);
         JSONParser parser = new JSONParser();
         JSONObject jsonObject = (JSONObject) parser.parse(s);

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -78,8 +78,6 @@ dependencies {
     shadowIntoJar 'net.sourceforge.jregex:jregex:1.2_01'
 
     shadowIntoJar 'org.apache.httpcomponents:httpclient:4.5.13'
-    // We use this explicitly for its Base64 class. It's also a dependency of httpclient.
-    shadowIntoJar("commons-codec:commons-codec:1.11")
     // We use StringUtils. Since we still support Java 7, we can't go much higher than this.
     shadowIntoJar("org.apache.commons:commons-lang3:3.8.1")
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/Murmur3StringMap.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/Murmur3StringMap.java
@@ -11,16 +11,15 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.newrelic.agent.util.StringMap;
-import org.apache.commons.codec.binary.Base64;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("UnstableApiUsage")
 public class Murmur3StringMap implements StringMap {
-    private static final Base64 base64 = new Base64();
     private final HashFunction hashFunction = Hashing.murmur3_128(394852370);
     private final Charset charSet = StandardCharsets.UTF_8;
 
@@ -42,8 +41,9 @@ public class Murmur3StringMap implements StringMap {
             key = string;
         } else {
             HashCode hash = hashFunction.newHasher().putString(string, charSet).hash();
-            byte[] asBytes = hash.asBytes();
-            key = new String(base64.encode(asBytes, 0, 8), StandardCharsets.US_ASCII);
+            final byte[] eightBytes = new byte[8];
+            hash.writeBytesTo(eightBytes, 0, 8);
+            key = new String(Base64.getEncoder().encode(eightBytes), StandardCharsets.US_ASCII);
         }
 
         stringMap.put(key, string);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/DistributedTracePayloadImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/DistributedTracePayloadImpl.java
@@ -7,20 +7,19 @@
 
 package com.newrelic.agent.tracing;
 
-import com.google.common.base.Charsets;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.DistributedTracePayload;
 import com.newrelic.agent.service.ServiceFactory;
-import org.apache.commons.codec.binary.Base64;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.logging.Level;
 
 import static com.newrelic.agent.tracing.DistributedTraceUtil.*;
 
 public class DistributedTracePayloadImpl implements DistributedTracePayload {
-    private static final Base64 base64 = new Base64();
 
     public final long timestamp;
     public final String parentType;
@@ -114,7 +113,7 @@ public class DistributedTracePayloadImpl implements DistributedTracePayload {
 
     @Override
     public String httpSafe() {
-        return base64.encodeAsString(text().getBytes(Charsets.UTF_8));
+        return Base64.getEncoder().encodeToString(text().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/DistributedTracePayloadParser.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/DistributedTracePayloadParser.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.tracing;
 
-import com.google.common.base.Charsets;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.logging.IAgentLogger;
 import com.newrelic.api.agent.MetricAggregator;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/DistributedTracePayloadParser.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/DistributedTracePayloadParser.java
@@ -11,18 +11,17 @@ import com.google.common.base.Charsets;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.logging.IAgentLogger;
 import com.newrelic.api.agent.MetricAggregator;
-import org.apache.commons.codec.binary.Base64;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.logging.Level;
 
 import static com.newrelic.agent.tracing.DistributedTraceUtil.*;
 
 public class DistributedTracePayloadParser {
-    private static final Base64 base64 = new Base64();
-
     private final MetricAggregator metricAggregator;
     private final DistributedTraceService distributedTraceService;
     private final IAgentLogger logger;
@@ -53,7 +52,7 @@ public class DistributedTracePayloadParser {
             char firstChar = payload.charAt(0);
             if (firstChar != '{') {
                 // This must be base64 encoded, decode it
-                payload = new String(base64.decode(payload), Charsets.UTF_8);
+                payload = new String(Base64.getDecoder().decode(payload), StandardCharsets.UTF_8);
             }
         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderWriter.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderWriter.java
@@ -14,11 +14,11 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
 import com.newrelic.agent.service.ServiceFactory;
-import org.apache.commons.codec.binary.Base64;
 import org.json.simple.JSONValue;
 
 /**
@@ -140,7 +140,7 @@ public class DataSenderWriter extends OutputStreamWriter {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return Base64.encodeBase64String(outStream.toByteArray());
+        return Base64.getEncoder().encodeToString(outStream.toByteArray());
     }
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/Obfuscator.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/Obfuscator.java
@@ -8,8 +8,7 @@
 package com.newrelic.agent.util;
 
 import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 
 /**
  * This class obfuscates and deobfuscates strings using a given key. It is used by the real user monitoring feature to
@@ -28,7 +27,7 @@ public class Obfuscator {
     public static String obfuscateNameUsingKey(String name, String key) {
         byte[] encodedBytes = name.getBytes(StandardCharsets.UTF_8);
         byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
-        return Base64.encodeBase64String(encode(encodedBytes, keyBytes));
+        return Base64.getEncoder().encodeToString(encode(encodedBytes, keyBytes));
     }
 
     private static byte[] encode(byte[] bytes, byte[] keyBytes) {
@@ -43,7 +42,7 @@ public class Obfuscator {
      *
      */
     public static String deobfuscateNameUsingKey(String name, String key) {
-        byte[] bytes = Base64.decodeBase64(name);
+        byte[] bytes = Base64.getDecoder().decode(name);
         byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
         return new String(encode(bytes, keyBytes), StandardCharsets.UTF_8);
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DataFetcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DataFetcher.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.utilization;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.MetricNames;
@@ -20,6 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
@@ -118,7 +118,7 @@ public class DataFetcher {
         // boot_id MUST be collected in Linux environments, otherwise it MUST be excluded from the hash.
         if (os.contains("linux")) {
             try {
-                String bootId = Files.asCharSource(new File("/proc/sys/kernel/random/boot_id"), Charsets.UTF_8).read().trim();
+                String bootId = Files.asCharSource(new File("/proc/sys/kernel/random/boot_id"), StandardCharsets.UTF_8).read().trim();
 
                 /* The agent MUST validate that /proc/sys/kernel/random/boot_id contains only ASCII characters. If the
                  * boot id contains non-ASCII characters, the agent MUST NOT send the boot_id key.

--- a/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
@@ -15,7 +15,6 @@ import com.newrelic.agent.modules.HttpModuleUtil;
 import com.newrelic.agent.modules.HttpModuleUtilImpl;
 import com.newrelic.agent.modules.ModuleUtil;
 import com.newrelic.agent.modules.ModuleUtilImpl;
-import org.apache.commons.codec.binary.Base64;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -26,6 +25,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.text.MessageFormat;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.zip.InflaterInputStream;
 
@@ -85,7 +85,7 @@ public class BootstrapAgent {
     }
 
     static String decodeAndDecompressAgentArguments(String agentArgs) throws IOException {
-        byte[] decodeBase64 = Base64.decodeBase64(agentArgs);
+        byte[] decodeBase64 = Base64.getDecoder().decode(agentArgs);
         InflaterInputStream zipStream = new InflaterInputStream(new ByteArrayInputStream(decodeBase64));
         return new BufferedReader(new InputStreamReader(zipStream)).readLine();
     }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/HeadersUtilTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/HeadersUtilTest.java
@@ -21,10 +21,10 @@ import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.agent.util.MockDistributedTraceService;
 import com.newrelic.api.agent.HeaderType;
 import com.newrelic.api.agent.InboundHeaders;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 
@@ -62,7 +62,7 @@ public class HeadersUtilTest {
         assertFalse(tx.sampled());
 
         assertTrue("map should contain newrelic header", map.containsKey("newrelic"));
-        String decodedHeader = new String(Base64.decodeBase64(map.get("newrelic")), StandardCharsets.UTF_8);
+        String decodedHeader = new String(Base64.getDecoder().decode(map.get("newrelic")), StandardCharsets.UTF_8);
         JsonObject jsonObject = new Gson().fromJson(decodedHeader, JsonObject.class);
         assertFalse("d.sa should be false because tx is not sampled", jsonObject.getAsJsonObject("d").get("sa").getAsBoolean());
         assertEquals("d.pr should be zero", 0f, jsonObject.getAsJsonObject("d").get("pr").getAsFloat(), 0.0001);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/JSONSerializerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/JSONSerializerTest.java
@@ -10,13 +10,13 @@ package com.newrelic.agent;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.google.common.base.Charsets;
 import com.newrelic.agent.profile.IProfile;
 import com.newrelic.agent.profile.ProfileData;
 import com.newrelic.agent.profile.ProfilerParameters;
@@ -130,7 +130,7 @@ public class JSONSerializerTest {
 
         Assert.assertNotNull(profileDataJson);
         // Check to make sure the profile data has a reasonable size
-        Assert.assertTrue(profileDataJson.getBytes(Charsets.UTF_8).length > 1024);
+        Assert.assertTrue(profileDataJson.getBytes(StandardCharsets.UTF_8).length > 1024);
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/database/DatabaseStatementResponseParserTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/database/DatabaseStatementResponseParserTest.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.database;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.newrelic.agent.MockCoreService;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
@@ -21,6 +20,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.text.MessageFormat;
@@ -515,7 +515,7 @@ public class DatabaseStatementResponseParserTest {
     public void testLargeHtmlTextSqlSlowdown() throws Exception {
         URL htmlFileUrl = this.getClass().getResource("/large_file.html");
         File htmlFile = new File(htmlFileUrl.getFile());
-        String largeHtmlText = Files.toString(htmlFile, Charsets.UTF_8);
+        String largeHtmlText = Files.toString(htmlFile, StandardCharsets.UTF_8);
 
         ParsedDatabaseStatement parsedStatement = parseStatement(
                 "Replace into table1 (col1, col2, col3, col4, col5) values ('string', 'string', '" + largeHtmlText + "', CURRENT_TIMESTAMP, int)");
@@ -529,7 +529,7 @@ public class DatabaseStatementResponseParserTest {
     public void testLargeSqlSlowdown() throws Exception {
         URL largeSqlFileUrl = this.getClass().getResource("/large_sql.sql");
         File largeSqlFile = new File(largeSqlFileUrl.getFile());
-        String largeSql = Files.toString(largeSqlFile, Charsets.UTF_8);
+        String largeSql = Files.toString(largeSqlFile, StandardCharsets.UTF_8);
         ParsedDatabaseStatement parsedStatement = parseStatement(largeSql);
 
         assertEquals("insert", parsedStatement.getOperation());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/database/SqlObfuscatorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/database/SqlObfuscatorTest.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.database;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.CharSource;
 import com.google.common.io.Files;
 import org.junit.Assert;
@@ -15,6 +14,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -269,7 +269,7 @@ public class SqlObfuscatorTest {
 
         URL htmlFileUrl = this.getClass().getResource("/html_ipsum.html");
         File htmlFile = new File(htmlFileUrl.getFile());
-        CharSource largeHtmlText = Files.asCharSource(htmlFile, Charsets.UTF_8);
+        CharSource largeHtmlText = Files.asCharSource(htmlFile, StandardCharsets.UTF_8);
         String rawSql = "Replace into table1 (col1, col2, col3, col4, col5) values ('string', 'string', '" + largeHtmlText +  "', CURRENT_TIMESTAMP, int)";
 
         String actualSql = sqlObfuscator.obfuscateSql(rawSql);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/profile/ProfileTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/profile/ProfileTest.java
@@ -26,7 +26,6 @@ import com.newrelic.agent.config.ConfigService;
 import com.newrelic.agent.config.ConfigServiceFactory;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.stats.TransactionStats;
-import org.apache.commons.codec.binary.Base64;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.Assert;
@@ -44,6 +43,7 @@ import java.lang.management.ThreadMXBean;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -666,7 +666,7 @@ public class ProfileTest {
             parsedData = data.get(4);
         } else {
             String rawData = (String) data.get(4);
-            byte[] compressedData = Base64.decodeBase64(rawData);
+            byte[] compressedData = Base64.getDecoder().decode(rawData);
 
             InflaterInputStream inStream = new InflaterInputStream(new ByteArrayInputStream(compressedData));
             rawData = CharStreams.toString(new InputStreamReader(inStream, Charsets.UTF_8));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/profile/ProfileTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/profile/ProfileTest.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.profile;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
@@ -647,10 +646,10 @@ public class ProfileTest {
         // After verifying data size, inflate the data to parse the json
         if (simpleCompression) {
             InflaterInputStream inStream = new InflaterInputStream(new ByteArrayInputStream(profileOutput));
-            String jsonOutput = CharStreams.toString(new InputStreamReader(inStream, Charsets.UTF_8));
+            String jsonOutput = CharStreams.toString(new InputStreamReader(inStream, StandardCharsets.UTF_8));
             parse = parser.parse(jsonOutput);
         } else {
-            parse = parser.parse(new String(profileOutput, Charsets.UTF_8));
+            parse = parser.parse(new String(profileOutput, StandardCharsets.UTF_8));
         }
         Assert.assertTrue(parse instanceof List);
 
@@ -669,7 +668,7 @@ public class ProfileTest {
             byte[] compressedData = Base64.getDecoder().decode(rawData);
 
             InflaterInputStream inStream = new InflaterInputStream(new ByteArrayInputStream(compressedData));
-            rawData = CharStreams.toString(new InputStreamReader(inStream, Charsets.UTF_8));
+            rawData = CharStreams.toString(new InputStreamReader(inStream, StandardCharsets.UTF_8));
             parsedData = parser.parse(rawData);
         }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/ProfileTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/ProfileTest.java
@@ -23,7 +23,6 @@ import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.threads.BasicThreadInfo;
 import com.newrelic.agent.threads.ThreadNameNormalizer;
 import com.newrelic.agent.trace.TransactionGuidFactory;
-import org.apache.commons.codec.binary.Base64;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.Assert;
@@ -41,6 +40,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -606,7 +606,7 @@ public class ProfileTest {
             parsedData = data.get(4);
         } else {
             String rawData = (String) data.get(4);
-            byte[] compressedData = Base64.decodeBase64(rawData);
+            byte[] compressedData = Base64.getDecoder().decode(rawData);
 
             InflaterInputStream inStream = new InflaterInputStream(new ByteArrayInputStream(compressedData));
             rawData = CharStreams.toString(new InputStreamReader(inStream, Charsets.UTF_8));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/ProfileTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/ProfileTest.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.profile.v2;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import com.newrelic.agent.MockServiceManager;
@@ -38,6 +37,7 @@ import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -587,10 +587,10 @@ public class ProfileTest {
         // After verifying data size, inflate the data to parse the json
         if (simpleCompression) {
             InflaterInputStream inStream = new InflaterInputStream(new ByteArrayInputStream(profileOutput));
-            String jsonOutput = CharStreams.toString(new InputStreamReader(inStream, Charsets.UTF_8));
+            String jsonOutput = CharStreams.toString(new InputStreamReader(inStream, StandardCharsets.UTF_8));
             parse = parser.parse(jsonOutput);
         } else {
-            parse = parser.parse(new String(profileOutput, Charsets.UTF_8));
+            parse = parser.parse(new String(profileOutput, StandardCharsets.UTF_8));
         }
         Assert.assertTrue(parse instanceof List);
 
@@ -609,7 +609,7 @@ public class ProfileTest {
             byte[] compressedData = Base64.getDecoder().decode(rawData);
 
             InflaterInputStream inStream = new InflaterInputStream(new ByteArrayInputStream(compressedData));
-            rawData = CharStreams.toString(new InputStreamReader(inStream, Charsets.UTF_8));
+            rawData = CharStreams.toString(new InputStreamReader(inStream, StandardCharsets.UTF_8));
             parsedData = parser.parse(rawData);
         }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/sql/SqlTraceServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/sql/SqlTraceServiceTest.java
@@ -52,7 +52,6 @@ import com.newrelic.agent.tracers.servlet.MockHttpRequest;
 import com.newrelic.agent.tracers.servlet.MockHttpResponse;
 import com.newrelic.agent.tracing.DistributedTraceServiceImpl;
 import com.newrelic.api.agent.ApplicationNamePriority;
-import org.apache.commons.codec.binary.Base64;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.JSONParser;
@@ -73,6 +72,7 @@ import java.io.Writer;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -747,7 +747,7 @@ public class SqlTraceServiceTest {
     }
 
     private Object decodeParams(Object object) {
-        byte[] bytes = Base64.decodeBase64(object.toString());
+        byte[] bytes = Base64.getDecoder().decode(object.toString());
         ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
         InputStream zipStream = new InflaterInputStream(inputStream);
         Reader in = new InputStreamReader(zipStream);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/trace/TransactionTraceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/trace/TransactionTraceTest.java
@@ -45,7 +45,6 @@ import com.newrelic.agent.tracers.metricname.SimpleMetricNameFormat;
 import com.newrelic.agent.tracing.DistributedTraceServiceImpl;
 import com.newrelic.agent.transaction.PriorityTransactionName;
 import com.newrelic.agent.transaction.TransactionTimer;
-import org.apache.commons.codec.binary.Base64;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -63,6 +62,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -1128,7 +1128,7 @@ public class TransactionTraceTest {
     }
 
     private Object decodeTransactionTraceData(Object object) {
-        byte[] bytes = Base64.decodeBase64(object.toString());
+        byte[] bytes = Base64.getDecoder().decode(object.toString());
         ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
         InputStream zipStream = new InflaterInputStream(inputStream);
         Reader in = new InputStreamReader(zipStream);


### PR DESCRIPTION
### Overview

1. Replace commons-codec Base64 with [Java 8's version](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html). This doesn't remove commons-codec because it's still a dependency of the httpclient 4.5. `Base64.getEncoder()` and `Base64.getDecoder()` return static constants so there's no construction or allocation happening.
2. Replace guava's Charsets constants with Java 7's [StandardCharsets](https://docs.oracle.com/javase/7/docs/api/java/nio/charset/StandardCharsets.html#UTF_8). The Javadoc implies that the members are deprecated in Java 7.

### Related Github Issue

none

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs? -- yes
[x] Does your code contain any breaking changes? Please describe. -- no
[x] Does your code introduce any new dependencies? Please describe. -- no
