### PR TITLE
Test example with static mocks

### DIFF
--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -46,18 +46,18 @@ jobs:
       - name: Run unit tests for each Java version as defined in the matrix (attempt 1)
         id: run_tests_1
         continue-on-error: true
-        timeout-minutes: 35
+        timeout-minutes: 45
         run: ./gradlew $GRADLE_OPTIONS test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-monix-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue
 
       - name: Run unit tests for each Java version as defined in the matrix (attempt 2)
         id: run_tests_2
         continue-on-error: true
-        timeout-minutes: 35
+        timeout-minutes: 45
         if: steps.run_tests_1.outcome == 'failure'
         run: ./gradlew $GRADLE_OPTIONS test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-monix-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue
 
       - name: Run unit tests for each Java version as defined in the matrix (attempt 3)
-        timeout-minutes: 35
+        timeout-minutes: 45
         if: steps.run_tests_2.outcome == 'failure'
         run: ./gradlew $GRADLE_OPTIONS test -x :functional_test:test -x :newrelic-scala-api:test -x :newrelic-scala-cats-api:test -x :newrelic-cats-effect3-api:test -x :newrelic-scala-monix-api:test -x :newrelic-scala-zio-api:test -Ptest${{ matrix.java-version }} -PnoInstrumentation --continue
 

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -64,6 +64,7 @@ jobs:
           echo "framework/play/play2.py" >> $excluded_tests
           echo "framework/snap/snap.py" >> $excluded_tests
           echo "r2dbc/mssql.py" >> $excluded_tests
+          echo "r2dbc/oracle.py" >> $excluded_tests
           echo "server/mule.py" >> $excluded_tests
           echo "server/weblogic.py" >> $excluded_tests
           # The files below are not tests

