### PR TITLE
Java 8 improvements

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/TimedTokenSet.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TimedTokenSet.java
@@ -67,15 +67,11 @@ public class TimedTokenSet implements TimedSet<TokenImpl> {
                             // cause for expiring one is the same as for expiring all (EXPLICIT). So markExpire needs to be
                             // called in either case, since it doesn't hurt to null out the tracer again, and it still needs
                             // to happen in the expire all case.
-                            expirationService.expireToken(new Runnable() {
-                                @Override
-                                public void run() {
-                                    // In the case of a token being expired we *must* spin off the work on to a
-                                    // second thread in order to prevent a possible deadlock between the expire code
-                                    // and other tx usages.
-                                    token.markExpired();
-                                }
-                            });
+                            //
+                            // In the case of a token being expired we *must* spin off the work on to a
+                            // second thread in order to prevent a possible deadlock between the expire code
+                            // and other tx usages.
+                            expirationService.expireToken(token::markExpired);
                         }
                     }
                 }).build();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -219,12 +219,7 @@ public class Transaction {
     // The appNameAndConfig combo has a deceptively complex behavior: we want both threadsafe lazy
     // initialization with lock-free updates. Setters must have priority over initialization.
 
-    private Callable<AppNameAndConfig> appNameAndConfigInitializer = new Callable<AppNameAndConfig>() {
-        @Override
-        public AppNameAndConfig call() throws Exception {
-            return AppNameAndConfig.getDefault();
-        }
-    };
+    private Callable<AppNameAndConfig> appNameAndConfigInitializer = AppNameAndConfig::getDefault;
     private LazyAtomicReference<AppNameAndConfig> appNameAndConfig = new LazyAtomicReference<>(appNameAndConfigInitializer);
 
     // (4) State that is guarded using the lock. Referenced objects must be threadsafe.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
@@ -192,14 +192,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
                 Agent.LOG.fine("Adding " + name + " as a Trace annotation");
                 internalizedNames.add(internalizeName(name));
             }
-            matchers.add(new AnnotationMatcher() {
-
-                @Override
-                public boolean matches(String annotationDesc) {
-                    return internalizedNames.contains(annotationDesc);
-                }
-
-            });
+            matchers.add(internalizedNames::contains);
         }
         return OrAnnotationMatcher.getOrMatcher(matchers.toArray(new AnnotationMatcher[0]));
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/LabelsConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/LabelsConfigImpl.java
@@ -122,12 +122,7 @@ public class LabelsConfigImpl implements LabelsConfig, JSONStreamAware {
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             final String name = entry.getKey();
             final String value = entry.getValue();
-            jsonLabels.add(new JSONStreamAware() {
-                @Override
-                public void writeJSONString(Writer out) throws IOException {
-                    JSONObject.writeJSONString(ImmutableMap.of("label_type", name, "label_value", value), out);
-                }
-            });
+            jsonLabels.add(out1 -> JSONObject.writeJSONString(ImmutableMap.of("label_type", name, "label_value", value), out1));
         }
         JSONArray.writeJSONString(jsonLabels, out);
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/core/CoreServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/core/CoreServiceImpl.java
@@ -63,13 +63,7 @@ public class CoreServiceImpl extends AbstractService implements CoreService {
         initializeBridgeApis();
 
         final long startTime = System.currentTimeMillis();
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                jvmShutdown(startTime);
-            }
-        };
-        Thread shutdownThread = new Thread(runnable, "New Relic JVM Shutdown");
+        Thread shutdownThread = new Thread(() -> jvmShutdown(startTime), "New Relic JVM Shutdown");
         Runtime.getRuntime().addShutdownHook(shutdownThread);
     }
 
@@ -96,13 +90,7 @@ public class CoreServiceImpl extends AbstractService implements CoreService {
 
     @Override
     public void shutdownAsync() {
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                shutdown();
-            }
-        };
-        Thread shutdownThread = new Thread(runnable, "New Relic Shutdown");
+        Thread shutdownThread = new Thread(this::shutdown, "New Relic Shutdown");
         shutdownThread.start();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
@@ -42,24 +42,9 @@ public class WebRequestDispatcher extends DefaultDispatcher implements WebRespon
 
     private static final String UNKNOWN_URI = "/Unknown";
 
