### PR TITLE
Gh pages utilities

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,69 @@
+# Github Pages Utility Scripts
+
+This directory contains command line scripts that read and write html, for the purposes of creating static html files for GH Pages.
+
+## `writeIndexPage.py`
+
+This script writes a generic `index.html` file for a directory.
+The `index.html` file lists and links to the contents of the directory.
+
+- **Argument**: `path/to/directory`
+- **Returns**: void, creates an index page at `path/to/directory/index.html`
+
+#### Requirements
+
+- Any version of Python.
+
+#### Usage
+
+Make sure you are on the gh-pages branch of this repository.
+
+To index `path/to/directory`, move to the root directory of the repository and run:
+
+```
+python ghpages_utils/writeIndexPage.py path/to/directory
+```
+
+## `writeTestsFailuresPage.py`
+
+This script is written specifically for the build artifacts of this repository's unit tests. When our unit tests run for `module-name`, they generate summary index files at `module-name/build/reports/tests/test/index.html`. This script checks these files for test failures, and writes an .html file summarizing and linking to the results.
+
+- **Argument**: `path/to/test/results`
+- **Returns**: void, creates an .html summary page at `path/to/test/results/index.html`
+
+#### Requirements
+
+- Python 2 or higher
+- `beautifulsoup`, install by running `pip install beautifulsoup4`
+
+#### Usage
+
+Make sure you are on the gh-pages branch of this repository.
+
+Given a `path/to/test/results`, this script expects the file structure:
+
+```
+path/to/test/results
+    module1-name
+        build
+            reports
+                tests
+                    test
+                        ...
+                        index.html
+                        ...
+    module2-name
+        build
+            reports
+                tests
+                    test
+                        ...
+                        index.html
+                        ...
+    ...
+```
+From the root of this repository, run:
+
+```
+python ghpages_utils/writeTestsFailuresPage.py path/to/test/results
+```

--- a/utils/writeIndexPage.py
+++ b/utils/writeIndexPage.py
@@ -2,10 +2,8 @@ import os
 import argparse
 
 def writeIndexPage(path):
-    #contents_list = generate_folder_structure(rootPath)
     dirName = os.path.basename(path)
 
-    #generate html contents
     contents_list = "<ul>"
     for item in os.listdir(path):
         contents_list += f'<li class="file"><a href="{item}">{item}</a></li>'