--- a/newrelic-agent/src/test/java/com/newrelic/agent/TransactionApiImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/TransactionApiImplTest.java
@@ -1,0 +1,420 @@
+package com.newrelic.agent;
+
+import com.newrelic.agent.bridge.NoOpTracedMethod;
+import com.newrelic.agent.bridge.TransactionNamePriority;
+import com.newrelic.agent.config.AgentConfigImpl;
+import com.newrelic.agent.config.ConfigService;
+import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.service.ServiceManager;
+import com.newrelic.agent.service.async.AsyncTransactionService;
+import com.newrelic.agent.tracers.Tracer;
+import com.newrelic.api.agent.ApplicationNamePriority;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransactionApiImplTest {
+    AsyncTransactionService mockAsyncTransactionService;
+
+    @Before
+    public void setup() {
+        configureServiceFactory();
+        mockAsyncTransactionService = mock(AsyncTransactionService.class);
+    }
+
+    @Test
+    public void equals_properlyDeterminesEquality() {
+        TransactionApiImpl transactionApi1 = new TransactionApiImpl();
+        TransactionApiImpl transactionApi2 = new TransactionApiImpl();
+        assertNotEquals(transactionApi1, new Object());
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            assertEquals(transactionApi1, transactionApi2);
+        }
+    }
+
+    @Test
+    public void hashCode_generatesProperHashValues() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(null);
+            assertEquals(42, transactionApi.hashCode());
+        }
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            assertNotEquals(42, transactionApi.hashCode());
+        }
+    }
+
+    @Test
+    public void setTransactionName_withActiveTxn_properlySetsTxnName() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        when(mockTxn.setTransactionName(TransactionNamePriority.SERVLET_NAME, true, "category", "part1", "part2")).thenReturn(true);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            assertTrue(transactionApi.setTransactionName(TransactionNamePriority.SERVLET_NAME, true, "category", "part1", "part2"));
+        }
+    }
+
+    @Test
+    public void setTransactionName_withNoTxn_ignoresRequest() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        verify(mockTxn, times(0)).setTransactionName(TransactionNamePriority.SERVLET_NAME, true, "category", "part1", "part2");
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            assertFalse(transactionApi.setTransactionName(TransactionNamePriority.SERVLET_NAME, true, "category", "part1", "part2"));
+        }
+    }
+
+    @Test
+    public void isTransactionNameSet_withActiveTxn_returnsTrue() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        when(mockTxn.isTransactionNameSet()).thenReturn(true);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            assertTrue(transactionApi.isTransactionNameSet());
+        }
+    }
+
+    @Test
+    public void isTransactionNameSet_withNoTxn_returnsFalse() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(null);
+            assertFalse(transactionApi.isTransactionNameSet());
+        }
+    }
+
+    @Test
+    public void getLastTracer_withTxn_returnsTracedMethod() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        TransactionActivity mockTxnActivity = mock(TransactionActivity.class);
+        Tracer mockTracer = mock(Tracer.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            when(mockTxn.getTransactionActivity()).thenReturn(mockTxnActivity);
+            when(mockTxnActivity.getLastTracer()).thenReturn(mockTracer);
+
+            assertEquals(mockTracer, transactionApi.getLastTracer());
+        }
+    }
+
+    @Test
+    public void getLastTracer_withNoTxn_returnsNoOpTraceMethod() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(null);
+
+            assertEquals(NoOpTracedMethod.INSTANCE, transactionApi.getLastTracer());
+        }
+    }
+
+    @Test
+    public void getLastTracer_withNullLastTracer_returnsNoOpTracedMethod() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        TransactionActivity mockTxnActivity = mock(TransactionActivity.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            when(mockTxn.getTransactionActivity()).thenReturn(mockTxnActivity);
+            when(mockTxnActivity.getLastTracer()).thenReturn(null);
+
+            assertEquals(NoOpTracedMethod.INSTANCE, transactionApi.getLastTracer());
+        }
+    }
+
+    @Test
+    public void ignore_withTxn_ignoresTheTxn() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.ignore();
+            verify(mockTxn).ignore();
+        }
+    }
+
+    @Test
+    public void ignoreErrors_withTxn_ignoresErrorsOnTxn() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.ignore();
+            verify(mockTxn).ignore();
+        }
+    }
+
+    @Test
+    public void ignoreApdex_withTxn_ignoresApdex() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.ignoreApdex();
+            verify(mockTxn).ignoreApdex();
+        }
+    }
+
+    @Test
+    public void beforeSendResponseHeaders_withTxn_addsOutboundHeaders() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.addOutboundResponseHeaders();
+            verify(mockTxn).addOutboundResponseHeaders();
+        }
+    }
+
+    @Test
+    public void isStarted_withTxn_returnsStartStatus() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isStarted();
+            verify(mockTxn).isStarted();
+        }
+    }
+
+    @Test
+    public void isAutoAppNamingEnabled_withTxn_returnsTxnAutoAppNamingFlag() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isAutoAppNamingEnabled();
+            verify(mockTxn).isAutoAppNamingEnabled();
+        }
+    }
+
+    @Test
+    public void isWebRequestSet_withTxn_returnsTxnWebRequestFlag() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isWebRequestSet();
+            verify(mockTxn).isWebRequestSet();
+        }
+    }
+
+    @Test
+    public void isWebResponseSet_withTxn_returnsTxnWebResponsetFlag() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isWebResponseSet();
+            verify(mockTxn).isWebResponseSet();
+        }
+    }
+
+    @Test
+    public void setApplicationName_withTxn_setsNameOnTxn() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.setApplicationName(ApplicationNamePriority.NONE, "appName");
+            verify(mockTxn).setApplicationName(ApplicationNamePriority.NONE, "appName");
+        }
+    }
+
+    @Test
+    public void isAutoAppNaming_withTxn_returnsAppNamingFlag() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isAutoAppNamingEnabled();
+            verify(mockTxn).isAutoAppNamingEnabled();
+        }
+    }
+
+    @Test
+    public void isWebRequestSet_withTxn_returnsWebRequestSetFlag() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isWebRequestSet();
+            verify(mockTxn).isWebRequestSet();
+        }
+    }
+
+    @Test
+    public void isWebResponseSet_withTxn_returnsWebResponetSetFlag() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isWebResponseSet();
+            verify(mockTxn).isWebResponseSet();
+        }
+    }
+
+    @Test
+    public void setWebRequest_withTxn_assignsRequest() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        com.newrelic.api.agent.Request mockRequest = mock(com.newrelic.api.agent.Request.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.setWebRequest(mockRequest);
+            verify(mockTxn).setWebRequest(mockRequest);
+        }
+    }
+
+    @Test
+    public void setWebResponse_withTxn_assignsResponse() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        com.newrelic.api.agent.Response mockResponse = mock(com.newrelic.api.agent.Response.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.setWebResponse(mockResponse);
+            verify(mockTxn).setWebResponse(mockResponse);
+        }
+    }
+
+    @Test
+    public void getWebResponse_withTxn_returnsResponse() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.getWebResponse();
+            verify(mockTxn).getWebResponse();
+        }
+    }
+
+    @Test
+    public void convertToWebTransaction_withTxn_convertsTxn() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.convertToWebTransaction();
+            verify(mockTxn).convertToWebTransaction();
+        }
+    }
+
+    @Test
+    public void isWebTransaction_withTxn_returnsWebTxnFlag() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.isWebTransaction();
+            verify(mockTxn).isWebTransaction();
+        }
+    }
+
+    @Test
+    public void requestInitialized_withTxn_initsRequest() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        com.newrelic.api.agent.Response mockResponse = mock(com.newrelic.api.agent.Response.class);
+        com.newrelic.api.agent.Request mockRequest = mock(com.newrelic.api.agent.Request.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.requestInitialized(mockRequest, mockResponse);
+            verify(mockTxn).requestInitialized(mockRequest, mockResponse);
+        }
+    }
+
+    @Test
+    public void requestDestroyed_withTxn_destroysRequest() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.requestDestroyed();
+            verify(mockTxn).requestDestroyed();
+        }
+    }
+
+    @Test
+    public void saveMessageParameters_withTxn_saveParams() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+        Map<String, String> map = new HashMap<>();
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.saveMessageParameters(map);
+            verify(mockTxn).saveMessageParameters(map);
+        }
+    }
+
+    @Test
+    public void getCrossProcessState_withTxn_returnsProcessState() {
+        TransactionApiImpl transactionApi = new TransactionApiImpl();
+        Transaction mockTxn = mock(Transaction.class);
+
+        try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
+            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
+            transactionApi.getCrossProcessState();
+            verify(mockTxn).getCrossProcessState();
+        }
+    }
+
+    private void configureServiceFactory() {
+        ServiceManager serviceManager = mock(ServiceManager.class);
+        when(serviceManager.getAsyncTxService()).thenReturn(mockAsyncTransactionService);
+        when(serviceManager.getConfigService()).thenReturn(Mockito.mock(ConfigService.class));
+        when(serviceManager.getConfigService().getDefaultAgentConfig()).thenReturn(AgentConfigImpl.createAgentConfig(null));
+        ServiceFactory.setServiceManager(serviceManager);
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/NonUrlClassLoadersTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/NonUrlClassLoadersTest.java
@@ -1,0 +1,23 @@
+package com.newrelic.agent.instrumentation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class NonUrlClassLoadersTest {
+    @Test
+    public void getNonUrlType_withNullName_returnsNull() {
+        assertNull(NonUrlClassLoaders.getNonUrlType(null));
+    }
+
+    @Test
+    public void getNonUrlType_withValidName_returnsProperInstance() {
+        assertEquals(NonUrlClassLoaders.JBOSS_6, NonUrlClassLoaders.getNonUrlType("org.jboss.classloader.spi.base.BaseClassLoader"));
+    }
+
+    @Test
+    public void getNonUrlType_withInvalidName_returnsNull() {
+        assertNull(NonUrlClassLoaders.getNonUrlType("foo"));
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/stats/DataUsageStatsTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/stats/DataUsageStatsTest.java
@@ -1,0 +1,63 @@
+package com.newrelic.agent.stats;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+public class DataUsageStatsTest {
+    @Test
+    public void clone_properlyClonesObject() throws CloneNotSupportedException {
+        DataUsageStats dataUsageStats = new DataUsageStatsImpl();
+        dataUsageStats.recordDataUsage(100L, 200L);
+        dataUsageStats.recordDataUsage(100L, 200L);
+
+        //Count: 2, sent 200, received: 400
+        DataUsageStats clone = (DataUsageStats)dataUsageStats.clone();
+        assertEquals(2, clone.getCount());
+        assertEquals(200L, clone.getBytesSent());
+        assertEquals(400L, clone.getBytesReceived());
+    }
+
+    @Test
+    public void hasData_returnsTrueWithDataPresent() {
+        DataUsageStats dataUsageStats = new DataUsageStatsImpl();
+        dataUsageStats.recordDataUsage(100L, 200L);
+        assertTrue(dataUsageStats.hasData());
+
+        dataUsageStats = new DataUsageStatsImpl();
+        assertFalse(dataUsageStats.hasData());
+    }
+
+    @Test
+    public void reset_setAllValuesToZero() {
+        DataUsageStats dataUsageStats = new DataUsageStatsImpl();
+        dataUsageStats.recordDataUsage(100L, 200L);
+        assertTrue(dataUsageStats.hasData());
+
+        dataUsageStats.reset();
+        assertFalse(dataUsageStats.hasData());
+        assertEquals(0, dataUsageStats.getCount());
+        assertEquals(0, dataUsageStats.getBytesReceived());
+        assertEquals(0, dataUsageStats.getBytesSent());
+    }
+
+    @Test
+    public void writeJSONString_writesToSuppliedWriter() throws IOException {
+        DataUsageStats dataUsageStats = new DataUsageStatsImpl();
+        dataUsageStats.recordDataUsage(100L, 200L);
+
+        try (MockedStatic<org.json.simple.JSONArray> mockJsonArray = mockStatic(org.json.simple.JSONArray.class)) {
+            dataUsageStats.writeJSONString(mock(Writer.class));
+            mockJsonArray.verify(() -> org.json.simple.JSONArray.writeJSONString(any(), any()));
+        }
+    }
+}


### PR DESCRIPTION
Basic static mock example:
```
try (MockedStatic<com.newrelic.agent.Transaction> mockStaticTxn = mockStatic(com.newrelic.agent.Transaction.class)) {
            mockStaticTxn.when(() -> com.newrelic.agent.Transaction.getTransaction(false)).thenReturn(mockTxn);
            //Call the method under test ...
            verify(mockTxn).requestDestroyed();
        }
```

The mocking is enclosed in a try-with-resource block so the mocked gets "closed" when we're done with it. The `when` clauses are lambda that work like instance mocks.