### PR TITLE
Add weave violation filter support. Resolves #1197

### DIFF
--- a/instrumentation/spring-4.3.0/build.gradle
+++ b/instrumentation/spring-4.3.0/build.gradle
@@ -11,7 +11,8 @@ dependencies {
 
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spring-4.3.0',
-            'Implementation-Title-Alias': 'spring_annotations' }
+            'Implementation-Title-Alias': 'spring_annotations',
+            'Weave-Violation-Filter': 'METHOD_MISSING_REQUIRED_ANNOTATIONS,CLASS_MISSING_REQUIRED_ANNOTATIONS' }
 }
 
 verifyInstrumentation {

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/WeaveViolationFilter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/WeaveViolationFilter.java
@@ -1,0 +1,62 @@
+package com.newrelic.weave;
+
+import com.google.common.collect.Queues;
+import com.newrelic.weave.violation.WeaveViolation;
+import com.newrelic.weave.violation.WeaveViolationType;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * A class used to filter specific violations from being added to {@link com.newrelic.weave.weavepackage.PackageValidationResult} instances.
+ * Instances of this class are created and stored with each {@link com.newrelic.weave.weavepackage.WeavePackageConfig} object (if
+ * filters are configured for the instrumentation package).
+ */
+public class WeaveViolationFilter {
+    private final List<WeaveViolationType> typesToFilter = new ArrayList<>();
+
+    private final String weavePackage;
+
+    public WeaveViolationFilter(String weavePackage, List<WeaveViolationType> types) {
+        this.typesToFilter.addAll(types);
+        this.weavePackage = weavePackage;
+    }
+
+    /**
+     * Remove ignorable {@link WeaveViolation} instances from the supplied collection of violations.
+     *
+     * @param violations the collection of WeaveViolations to apply the filter to
+     * @return a filtered collection of WeaveViolations
+     */
+    public Collection<WeaveViolation> filterViolationCollection(Collection<WeaveViolation> violations) {
+        Queue<WeaveViolation> newViolationCollection = Queues.newConcurrentLinkedQueue();
+        for (WeaveViolation violation : violations) {
+            if (!shouldIgnoreViolation(violation)) {
+                newViolationCollection.add(violation);
+            }
+        }
+
+        return  newViolationCollection;
+    }
+
+    /**
+     * Return true if the supplied {@link WeaveViolation} instance should be ignored based on the filter
+     *
+     * @param violation the WeaveViolation to check
+     * @return true if this WeaveViolation should be filtered
+     */
+    public boolean shouldIgnoreViolation(WeaveViolation violation) {
+        return typesToFilter.contains(violation.getType());
+    }
+
+    /**
+     * Return the weave package this filter belongs to
+     *
+     * @return the weave package name
+     */
+    public String getWeavePackage() {
+        return this.weavePackage;
+    }
+}

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/PackageValidationResult.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/PackageValidationResult.java
@@ -191,7 +191,7 @@ public class PackageValidationResult {
         }
     }
 
