### PR TITLE
Disabling kafka-connect-spans by default

### DIFF
--- a/instrumentation/kafka-connect-spans-2.0.0/build.gradle
+++ b/instrumentation/kafka-connect-spans-2.0.0/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 }
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-connect-spans-2.0.0',
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-connect-spans-2.0.0', 'Enabled': 'false',
             'Implementation-Title-Alias': 'kafka-connect-spans' }
 }
 

--- a/instrumentation/kafka-connect-spans-3.3.0/build.gradle
+++ b/instrumentation/kafka-connect-spans-3.3.0/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 }
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-connect-spans-3.3.0',
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-connect-spans-3.3.0', 'Enabled': 'false',
             'Implementation-Title-Alias': 'kafka-connect-spans' }
 }
 


### PR DESCRIPTION
### Overview
Disabling Kafka Connect Span instrumentation by default.

This instrumentation could incur noticeable overhead, so it should only be turned on when configured.