### PR TITLE
HttpUrlConnection cleanup thread name normalization

### DIFF
--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/DefaultThreadFactory.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/DefaultThreadFactory.java
@@ -33,8 +33,7 @@ public class DefaultThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(Runnable r) {
         int num = threadNumber.getAndIncrement();
-        String threadName = num == 1 ? name : name + " " + num;
-        Thread t = new Thread(r, threadName);
+        Thread t = new Thread(r, name + " " + num);
         if (daemon) {
             t.setDaemon(true);
         }


### PR DESCRIPTION
### Overview
HttpUrlConnection instrumentation has a thread pool where all the threads have a name with a number on the end, except the first thread.
This causes the first thread to report different metrics than the other ones.

This PR normalizes the name of the threads so all end in a number, so all will report under the same metrics.