### PR TITLE
unit tests; update mockito dependency

### DIFF
--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcDataSourceConnectionFactoryTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcDataSourceConnectionFactoryTest.java
@@ -40,13 +40,23 @@ public class JdbcDataSourceConnectionFactoryTest {
     }
 
     @Test
-    public void getConnection_withoutDriverWithUsernameAndPassword_returnsConnection() throws SQLException {
+    public void getConnection_DriverWithoutUsernameAndPassword_returnsConnection() throws SQLException {
         Mockito.when(mockDataSource.getConnection()).thenReturn(mockConnection);
 
-        JdbcDataSourceConnectionFactory factory = new JdbcDataSourceConnectionFactory(mockVendor, mockDataSource, null, null);
+        JdbcDataSourceConnectionFactory factory = new JdbcDataSourceConnectionFactory(mockVendor, mockDataSource);
         Connection conn = factory.getConnection();
 
         Assert.assertEquals(mockConnection, conn);
+        Mockito.verify(mockDataSource).getConnection();
+    }
+
+    @Test(expected = SQLException.class)
+    public void getConnection_rethrowsSqlException() throws SQLException {
+        Mockito.when(mockDataSource.getConnection()).thenThrow(new SQLException("test"));
+
+        JdbcDataSourceConnectionFactory factory = new JdbcDataSourceConnectionFactory(mockVendor, mockDataSource);
+        Connection conn = factory.getConnection();
+
         Mockito.verify(mockDataSource).getConnection();
     }
 

--- a/agent-bridge/build.gradle
+++ b/agent-bridge/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     api(project(":newrelic-api"))
     api(project(":newrelic-weaver-api"))
 
+    testImplementation("org.mockito:mockito-inline:3.9.0")
     testImplementation(fileTree(dir: 'src/test/resources/com/newrelic/agent/bridge', include: '*.jar'))
 }
 

--- a/agent-bridge/src/test/java/com/newrelic/agent/bridge/logging/AppLoggingUtilsTest.java
+++ b/agent-bridge/src/test/java/com/newrelic/agent/bridge/logging/AppLoggingUtilsTest.java
@@ -6,12 +6,18 @@
  */
 package com.newrelic.agent.bridge.logging;
 
