### PR TITLE
Add coverage service module

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarDataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarDataTest.java
@@ -1,0 +1,78 @@
+package com.newrelic.agent.service.module;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class JarDataTest {
+
+    @Test
+    public void testWriteJSONString() throws IOException {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("tiny", "tambourines");
+        attributes.put("giant", "giraffes");
+        JarInfo info = new JarInfo("2.0.0", attributes);
+        JarData data = new JarData("benny", info);
+
+        Writer writer = new StringWriter();
+        data.writeJSONString(writer);
+        String expected = "[\"benny\",\"2.0.0\",{\"tiny\":\"tambourines\",\"giant\":\"giraffes\"}]";
+        assertEquals(expected, writer.toString());
+    }
+
+    @Test
+    public void testEqualsAndHashCode(){
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("tiny", "tambourines");
+        attributes.put("giant", "giraffes");
+        JarInfo info = new JarInfo("2.0.0", attributes);
+        JarInfo infoDifferentVersion = new JarInfo("1.0.0", attributes);
+        JarInfo infoDifferentAttributes = new JarInfo("2.0.0", null);
+
+        JarData data1 = new JarData("arthur", info);
+        JarData data2 = new JarData("benny", info);
+        JarData data3 = new JarData("arthur", infoDifferentVersion);
+        JarData data4 = new JarData("arthur", infoDifferentAttributes);
+        JarData missingName = new JarData(null, info);
+
+        FakeJarData fakeData = new FakeJarData("arthur", info);
+
+        assertEquals(data1, data1);
+
+        assertNotEquals(data1, data2);
+        assertNotEquals(data2, data1);
+        assertNotEquals(data1.hashCode(), data2.hashCode());
+
+        assertNotEquals(data1, data3);
+        assertNotEquals(data3, data1);
+        assertNotEquals(data1.hashCode(), data3.hashCode());
+
+        assertEquals(data1, data4);
+        assertEquals(data4, data1);
+        assertEquals(data1.hashCode(), data4.hashCode());
+
+        assertNotEquals(data1, missingName);
+        assertNotEquals(missingName, data1);
+        assertNotEquals(data1.hashCode(), missingName.hashCode());
+
+        assertNotEquals(data1, fakeData);
+        assertNotEquals(data1, null);
+    }
+
+    private class FakeJarData {
+
+        String name;
+        JarInfo info;
+        public FakeJarData(String name, JarInfo info) {
+            this.name = name;
+            this.info = info;
+        }
+    }
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarInfoTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarInfoTest.java
@@ -32,25 +32,21 @@ public class JarInfoTest {
         Map<String, String> attributes1 = new HashMap<>();
         attributes1.put("blep", "blop");
         attributes1.put("goob", "grog");
-        JarInfo jar1 = new JarInfo("1.0.1", attributes1);
 
         Map<String, String> attributes2 = new HashMap<>();
         attributes2.put("blep", "blop");
         attributes2.put("goob", "grog");
-        JarInfo jar2 = new JarInfo("1.0.1", attributes2);
 
+        JarInfo jar1 = new JarInfo("1.0.1", attributes1);
+        JarInfo jar2 = new JarInfo("1.0.1", attributes2);
         JarInfo jar3 = new JarInfo("1.0.1", null);
         JarInfo jar4 = new JarInfo("1.0.1", null);
-
         JarInfo jar5 = new JarInfo(null, null);
         JarInfo jar6 = new JarInfo(null, null);
 
-        JarInfo nullJar1 = null;
         FakeJarInfo fakeJar = new FakeJarInfo("1.0.1", attributes1);
 
         assertEquals(jar1, jar1);
-        assertNotEquals(jar1, nullJar1);
-        assertNotEquals(nullJar1, jar1);
 
         assertEquals(jar1, jar2);
         assertEquals(jar2, jar1);
@@ -58,6 +54,7 @@ public class JarInfoTest {
 
         assertNotEquals(jar3, jar1);
         assertNotEquals(jar1, jar3);
+        assertNotEquals(jar3.hashCode(), jar1.hashCode());
 
         assertEquals(jar3, jar4);
         assertEquals(jar4, jar3);
@@ -65,10 +62,14 @@ public class JarInfoTest {
 
         assertNotEquals(jar5, jar3);
         assertNotEquals(jar3, jar5);
+        assertNotEquals(jar3.hashCode(), jar5.hashCode());
 
         assertEquals(jar5, jar6);
         assertEquals(jar6, jar5);
         assertEquals(jar5.hashCode(), jar6.hashCode());
+
+        assertNotEquals(jar1, null);
+        assertNotEquals(null, jar1);
 
         assertNotEquals(jar1, fakeJar);
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarInfoTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarInfoTest.java
@@ -1,0 +1,87 @@
+package com.newrelic.agent.service.module;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class JarInfoTest {
+
+    @Test
+    public void testStaticMissingJarInfo(){
+        String expected = "JarInfo [version=" + JarCollectorServiceProcessor.UNKNOWN_VERSION + ", attributes={}]";
+        assertEquals(expected, JarInfo.MISSING.toString());
+    }
+
+    @Test
+    public void testToString(){
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("foo", "bar");
+        attributes.put("baz", "lemon");
+        JarInfo info = new JarInfo("9.0.0", attributes);
+
+        String expected = "JarInfo [version=9.0.0, attributes={foo=bar, baz=lemon}]";
+        assertEquals(expected, info.toString());
+
+    }
+
+    @Test
+    public void testEqualsAndHashCode(){
+        Map<String, String> attributes1 = new HashMap<>();
+        attributes1.put("blep", "blop");
+        attributes1.put("goob", "grog");
+        JarInfo jar1 = new JarInfo("1.0.1", attributes1);
+
+        Map<String, String> attributes2 = new HashMap<>();
+        attributes2.put("blep", "blop");
+        attributes2.put("goob", "grog");
+        JarInfo jar2 = new JarInfo("1.0.1", attributes2);
+
+        JarInfo jar3 = new JarInfo("1.0.1", null);
+        JarInfo jar4 = new JarInfo("1.0.1", null);
+
+        JarInfo jar5 = new JarInfo(null, null);
+        JarInfo jar6 = new JarInfo(null, null);
+
+        JarInfo nullJar1 = null;
+        FakeJarInfo fakeJar = new FakeJarInfo("1.0.1", attributes1);
+
+        assertEquals(jar1, jar1);
+        assertNotEquals(jar1, nullJar1);
+        assertNotEquals(nullJar1, jar1);
+
+        assertEquals(jar1, jar2);
+        assertEquals(jar2, jar1);
+        assertEquals(jar1.hashCode(), jar2.hashCode());
+
+        assertNotEquals(jar3, jar1);
+        assertNotEquals(jar1, jar3);
+
+        assertEquals(jar3, jar4);
+        assertEquals(jar4, jar3);
+        assertEquals(jar3.hashCode(), jar4.hashCode());
+
+        assertNotEquals(jar5, jar3);
+        assertNotEquals(jar3, jar5);
+
+        assertEquals(jar5, jar6);
+        assertEquals(jar6, jar5);
+        assertEquals(jar5.hashCode(), jar6.hashCode());
+
+        assertNotEquals(jar1, fakeJar);
+
+    }
+
+    private class FakeJarInfo {
+        String version;
+        Map<String, String> attributes;
+
+        public FakeJarInfo(String fakeVersion, Map<String, String> fakeAttributes) {
+            this.version = fakeVersion;
+            this.attributes = fakeAttributes;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds tests to **JarInfo** and **JarData** in newrelic.agent.service.module. 