### PR TITLE
Add coverage agentbridgedatastore

### DIFF
--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/LegacyDatabaseMetricsTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/LegacyDatabaseMetricsTest.java
@@ -1,0 +1,11 @@
+package com.newrelic.agent.bridge.datastore;
+
+import org.junit.Before;
+
+import static org.junit.Assert.*;
+public class LegacyDatabaseMetricsTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+}

--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/LegacyDatabaseMetricsTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/LegacyDatabaseMetricsTest.java
@@ -1,11 +1,46 @@
 package com.newrelic.agent.bridge.datastore;
 
 import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import java.text.MessageFormat;
+
+import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.TracedMethod;
+
 public class LegacyDatabaseMetricsTest {
 
+    Transaction mockTransaction;
+    TracedMethod mockTracedMethod;
+
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
+        mockTransaction = Mockito.mock(Transaction.class);
+        mockTracedMethod = Mockito.mock(TracedMethod.class);
+    }
+
+    @Test
+    public void doDatabaseMetrics_shouldCall_setupMethods(){
+        LegacyDatabaseMetrics.doDatabaseMetrics(mockTransaction, mockTracedMethod, "lazy", "dog");
+
+        Mockito.verify(mockTracedMethod).setMetricName(MessageFormat.format(LegacyDatabaseMetrics.STATEMENT, "lazy", "dog"));
+        Mockito.verify(mockTracedMethod).addRollupMetricName(MessageFormat.format(LegacyDatabaseMetrics.STATEMENT, "lazy", "dog"));
+        Mockito.verify(mockTracedMethod).addRollupMetricName(MessageFormat.format(LegacyDatabaseMetrics.OPERATION, "dog"));
+        Mockito.verify(mockTracedMethod).addRollupMetricName(LegacyDatabaseMetrics.ALL);
+    }
+
+    @Test
+    public void doDatabaseMetrics_shouldHandle_webTransactions(){
+        Mockito.when(mockTransaction.isWebTransaction()).thenReturn(true);
+        LegacyDatabaseMetrics.doDatabaseMetrics(mockTransaction, mockTracedMethod, "brown", "cow");
+        Mockito.verify(mockTracedMethod).addRollupMetricName(LegacyDatabaseMetrics.ALL_WEB);
+    }
+
+    @Test
+    public void doDatabaseMetrics_shouldHandle_nonWebTransactions(){
+        Mockito.when(mockTransaction.isWebTransaction()).thenReturn(false);
+        LegacyDatabaseMetrics.doDatabaseMetrics(mockTransaction, mockTracedMethod, "jumping", "mouse");
+        Mockito.verify(mockTracedMethod).addRollupMetricName(LegacyDatabaseMetrics.ALL_OTHER);
     }
 }

--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/R2dbcObfuscatorTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/R2dbcObfuscatorTest.java
@@ -55,4 +55,18 @@ public class R2dbcObfuscatorTest {
         String testFindDoubleQuotesNotDollarQuotes = "Found \"double_quoted_string\" but not $message$tagged_string$message$";
         assertEquals("Found ? but not $message$tagged_string$message$", R2dbcObfuscator.MYSQL_QUERY_CONVERTER.toObfuscatedQueryString(testFindDoubleQuotesNotDollarQuotes));
     }
+
+    @Test
+    public void queryConverter_shouldHandle_emptyQueries(){
+        assertEquals(null, R2dbcObfuscator.QUERY_CONVERTER.toObfuscatedQueryString(null));
+        assertEquals("", R2dbcObfuscator.QUERY_CONVERTER.toObfuscatedQueryString(""));
+    }
+
+    @Test
+    public void allQueryConverters_returnRawSql(){
+        String rawSql = "The lazy brown cow munched his grass";
+        assertEquals(rawSql, R2dbcObfuscator.QUERY_CONVERTER.toRawQueryString(rawSql));
+        assertEquals(rawSql, R2dbcObfuscator.POSTGRES_QUERY_CONVERTER.toRawQueryString(rawSql));
+        assertEquals(rawSql, R2dbcObfuscator.MYSQL_QUERY_CONVERTER.toRawQueryString(rawSql));
+    }
 }


### PR DESCRIPTION
This PR adds tests to agent-bridge-datastore:
- A few additional tests for R2dbcObfuscator
- A new test class for LegacyDatabaseMetrics