-import com.newrelic.agent.bridge.logging.AppLoggingUtils;
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.NewRelic;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AppLoggingUtilsTest {
 
@@ -27,5 +33,163 @@ public class AppLoggingUtilsTest {
         String encodedValue = AppLoggingUtils.urlEncode(valueToEncode);
 
         Assert.assertEquals(expectedEncodedValue, encodedValue);
+    }
+
+    @Test
+    public void urlEncode_withEncodingError_returnsOriginalString() {
+        final String valueToEncode = "|My Application|";
+
+        try (MockedStatic<URLEncoder> mockUrlEncoder = Mockito.mockStatic(URLEncoder.class)) {
+            mockUrlEncoder.when(() -> URLEncoder.encode(valueToEncode, StandardCharsets.UTF_8.toString())).thenThrow(UnsupportedEncodingException.class);
+
+            Assert.assertEquals(valueToEncode, AppLoggingUtils.urlEncode(valueToEncode));
+        }
+    }
+
+    @Test
+    public void getLinkingMetadataBlob_withNonNullMetadata_createsProperlyFormattedBlob() {
+        Agent mockAgent = Mockito.mock(Agent.class);
+
+        Map<String, String> metadataMap = new HashMap<>();
+        metadataMap.put(AppLoggingUtils.ENTITY_GUID, "1234");
+        metadataMap.put(AppLoggingUtils.HOSTNAME, "host");
+        metadataMap.put(AppLoggingUtils.TRACE_ID, "9876");
+        metadataMap.put(AppLoggingUtils.SPAN_ID, "567");
+        metadataMap.put(AppLoggingUtils.ENTITY_NAME, "name");
+
+        Mockito.when(mockAgent.getLinkingMetadata()).thenReturn(metadataMap);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertEquals(" NR-LINKING|1234|host|9876|567|name|", AppLoggingUtils.getLinkingMetadataBlob());
+        }
+    }
+
+    @Test
+    public void getLinkingMetadataBlob_withNullMetadata_createsSparseBlob() {
+        Agent mockAgent = Mockito.mock(Agent.class);
+
+        Mockito.when(mockAgent.getLinkingMetadata()).thenReturn(null);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertEquals(" NR-LINKING|", AppLoggingUtils.getLinkingMetadataBlob());
+        }
+    }
+
+    @Test
+    public void isApplicationLoggingEnabled_returnsTrueIfEnabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.enabled", true)).thenReturn(true);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertTrue(AppLoggingUtils.isApplicationLoggingEnabled());
+        }
+    }
+
+    @Test
+    public void isApplicationLoggingEnabled_returnsFalseIfDisabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.enabled", true)).thenReturn(false);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertFalse(AppLoggingUtils.isApplicationLoggingEnabled());
+        }
+    }
+    @Test
+    public void isApplicationLoggingMetricsEnabled_returnsTrueIfEnabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.metrics.enabled", true)).thenReturn(true);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertTrue(AppLoggingUtils.isApplicationLoggingMetricsEnabled());
+        }
+    }
+
+    @Test
+    public void isApplicationLoggingMetricsEnabled_returnsFalseIfDisabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.metrics.enabled", true)).thenReturn(false);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertFalse(AppLoggingUtils.isApplicationLoggingMetricsEnabled());
+        }
+    }
+    @Test
+    public void isApplicationLoggingForwardingEnabled_returnsTrueIfEnabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.forwarding.enabled", true)).thenReturn(true);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertTrue(AppLoggingUtils.isApplicationLoggingForwardingEnabled());
+        }
+    }
+
+    @Test
+    public void isApplicationLoggingForwardingEnabled_returnsFalseIfDisabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.forwarding.enabled", true)).thenReturn(false);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertFalse(AppLoggingUtils.isApplicationLoggingForwardingEnabled());
+        }
+    }
+    @Test
+    public void isApplicationLoggingLocalDecoratingEnabled_returnsTrueIfEnabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.local_decorating.enabled", false)).thenReturn(true);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertTrue(AppLoggingUtils.isApplicationLoggingLocalDecoratingEnabled());
+        }
+    }
+
+    @Test
+    public void isApplicationLoggingLocalDecoratingEnabled_returnsFalseIfDisabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.local_decorating.enabled", false)).thenReturn(false);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertFalse(AppLoggingUtils.isApplicationLoggingLocalDecoratingEnabled());
+        }
+    }
+    @Test
+    public void isAppLoggingContextDataEnabled_returnsTrueIfEnabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.forwarding.context_data.enabled", false)).thenReturn(true);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertTrue(AppLoggingUtils.isAppLoggingContextDataEnabled());
+        }
+    }
+
+    @Test
+    public void isAppLoggingContextDataEnabled_returnsFalseIfDisabled() {
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Mockito.when(mockAgent.getConfig().getValue("application_logging.forwarding.context_data.enabled", false)).thenReturn(false);
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+
+            Assert.assertFalse(AppLoggingUtils.isAppLoggingContextDataEnabled());
+        }
     }
 }

--- a/agent-bridge/src/test/java/com/newrelic/agent/bridge/logging/LogAttributeKeyTest.java
+++ b/agent-bridge/src/test/java/com/newrelic/agent/bridge/logging/LogAttributeKeyTest.java
@@ -1,0 +1,38 @@
+package com.newrelic.agent.bridge.logging;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogAttributeKeyTest {
+    @Test
+    public void getKey_returnsKey() {
+        LogAttributeKey logAttributeKey = new LogAttributeKey("key", LogAttributeType.AGENT);
+        Assert.assertEquals("key", logAttributeKey.getKey());
+    }
+
+    @Test
+    public void getPrefixedKey_withAgentLogAttributeType_addsEmptyPrefix() {
+        LogAttributeKey logAttributeKey = new LogAttributeKey("key", LogAttributeType.AGENT);
+        Assert.assertEquals("key", logAttributeKey.getPrefixedKey());
+    }
+
+    @Test
+    public void getPrefixedKey_withContextLogAttributeType_addsContextPrefix() {
+        LogAttributeKey logAttributeKey = new LogAttributeKey("key", LogAttributeType.CONTEXT);
+        Assert.assertEquals("context.key", logAttributeKey.getPrefixedKey());
+    }
+
+    @Test
+    public void getType_returnsType() {
+        LogAttributeKey logAttributeKey = new LogAttributeKey("key", LogAttributeType.AGENT);
+        Assert.assertEquals(LogAttributeType.AGENT, logAttributeKey.getType());
+    }
+
+    @Test
+    public void equals_properlyChecksEquality() {
+        LogAttributeKey logAttributeKey1 = new LogAttributeKey("key", LogAttributeType.AGENT);
+        LogAttributeKey logAttributeKey2 = new LogAttributeKey("key", LogAttributeType.AGENT);
+
+        Assert.assertEquals(logAttributeKey1, logAttributeKey2);
+    }
+}

