### PR TITLE
Adding missing environment variable on Create Custom Jar workflow

### DIFF
--- a/.github/workflows/Create-Custom-Jar.yml
+++ b/.github/workflows/Create-Custom-Jar.yml
@@ -15,6 +15,9 @@ jobs:
   create_custom_jar:
     name: Create jar
     runs-on: ubuntu-20.04
+    env:
+      # we use this in env var for conditionals (secrets can't be used in conditionals)
+      AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
 
       - name: Checkout Java agent


### PR DESCRIPTION
### Overview
The custom jar workflow was missing an environment variable which prevented the AWS credentials from being set.
