### PR TITLE
JCenter fixes

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Download S3 instrumentation jar zip
       shell: bash
       run: |
-        aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20220805.zip proprietary-jars.zip && unzip proprietary-jars.zip  
+        aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20230623.zip proprietary-jars.zip && unzip proprietary-jars.zip
         if [ $? -ne 0 ]; then
           echo "Instrumentation jar zip unavailable." >> $GITHUB_STEP_SUMMARY
         fi

--- a/instrumentation/aws-wrap-0.7.0/build.gradle
+++ b/instrumentation/aws-wrap-0.7.0/build.gradle
@@ -32,13 +32,8 @@ jar {
   manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-wrap-0.7.0' }
 }
 
-verifyInstrumentation {
-  passesOnly 'com.github.dwhjames:aws-wrap_2.10:[0.7.0,)'
-  passesOnly 'com.github.dwhjames:aws-wrap_2.11:[0.7.0,)'
-  excludeRegex '.*v0.8.0.*'
-}
-
 site {
     title 'AWS Wrap'
     type 'Other'
+    versionOverride '[0.7.0,)'
 }

--- a/instrumentation/jboss-7/build.gradle
+++ b/instrumentation/jboss-7/build.gradle
@@ -27,15 +27,8 @@ jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.jboss-7' }
 }
 
-verifyInstrumentation {
-    passes('org.jboss.web:jbossweb:[7.0,)') {
-        implementation("jakarta.servlet:jakarta.servlet-api:4.0.4")
-    }
-    excludeRegex(".*(Alpha|Beta|CR).*")
-    exclude("org.jboss.web:jbossweb:7.5.6.Final") // this appears to be a bad release that was excluded from multiple repos
-}
-
 site {
     title 'JBoss'
     type 'Appserver'
+    versionOverride '[7.0,)'
 }

--- a/instrumentation/resin-4/lib/.gitignore
+++ b/instrumentation/resin-4/lib/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/instrumentation/solr-jmx-7.0.0/build.gradle
+++ b/instrumentation/solr-jmx-7.0.0/build.gradle
@@ -9,25 +9,13 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
 
     implementation("org.apache.lucene:lucene-core:7.0.0")
-    implementation("org.apache.solr:solr-core:7.0.0")
-    // some dependencies of solr-core:7.0.0 are no longer available, so should be provided on lib
-    implementation(fileTree(include: ["*.jar"], dir: "lib"))
+    implementation("org.apache.solr:solr-core:7.0.0") {
+        exclude(group: "org.restlet.jee", module: "org.restlet")
+        exclude(group: "org.restlet.jee", module: "org.restlet.ext.servlet")
+    }
 }
-
-def shouldBuild = fileTree(include: ["*.jar"], dir: "lib").size() > 0
-
-compileJava {
-    enabled(shouldBuild)
-}
-
-compileTestJava {
-    enabled(shouldBuild)
-}
-
-tasks.getByName("writeCachedWeaveAttributes").enabled(shouldBuild)
 
 jar {
-    enabled(shouldBuild)
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.solr-jmx-7.0.0' }
 }
 


### PR DESCRIPTION
### Overview
- Removes verify instrumentation configuration from aws-wrap and jboss-7, since these are no longer available, we cannot download the artifacts to test;
- Adds a .gitignore to `instrumentation/resin-4/lib/` to prevent any file there from being committed;
- Updates the setup environment composite action to use the new proprietary-jars file.
