### PR TITLE
we only need 1 each archive

### DIFF
--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -80,7 +80,7 @@ jobs:
           fail_ci_if_error: false #default is false, but being explicit about what to expect.
 
       - name: Capture Jacoco reports
-        if: success()
+        if: matrix.java-version == '11'
         uses: actions/upload-artifact@v3
         with:
           name: jacoco-reports-java-${{ matrix.java-version }}

--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -70,7 +70,7 @@ jobs:
           fail_ci_if_error: false #default is false, but being explicit about what to expect.
 
       - name: Capture Jacoco reports
-        if: success()
+        if: matrix.java-version == '17'
         uses: actions/upload-artifact@v3
         with:
           name: jacoco-reports-java-${{ matrix.java-version }}


### PR DESCRIPTION
This just reduces our footprint and runtime a little more by only uploading the jacoco coverage html archives for one Java test (one for the scala tests and one for the java units). These reports are all the same, so no need to save and upload for each JRE run.