@@ -23,13 +21,13 @@ def writeIndexPage(path):
     </body>
     </html>
     '''
+
     indexPath = os.path.join(path, 'index.html')
     with open(indexPath, 'w') as file:
         file.write(html_string)
 
-
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Description of your script')
+    parser = argparse.ArgumentParser(description='Write an index.html file for a directory.')
     parser.add_argument('root', help='The root path of a folder to index.')
     args = parser.parse_args()
     writeIndexPage(args.root)

--- a/utils/writeIndexPage.py
+++ b/utils/writeIndexPage.py
@@ -1,0 +1,35 @@
+import os
+import argparse
+
+def writeIndexPage(path):
+    #contents_list = generate_folder_structure(rootPath)
+    dirName = os.path.basename(path)
+
+    #generate html contents
+    contents_list = "<ul>"
+    for item in os.listdir(path):
+        contents_list += f'<li class="file"><a href="{item}">{item}</a></li>'
+    contents_list += "</ul>"
+
+    html_string = f'''
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>{dirName}</title>
+    </head>
+    <body>
+    <h1>{dirName}</h1>
+    {contents_list}
+    </body>
+    </html>
+    '''
+    indexPath = os.path.join(path, 'index.html')
+    with open(indexPath, 'w') as file:
+        file.write(html_string)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Description of your script')
+    parser.add_argument('root', help='The root path of a folder to index.')
+    args = parser.parse_args()
+    writeIndexPage(args.root)

--- a/utils/writeTestsFailuresPage.py
+++ b/utils/writeTestsFailuresPage.py
@@ -1,0 +1,63 @@
+import os
+import argparse
+from bs4 import BeautifulSoup
+
+# Check the test report index.html files within a directory for failures.
+# The test report index files are expected at ./SUBFOLDER/build/reports/tests/test/index.html. All
+# other index files will be ignored.
+
+def writeTestsFailuresPage(root_path):
+    failCount = 0
+    failingTests = ""
+    passingTests = ""
+
+    #check results for each test suite
+    for folder in os.listdir(root_path):
+        summary_path = os.path.join(root_path, folder, 'build', 'reports', 'tests', 'test', 'index.html')
+        if os.path.exists(summary_path):
+            relative_path = os.path.relpath(summary_path, root_path)
+            test_item = f"<li><a href='{relative_path}'>{relative_path}</a></li>"
+            with open(summary_path, 'r') as html_file:
+                soup = BeautifulSoup(html_file, 'html.parser')
+                failures = soup.find(id='failures')
+                if failures and '0' not in failures.get_text().strip():
+                    failCount += 1
+                    failingTests += test_item
+                else:
+                    passingTests += test_item
+
+    html_string = f'''
+      <!DOCTYPE html>
+      <html>
+      <head>
+      <title>Unit Test Results</title>
+      <style>
+        #failing li {{
+            color: red
+        }}
+        #passing li {{
+            color: green
+        }}
+      </style>
+      </head>
+      <body>
+      <h1>Unit Test Results</h1>
+      <div id = 'failing'><h2>Failing Test Suites</h2>
+          <ul> {failingTests} </ul>
+      </div>
+      <div id='passing'> <h2>Passing Test Suites</h2>
+          <ul> {passingTests} </ul>
+      </div>
+      </body>
+      </html>
+      '''
+    index_path = os.path.join(root_path, 'index.html')
+    with open(index_path, 'w') as index_file:
+        index_file.write(html_string)
+    print(f'Test reports published to {root_path} with {failCount} failing suites.')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Description of your script')
+    parser.add_argument('root', help='The root path of a folder containing test reports.')
+    args = parser.parse_args()
+    writeTestsFailuresPage(args.root)

--- a/utils/writeTestsFailuresPage.py
+++ b/utils/writeTestsFailuresPage.py
@@ -2,29 +2,29 @@ import os
 import argparse
 from bs4 import BeautifulSoup
 
-# Check the test report index.html files within a directory for failures.
-# The test report index files are expected at ./SUBFOLDER/build/reports/tests/test/index.html. All
-# other index files will be ignored.
+#Write an HTML file listing and forwarding to the failing test suites in a test folder.
+#This script is specifically for this repository's unit test build artifacts.
+#The expected index files are at module-name/build/reports/tests/test/index.html
 
 def writeTestsFailuresPage(root_path):
-    failCount = 0
-    failingTests = ""
-    passingTests = ""
-
-    #check results for each test suite
+    fail_count = 0
+    failing_tests = ""
+    passing_tests = ""
     for folder in os.listdir(root_path):
         summary_path = os.path.join(root_path, folder, 'build', 'reports', 'tests', 'test', 'index.html')
         if os.path.exists(summary_path):
             relative_path = os.path.relpath(summary_path, root_path)
-            test_item = f"<li><a href='{relative_path}'>{relative_path}</a></li>"
+            test_link = f"<li><a href='{relative_path}'>{relative_path}</a></li>"
+
+            #Check the target HTML file for its reported number of failures.
             with open(summary_path, 'r') as html_file:
                 soup = BeautifulSoup(html_file, 'html.parser')
-                failures = soup.find(id='failures')
-                if failures and '0' not in failures.get_text().strip():
-                    failCount += 1
-                    failingTests += test_item
+                failures_counter = soup.find(id='failures').find(class_='counter')
+                if failures_counter and ('0'!=failures_counter.get_text().strip()):
+                    fail_count += 1
+                    failing_tests += test_link
                 else:
-                    passingTests += test_item
+                    passing_tests += test_link
 
     html_string = f'''
       <!DOCTYPE html>
@@ -43,10 +43,10 @@ def writeTestsFailuresPage(root_path):
       <body>
       <h1>Unit Test Results</h1>
       <div id = 'failing'><h2>Failing Test Suites</h2>
-          <ul> {failingTests} </ul>
+          <ul> {failing_tests} </ul>
       </div>
       <div id='passing'> <h2>Passing Test Suites</h2>
-          <ul> {passingTests} </ul>
+          <ul> {passing_tests} </ul>
       </div>
       </body>
       </html>
@@ -54,7 +54,7 @@ def writeTestsFailuresPage(root_path):
     index_path = os.path.join(root_path, 'index.html')
     with open(index_path, 'w') as index_file:
         index_file.write(html_string)
-    print(f'Test reports published to {root_path} with {failCount} failing suites.')
+    print(f'Test reports published to {root_path} with {fail_count} failing suites.')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Description of your script')


### PR DESCRIPTION
### Overview
This PR adds utility scripts to the gh-pages branch. The scripts write .html files to display on our gh-pages hosted site.
There are two scripts in this PR:

- `writeIndexPage.py`: writes an index.html page for a resource listing and forwarding to its contents.
- `writeTestsFailuresPage.py`: parses the html files in a test folder for failures, then lists and forwards to failing test suites.

The included README.md summarizes the scripts and their usage.