### PR TITLE
Add coverage nragent logging

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/logging/Log4jLogManagerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/logging/Log4jLogManagerTest.java
@@ -1,0 +1,72 @@
+package com.newrelic.agent.logging;
+
+import com.newrelic.agent.config.AgentConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+public class Log4jLogManagerTest {
+    Log4jLogManager logManager;
+    AgentConfig mockAgentConfig;
+    @Before
+    public void setup(){
+        logManager = Log4jLogManager.create("quizzy bees");
+        mockAgentConfig = Mockito.mock(AgentConfig.class);
+        Mockito.when(mockAgentConfig.getLogFileName()).thenReturn("test"); //default mock value 'null' causes NPE
+    }
+
+    @Test
+    public void logLevel_debugEnabled_shouldBeTrace(){
+        Mockito.when(mockAgentConfig.isDebugEnabled()).thenReturn(true);
+        logManager.configureLogger(mockAgentConfig);
+        assertEquals("trace", logManager.getLogLevel().toLowerCase());
+
+    }
+
+    @Test
+    public void logLevel_debugDisabled_shouldMatchAgentConfig(){
+        Mockito.when(mockAgentConfig.isDebugEnabled()).thenReturn(false);
+
+        Mockito.when(mockAgentConfig.getLogLevel()).thenReturn("INFO");
+        logManager.configureLogger(mockAgentConfig);
+        assertEquals("info", logManager.getLogLevel().toLowerCase());
+
+        Mockito.when(mockAgentConfig.getLogLevel()).thenReturn("error");
+        logManager.configureLogger(mockAgentConfig);
+        assertEquals("error", logManager.getLogLevel().toLowerCase());
+
+        Mockito.when(mockAgentConfig.getLogLevel()).thenReturn("warn");
+        logManager.configureLogger(mockAgentConfig);
+        assertEquals("warn", logManager.getLogLevel().toLowerCase());
+
+        Mockito.when(mockAgentConfig.getLogLevel()).thenReturn("finest");
+        logManager.configureLogger(mockAgentConfig);
+        assertEquals("trace", logManager.getLogLevel().toLowerCase());
+    }
+
+    @Test
+    public void configureLogLevel_agentConfigInvalid_shouldDefaultToInfo(){
+        Mockito.when(mockAgentConfig.isDebugEnabled()).thenReturn(false);
+
+        Mockito.when(mockAgentConfig.getLogLevel()).thenReturn("hogwash");
+        logManager.configureLogger(mockAgentConfig);
+        assertEquals("info", logManager.getLogLevel().toLowerCase());
+
+        Mockito.when(mockAgentConfig.getLogLevel()).thenReturn(null);
+        logManager.configureLogger(mockAgentConfig);
+        assertEquals("info", logManager.getLogLevel().toLowerCase());
+    }
+
+    @Test
+    public void configureLogger_shouldHandle_loggingToStdOut(){
+        Mockito.when(mockAgentConfig.isLoggingToStdOut()).thenReturn(true);
+        Mockito.when(mockAgentConfig.isDebugEnabled()).thenReturn(false);
+
+        logManager.configureLogger(mockAgentConfig); //shouldn't throw
+
+    }
+
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/logging/Log4jLogManagerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/logging/Log4jLogManagerTest.java
@@ -15,6 +15,10 @@ import static org.junit.Assert.*;
 public class Log4jLogManagerTest {
     Log4jLogManager logManager;
     AgentConfig mockAgentConfig;
+
+    private String CONSOLE_APPENDER_NAME = "Console"; //this is declared private static in Log4jLogger
+
+    private String FILE_APPENDER_NAME = FileAppenderFactory.FILE_APPENDER_NAME;
     @Before
     public void setup(){
         logManager = Log4jLogManager.create("quizzy bees");
@@ -76,7 +80,7 @@ public class Log4jLogManagerTest {
         Configuration config = ctx.getConfiguration();
         LoggerConfig loggerConfig = config.getLoggerConfig("quizzy bees");
 
-        assertNotNull(loggerConfig.getAppenders().get("Console"));
+        assertNotNull(loggerConfig.getAppenders().get(CONSOLE_APPENDER_NAME));
 
     }
 
@@ -91,21 +95,24 @@ public class Log4jLogManagerTest {
         Configuration config = ctx.getConfiguration();
         LoggerConfig loggerConfig = config.getLoggerConfig("quizzy bees");
 
-        assertNull(loggerConfig.getAppenders().get("Console"));
+        assertNull(loggerConfig.getAppenders().get(CONSOLE_APPENDER_NAME));
 
     }
 
-    //ASK FOR HELP ABOUT THIS
-//    @Test
-//    public void configureFileHandler_shouldWriteToFile(){
-//        File directory = new File("./");
-//        String EXPECTED_LOG_FILE_PATH = "";
-//        Mockito.when(mockAgentConfig.isLoggingToStdOut()).thenReturn(false);
-//        Mockito.when(mockAgentConfig.isDebugEnabled()).thenReturn(false);
-//
-//        logManager.configureLogger(mockAgentConfig);
-//
-//    }
+    @Test
+    public void configureFileHandler_shouldAddFileAppender(){
+        Mockito.when(mockAgentConfig.isLoggingToStdOut()).thenReturn(false);
+        Mockito.when(mockAgentConfig.isDebugEnabled()).thenReturn(false);
+
+        logManager.configureLogger(mockAgentConfig);
+
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig("quizzy bees");
+
+        assertNotNull(loggerConfig.getAppenders().get(FILE_APPENDER_NAME));
+
+    }
 
 
 }


### PR DESCRIPTION
This PR creates unit tests for the Log4jLogManager class, specifically for the method `configureLogger`. The tests assert on how the logger responds to the agentConfig. 