--- a/agent-bridge/src/test/java/com/newrelic/agent/tracers/TracerFlagsTest.java
+++ b/agent-bridge/src/test/java/com/newrelic/agent/tracers/TracerFlagsTest.java
@@ -1,0 +1,57 @@
+package com.newrelic.agent.tracers;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TracerFlagsTest {
+    @Test
+    public void isRoot_returnsCorrectValue() {
+        Assert.assertTrue(TracerFlags.isRoot(TracerFlags.DISPATCHER | TracerFlags.ASYNC));
+        Assert.assertTrue(TracerFlags.isRoot(TracerFlags.DISPATCHER));
+        Assert.assertTrue(TracerFlags.isRoot(TracerFlags.ASYNC));
+        Assert.assertFalse(TracerFlags.isRoot(TracerFlags.LEAF));
+        Assert.assertFalse(TracerFlags.isRoot(0));
+    }
+
+    @Test
+    public void forceMandatoryRootFlags_setProperFlags() {
+        Assert.assertEquals((TracerFlags.GENERATE_SCOPED_METRIC | TracerFlags.TRANSACTION_TRACER_SEGMENT), TracerFlags.forceMandatoryRootFlags(0));
+    }
+
+    @Test
+    public void isAsync_returnsCorrectValue() {
+        Assert.assertTrue(TracerFlags.isAsync(TracerFlags.ASYNC));
+        Assert.assertFalse(TracerFlags.isAsync(TracerFlags.DISPATCHER));
+        Assert.assertFalse(TracerFlags.isAsync(0));
+    }
+
+    @Test
+    public void isDispatcher_returnsCorrectValue() {
+        Assert.assertTrue(TracerFlags.isDispatcher(TracerFlags.DISPATCHER));
+        Assert.assertFalse(TracerFlags.isDispatcher(TracerFlags.ASYNC));
+        Assert.assertFalse(TracerFlags.isDispatcher(0));
+    }
+
+    @Test
+    public void isCustom_returnsCorrectValue() {
+        Assert.assertTrue(TracerFlags.isCustom(TracerFlags.CUSTOM));
+        Assert.assertFalse(TracerFlags.isCustom(TracerFlags.ASYNC));
+        Assert.assertFalse(TracerFlags.isCustom(0));
+    }
+
+    @Test
+    public void getDispatcherFlags_returnsDispatcherFlag() {
+        Assert.assertEquals(TracerFlags.DISPATCHER, TracerFlags.getDispatcherFlags(true));
+        Assert.assertEquals(0, TracerFlags.getDispatcherFlags(false));
+    }
+
+    @Test
+    public void clearAsync_removesAsyncFlagIfPresent() {
+        Assert.assertEquals(0, TracerFlags.clearAsync(TracerFlags.ASYNC));
+    }
+
+    @Test
+    public void clearSegment_removesSegmentFlagIfPresent() {
+        Assert.assertEquals(0, TracerFlags.clearSegment(TracerFlags.TRANSACTION_TRACER_SEGMENT));
+    }
+}

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -250,7 +250,10 @@ jacocoTestReport {
                               'com/newrelic/agent/model/TransactionTiming.class',
                               'com/newrelic/agent/model/TransactionTiming$*.class',
                               'com/newrelic/api/agent/NewRelic.class',
-                              'com/newrelic/weave/verification/*.class'
+                              'com/newrelic/weave/verification/*.class',
+                              'com/newrelic/agent/bridge/datastore/DatastoreMetrics.class',
+                              'com/newrelic/api/agent/ApplicationNamePriority.class',
+                              'com/newrelic/agent/bridge/TransactionNamePriority'
                     ])
         }))
     }
@@ -263,7 +266,7 @@ jacocoTestReport {
 
 dependencies {
     testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-core:3.9.0")
+    testImplementation("org.mockito:mockito-inline:3.9.0")
     testImplementation("org.hamcrest:hamcrest-library:1.3")
     testImplementation(project(":test-annotations"))
 }

--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -266,7 +266,7 @@ jacocoTestReport {
 
 dependencies {
     testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-inline:3.9.0")
+    testImplementation("org.mockito:mockito-core:3.9.0")
     testImplementation("org.hamcrest:hamcrest-library:1.3")
     testImplementation(project(":test-annotations"))
 }


### PR DESCRIPTION
I updated the mockito dependency to use the "inline-mockito" rather than mockito-core to add the ability to mock static methods. I want to see if this breaks any unit tests.