### PR TITLE
Verify instrumentation fix

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -19,9 +19,6 @@ runs:
           11
           8
 
-    - name: Check Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
-
     - name: set gradle.properties
       shell: bash
       run: |

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -69,5 +69,8 @@ jobs:
           path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: ${{ github.run_id }}
 
+      # Verify instrumentation must run with Java 17
       - name: Running verifyInstrumentation on (${{ matrix.modules }})
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
         run: ./gradlew $GRADLE_OPTIONS --info :instrumentation:${{ matrix.modules }}:verifyInstrumentation


### PR DESCRIPTION
### Overview
Makes the Verify Instrumentation job run using Java 17.
Also removes the gradle wrapper verification, which causes lots of failures due to the Gradle servers not responding.
