### PR TITLE
Capping graphql compatibility

### DIFF
--- a/instrumentation/graphql-java-17.0/build.gradle
+++ b/instrumentation/graphql-java-17.0/build.gradle
@@ -16,7 +16,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'com.graphql-java:graphql-java:[17.0,)'
+    passesOnly 'com.graphql-java:graphql-java:[17.0,21.0)'
     excludeRegex 'com.graphql-java:graphql-java:(0.0.0|201|202).*'
     excludeRegex 'com.graphql-java:graphql-java:.*(vTEST|-beta|-alpha1|-nf-execution|-rc|-TEST).*'
 }


### PR DESCRIPTION
### Overview
Verify Instrumentation workflow checked that the version 21 of this library will not work with the current instrumentation module.

### Related Github Issue
#1375 
