### PR TITLE
only upload coverage reports to codecov once

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  max_report_age: off

--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -72,9 +72,10 @@ jobs:
 
 
       - name: Upload coverage to Codecov
-        if: success()
+        if: matrix.java-version == '11'
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/build/reports/jacoco/test/jacocoTestReport.xml'
           fail_ci_if_error: false #default is false, but being explicit about what to expect.
 

--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -62,9 +62,10 @@ jobs:
         run: ./gradlew $GRADLE_OPTIONS test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-monix-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue
 
       - name: Upload coverage to Codecov
-        if: success()
+        if: matrix.java-version == '17'
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/build/reports/jacoco/test/jacocoTestReport.xml'
           fail_ci_if_error: false #default is false, but being explicit about what to expect.
 


### PR DESCRIPTION
Previously, we were collecting the reports and uploading to codecov for each version of the java runs. This is unnecessary because the coverage is the same across versions. We only need to upload once.
I chose Java 17 for the Java units and Java 11 for the scala specific tests.   

It's unclear if this directly resolved the issue with codecov that we were experiencing. That is still an open question, however the most recent runs have succeeded.  It's possible that the overwrites were causing an issue, but there is no direct evedince of that as we did not have any error reporting from codecov.  The GHA action showed successful uploads. Codecov side was showing upload errors.  Will observe, but either way, this optimization is better.

*also, use token for more efficient uploads and codecov rec related to gha API limitations.
