### PR TITLE
Fix build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
 
     def isJavaProject = ![

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,9 @@ sourceCompatibility = 1.8
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
+    maven {
+        url "https://plugins.gradle.org/m2/"
+    }
 }
 
 dependencies {

--- a/instrumentation/aws-wrap-0.7.0/README.md
+++ b/instrumentation/aws-wrap-0.7.0/README.md
@@ -1,0 +1,12 @@
+## Building
+
+New Relic does not distribute the jar(s) required to build this instrumentation module nor are they available from a public repository such as Maven Central or jcenter.
+
+To build this instrumentation module you must provide the jar(s) and place them into the `/lib` subdirectory as follows:
+
+```groovy
+instrumentation/aws-wrap-0.7.0/lib/aws-wrap_2.10-0.9.2.jar
+```
+
+## Required jar versions 
+`aws-wrap_2.10` - 0.9.0 or above

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -2,27 +2,33 @@ apply plugin: 'scala'
 
 isScalaProjectEnabled(project, "scala-2.10")
 
-repositories {
-  maven {
-    // repo for aws-wrap
-    url 'https://dl.bintray.com/dwhjames/maven'
-  }
-}
-
 dependencies {
   implementation(project(":newrelic-api"))
   implementation(project(":agent-bridge"))
   implementation(project(":newrelic-weaver-api"))
   implementation(project(":newrelic-weaver-scala-api"))
-  // https://dl.bintray.com/dwhjames/maven/com/github/dwhjames/aws-wrap_2.10/0.8.0/aws-wrap_2.10-0.8.0.jar
-  implementation("com.github.dwhjames:aws-wrap_2.10:0.9.2")
   implementation("org.scala-lang:scala-library:2.10.7")
+  // com.github.dwhjames:aws-wrap_2.10:0.9.2 is expected to be in the lib folder
+  implementation(fileTree(include: ["*.jar"], dir: "lib"))
 
   testImplementation("com.amazonaws:aws-java-sdk:1.10.64")
   testImplementation(project(":instrumentation:aws-java-sdk-s3-1.2.13")){ transitive = false }
 }
 
+def shouldBuild = fileTree(include: ["*.jar"], dir: "lib").size() > 0
+
+compileJava {
+  enabled(shouldBuild)
+}
+
+compileTestJava {
+  enabled(shouldBuild)
+}
+
+tasks.getByName("writeCachedWeaveAttributes").enabled(shouldBuild)
+
 jar {
+  enabled(shouldBuild)
   manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-wrap-0.7.0' }
 }
 

--- a/instrumentation/aws-wrap-0.7.0/lib/.gitignore
+++ b/instrumentation/aws-wrap-0.7.0/lib/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/instrumentation/jboss-7/README.md
+++ b/instrumentation/jboss-7/README.md
@@ -1,0 +1,12 @@
+## Building
+
+New Relic does not distribute the jar(s) required to build this instrumentation module nor are they available from a public repository such as Maven Central or jcenter.
+
+To build this instrumentation module you must provide the jar(s) and place them into the `/lib` subdirectory as follows:
+
+```groovy
+instrumentation/jboss-7/lib/jbossweb-7.5.10.Final.jar
+```
+
+## Required jar versions 
+`jbossweb` - 7.5.7.Final or above

--- a/instrumentation/jboss-7/build.gradle
+++ b/instrumentation/jboss-7/build.gradle
@@ -1,17 +1,29 @@
 repositories {
     mavenCentral()
-    maven {
-        url 'https://repo.spring.io/plugins-release'
-    }
 }
 
 dependencies {
     implementation(project(":agent-bridge"))
-    implementation("org.jboss.web:jbossweb:7.5.10.Final")
     implementation("jakarta.servlet:jakarta.servlet-api:4.0.4")
+
+    // org.jboss.web:jbossweb:7.5.10.Final is expected to be in the lib folder
+    implementation(fileTree(include: ["*.jar"], dir: "lib"))
 }
 
+def shouldBuild = fileTree(include: ["*.jar"], dir: "lib").size() > 0
+
+compileJava {
+    enabled(shouldBuild)
+}
+
+compileTestJava {
+    enabled(shouldBuild)
+}
+
+tasks.getByName("writeCachedWeaveAttributes").enabled(shouldBuild)
+
 jar {
+    enabled(shouldBuild)
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.jboss-7' }
 }
 

--- a/instrumentation/jboss-7/lib/.gitignore
+++ b/instrumentation/jboss-7/lib/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/instrumentation/play-2.3/build.gradle
+++ b/instrumentation/play-2.3/build.gradle
@@ -2,10 +2,16 @@ apply plugin: 'scala'
 
 isScalaProjectEnabled(project, "scala-2.10")
 
+repositories {
+    maven {
+        url 'https://repo.typesafe.com/typesafe/maven-releases/'
+    }
+}
+
 dependencies {
     implementation(project(":agent-bridge"))
     implementation(project(":newrelic-weaver-api"))
-    implementation("com.typesafe.play:play_2.10:2.3.9")
+    implementation("com.typesafe.play:play_2.10:2.3.10")
     implementation("org.scala-lang:scala-library:2.10.7")
 }
 

--- a/instrumentation/solr-jmx-7.0.0/README.md
+++ b/instrumentation/solr-jmx-7.0.0/README.md
@@ -1,0 +1,14 @@
+## Building
+
+New Relic does not distribute the jar(s) required to build this instrumentation module nor are they available from a public repository such as Maven Central or jcenter.
+
+To build this instrumentation module you must provide the jar(s) and place them into the `/lib` subdirectory as follows:
+
+```groovy
+instrumentation/solr-jmx-7.0.0/lib/org.restlet-2.3.0.jar
+instrumentation/solr-jmx-7.0.0/lib/org.restlet.ext.servlet-2.3.0.jar
+```
+
+## Required jar versions 
+`org.restlet` - 2.3.0 or above
+`org.restlet.ext.servlet` - 2.3.0 or above

--- a/instrumentation/solr-jmx-7.0.0/build.gradle
+++ b/instrumentation/solr-jmx-7.0.0/build.gradle
@@ -1,8 +1,5 @@
 repositories {
     mavenCentral()
-    maven {
-        url 'https://repo.spring.io/plugins-release'
-    }
 }
 
 dependencies {
@@ -13,9 +10,24 @@ dependencies {
 
     implementation("org.apache.lucene:lucene-core:7.0.0")
     implementation("org.apache.solr:solr-core:7.0.0")
+    // some dependencies of solr-core:7.0.0 are no longer available, so should be provided on lib
+    implementation(fileTree(include: ["*.jar"], dir: "lib"))
 }
 
+def shouldBuild = fileTree(include: ["*.jar"], dir: "lib").size() > 0
+
+compileJava {
+    enabled(shouldBuild)
+}
+
+compileTestJava {
+    enabled(shouldBuild)
+}
+
+tasks.getByName("writeCachedWeaveAttributes").enabled(shouldBuild)
+
 jar {
+    enabled(shouldBuild)
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.solr-jmx-7.0.0' }
 }
 

--- a/instrumentation/solr-jmx-7.0.0/lib/.gitignore
+++ b/instrumentation/solr-jmx-7.0.0/lib/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -17,7 +17,6 @@ apply from: '../gradle/script/spotbugs-config.gradle'
 repositories {
     mavenCentral()
     mavenLocal()
-    jcenter()
 }
 
 configurations {


### PR DESCRIPTION
### Overview
Some time ago (could have been yesterday), JCenter stopped serving artifacts and started redirecting to Maven Central.
But some artifacts do no exist in Maven Central. So after our cache expired, builds started failing.

To fix this two options were available:
- find a different repo that hosts the necessary artifacts;
- add those artifacts to our proprietary jars file.

Each commit in this PR fix one specific module and indicates in its message the solution. 