-    private void buildResults(ClassCache classCache, ClassNode originalClassNode, String weaveClassName,
+    private boolean buildResults(ClassCache classCache, ClassNode originalClassNode, String weaveClassName,
             ClassNode weaveNode, Map<String, PreparedMatch> results, boolean isBaseMatch,
             Set<String> requiredClassAnnotations, Set<String> requiredMethodAnnotations, ClassNode errorHandler,
             Map<String, byte[]> annotationProxyClasses) throws IOException {
@@ -227,6 +227,9 @@ public class PackageValidationResult {
         }
 
         violations.addAll((this.weaveViolationFilter == null ? match.getViolations() : this.weaveViolationFilter.filterViolationCollection(match.getViolations())));
+
+        //Return true if this match had violations, even if they were filtered out of the PackageValidationResult violation list
+        return match.getViolations().size() > 0;
     }
 
     /**
@@ -461,12 +464,12 @@ public class PackageValidationResult {
         try {
             boolean isInterfaceMatch = WeaveUtils.isWeaveWithAnnotationInterfaceMatch(weaveNode);
             Map<String, PreparedMatch> results = new HashMap<>();
-            buildResults(cache, targetNode, weaveNode.name, weaveNode, results, isInterfaceMatch,
+            boolean targetNodeContainsViolations = buildResults(cache, targetNode, weaveNode.name, weaveNode, results, isInterfaceMatch,
                     weavePackage.getRequiredAnnotationClassesForAnnotationWeave(weaveNode.name),
                     weavePackage.getRequiredAnnotationClassesForMethodAnnotationWeave(weaveNode.name),
                     errorHandler, annotationProxyClasses);
 
-            if (!violations.isEmpty()) {
+            if (targetNodeContainsViolations) {
                 return composite;
             }
 

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageConfig.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageConfig.java
@@ -7,11 +7,15 @@
 
 package com.newrelic.weave.weavepackage;
 
+import com.newrelic.weave.WeaveViolationFilter;
+import com.newrelic.weave.violation.WeaveViolationType;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.regex.Matcher;
@@ -37,6 +41,7 @@ public class WeavePackageConfig implements Comparable<WeavePackageConfig>{
         private boolean enabled = true;
         private long priority = 0L;
         private boolean custom = false;
+        private WeaveViolationFilter weaveViolationFilter = null;
         private ClassNode errorHandleClassNode = ErrorTrapHandler.NO_ERROR_TRAP_HANDLER;
         private WeavePreprocessor preprocessor = WeavePreprocessor.NO_PREPROCESSOR;
         private WeavePostprocessor postprocessor = WeavePostprocessor.NO_POSTPROCESSOR;
@@ -149,6 +154,41 @@ public class WeavePackageConfig implements Comparable<WeavePackageConfig>{
          */
         public Builder priority(long priority) {
             this.priority = priority;
+            return this;
+        }
+
+        /**
+         * Using the supplied {@code violationFilterToken}, create a {@link WeaveViolationFilter} instance to be stored
+         * as part of the config.
+         * <p>
+         * The filter is configured by adding a manifest attribute of {@code Weave-Violation-Filter} with a value
+         * of {@link WeaveViolationType} strings, seperated by a comma. For example:
+         * <pre>
+         *     Weave-Violation-Filter: METHOD_MISSING_REQUIRED_ANNOTATIONS,CLASS_MISSING_REQUIRED_ANNOTATIONS
+         * </pre>
+         *
+         * Weave violations that match any of the configured types will be ignored and not added to the
+         * {@link PackageValidationResult}'s violation list. If no types are configured in the manifest,
+         * no filter will be created or applied.
+         *
+         * @param violationFilterToken the comma seperated String of WeaveViolationTypes to ignore
+         * @return builder with updated state
+         */
+        public Builder weaveViolationFilters(String violationFilterToken) {
+            if (violationFilterToken != null) {
+                String [] filterTokens = violationFilterToken.split(",");
+                List<WeaveViolationType> types = new ArrayList<>();
+                for (String type : filterTokens) {
+                    try {
+                        types.add(WeaveViolationType.valueOf(type));
+                    } catch (IllegalArgumentException ignored) {}
+                }
+
+                if (types.size() > 0 ) {
+                    this.weaveViolationFilter = new WeaveViolationFilter(this.name, types);
+                }
+            }
+
             return this;
         }
 
@@ -276,7 +316,10 @@ public class WeavePackageConfig implements Comparable<WeavePackageConfig>{
             String priorityS = mainAttributes.getValue("Priority");
             long priority = priorityS == null ? 0 : Long.parseLong(priorityS);
 
-            return this.name(name).alias(alias).vendorId(vendorId).version(version).enabled(enabled).priority(priority);
+            String violationFilterToken = mainAttributes.getValue("Weave-Violation-Filter");
+
+            return this.name(name).alias(alias).vendorId(vendorId).version(version).enabled(enabled).priority(priority)
+                    .weaveViolationFilters(violationFilterToken);
         }
 
         /**
@@ -290,7 +333,7 @@ public class WeavePackageConfig implements Comparable<WeavePackageConfig>{
                 throw new RuntimeException("WeavePackageConfig must have an Implementation-Name");
             }
             return new WeavePackageConfig(name, alias, vendorId, version, enabled, priority, source, custom, instrumentation,
-                    errorHandleClassNode, preprocessor, postprocessor, extensionClassTemplate);
+                    errorHandleClassNode, preprocessor, postprocessor, extensionClassTemplate, weaveViolationFilter);
         }
     }
 
@@ -321,10 +364,12 @@ public class WeavePackageConfig implements Comparable<WeavePackageConfig>{
     private final WeavePostprocessor postprocessor;
     private final ClassNode extensionClassTemplate;
     private final long priority;
+    private final WeaveViolationFilter weaveViolationFilter;
 
     private WeavePackageConfig(String name, String alias, String vendorId, float version, boolean enabled,
             long priority, String source, boolean custom, Instrumentation instrumentation, ClassNode errorTrapClassNode,
-            WeavePreprocessor preprocessor, WeavePostprocessor postprocessor, ClassNode extensionClassTemplate) {
+            WeavePreprocessor preprocessor, WeavePostprocessor postprocessor, ClassNode extensionClassTemplate,
+            WeaveViolationFilter weaveViolationFilter) {
         this.name = name;
         this.alias = alias;
         this.vendorId = vendorId;
@@ -339,6 +384,7 @@ public class WeavePackageConfig implements Comparable<WeavePackageConfig>{
         this.preprocessor = preprocessor;
         this.postprocessor = postprocessor;
         this.extensionClassTemplate = extensionClassTemplate;
+        this.weaveViolationFilter = weaveViolationFilter;
     }
 
     /**
@@ -397,6 +443,13 @@ public class WeavePackageConfig implements Comparable<WeavePackageConfig>{
      */
     public boolean isCustom() {
         return custom;
+    }
+
+    /**
+     * The {@link WeaveViolationFilter} instance, if violations to filter are configured in the module manifest; null otherwise
+     */
+    public WeaveViolationFilter getWeaveViolationFilter() {
+        return this.weaveViolationFilter;
     }
 
     /**

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveViolationFilterTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveViolationFilterTest.java
@@ -1,0 +1,69 @@
+package com.newrelic.weave;
+
+import com.newrelic.weave.violation.WeaveViolation;
+import com.newrelic.weave.violation.WeaveViolationType;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WeaveViolationFilterTest {
+    List<WeaveViolationType> violationTypes;
+
+    @Before
+    public void setup() {
+        violationTypes = new ArrayList<>();
+        violationTypes.add(WeaveViolationType.METHOD_MISSING_REQUIRED_ANNOTATIONS);
+        violationTypes.add(WeaveViolationType.CLASS_MISSING_REQUIRED_ANNOTATIONS);
+    }
+
+
+    @Test
+    public void shouldIgnoreViolation_withIgnorableViolation_returnsTrue() {
+        WeaveViolationFilter filter = new WeaveViolationFilter("com/nr/agent/instrumentation/SpringController_Instrumentation", violationTypes);
+
+        WeaveViolation violation = new WeaveViolation(WeaveViolationType.METHOD_MISSING_REQUIRED_ANNOTATIONS, "com/nr/agent/instrumentation/SpringController_Instrumentation");
+        assertTrue(filter.shouldIgnoreViolation(violation));
+
+        violation = new WeaveViolation(WeaveViolationType.CLASS_MISSING_REQUIRED_ANNOTATIONS, "com/nr/agent/instrumentation/SpringController_Instrumentation");
+        assertTrue(filter.shouldIgnoreViolation(violation));
+    }
+
+    @Test
+    public void shouldIgnoreViolation_withNonIgnorableViolation_returnsFalse() {
+        WeaveViolationFilter filter = new WeaveViolationFilter("com/nr/agent/instrumentation/SpringController_Instrumentation", violationTypes);
+
+        WeaveViolation violation = new WeaveViolation(WeaveViolationType.FIELD_TYPE_MISMATCH, "com/nr/agent/instrumentation/SpringController_Instrumentation");
+        assertFalse(filter.shouldIgnoreViolation(violation));
+    }
+
+    @Test
+    public void filterViolationCollection_filtersIgnorableViolations() {
+        WeaveViolationFilter filter = new WeaveViolationFilter("com/nr/agent/instrumentation/SpringController_Instrumentation", violationTypes);
+
+        Collection<WeaveViolation> violations = new ArrayList<>();
+        violations.add(new WeaveViolation(WeaveViolationType.METHOD_MISSING_REQUIRED_ANNOTATIONS, "com/nr/agent/instrumentation/SpringController_Instrumentation"));
+        violations.add(new WeaveViolation(WeaveViolationType.CLASS_MISSING_REQUIRED_ANNOTATIONS, "com/nr/agent/instrumentation/SpringController_Instrumentation"));
+        violations.add(new WeaveViolation(WeaveViolationType.EXPECTED_NEW_FIELD_ANNOTATION, "com/nr/agent/instrumentation/SpringController_Instrumentation"));
+        violations.add(new WeaveViolation(WeaveViolationType.CLASS_ACCESS_MISMATCH, "com/nr/agent/instrumentation/SpringController_Instrumentation"));
+
+        assertEquals(4, violations.size());
+
+        Collection<WeaveViolation> filteredViolations = filter.filterViolationCollection(violations);
+        assertEquals(2, filteredViolations.size());
+        assertTrue(filteredViolations.contains(new WeaveViolation(WeaveViolationType.EXPECTED_NEW_FIELD_ANNOTATION, "com/nr/agent/instrumentation/SpringController_Instrumentation")));
+        assertTrue(filteredViolations.contains(new WeaveViolation(WeaveViolationType.CLASS_ACCESS_MISMATCH, "com/nr/agent/instrumentation/SpringController_Instrumentation")));
+    }
+
+    @Test
+    public void getWeavePackage_returnsCorrectValue() {
+        WeaveViolationFilter filter = new WeaveViolationFilter("com/nr/agent/instrumentation/SpringController_Instrumentation", violationTypes);
+        assertEquals("com/nr/agent/instrumentation/SpringController_Instrumentation", filter.getWeavePackage());
+    }
+}

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageConfigTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/WeavePackageConfigTest.java
@@ -1,0 +1,33 @@
+package com.newrelic.weave.weavepackage;
+
+import com.newrelic.weave.WeaveViolationFilter;
+import com.newrelic.weave.violation.WeaveViolation;
+import com.newrelic.weave.violation.WeaveViolationType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class WeavePackageConfigTest {
+    @Test
+    public void ConfigBuilder_withConfiguredFilters_createsWeaveViolationFilter() {
+        WeavePackageConfig.Builder builder = new WeavePackageConfig.Builder();
+        WeavePackageConfig config = builder.name("test")
+                .weaveViolationFilters("METHOD_MISSING_REQUIRED_ANNOTATIONS,CLASS_MISSING_REQUIRED_ANNOTATIONS")
+                .build();
+
+        WeaveViolationFilter filter = config.getWeaveViolationFilter();
+        assertEquals("test", filter.getWeavePackage());
+        assertTrue(filter.shouldIgnoreViolation(new WeaveViolation(WeaveViolationType.CLASS_MISSING_REQUIRED_ANNOTATIONS, "clazz")));
+        assertTrue(filter.shouldIgnoreViolation(new WeaveViolation(WeaveViolationType.METHOD_MISSING_REQUIRED_ANNOTATIONS, "clazz")));
+    }
+
+    @Test
+    public void ConfigBuilder_withoutConfiguredFilters_doesNotCreatesWeaveViolationFilter() {
+        WeavePackageConfig.Builder builder = new WeavePackageConfig.Builder();
+        WeavePackageConfig config = builder.name("test").build();
+
+        assertNull(config.getWeaveViolationFilter());
+    }
+}


### PR DESCRIPTION
- Adds the ability to filter/ignore specific weave violations, configured per instrumentation module.
- Configures the spring-4.3.0 module to ignore `METHOD_MISSING_REQUIRED_ANNOTATIONS` and `CLASS_MISSING_REQUIRED_ANNOTATIONS` weave violations.

The filter is configured by adding a manifest attribute of `Weave-Violation-Filter` with a value of  WeaveViolationType strings, separated by a comma. For example:
```
Weave-Violation-Filter: METHOD_MISSING_REQUIRED_ANNOTATIONS,CLASS_MISSING_REQUIRED_ANNOTATIONS
```

In the context of an agent's instrumentation module, this is configured in the module's `build.gradle` file:
```
jar {
    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.spring-4.3.0',
            'Implementation-Title-Alias': 'spring_annotations',
            'Weave-Violation-Filter': 'METHOD_MISSING_REQUIRED_ANNOTATIONS,CLASS_MISSING_REQUIRED_ANNOTATIONS' }
}
```

Weave violations that match any of the configured types will be ignored and not added to the PackageValidationResult's violation list. If no types are configured in the manifest, no filter will be created or applied.

Specifically for the Spring instrumentation, the module is configured to ignore both `METHOD_MISSING_REQUIRED_ANNOTATIONS` and `CLASS_MISSING_REQUIRED_ANNOTATIONS` violations. This is because previously, if a Spring controller was missing the `@RestController` or `@Controller` annotation, a violation would be added to the PackageValidationResult object, which would cause subsequent controllers with the proper annotations to not be instrumented. This combination of filters will also ignore violations where the controller has a proper `@Controller` but is missing method level annotations.

Thanks to @mgr32 for the detailed analysis and repro app.