### PR TITLE
202 azul updates

### DIFF
--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -104,7 +104,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.list-tests.outputs.tests) }}
-      max-parallel: 20
     steps:
       - name: Retrieve agent from cache
         id: retrieve-agent


### PR DESCRIPTION
- Added versions 17 and 20 for Azul to the config for AIT runs.
- Moved the docker cleanup step earlier in the process, to fix some space issues during JDK installs
