### PR TITLE
exclude pointless classes from cov

### DIFF
--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -224,7 +224,12 @@ test {
 jacocoTestReport {
 
     dependsOn test
-
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: ['**/*NoOp*.class'])
+        }))
+    }
     reports {
         xml.required = true
         html.outputLocation = layout.buildDirectory.dir('reports/jacoco')


### PR DESCRIPTION
improve our coverage results by excluding the NoOp classes. These are just stubs with getters and setters.  There is no good reason to evaluate these classes.

