### PR TITLE
Using read only Gradle cache for most workflows

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,5 +1,10 @@
 name: Setup Environment
 description:  Sets up the environment to build/test the agent.
+inputs:
+  gradle-cache-read-only:
+    description: 'Whether the Gradle cache should be read only'
+    required: false
+    default: 'true'
 # This action expects the agent to be checked out at $GITHUB_WORKSPACE.
 # It will also set up the instrumentation jar zip if AWS credentials are set.
 # This action requires these because composite actions cannot use secrets.
@@ -29,6 +34,8 @@ runs:
 
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
+      with:
+        cache-read-only: ${{ inputs.gradle-cache-read-only }}
 
     - name: Setup Gradle options
       shell: bash

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
-          key: ${{ github.run_id }}
+          key: agent-jar-${{ github.run_id }}
           fail-on-cache-miss: true
 
       ## Ongoing tests with artifactory dependencies

--- a/.github/workflows/VerifyInstrumentation.yml
+++ b/.github/workflows/VerifyInstrumentation.yml
@@ -16,7 +16,7 @@ on:
         type: string
         description: 'The ref (branch, SHA, tag?) to run the tests on'
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * MON-FRI'
 
 jobs:
   # build the agent and saves Gradle's cache so all modules can use the cache
@@ -25,6 +25,7 @@ jobs:
     uses: ./.github/workflows/X-Reusable-BuildAgent.yml
     with:
       agent-ref: ${{ inputs.agent-ref || 'main' }}
+      gradle-cache-read-only: ${{ github.event_name != 'schedule' }}
     secrets: inherit
 
   # GHA Matrix strategy only allows 255 entries.

--- a/.github/workflows/X-Reusable-BuildAgent.yml
+++ b/.github/workflows/X-Reusable-BuildAgent.yml
@@ -8,6 +8,11 @@ on:
         default: main
         type: string
         description: 'The ref (branch, SHA, tag?) to run the tests on'
+      gradle-cache-read-only:
+        required: false
+        default: true
+        type: boolean
+        description: 'Whether the gradle cache should be read only'
 jobs:
   # build the agent and saves Gradle's cache so all modules can use the cache
   build-agent:
@@ -31,6 +36,8 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          gradle-cache-read-only: ${{ inputs.gradle-cache-read-only }}
 
       - name: Build agent
         run: ./gradlew $GRADLE_OPTIONS clean jar
@@ -39,4 +46,4 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
-          key: ${{ github.run_id }}
+          key: agent-jar-${{ github.run_id }}

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
-          key: ${{ github.run_id }}
+          key: agent-jar-${{ github.run_id }}
           fail-on-cache-miss: true
 
       # Verify instrumentation must run with Java 17


### PR DESCRIPTION
### Overview
Verify instrumentation uses an excessive amount of caching for its Gradle tasks.
This is causing some cache entries to be evicted before they should, due to size limit imposed by GHA.
Also, the GHA cache servers start sending 429 responses due to the amount of transfers this action makes.
By decreasing the amount of cache sent both issues should be decreased if not eliminated.

This PR changes how the Gradle cache is used. It will be read only for all workflows, except the build agent for the scheduled Verify Instrumentation run.
With this we should have a reasonable sized cache, which should be enough to help all the builds.