### PR TITLE
Upgrade mockito

### DIFF
--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -234,7 +234,7 @@ jacocoTestReport {
 
 dependencies {
     testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0")
     testImplementation("org.hamcrest:hamcrest-library:1.3")
     testImplementation(project(":test-annotations"))
 }

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -234,7 +234,7 @@ jacocoTestReport {
 
 dependencies {
     testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-core:3.9.0")
+    testImplementation("org.mockito:mockito-core:4.11.0")
     testImplementation("org.hamcrest:hamcrest-library:1.3")
     testImplementation(project(":test-annotations"))
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/AgentHelper.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/AgentHelper.java
@@ -68,7 +68,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 
 public abstract class AgentHelper {
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/CrossProcessStateCatApiTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/CrossProcessStateCatApiTest.java
@@ -50,7 +50,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 public class CrossProcessStateCatApiTest {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/CrossProcessStateTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/CrossProcessStateTest.java
@@ -32,10 +32,10 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/newrelic-agent/src/test/java/com/newrelic/agent/TransactionTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/TransactionTest.java
@@ -841,7 +841,7 @@ public class TransactionTest {
         Mockito.verify(transactionService, Mockito.atLeastOnce()).transactionStarted(Mockito.any(Transaction.class));
         Mockito.verify(transactionService, Mockito.atLeastOnce()).transactionFinished(Mockito.any(
                 TransactionData.class), Mockito.any(TransactionStats.class));
-        Mockito.verifyZeroInteractions(transactionService);
+        Mockito.verifyNoMoreInteractions(transactionService);
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ErrorCollectorConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ErrorCollectorConfigImplTest.java
@@ -1278,12 +1278,12 @@ public class ErrorCollectorConfigImplTest {
 
         public void verifyNoMessage() {
             Mockito.verify(mockLogger, Mockito.never()).log(
-                    Mockito.any(Level.class), Mockito.anyString(), Mockito.anyVararg());
+                    Mockito.any(Level.class), Mockito.anyString(), Mockito.any());
         }
 
         public void verifyMessage(Level at) {
-            Mockito.verify(mockLogger).log(Mockito.eq(at), Mockito.anyString(), Mockito.anyObject(),
-                    Mockito.anyObject(), Mockito.anyObject());
+            Mockito.verify(mockLogger).log(Mockito.eq(at), Mockito.anyString(), Mockito.any(),
+                    Mockito.any(), Mockito.any());
         }
 
         public void close() {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/api/ApiImplementationUpdateTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/api/ApiImplementationUpdateTest.java
@@ -62,7 +62,7 @@ public class ApiImplementationUpdateTest {
         reader.accept(visitor, ClassReader.SKIP_CODE);
 
         Mockito.verify(iInstrumentationContext, Mockito.never()).putMatch(
-                Mockito.<ClassMatchVisitorFactory> anyObject(), Mockito.<Match> anyObject());
+                Mockito.<ClassMatchVisitorFactory> any(), Mockito.<Match> any());
 
     }
 
@@ -88,7 +88,7 @@ public class ApiImplementationUpdateTest {
                 iInstrumentationContext);
         reader.accept(visitor, ClassReader.SKIP_CODE);
 
-        Mockito.verify(iInstrumentationContext, Mockito.only()).putMatch(arg.capture(), Mockito.<Match> anyObject());
+        Mockito.verify(iInstrumentationContext, Mockito.only()).putMatch(arg.capture(), Mockito.<Match> any());
         Assert.assertSame(matcher, arg.getValue());
 
     }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/weaver/preprocessors/AgentPostprocessorsTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/weaver/preprocessors/AgentPostprocessorsTest.java
@@ -49,7 +49,7 @@ import static com.newrelic.agent.instrumentation.weaver.preprocessors.AgentPrepr
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/ProfileTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/ProfileTest.java
@@ -48,8 +48,8 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/ClassNoticingFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/ClassNoticingFactoryTest.java
@@ -1,35 +1,24 @@
 package com.newrelic.agent.service.module;
 
+import com.newrelic.agent.bridge.TestLogger;
+import com.newrelic.agent.instrumentation.context.InstrumentationContext;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
 
-import com.newrelic.agent.bridge.TestLogger;
-import com.newrelic.agent.instrumentation.context.InstrumentationContext;
-import org.apache.commons.validator.Arg;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class ClassNoticingFactoryTest {
@@ -77,7 +66,7 @@ public class ClassNoticingFactoryTest {
         String codeSourceLocation = this.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
         if (codeSourceLocation.endsWith("/")) {
             // we expect the test classes to be staged in a gradle directory, not in a jar.
-            verifyZeroInteractions(factory, executorService);
+            verifyNoMoreInteractions(factory, executorService);
         } else {
             fail("Unexpected jar for test class?? " + codeSourceLocation);
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/asm/ClassResolversTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/asm/ClassResolversTest.java
@@ -60,7 +60,7 @@ public class ClassResolversTest {
         Mockito.verify(resolver1, Mockito.times(1)).getClassResource("foo/bar");
 
         Mockito.verifyNoMoreInteractions(resolver1);
-        Mockito.verifyZeroInteractions(resolver2);
+        Mockito.verifyNoMoreInteractions(resolver2);
     }
 
     private File createJarFile() throws IOException {


### PR DESCRIPTION
### Overview
This PR upgrades mockito to the lastest version that supports Java 8.
It also changes the mock engine to mockito-inline, which is the default since the latest major version.

These changes are needed to properly mock static methods.