### PR TITLE
Add UltraLightTracer to the coverage exclusions list

### DIFF
--- a/gradle/script/java.gradle
+++ b/gradle/script/java.gradle
@@ -253,7 +253,8 @@ jacocoTestReport {
                               'com/newrelic/weave/verification/*.class',
                               'com/newrelic/agent/bridge/datastore/DatastoreMetrics.class',
                               'com/newrelic/api/agent/ApplicationNamePriority.class',
-                              'com/newrelic/agent/bridge/TransactionNamePriority.class'
+                              'com/newrelic/agent/bridge/TransactionNamePriority.class',
+                              'com/newrelic/agent/tracers/UltraLightTracer.class'
                     ])
         }))
     }


### PR DESCRIPTION
This PR adds the newrelic.agent.tracers.UltraLightTracer class to the jacoco coverage exclusions list. This class is a candidate for exclusion because it has scant functionality and many no-ops. 