### PR TITLE
Add tests stats

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/stats/StatsImpl.java
@@ -59,7 +59,7 @@ public class StatsImpl extends AbstractStats implements Stats {
             throw new IllegalArgumentException("Data points must be numbers");
         }
         double sos = sumOfSquares + (value * value);
-        if (sos < sumOfSquares) {
+        if (Double.isInfinite(sos)) {
             throw new IllegalArgumentException("Data value " + value + " caused sum of squares to roll over");
         }
         if (count > 0) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/stats/ApdexStatsImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/stats/ApdexStatsImplTest.java
@@ -1,0 +1,101 @@
+package com.newrelic.agent.stats;
+
+import com.newrelic.agent.model.ApdexPerfZone;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mockStatic;
+
+public class ApdexStatsImplTest {
+
+    @Test
+    public void testClone() throws CloneNotSupportedException{
+        ApdexStatsImpl apdexStats = new ApdexStatsImpl(3, 5, 8);
+        ApdexStatsImpl clone = (ApdexStatsImpl) apdexStats.clone();
+
+        assertEquals(3, clone.getApdexSatisfying());
+        assertEquals(5, clone.getApdexTolerating());
+        assertEquals(8, clone.getApdexFrustrating());
+
+        assertNotEquals(apdexStats.toString(), clone.toString());
+        assertNotSame(clone, apdexStats);
+
+    }
+
+    @Test
+    public void testHasData() {
+        ApdexStatsImpl apdexStatsNoData = new ApdexStatsImpl(0, 0, 0);
+        ApdexStatsImpl apdexStatsSomeData1 = new ApdexStatsImpl(1, 0, 0);
+        ApdexStatsImpl apdexStatsSomeData2 = new ApdexStatsImpl(0, 2, 0);
+        ApdexStatsImpl apdexStatsSomeData3 = new ApdexStatsImpl(0, 0, 1);
+        ApdexStatsImpl apdexStatsAllTheData = new ApdexStatsImpl(1, 2, 3);
+
+        assertFalse(apdexStatsNoData.hasData());
+        assertTrue(apdexStatsSomeData1.hasData());
+        assertTrue(apdexStatsSomeData2.hasData());
+        assertTrue(apdexStatsSomeData3.hasData());
+        assertTrue(apdexStatsAllTheData.hasData());
+
+    }
+
+    @Test
+    public void testReset() {
+        ApdexStatsImpl apdexStats = new ApdexStatsImpl(1,2 , 3);
+        apdexStats.reset();
+        assertFalse(apdexStats.hasData());
+    }
+
+    @Test
+    public void recordApdexResponseTime_correctlyIncrements_perfZones(){
+        ApdexStatsImpl apdexStats = new ApdexStatsImpl(3, 5, 8);
+        try (MockedStatic<ApdexPerfZoneDetermination> mockStaticApdexPerfZoneDet = mockStatic(ApdexPerfZoneDetermination.class)){
+
+            //The responseTime/adpexT combos below align with the current thresholds for Satisfying, Tolerating, and Frustrating in ApdexPerfZoneDetermination.
+            //Tested with MockedStatic so that this test will pass if the thresholds for the zones ever change.
+            mockStaticApdexPerfZoneDet.when(()-> ApdexPerfZoneDetermination.getZone(10L, 40L)).thenReturn(ApdexPerfZone.SATISFYING);
+            mockStaticApdexPerfZoneDet.when(()-> ApdexPerfZoneDetermination.getZone(150L, 40L)).thenReturn(ApdexPerfZone.TOLERATING);
+            mockStaticApdexPerfZoneDet.when(()-> ApdexPerfZoneDetermination.getZone(200L, 40L)).thenReturn(ApdexPerfZone.FRUSTRATING);
+
+            apdexStats.recordApdexResponseTime(10L, 40L);
+            assertEquals(4, apdexStats.getApdexSatisfying());
+            assertEquals(5, apdexStats.getApdexTolerating());
+            assertEquals(8, apdexStats.getApdexFrustrating());
+
+            apdexStats.recordApdexResponseTime(150L, 40L);
+            assertEquals(4, apdexStats.getApdexSatisfying());
+            assertEquals(6, apdexStats.getApdexTolerating());
+            assertEquals(8, apdexStats.getApdexFrustrating());
+
+            apdexStats.recordApdexResponseTime(200L, 40L);
+            assertEquals(4, apdexStats.getApdexSatisfying());
+            assertEquals(6, apdexStats.getApdexTolerating());
+            assertEquals(9, apdexStats.getApdexFrustrating());
+        }
+
+    }
+
+    @Test
+    public void merge_nonApdexStats_doesNothing(){
+        ApdexStatsImpl apdexStats = new ApdexStatsImpl(3, 5, 8);
+        StatsImpl notApdexStatsObj = new StatsImpl(1, 2, 3, 4, 5);
+        apdexStats.merge(notApdexStatsObj);
+
+        assertEquals(3, apdexStats.getApdexSatisfying());
+        assertEquals(5, apdexStats.getApdexTolerating());
+        assertEquals(8, apdexStats.getApdexFrustrating());
+
+    }
+
+    @Test
+    public void merge_apdexStats_incrementsAllFields(){
+        ApdexStatsImpl apdexStats = new ApdexStatsImpl(3, 5, 8);
+        ApdexStatsImpl otherApdexStats = new ApdexStatsImpl(10, 11, 12);
+        apdexStats.merge(otherApdexStats);
+
+        assertEquals(13, apdexStats.getApdexSatisfying());
+        assertEquals(16, apdexStats.getApdexTolerating());
+        assertEquals(20, apdexStats.getApdexFrustrating());
+    }
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/stats/SimpleStatsEngineTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/stats/SimpleStatsEngineTest.java
@@ -1,0 +1,81 @@
+package com.newrelic.agent.stats;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SimpleStatsEngineTest {
+
+    SimpleStatsEngine eng;
+    @Before
+    public void setup(){
+        this.eng = new SimpleStatsEngine(10);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getStats_nullMetrics_shouldThrow(){
+        eng.getStats(null);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getStats_metricWithWrongStatsType_shouldThrow(){
+        String dummyMetric = "fake_metric";
+        eng.recordEmptyStats(dummyMetric);
+        eng.getStats(dummyMetric);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getOrCreateResponseTimeStats_nullMetric_shouldThrow(){
+        eng.getOrCreateResponseTimeStats(null);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getOrCreateResponseTimeStats_metricWithWrongStatsType_shouldThrow(){
+        String dummyMetric = "fake_metric";
+        eng.recordEmptyStats(dummyMetric);
+        eng.getOrCreateResponseTimeStats(dummyMetric);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void recordEmptyStats_nullMetric_shouldThrow(){
+        eng.recordEmptyStats(null);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getApdexStats_nullMetric_shouldThrow(){
+        eng.getApdexStats(null);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getApdexStats_metricWithWrongStatsType_shouldThrow(){
+        String dummyMetric = "fake_metric";
+        eng.recordEmptyStats(dummyMetric);
+        eng.getApdexStats(dummyMetric);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getDataUsageStats_nullMetric_shouldThrow(){
+        eng.getDataUsageStats(null);
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getDataUsageStats_metricWithWrongStatsType_shouldThrow(){
+        String dummyMetric = "fake_metric";
+        eng.recordEmptyStats(dummyMetric);
+        eng.getDataUsageStats(dummyMetric);
+    }
+
+    @Test
+    public void testToString(){
+        eng.recordEmptyStats("foo");
+        ResponseTimeStats responseTimeStats = eng.getOrCreateResponseTimeStats("baz");
+        String statsString = eng.getStatsMap().toString();
+        assertEquals("SimpleStatsEngine [stats=" + statsString + "]", eng.toString());
+
+    }
+
+
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/stats/StatsImplTest.java
@@ -1,0 +1,54 @@
+package com.newrelic.agent.stats;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StatsImplTest {
+
+    @Test
+    public void testClone() throws CloneNotSupportedException{
+        StatsImpl stats = new StatsImpl(2, 3.12f, 5.01f, 8.95f, 13.02);
+        StatsImpl statsClone = (StatsImpl) stats.clone();
+        double delta = .00001;
+
+
+        assertNotSame(stats, statsClone);
+        assertEquals(2, statsClone.getCallCount());
+        assertEquals(3.12, statsClone.getTotal(), delta);
+        assertEquals(5.01, statsClone.getMinCallTime(), delta);
+        assertEquals(8.95, statsClone.getMaxCallTime(), delta);
+        assertEquals(13.02, statsClone.getSumOfSquares(), delta);
+
+    }
+
+    @Test
+    public void testToString(){
+        StatsImpl stats = new StatsImpl(2, 3.12f, 5.01f, 8.95f, 13.02);
+        String suffix = "[total=3.12, count=2, minValue=5.01, maxValue=8.95, sumOfSquares=13.02]";
+        assertTrue(stats.toString().endsWith(suffix));
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void recordDataPoint_throws_whenSOSTooLarge(){
+        double maxDouble = Double.MAX_VALUE;
+        StatsImpl stats = new StatsImpl(2, 3.12f, 5.01f, 8.95f, maxDouble);
+        stats.recordDataPoint(Float.MAX_VALUE);
+    }
+
+    @Test
+    public void testHasData(){
+        StatsImpl stats = new StatsImpl(1, 2.2f, 4.007f, 8.12f, 75.68);
+        assertTrue(stats.hasData());
+
+        stats.reset();
+        assertFalse(stats.hasData());
+
+        StatsImpl statsSomeData = new StatsImpl(0, 2.2f, 3f, 4f, 6.6);
+        StatsImpl statsSomeOtherData = new StatsImpl(4, 0, 3f, 4f, 6.6);
+        assertTrue(statsSomeData.hasData());
+        assertTrue(statsSomeOtherData.hasData());
+    }
+
+}


### PR DESCRIPTION
This PR:
- Alters a rollover check in the StatsImpl class to use Double.isInfinite() rather than the < operator, as doubles do not wraparound on overflow. 
- adds additional unit tests to the newrelic.agent.stats package. 

