### PR TITLE
Fixing alias for Kafka Connect instrumentations

### DIFF
--- a/instrumentation/kafka-connect-spans-2.0.0/build.gradle
+++ b/instrumentation/kafka-connect-spans-2.0.0/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-connect-spans-2.0.0',
-            'Implementation-Title-Alias': 'kafka-connect' }
+            'Implementation-Title-Alias': 'kafka-connect-spans' }
 }
 
 verifyInstrumentation {

--- a/instrumentation/kafka-connect-spans-3.3.0/build.gradle
+++ b/instrumentation/kafka-connect-spans-3.3.0/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-connect-spans-3.3.0',
-            'Implementation-Title-Alias': 'kafka-connect' }
+            'Implementation-Title-Alias': 'kafka-connect-spans' }
 }
 
 verifyInstrumentation {


### PR DESCRIPTION
### Overview
Kafka Connect spans instrumentation aliases were `kafka-connect`. Which does not match the metrics instrumentation which is `kafka-connect-metrics`. This PR fixes that.