-    private static final StatusCodePolicy LAST_STATUS_CODE_POLICY = new StatusCodePolicy() {
-        @Override
-        public int nextStatus(int currentStatus, int lastStatus) {
-            return lastStatus;
-        }
-    };
-    private static final StatusCodePolicy ERROR_STATUS_CODE_POLICY = new StatusCodePolicy() {
-        @Override
-        public int nextStatus(int currentStatus, int lastStatus) {
-            return currentStatus < HttpURLConnection.HTTP_BAD_REQUEST ? lastStatus : currentStatus;
-        }
-    };
-    private static final StatusCodePolicy FREEZE_STATUS_CODE_POLICY = new StatusCodePolicy() {
-        @Override
-        public int nextStatus(int currentStatus, int lastStatus) {
-            return currentStatus;
-        }
-    };
+    private static final StatusCodePolicy LAST_STATUS_CODE_POLICY = (currentStatus, lastStatus) -> lastStatus;
+    private static final StatusCodePolicy ERROR_STATUS_CODE_POLICY = (currentStatus, lastStatus) -> currentStatus < HttpURLConnection.HTTP_BAD_REQUEST ? lastStatus : currentStatus;
+    private static final StatusCodePolicy FREEZE_STATUS_CODE_POLICY = (currentStatus, lastStatus) -> currentStatus;
     private final AtomicBoolean responseRecorded = new AtomicBoolean(false);
     private volatile Request request;
     private volatile Response response;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
