### PR TITLE
Spotbugs corrections from NR-118554 and NR-118558

### DIFF
--- a/gradle/script/spotbugs-exclude-filter.xml
+++ b/gradle/script/spotbugs-exclude-filter.xml
@@ -4,14 +4,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
 
-    <!--
-        - Only include high priority findings
-        - Ignore DM_DEFAULT_ENCODING
-            i18n encoding issues
-        - Ignore NM_SAME_SIMPLE_NAME_AS_SUPERCLASS, NM_SAME_SIMPLE_NAME_AS_INTERFACE
-            This class/interface has a simple name that is identical to that of an implemented/extended interface, except that the class/interface
-            is in a different package
-    -->
     <!-- Only include high priority findings -->
     <Match>
         <Not>

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionApiImpl.java
@@ -47,7 +47,7 @@ import java.util.logging.Level;
  */
 public class TransactionApiImpl implements com.newrelic.agent.bridge.Transaction {
 
-    public static TransactionApiImpl INSTANCE = new TransactionApiImpl();
+    public static final TransactionApiImpl INSTANCE = new TransactionApiImpl();
 
     /**
      * Two ApiImpl classes are equal if their wrapped Transactions are the same object. They are also equal if neither
@@ -478,12 +478,8 @@ public class TransactionApiImpl implements com.newrelic.agent.bridge.Transaction
         if(txa != null) {
           tx.checkFinishTransactionFromActivity(txa);
         }
-      if (null != tx) {
         Transaction.clearTransaction();
         return true;
-      } else {
-        return false;
-      }
     }
 
   @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AgentAttributeSender.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AgentAttributeSender.java
@@ -12,7 +12,7 @@ import com.newrelic.agent.Transaction;
 import java.util.Map;
 
 public class AgentAttributeSender extends AttributeSender {
-    protected static String ATTRIBUTE_TYPE = "agent";
+    protected static final String ATTRIBUTE_TYPE = "agent";
 
     public AgentAttributeSender() {
         super(new AttributeValidator(ATTRIBUTE_TYPE));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/CustomAttributeSender.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/CustomAttributeSender.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.logging.Level;
 
 public class CustomAttributeSender extends AttributeSender {
-    protected static String ATTRIBUTE_TYPE = "custom";
+    protected static final String ATTRIBUTE_TYPE = "custom";
 
     public CustomAttributeSender() {
         super(new AttributeValidator(ATTRIBUTE_TYPE));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorMessageReplacer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorMessageReplacer.java
@@ -52,7 +52,7 @@ public class ErrorMessageReplacer {
     }
 
     @VisibleForTesting
-    public static ErrorMessageReplacer NO_REPLACEMENT = new ErrorMessageReplacer(new StripExceptionConfig() {
+    public static final ErrorMessageReplacer NO_REPLACEMENT = new ErrorMessageReplacer(new StripExceptionConfig() {
         @Override
         public boolean isEnabled() {
             return false;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/PointCutConfiguration.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/PointCutConfiguration.java
@@ -88,10 +88,6 @@ public class PointCutConfiguration {
 
         boolean groupExplicitlyDisabled = !pointCutGroupConfig.getProperty("enabled", true);
         boolean classExplicitlyDisabled = !pointCutConfig.getProperty("enabled", true);
-        if (groupExplicitlyDisabled && classExplicitlyEnabled) {
-            Agent.LOG.info(MessageFormat.format("Disabled point cut \"{1}\" (\"{2}\")",  getName(), getGroupName()));
-            return false;
-        }
         if (groupExplicitlyDisabled || classExplicitlyDisabled) {
             Agent.LOG.info(MessageFormat.format("Disabled point cut \"{1}\" (\"{2}\")",  getName(), getGroupName()));
             return false;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ManyClassMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/classmatchers/ManyClassMatcher.java
@@ -72,7 +72,7 @@ public abstract class ManyClassMatcher extends ClassMatcher {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + matchers + ")";
+        return getClass().getSimpleName() + "(" + Arrays.toString(matchers) + ")";
     }
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/profile/ProfilerParameters.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/profile/ProfilerParameters.java
@@ -90,10 +90,7 @@ public class ProfilerParameters implements JSONStreamAware {
     }
 
     public ProfilerParameters setProfilerFormat(String profileFormat) {
-        if (profileFormat != null) {
-            profileFormat.trim();
-        }
-        this.profilerFormat = profileFormat;
+        this.profilerFormat = profileFormat == null ? null : profileFormat.trim();
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -41,7 +41,7 @@ public class SpanEventFactory {
     // Truncate `db.statement` at 2000 characters
     private static final int DB_STATEMENT_TRUNCATE_LENGTH = 2000;
 
-    public static Supplier<Long> DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER = System::currentTimeMillis;
+    public static final Supplier<Long> DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER = System::currentTimeMillis;
 
     private final SpanEvent.Builder builder = SpanEvent.builder();
     private final String appName;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/trace/RandomTransactionSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/trace/RandomTransactionSampler.java
@@ -15,6 +15,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
@@ -57,7 +58,7 @@ public class RandomTransactionSampler implements ITransactionSampler {
         if (td == null) {
             return Collections.emptyList();
         }
-        if (td.getApplicationName() != appName) {
+        if (!Objects.equals(td.getApplicationName(), appName)) {
             return Collections.emptyList();
         }
         if (shouldFinish()) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
@@ -40,7 +40,7 @@ import java.util.logging.Level;
 public abstract class AbstractTracer implements Tracer, AttributeHolder {
 
     static final int INITIAL_PARAMETER_MAP_SIZE = 5;
-    protected static String ATTRIBUTE_TYPE = "custom";
+    protected static final String ATTRIBUTE_TYPE = "custom";
 
     private final TransactionActivity transactionActivity;
     private AttributeValidator attributeValidator;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/MethodExitTracerNoSkip.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/MethodExitTracerNoSkip.java
@@ -41,7 +41,7 @@ public abstract class MethodExitTracerNoSkip extends AbstractTracer {
     public MethodExitTracerNoSkip(ClassMethodSignature signature, Transaction transaction) {
         super(transaction);
         this.signature = signature;
-        this.parentTracer = transaction == null ? null : transaction.getTransactionActivity().getLastTracer();
+        this.parentTracer = transaction.getTransactionActivity().getLastTracer();
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/jasper/GeneratorVisitTracerFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/jasper/GeneratorVisitTracerFactory.java
@@ -23,8 +23,8 @@ import com.newrelic.agent.tracers.Tracer;
 
 public class GeneratorVisitTracerFactory extends AbstractTracerFactory {
 
-    protected static String RUM_STATE_PROCESSOR_KEY = RUMStateProcessor.class.getName();
-    private static String UNKNOWN_JSP = "UNKNOWN";
+    protected static final String RUM_STATE_PROCESSOR_KEY = RUMStateProcessor.class.getName();
+    private static final String UNKNOWN_JSP = "UNKNOWN";
     private static final Pattern COMMENT_PATTERN = Pattern.compile("<!\\s*--.*?--\\s*\\>", Pattern.CASE_INSENSITIVE
             | Pattern.DOTALL);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/GCP.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/GCP.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.logging.Level;
 
 public class GCP implements CloudVendor {
-    public static String PROVIDER = "gcp";
+    public static final String PROVIDER = "gcp";
     private final CloudUtility cloudUtility;
 
     public GCP(CloudUtility cloudUtility) {


### PR DESCRIPTION
Added `final` to certain variables:
- com.newrelic.agent.TransactionApiImpl.INSTANCE
- com.newrelic.agent.attributes.AgentAttributeSender.ATTRIBUTE_TYPE
- com.newrelic.agent.attributes.CustomAttributeSender.ATTRIBUTE_TYPE
- com.newrelic.agent.errors.ErrorMessageReplacer.NO_REPLACEMENT
- com.newrelic.agent.service.analytics.SpanEventFactory.DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER
- com.newrelic.agent.tracers.AbstractTracer.ATTRIBUTE_TYPE
- com.newrelic.agent.tracers.jasper.GeneratorVisitTracerFactory.RUM_STATE_PROCESSOR_KEY
- com.newrelic.agent.utilization.GCP.PROVIDER

Other corrections:
-com.newrelic.agent.trace.RandomTransactionSampler.harvest(String)
  - Comparision of String param using == or != , line 60
- com.newrelic.agent.TransactionApiImpl.clearTransaction()
  - Null check of tx at line 477 of value previously de-ref'ed in clearTransaction(), line 481
- com.newrelic.agent.tracers.MethodExitTracerNoSkip(ClassMethodSignature, Transaction)
  - Null check of transaction at line 44 of value previously de-ref'ed in com.newrelic.agent.tracers.MethodExitTracerNoSkip(ClassMethodSignature, Transaction), line 44
- com.newrelic.agent.profile.ProfilerParameters.setProfilerFormat(String)
  - Return value of String.trim() ignored, line 94
- com.newrelic.agent.instrumentation.classmatchers.ManyClassMatcher.toString()
  - Invocation of toString(), line 75
- com.newrelic.agent.instrumentation.PointCutConfiguration.isEnabled()
  - Useless condition - it's known that classExplicitlyEnabled == false at this point, line 91