### PR TITLE
Docker fix

### DIFF
--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -64,7 +64,6 @@ jobs:
           echo "framework/play/play2.py" >> $excluded_tests
           echo "framework/snap/snap.py" >> $excluded_tests
           echo "r2dbc/mssql.py" >> $excluded_tests
-          echo "r2dbc/oracle.py" >> $excluded_tests
           echo "server/mule.py" >> $excluded_tests
           echo "server/weblogic.py" >> $excluded_tests
           # The files below are not tests
@@ -255,6 +254,7 @@ jobs:
       - name: Create virtualenv and run ${{ matrix.tests }}
         if: ${{ failure() || success() }}
         run: |
+          docker rmi $(docker images -q)
           cd agent-integration-tests
           echo "conf/testenv complains of the path below - creating symlink for now"
           ln -s ${GITHUB_WORKSPACE}/apps /home/runner/apps

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -241,20 +241,23 @@ jobs:
 
       ## End JDK Install
 
+      # looks like docker is not properly sanitized between runs in GHA
+      # so its disk space may be pilling up and blows up during our tests
+      - name: Clean Docker volume data
+        run: docker system prune --all
+
       ## TESTING SECTION
 
       # Replication of steps from ait README
 
       - name: CD to agent-integration-tests dir.
-        run: |
-          cd agent-integration-tests/
+        run: cd agent-integration-tests/
 
       ## WE LOSE THE VIRTUAL ENVIRONMENT ONCE WE LEAVE THE STEP
       ## TODO: This should really be a custom action, too many commands
       - name: Create virtualenv and run ${{ matrix.tests }}
         if: ${{ failure() || success() }}
         run: |
-          docker rmi $(docker images -q)
           cd agent-integration-tests
           echo "conf/testenv complains of the path below - creating symlink for now"
           ln -s ${GITHUB_WORKSPACE}/apps /home/runner/apps

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -243,8 +243,8 @@ jobs:
 
       # looks like docker is not properly sanitized between runs in GHA
       # so its disk space may be pilling up and blows up during our tests
-      - name: Clean Docker volume data
-        run: docker system prune --all
+      - name: Clean Docker image data
+        run: docker rmi $(docker images -q)
 
       ## TESTING SECTION
 


### PR DESCRIPTION
### Overview
Recently some tests that use testcontainers start failing.
The first one would blow up and give no clue to what was going on.
Then a few more started failing, but they provided logs which helped diagnose the problem.

It seems that the Docker was running out of its disk space. Looks like that is not hygienized between runs.
So this PR adds a step to clean that up. It also re enables a test that was recently disabled.