### PR TITLE
Update spotbugs-config.gradle

### DIFF
--- a/gradle/script/spotbugs-config.gradle
+++ b/gradle/script/spotbugs-config.gradle
@@ -1,8 +1,5 @@
 
-def isSpotbugsEligible = ['newrelic-agent', 'newrelic-weaver', 'agent-bridge', 'agent-bridge-datastore', 'agent-model', 'agent-interfaces', 'newrelic-api'].contains(project.name)
-if (isSpotbugsEligible) {
-    apply plugin: 'com.github.spotbugs'
-}
+apply plugin: 'com.github.spotbugs'
 
 spotbugs {
     ignoreFailures = true


### PR DESCRIPTION
### Overview
Since the modules that include the spotbugs-config.gradle file are the ones that pass that logic, there is no need to do the check.
