### PR TITLE
implement getStatus for nrwrapper

### DIFF
--- a/instrumentation/servlet-5.0/src/main/java/com/nr/instrumentation/servlet5/NRResponseWrapper.java
+++ b/instrumentation/servlet-5.0/src/main/java/com/nr/instrumentation/servlet5/NRResponseWrapper.java
@@ -20,14 +20,9 @@ public class NRResponseWrapper implements Response {
         this.response = response;
     }
 
-    /**
-     * Since {@link #getStatus()} does not exist prior to Servlet 3.0, return 0, meaning "unknown".
-     * 
-     * @since Servlet 3.0
-     */
     @Override
     public int getStatus() throws Exception {
-        return 0;
+        return response.getStatus();
     }
 
     @Override

--- a/instrumentation/servlet-6.0/src/main/java/com/nr/instrumentation/servlet6/NRResponseWrapper.java
+++ b/instrumentation/servlet-6.0/src/main/java/com/nr/instrumentation/servlet6/NRResponseWrapper.java
@@ -20,14 +20,9 @@ public class NRResponseWrapper implements Response {
         this.response = response;
     }
 
-    /**
-     * Since {@link #getStatus()} does not exist prior to Servlet 3.0, return 0, meaning "unknown".
-     * 
-     * @since Servlet 3.0
-     */
     @Override
     public int getStatus() throws Exception {
-        return 0;
+        return response.getStatus();
     }
 
     @Override


### PR DESCRIPTION
NRResponseWrapper class in our Servlet 5 and Servlet 6 instrumentation doesn't implement the getStatus method.
This came up in testing Jakarata 10 EE.  Testing shows that the http.StatusCode method was not being added to agent attributes (an assertion on attribute map length revealed the issue).

The method in the wrapper always returns 0 causing the put to the attributes to be skipped.
https://github.com/newrelic/newrelic-java-agent/blob/aeb1c4e0d8d0852909d8012fc92721c57ade1136/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java#L107