@@ -271,13 +271,7 @@ public class ExtensionService extends AbstractService implements HarvestListener
 
     private void reloadWeaveInstrumentationIfModified() {
         File[] jarFiles = getExtensionFiles(ExtensionFileTypes.JAR.getFilter());
-        Collection<File> weaveFiles = Collections2.filter(Arrays.asList(jarFiles), new Predicate<File>() {
-            @Override
-            public boolean apply(File extension) {
-                boolean isWeave = JarExtension.isWeaveInstrumentation(extension);
-                return isWeave;
-            }
-        });
+        Collection<File> weaveFiles = Collections2.filter(Arrays.asList(jarFiles), JarExtension::isWeaveInstrumentation);
 
         Collection<File> newWeaveFiles = new HashSet<>();
         Collection<File> removedWeaveFiles = new HashSet<>();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionsLoadedListener.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionsLoadedListener.java
@@ -13,9 +13,6 @@ import java.util.Set;
 public interface ExtensionsLoadedListener {
     void loaded(Set<File> extensions);
 
-    ExtensionsLoadedListener NOOP = new ExtensionsLoadedListener() {
-        @Override
-        public void loaded(Set<File> extensions) {
-        }
+    ExtensionsLoadedListener NOOP = extensions -> {
     };
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/AbstractTracingMethodAdapter.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/AbstractTracingMethodAdapter.java
@@ -205,13 +205,9 @@ abstract class AbstractTracingMethodAdapter extends AdviceAdapter {
     }
 
     protected final void invokeTraceFinishWithThrowable(final int exceptionVar) {
-        methodBuilder.loadUnsuccessful().loadArray(Object.class, new Runnable() {
-            @Override
-            public void run() {
-                visitVarInsn(ALOAD, exceptionVar);
-            }
-        }).invokeInvocationHandlerInterface(true);
-
+        methodBuilder.loadUnsuccessful()
+                .loadArray(Object.class, (Runnable) () -> visitVarInsn(ALOAD, exceptionVar))
+                .invokeInvocationHandlerInterface(true);
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
@@ -113,13 +113,7 @@ public class ClassTransformerServiceImpl extends AbstractService implements Clas
     }
 
     private void queueRetransform() {
-        executor.schedule(new Runnable() {
-
-            @Override
-            public void run() {
-                retransformMatchingClasses();
-            }
-        }, getRetransformPeriodInSeconds(), TimeUnit.SECONDS);
+        executor.schedule(() -> retransformMatchingClasses(), getRetransformPeriodInSeconds(), TimeUnit.SECONDS);
     }
 
     private long getRetransformPeriodInSeconds() {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/OptimizedClassMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/OptimizedClassMatcher.java
@@ -95,14 +95,7 @@ public final class OptimizedClassMatcher implements ClassMatchVisitorFactory {
         return new ClassMethods(loader, reader, classBeingRedefined, cv, context);
     }
 
-    static final Supplier<Set<String>> STRING_COLLECTION_SUPPLIER = new Supplier<Set<String>>() {
-
-        @Override
-        public Set<String> get() {
-            return new HashSet<>();
-        }
-
-    };
+    static final Supplier<Set<String>> STRING_COLLECTION_SUPPLIER = HashSet::new;
 
     private Multimap<ClassAndMethodMatcher, String> newClassMatches() {
 
@@ -200,14 +193,7 @@ public final class OptimizedClassMatcher implements ClassMatchVisitorFactory {
 
         private SetMultimap<Method, ClassAndMethodMatcher> getOrCreateMatches() {
             if (matches == null) {
-                matches = Multimaps.newSetMultimap(new HashMap<Method, Collection<ClassAndMethodMatcher>>(),
-                        new Supplier<Set<ClassAndMethodMatcher>>() {
-
-                            @Override
-                            public Set<ClassAndMethodMatcher> get() {
-                                return new HashSet<>();
-                            }
-                        });
+                matches = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
             }
             return matches;
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/OptimizedClassMatcherBuilder.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/OptimizedClassMatcherBuilder.java
@@ -35,26 +35,20 @@ public class OptimizedClassMatcherBuilder {
         return new OptimizedClassMatcherBuilder();
     }
 
-    private static final Supplier<Set<ClassAndMethodMatcher>> CLASS_AND_METHOD_MATCHER_SET_SUPPLIER = new Supplier<Set<ClassAndMethodMatcher>>() {
-
-        @Override
-        public Set<ClassAndMethodMatcher> get() {
-            return Collections.newSetFromMap(new HashMap<ClassAndMethodMatcher, Boolean>());
-        }
-    };
+    private static final Supplier<Set<ClassAndMethodMatcher>> CLASS_AND_METHOD_MATCHER_SET_SUPPLIER = () -> Collections.newSetFromMap(new HashMap<>());
 
     /**
-     * A map of method matchers to their ClassAndMethodMatcher. This will contains method matchers which loosely match
+     * A map of method matchers to their ClassAndMethodMatcher. This will contain method matchers which loosely match
      * methods, like the {@link AllMethodsMatcher} or {@link ExactParamsMethodMatcher}.
      */
     private final SetMultimap<MethodMatcher, ClassAndMethodMatcher> methodMatchers = Multimaps.newSetMultimap(
-            new HashMap<MethodMatcher, Collection<ClassAndMethodMatcher>>(), CLASS_AND_METHOD_MATCHER_SET_SUPPLIER);
+            new HashMap<>(), CLASS_AND_METHOD_MATCHER_SET_SUPPLIER);
 
     /**
      * A set multimap of exact methods to match to the ClassAndMethodMatchers which match them.
      */
     private final SetMultimap<Method, ClassAndMethodMatcher> methods = Multimaps.newSetMultimap(
-            new HashMap<Method, Collection<ClassAndMethodMatcher>>(), CLASS_AND_METHOD_MATCHER_SET_SUPPLIER);
+            new HashMap<>(), CLASS_AND_METHOD_MATCHER_SET_SUPPLIER);
 
     /**
      * A set of method annotation descriptors to match. Note that the class matchers of this guys are not used.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassMatchVisitorFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassMatchVisitorFactory.java
@@ -19,12 +19,6 @@ public interface ClassMatchVisitorFactory {
     ClassVisitor newClassMatchVisitor(ClassLoader loader, Class<?> classBeingRedefined, ClassReader reader,
             ClassVisitor cv, InstrumentationContext context);
 
-    ClassMatchVisitorFactory NO_OP_FACTORY = new ClassMatchVisitorFactory() {
-        @Override
-        public ClassVisitor newClassMatchVisitor(ClassLoader loader, Class<?> classBeingRedefined, ClassReader reader, ClassVisitor cv,
-                InstrumentationContext context) {
-            return null;
-        }
-    };
+    ClassMatchVisitorFactory NO_OP_FACTORY = (loader, classBeingRedefined, reader, cv, context) -> null;
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
@@ -88,14 +88,7 @@ public class FlyweightTraceMethodVisitor extends AdviceAdapter {
     private Map<Method, Handler> getTracedMethodMethodHandlers() {
         Map<Method, Handler> map = new HashMap<>();
 
-        map.put(new Method("getMetricName", "()Ljava/lang/String;"), new Handler() {
-
-            @Override
-            public void handle(AdviceAdapter mv) {
-
-                mv.loadLocal(metricNameLocal);
-            }
-        });
+        map.put(new Method("getMetricName", "()Ljava/lang/String;"), mv -> mv.loadLocal(metricNameLocal));
 
         map.put(new Method("setMetricName", "([Ljava/lang/String;)V"), new Handler() {
 
@@ -145,13 +138,7 @@ public class FlyweightTraceMethodVisitor extends AdviceAdapter {
         addUnsupportedMethod(map, new Method("addCustomAttribute", "(Ljava/lang/String;Z)V"));
         addUnsupportedMethod(map, new Method("addCustomAttributes", "(Ljava/util/Map;)V"));
 
-        map.put(new Method("getParentTracedMethod", "()Lcom/newrelic/agent/bridge/TracedMethod;"), new Handler() {
-
-            @Override
-            public void handle(AdviceAdapter mv) {
-                mv.loadLocal(parentTracerLocal);
-            }
-        });
+        map.put(new Method("getParentTracedMethod", "()Lcom/newrelic/agent/bridge/TracedMethod;"), mv -> mv.loadLocal(parentTracerLocal));
 
         return map;
     }
@@ -276,12 +263,7 @@ public class FlyweightTraceMethodVisitor extends AdviceAdapter {
         // System.nanoTime when those values are
         // encountered
         long startTime = loader.loadLocal(startTimeLocal, Type.LONG_TYPE, -1L);
-        long loadEndTime = loader.load(-2l, new Runnable() {
-            @Override
-            public void run() {
-                invokeStatic(Type.getType(System.class), new Method("nanoTime", Type.LONG_TYPE, new Type[0]));
-            }
-        });
+        long loadEndTime = loader.load(-2l, () -> invokeStatic(Type.getType(System.class), new Method("nanoTime", Type.LONG_TYPE, new Type[0])));
 
         Transaction transactionApi = builder.build();
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/TraceMethodVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/TraceMethodVisitor.java
@@ -121,13 +121,7 @@ public class TraceMethodVisitor extends AdviceAdapter {
 
         } else {
 
-            Object[] loadArgs = loader.load(Object[].class, new Runnable() {
-
-                @Override
-                public void run() {
-                    loadArgArray();
-                }
-            });
+            Object[] loadArgs = loader.load(Object[].class, this::loadArgArray);
 
             instrumentation.createTracer(loader.loadThis(this.access), signatureId, traceDetails.dispatcher(),
                     metricName, tracerFactory, loadArgs);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/preprocessors/AgentPreprocessors.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/preprocessors/AgentPreprocessors.java
@@ -198,12 +198,7 @@ public class AgentPreprocessors implements WeavePreprocessor {
                         final int throwableLocal = newLocal(Type.getType(Throwable.class));
                         storeLocal(throwableLocal);
 
-                        Runnable throwableMessage = new Runnable() {
-                            @Override
-                            public void run() {
-                                loadLocal(throwableLocal);
-                            }
-                        };
+                        Runnable throwableMessage = () -> loadLocal(throwableLocal);
 
                         BridgeUtils.getLogger(this).logToChild(weavePackageName, Level.FINE,
                                 "{0}.{1}{2} threw an exception: {3}", className, name, desc, throwableMessage);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/normalization/NormalizationRuleFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/normalization/NormalizationRuleFactory.java
@@ -113,14 +113,7 @@ public class NormalizationRuleFactory {
     }
 
     private static void sortRules(List<NormalizationRule> rules) {
-        Collections.sort(rules, new Comparator<NormalizationRule>() {
-            @Override
-            public int compare(NormalizationRule lhs, NormalizationRule rhs) {
-                Integer lhsOrder = lhs.getOrder();
-                Integer rhsOrder = rhs.getOrder();
-                return lhsOrder.compareTo(rhsOrder);
-            }
-        });
+        rules.sort(Comparator.comparing(NormalizationRule::getOrder));
     }
 
     private static NormalizationRule createRule(Map<String, Object> ruleData) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/ProfileSegment.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/ProfileSegment.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.profile;
 
-import com.google.common.collect.Maps;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONStreamAware;
 
@@ -17,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,7 +29,7 @@ public class ProfileSegment implements JSONStreamAware {
     private final ProfiledMethod method;
     private int runnableCallCount = 0;
     private int nonrunnableCallCount = 0;
-    private final Map<ProfiledMethod, ProfileSegment> children = Maps.newIdentityHashMap();
+    private final Map<ProfiledMethod, ProfileSegment> children = new IdentityHashMap<>();
 
     /**
      * Parameters are guaranteed to be non-null.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/ProfileTree.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/ProfileTree.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.profile;
 
-import com.google.common.collect.Maps;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONStreamAware;
 
@@ -17,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,7 +28,7 @@ import java.util.Set;
  */
 public class ProfileTree implements JSONStreamAware {
 
-    private final Map<ProfiledMethod, ProfileSegment> rootSegments = Maps.newIdentityHashMap();
+    private final Map<ProfiledMethod, ProfileSegment> rootSegments = new IdentityHashMap<>();
     /**
      * A map of stack trace elements to ProfiledMethods. This helps us create fewer {@link ProfiledMethod} instances and
      * allows us to use identity hashmaps.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/Profile.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/Profile.java
@@ -123,12 +123,7 @@ public class Profile implements IProfile {
     }
     
     CacheLoader<String, ProfileTree> createCacheLoader(final boolean reportCpu) {
-        return new CacheLoader<String, ProfileTree>() {
-            @Override
-            public ProfileTree load(String key) throws Exception {
-                return new ProfileTree(Profile.this, reportCpu);
-            }
-        };
+        return key -> new ProfileTree(Profile.this, reportCpu);
     }
 
     private Map<Long, Long> getThreadCpuTimes() {        

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/ProfiledMethod.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/ProfiledMethod.java
@@ -125,14 +125,7 @@ public class ProfiledMethod implements JSONStreamAware {
             data.add(info.getJsonMethodMaps(stringMap));
         }
         
-        return new JSONStreamAware() {
-
-            @Override
-            public void writeJSONString(Writer out) throws IOException {
-                JSONArray.writeJSONString(data, out);
-            }
-            
-        };
+        return out -> JSONArray.writeJSONString(data, out);
     }
     
     void setMethodInfo(MethodInfo methodInfo) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/ProfilerService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/v2/ProfilerService.java
@@ -29,12 +29,7 @@ public class ProfilerService extends AbstractService implements ProfilerControl 
 
     private volatile ProfileSession currentSession;
     private final ScheduledExecutorService scheduledExecutor;
-    private final TransactionListener transactionListener = new TransactionListener() {                    
-        @Override
-        public void dispatcherTransactionFinished(TransactionData transactionData, TransactionStats transactionStats) {
-            transactionFinished(transactionData);
-        }
-    };
+    private final TransactionListener transactionListener = (transactionData, transactionStats) -> transactionFinished(transactionData);
 
     private final TransactionProfileService transactionProfileService;
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceTiming.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceTiming.java
@@ -22,12 +22,7 @@ import java.util.logging.Level;
  */
 public class ServiceTiming {
 
-    private static final Comparator<ServiceNameAndTime> serviceNameComparator = new Comparator<ServiceNameAndTime>() {
-        @Override
-        public int compare(ServiceNameAndTime service1, ServiceNameAndTime service2) {
-            return service1.serviceName.compareTo(service2.serviceName);
-        }
-    };
+    private static final Comparator<ServiceNameAndTime> serviceNameComparator = Comparator.comparing(ServiceNameAndTime::getServiceName);
 
     private static final Map<ServiceNameAndType, Long> serviceTimings = new LinkedHashMap<>();
     private static final Set<ServiceNameAndTime> serviceInitializationTimings = new TreeSet<>(serviceNameComparator);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/SpanEventsServiceFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/SpanEventsServiceFactory.java
@@ -89,15 +89,12 @@ public class SpanEventsServiceFactory {
     }
 
     private void configureUpdateOnConfigChange(final Map<String, SpanErrorBuilder> errorBuilderForApp) {
-        configService.addIAgentConfigListener(new AgentConfigListener() {
-            @Override
-            public void configChanged(String appName, AgentConfig agentConfig) {
+        configService.addIAgentConfigListener((appName, agentConfig) ->
                 errorBuilderForApp.put(agentConfig.getApplicationName(), new SpanErrorBuilder(
                         new ErrorAnalyzerImpl(agentConfig.getErrorCollectorConfig()),
                         new ErrorMessageReplacer(agentConfig.getStripExceptionConfig())
-                ));
-            }
-        });
+                ))
+        );
     }
 
     private Map<String, SpanErrorBuilder> buildSpanEventErrorBuilder(AgentConfig agentConfig, SpanErrorBuilder spanErrorBuilder) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/DistributedSamplingPriorityQueue.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/DistributedSamplingPriorityQueue.java
@@ -55,12 +55,7 @@ public class DistributedSamplingPriorityQueue<E extends PriorityAware> implement
     public DistributedSamplingPriorityQueue(String appName, String serviceName, int reservoirSize, int decidedLast, int target, Comparator<E> comparator) {
         this.appName = appName;
         this.serviceName = serviceName;
-        this.comparator = comparator == null ? new Comparator<E>() {
-            @Override
-            public int compare(E left, E right) {
-                return Float.compare(right.getPriority(), left.getPriority());
-            }
-        } : comparator;
+        this.comparator = comparator == null ? (left, right) -> Float.compare(right.getPriority(), left.getPriority()) : comparator;
         this.data = createQueue(reservoirSize, this.comparator);
         this.recorded = new AtomicInteger(0);
         this.decidedLast = decidedLast;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -41,12 +41,7 @@ public class SpanEventFactory {
     // Truncate `db.statement` at 2000 characters
     private static final int DB_STATEMENT_TRUNCATE_LENGTH = 2000;
 
-    public static Supplier<Long> DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER = new Supplier<Long>() {
-        @Override
-        public Long get() {
-            return System.currentTimeMillis();
-        }
-    };
+    public static Supplier<Long> DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER = System::currentTimeMillis;
 
     private final SpanEvent.Builder builder = SpanEvent.builder();
     private final String appName;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
@@ -199,12 +199,7 @@ public class TracerToSpanEvent {
     }
 
     private Map<String, ?> filterAttributes(Map<String, ?> intrinsicAttributes) {
-        return Maps.filterKeys(intrinsicAttributes, new Predicate<String>() {
-            @Override
-            public boolean apply(String key) {
-                return !UNWANTED_SPAN_ATTRIBUTES.contains(key);
-            }
-        });
+        return Maps.filterKeys(intrinsicAttributes, key -> !UNWANTED_SPAN_ATTRIBUTES.contains(key));
     }
 
     private String getParentId(Tracer tracer, TransactionData transactionData, boolean crossProcessOnly) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/asm/AnnotationDetails.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/asm/AnnotationDetails.java
@@ -57,14 +57,7 @@ public class AnnotationDetails extends AnnotationVisitor {
 
     Multimap<String, Object> getOrCreateAttributes() {
         if (attributes == null) {
-            attributes = Multimaps.newListMultimap(new HashMap<String, Collection<Object>>(),
-                    new Supplier<List<Object>>() {
-
-                        @Override
-                        public List<Object> get() {
-                            return new ArrayList<>();
-                        }
-                    });
+            attributes = Multimaps.newListMultimap(new HashMap<>(), ArrayList::new);
         }
         return attributes;
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/asm/BytecodeGenProxyBuilder.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/asm/BytecodeGenProxyBuilder.java
@@ -280,14 +280,7 @@ public class BytecodeGenProxyBuilder<T> {
 
         @Override
         public <N extends Number> N loadLocal(final int local, final Type type, final N value) {
-            Runnable r = new Runnable() {
-
-                @Override
-                public void run() {
-
-                    methodAdapter.loadLocal(local, type);
-                }
-            };
+            Runnable r = () -> methodAdapter.loadLocal(local, type);
             return load(value, r);
         }
 
@@ -357,13 +350,7 @@ public class BytecodeGenProxyBuilder<T> {
          */
         @Override
         public <O> O loadLocal(final int localId, final Class<O> clazz) {
-            return load(clazz, new Runnable() {
-
-                @Override
-                public void run() {
-                    methodAdapter.loadLocal(localId, Type.getType(clazz));
-                }
-            });
+            return load(clazz, () -> methodAdapter.loadLocal(localId, Type.getType(clazz)));
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/CloudUtility.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/CloudUtility.java
@@ -35,12 +35,7 @@ public class CloudUtility {
     private final Function<Integer, CloseableHttpClient> httpClientCreator;
 
     public CloudUtility() {
-        this(new Function<Integer, CloseableHttpClient>() {
-            @Override
-            public CloseableHttpClient apply(Integer requestTimeoutMillis) {
-                return configureHttpClient(requestTimeoutMillis);
-            }
-        });
+        this(CloudUtility::configureHttpClient);
     }
 
     CloudUtility(Function<Integer, CloseableHttpClient> httpClientCreator) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracing/W3CTraceContextCrossAgentTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracing/W3CTraceContextCrossAgentTest.java
@@ -8,7 +8,6 @@
 package com.newrelic.agent.tracing;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.newrelic.agent.*;
 import com.newrelic.agent.attributes.AttributesService;
 import com.newrelic.agent.attributes.CrossAgentInput;
@@ -97,14 +96,14 @@ public class W3CTraceContextCrossAgentTest {
         serviceManager = new MockServiceManager();
         ServiceFactory.setServiceManager(serviceManager);
 
-        Map<String, Object> config = Maps.newHashMap();
+        Map<String, Object> config = new HashMap<>();
         config.put(AgentConfigImpl.APP_NAME, APP_NAME);
 
-        Map<String, Object> dtConfig = Maps.newHashMap();
+        Map<String, Object> dtConfig = new HashMap<>();
         dtConfig.put("enabled", true);
         dtConfig.put("exclude_newrelic_header", true);
         config.put("distributed_tracing", dtConfig);
-        Map<String, Object> spanConfig = Maps.newHashMap();
+        Map<String, Object> spanConfig = new HashMap<>();
         spanConfig.put("collect_span_events", true);
         config.put("span_events", spanConfig);
 
@@ -194,7 +193,7 @@ public class W3CTraceContextCrossAgentTest {
                 intrinsics == null ? Collections.<String, Object>emptyMap() : (Map<String, Object>) intrinsics.get("Transaction");
         Map<String, Object> spanAssertions = intrinsics == null ? Collections.<String, Object>emptyMap() : (Map<String, Object>) intrinsics.get("Span");
 
-        Map<String, Object> connectInfo = Maps.newHashMap();
+        Map<String, Object> connectInfo = new HashMap<>();
         connectInfo.put(DistributedTracingConfig.ACCOUNT_ID, accountId);
         connectInfo.put(DistributedTracingConfig.TRUSTED_ACCOUNT_KEY, accountKey);
         connectInfo.put(DistributedTracingConfig.PRIMARY_APPLICATION_ID, "2827902");
@@ -301,15 +300,15 @@ public class W3CTraceContextCrossAgentTest {
     }
 
     private void replaceConfig(boolean spanEventsEnabled) {
-        Map<String, Object> config = Maps.newHashMap();
+        Map<String, Object> config = new HashMap<>();
         config.put(AgentConfigImpl.APP_NAME, APP_NAME);
 
-        Map<String, Object> dtConfig = Maps.newHashMap();
+        Map<String, Object> dtConfig = new HashMap<>();
         dtConfig.put("enabled", true);
         dtConfig.put("exclude_newrelic_header", true);
         config.put("distributed_tracing", dtConfig);
 
-        Map<String, Object> spansConfig = Maps.newHashMap();
+        Map<String, Object> spansConfig = new HashMap<>();
         spansConfig.put("enabled", spanEventsEnabled);
         spansConfig.put("collect_span_events", true);
         config.put("span_events", spansConfig);


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
Three improvements related to Java 8 functionality.

1. *Lambdas*. The agent cannot use lambdas in instrumentation modules due to relocation/naming issues that have never been solved in the weaver. However, the rest of the agent is "just code" and shouldn't have issues using lambdas or method references.
2. *Comparators*. A few places define Comparators using anonymous classes when a helper could be combined with a lambda.
3. *Less Guava*. Remove unnecessary Guava collection constructors. Before the advent of the diamond operator, Guava's collection constructors like `Maps.newHashMap` allowed users to have a shorter constructor call. Now, many of these constructors are unnecessary. They're only an advantage in the calls where you pass in an expected number of elements and they expand the expectation by a factor to reduce resizes.

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[x] Are your contributions backwards compatible with relevant frameworks and APIs?
[x] Does your code contain any breaking changes? - No
[x] Does your code introduce any new dependencies? - No
