### PR TITLE
Disable IAST if high_security is enabled.

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -9,7 +9,12 @@ package com.newrelic.agent;
 
 import com.google.common.collect.ImmutableMap;
 import com.newrelic.agent.bridge.AgentBridge;
-import com.newrelic.agent.config.*;
+import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.AgentJarHelper;
+import com.newrelic.agent.config.ConfigService;
+import com.newrelic.agent.config.ConfigServiceFactory;
+import com.newrelic.agent.config.JarResource;
+import com.newrelic.agent.config.JavaVersionUtils;
 import com.newrelic.agent.core.CoreService;
 import com.newrelic.agent.core.CoreServiceImpl;
 import com.newrelic.agent.logging.AgentLogManager;
@@ -49,7 +54,9 @@ import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 
-import static com.newrelic.agent.config.SecurityAgentConfig.*;
+import static com.newrelic.agent.config.SecurityAgentConfig.isSecurityEnabled;
+import static com.newrelic.agent.config.SecurityAgentConfig.shouldInitializeSecurityAgent;
+import static com.newrelic.agent.config.SecurityAgentConfig.addSecurityAgentConfigSupportabilityMetrics;
 
 /**
  * New Relic Agent class. The premain you see here is but a fleeting shadow of the true premain. The real premain,
@@ -239,7 +246,7 @@ public final class Agent {
                 ServiceFactory.getServiceManager().getRPMServiceManager().addConnectionListener(new ConnectionListener() {
                     @Override
                     public void connected(IRPMService rpmService, AgentConfig agentConfig) {
-                        if(isSecurityEnabled()) {
+                        if (isSecurityEnabled()) {
                             try {
                                 URL securityJarURL = EmbeddedJarFilesImpl.INSTANCE.getJarFileInAgent(BootstrapLoader.NEWRELIC_SECURITY_AGENT).toURI().toURL();
                                 LOG.log(Level.INFO, "Connected to New Relic. Starting New Relic Security module");

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SecurityAgentConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SecurityAgentConfig.java
@@ -57,7 +57,9 @@ public class SecurityAgentConfig {
      * @return True if security agent should be initialized, false if not
      */
     public static boolean shouldInitializeSecurityAgent() {
-        return config.getValue(SECURITY_AGENT_ENABLED, SECURITY_AGENT_ENABLED_DEFAULT) && (config.getValue(SECURITY_ENABLED) != null);
+        return !config.getValue(AgentConfigImpl.HIGH_SECURITY, AgentConfigImpl.DEFAULT_HIGH_SECURITY) &&
+                config.getValue(SECURITY_AGENT_ENABLED, SECURITY_AGENT_ENABLED_DEFAULT) &&
+                (config.getValue(SECURITY_ENABLED) != null);
     }
 
     /**
@@ -66,7 +68,8 @@ public class SecurityAgentConfig {
      * @return True if security agent should be enabled, false if it should be completely disabled
      */
     public static boolean isSecurityAgentEnabled() {
-        return config.getValue(SECURITY_AGENT_ENABLED, SECURITY_AGENT_ENABLED_DEFAULT);
+        return config.getValue(SECURITY_AGENT_ENABLED, SECURITY_AGENT_ENABLED_DEFAULT) &&
+                !config.getValue(AgentConfigImpl.HIGH_SECURITY, AgentConfigImpl.DEFAULT_HIGH_SECURITY);
     }
 
     /**
@@ -75,7 +78,8 @@ public class SecurityAgentConfig {
      * @return True if security agent should send data, false if it should not
      */
     public static boolean isSecurityEnabled() {
-        return config.getValue(SECURITY_ENABLED, SECURITY_ENABLED_DEFAULT);
+        return config.getValue(SECURITY_ENABLED, SECURITY_ENABLED_DEFAULT) &&
+                !config.getValue(AgentConfigImpl.HIGH_SECURITY, AgentConfigImpl.DEFAULT_HIGH_SECURITY);
     }
 
     /**


### PR DESCRIPTION
In high_security mode request and message queue parameters can't be collected, without request and it's parameters IAST won't be able to work properly, hence disabling.
reference: https://docs.newrelic.com/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#cfg-enable_high_security