### PR TITLE
remove scala codecov upload

### DIFF
--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -70,15 +70,6 @@ jobs:
           # Removed ":newrelic-cats-effect3-api:test" temporarily
           ./gradlew $GRADLE_OPTIONS :newrelic-scala-api:test :newrelic-scala-cats-api:test :newrelic-scala-zio-api:test :newrelic-scala-monix-api:test -PincludeScala -Ptest${{ matrix.java-version }} --continue
 
-
-      - name: Upload coverage to Codecov
-        if: matrix.java-version == '11'
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: '**/build/reports/jacoco/test/jacocoTestReport.xml'
-          fail_ci_if_error: false #default is false, but being explicit about what to expect.
-
       - name: Capture Jacoco reports
         if: matrix.java-version == '11'
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
remove scala codecov upload
These add little value. 76 lines of code covered at 100%.  We are removing because they cause the upload to codecov to inflate the coverage and causes confusion when trying to understand the coverage and trend.
