### PR TITLE
Decouple jar scanning function from class match vistor collection

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IgnoringJarCollectorService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IgnoringJarCollectorService.java
@@ -11,6 +11,7 @@ import com.newrelic.agent.Agent;
 import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.logging.IAgentLogger;
 import com.newrelic.agent.service.module.ClassToJarPathSubmitter;
+import com.newrelic.agent.service.module.ClassToJarPathSubmitterImpl;
 import com.newrelic.agent.service.module.JarCollectorService;
 
 public class IgnoringJarCollectorService implements JarCollectorService {
@@ -21,7 +22,7 @@ public class IgnoringJarCollectorService implements JarCollectorService {
 
     @Override
     public ClassToJarPathSubmitter getClassToJarPathSubmitter() {
-        return null;
+        return ClassToJarPathSubmitterImpl.NO_OP_INSTANCE;
     }
 
     @Override

--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IgnoringJarCollectorService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IgnoringJarCollectorService.java
@@ -10,17 +10,18 @@ package com.newrelic.agent.introspec.internal;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.logging.IAgentLogger;
+import com.newrelic.agent.service.module.ClassToJarPathSubmitter;
 import com.newrelic.agent.service.module.JarCollectorService;
 
 public class IgnoringJarCollectorService implements JarCollectorService {
     @Override
-    public ClassMatchVisitorFactory getSourceVisitor() {
-        return null;
+    public void harvest(String appName) {
+
     }
 
     @Override
-    public void harvest(String appName) {
-
+    public ClassToJarPathSubmitter getClassToJarPathSubmitter() {
+        return null;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
@@ -63,6 +63,13 @@ public class InstrumentationClassTransformer implements ClassFileTransformer {
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
             ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
         long transformStartTimeInNs = System.nanoTime();
+
+        //Submit the class for possible analysis from the jar collector
+        if((protectionDomain != null) && (protectionDomain.getCodeSource() != null)) {
+            Agent.LOG.finest(MessageFormat.format("DUF- submitting {0} to jar collector", className));
+            ServiceFactory.getJarCollectorService().getClassToJarPathSubmitter().processUrl(protectionDomain.getCodeSource().getLocation());
+        }
+
         try {
             if (className == null) {
                 return null;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
@@ -66,7 +66,6 @@ public class InstrumentationClassTransformer implements ClassFileTransformer {
 
         //Submit the class for possible analysis from the jar collector
         if((protectionDomain != null) && (protectionDomain.getCodeSource() != null)) {
-            Agent.LOG.finest(MessageFormat.format("DUF- submitting {0} to jar collector", className));
             ServiceFactory.getJarCollectorService().getClassToJarPathSubmitter().processUrl(protectionDomain.getCodeSource().getLocation());
         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
@@ -66,9 +66,7 @@ public class InstrumentationClassTransformer implements ClassFileTransformer {
         long transformStartTimeInNs = System.nanoTime();
 
         //Submit the class for possible analysis from the jar collector
-        if((protectionDomain != null) && (protectionDomain.getCodeSource() != null)) {
-            ServiceFactory.getJarCollectorService().getClassToJarPathSubmitter().processUrl(protectionDomain.getCodeSource().getLocation());
-        }
+        submitTransformCandidateToJarCollector(protectionDomain);
 
         try {
             if (className == null) {
@@ -182,4 +180,9 @@ public class InstrumentationClassTransformer implements ClassFileTransformer {
         return false;
     }
 
+    private void submitTransformCandidateToJarCollector(ProtectionDomain protectionDomain) {
+        if ((protectionDomain != null) && (protectionDomain.getCodeSource() != null)) {
+            ServiceFactory.getJarCollectorService().getClassToJarPathSubmitter().processUrl(protectionDomain.getCodeSource().getLocation());
+        }
+    }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
@@ -15,6 +15,7 @@ import com.newrelic.agent.instrumentation.classmatchers.OptimizedClassMatcher;
 import com.newrelic.agent.instrumentation.custom.ScalaTraitFinalFieldTransformer;
 import com.newrelic.agent.instrumentation.tracing.TraceClassTransformer;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.service.module.ClassToJarPathSubmitterImpl;
 import com.newrelic.agent.stats.StatsWorks;
 import com.newrelic.agent.util.asm.Utils;
 import org.objectweb.asm.ClassReader;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextManager.java
@@ -147,7 +147,6 @@ public class InstrumentationContextManager {
         }
 
         classloaderExclusions = agentConfig.getClassTransformerConfig().getClassloaderExclusions();
-        matchVisitors.put(ServiceFactory.getJarCollectorService().getSourceVisitor(), NO_OP_TRANSFORMER);
         matchVisitors.put(ServiceFactory.getSourceLanguageService().getSourceVisitor(), NO_OP_TRANSFORMER);
 
         try {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -184,9 +184,8 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
 
         JarCollectorInputs jarCollectorInputs = JarCollectorInputs.build(jarCollectorEnabled, jarAnalystFactory, executorService, jarCollectorLogger);
 
-        jarCollectorService = new JarCollectorServiceImpl(
-                jarCollectorLogger, jarCollectorEnabled, shouldSendAllJars, analyzedJars, jarCollectorInputs.getClassNoticingFactory()
-        );
+        jarCollectorService = new JarCollectorServiceImpl(jarCollectorLogger, jarCollectorEnabled, shouldSendAllJars, analyzedJars,
+                jarCollectorInputs.getClassToJarPathSubmitter());
 
         extensionService = new ExtensionService(configService, jarCollectorInputs.getExtensionAnalysisProducer());
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/module/ClassToJarPathSubmitter.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/module/ClassToJarPathSubmitter.java
@@ -1,0 +1,14 @@
+package com.newrelic.agent.service.module;
+
+import java.net.URL;
+
+public interface ClassToJarPathSubmitter {
+
+    /**
+     * Determines if the supplied URL maps to a jar-type code location and if so, submits
+     * the jar to the jar collector analysis queue.
+     *
+     * @param url the URL to analyse
+     */
+    void processUrl(URL url);
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorInputs.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorInputs.java
@@ -8,30 +8,30 @@ import java.util.concurrent.ExecutorService;
 
 public class JarCollectorInputs {
     private final ExtensionsLoadedListener extensionAnalysisProducer;
-    private final ClassMatchVisitorFactory classNoticingFactory;
+    private final ClassToJarPathSubmitter classToJarPathSubmitter;
 
-    JarCollectorInputs(ExtensionsLoadedListener extensionAnalysisProducer, ClassMatchVisitorFactory classNoticingFactory) {
+    JarCollectorInputs(ExtensionsLoadedListener extensionAnalysisProducer, ClassToJarPathSubmitter classToJarPathSubmitter) {
         this.extensionAnalysisProducer = extensionAnalysisProducer;
-        this.classNoticingFactory = classNoticingFactory;
+        this.classToJarPathSubmitter = classToJarPathSubmitter;
     }
 
     public static JarCollectorInputs build(boolean jarCollectorEnabled, JarAnalystFactory jarAnalystFactory, ExecutorService executorService,
                               Logger jarCollectorLogger) {
-        ClassMatchVisitorFactory classNoticingFactory = jarCollectorEnabled
-                ? new ClassNoticingFactory(jarAnalystFactory, executorService, jarCollectorLogger)
-                : ClassMatchVisitorFactory.NO_OP_FACTORY;
+        ClassToJarPathSubmitter classToJarPathSubmitter = jarCollectorEnabled
+                ? new ClassToJarPathSubmitterImpl(jarAnalystFactory, executorService, jarCollectorLogger)
+                : ClassToJarPathSubmitterImpl.NO_OP_INSTANCE;
 
         ExtensionsLoadedListener extensionAnalysisProducer = jarCollectorEnabled
                 ? new ExtensionAnalysisProducer(jarAnalystFactory, executorService, jarCollectorLogger)
                 : ExtensionsLoadedListener.NOOP;
-        return new JarCollectorInputs(extensionAnalysisProducer, classNoticingFactory);
+        return new JarCollectorInputs(extensionAnalysisProducer, classToJarPathSubmitter);
     }
 
     public ExtensionsLoadedListener getExtensionAnalysisProducer() {
         return extensionAnalysisProducer;
     }
 
-    public ClassMatchVisitorFactory getClassNoticingFactory() {
-        return classNoticingFactory;
+    public ClassToJarPathSubmitter getClassToJarPathSubmitter() {
+        return classToJarPathSubmitter;
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorService.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.service.module;
 
-import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.service.Service;
 
 /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorService.java
@@ -14,8 +14,7 @@ import com.newrelic.agent.service.Service;
  * Interface for collecting and sending jars to RPM.
  */
 public interface JarCollectorService extends Service {
-
-    ClassMatchVisitorFactory getSourceVisitor();
-
     void harvest(String appName);
+
+    ClassToJarPathSubmitter getClassToJarPathSubmitter();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/module/JarCollectorServiceImpl.java
@@ -31,8 +31,7 @@ public class JarCollectorServiceImpl extends AbstractService implements JarColle
     private final boolean enabled;
     private final AtomicBoolean shouldSendAllJars;
     private final TrackedAddSet<JarData> analyzedJars;
-    private final ClassMatchVisitorFactory classMatchVisitorFactory;
-
+    private final ClassToJarPathSubmitter classToJarPathSubmitter;
     private volatile List<JarData> jarsNotSentLastHarvest = Collections.emptyList();
 
     public JarCollectorServiceImpl(
@@ -40,13 +39,13 @@ public class JarCollectorServiceImpl extends AbstractService implements JarColle
             boolean enabled,
             AtomicBoolean shouldSendAllJars,
             TrackedAddSet<JarData> analyzedJars,
-            ClassMatchVisitorFactory classNoticingFactory) {
+            ClassToJarPathSubmitter classToJarPathSubmitter) {
         super(JarCollectorService.class.getSimpleName());
 
         this.shouldSendAllJars = shouldSendAllJars;
         this.analyzedJars = analyzedJars;
         this.logger = logger;
-        this.classMatchVisitorFactory = classNoticingFactory;
+        this.classToJarPathSubmitter = classToJarPathSubmitter;
         this.enabled = enabled;
 
         if (JarCollectorConfigImpl.isUsingDeprecatedConfigSettings()) {
@@ -61,11 +60,6 @@ public class JarCollectorServiceImpl extends AbstractService implements JarColle
     @Override
     public final boolean isEnabled() {
         return enabled;
-    }
-
-    @Override
-    public ClassMatchVisitorFactory getSourceVisitor() {
-        return classMatchVisitorFactory;
     }
 
     @Override
@@ -100,6 +94,10 @@ public class JarCollectorServiceImpl extends AbstractService implements JarColle
         }
     }
 
+    @Override
+    public ClassToJarPathSubmitter getClassToJarPathSubmitter() {
+        return classToJarPathSubmitter;
+    }
 
     private List<JarData> getJars() {
         if (shouldSendAllJars.getAndSet(false)) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
@@ -135,7 +135,6 @@ public class MockServiceManager extends AbstractService implements ServiceManage
         dbService = new DatabaseService();
         extensionService = new ExtensionService(configService, ExtensionsLoadedListener.NOOP);
         jarCollectorService = Mockito.mock(JarCollectorService.class);
-        Mockito.when(jarCollectorService.getSourceVisitor()).thenReturn(Mockito.mock(ClassMatchVisitorFactory.class));
         sourceLanguageService = new SourceLanguageService();
         expirationService = new ExpirationService();
         distributedTraceService = Mockito.mock(DistributedTraceService.class);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
@@ -45,6 +45,7 @@ import com.newrelic.agent.service.analytics.TransactionEventsService;
 import com.newrelic.agent.service.async.AsyncTransactionService;
 import com.newrelic.agent.service.logging.LogSenderService;
 import com.newrelic.agent.service.logging.LogSenderServiceImpl;
+import com.newrelic.agent.service.module.ClassToJarPathSubmitterImpl;
 import com.newrelic.agent.service.module.JarCollectorService;
 import com.newrelic.agent.sql.SqlTraceService;
 import com.newrelic.agent.stats.StatsService;
@@ -135,6 +136,7 @@ public class MockServiceManager extends AbstractService implements ServiceManage
         dbService = new DatabaseService();
         extensionService = new ExtensionService(configService, ExtensionsLoadedListener.NOOP);
         jarCollectorService = Mockito.mock(JarCollectorService.class);
+        Mockito.when(jarCollectorService.getClassToJarPathSubmitter()).thenReturn(ClassToJarPathSubmitterImpl.NO_OP_INSTANCE);
         sourceLanguageService = new SourceLanguageService();
         expirationService = new ExpirationService();
         distributedTraceService = Mockito.mock(DistributedTraceService.class);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
@@ -162,7 +162,6 @@ public class ClassTransformerConfigImplTest {
         MockServiceManager serviceManager = new MockServiceManager(configService);
         ServiceFactory.setServiceManager(serviceManager);
         JarCollectorService mockJarCollector = serviceManager.getJarCollectorService();
-        when(mockJarCollector.getSourceVisitor()).thenReturn(ClassMatchVisitorFactory.NO_OP_FACTORY);
 
         InstrumentationContextManager icm = new InstrumentationContextManager(Mockito.mock(InstrumentationProxy.class));
         Assert.assertFalse(icm.isClassloaderExcluded(new GoodClassLoader()));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/IncludeExcludeTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/IncludeExcludeTest.java
@@ -36,7 +36,6 @@ public class IncludeExcludeTest {
         MockServiceManager serviceManager = new MockServiceManager(configService);
         ServiceFactory.setServiceManager(serviceManager);
         JarCollectorService mockJarCollector = serviceManager.getJarCollectorService();
-        when(mockJarCollector.getSourceVisitor()).thenReturn(ClassMatchVisitorFactory.NO_OP_FACTORY);
     }
 
     private Map<String, Object> createConfigMap() {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/ClassToJarPathSubmitterTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/ClassToJarPathSubmitterTest.java
@@ -21,23 +21,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-public class ClassNoticingFactoryTest {
+public class ClassToJarPathSubmitterTest {
     @Test
-    public void noticingJunit() throws IOException {
+    public void detectJunitLocation() throws IOException {
         ExecutorService executorService = mock(ExecutorService.class);
 
         JarAnalystFactory factory = mock(JarAnalystFactory.class);
         when(factory.createURLAnalyzer(any(URL.class))).thenReturn(mock(Runnable.class));
 
-        ClassNoticingFactory target = new ClassNoticingFactory(factory, executorService, new TestLogger());
-
-        target.newClassMatchVisitor(
-                Test.class.getClassLoader(),
-                Test.class,
-                new ClassReader("org.junit.Test"),
-                new ClassWriter(0),
-                new InstrumentationContext(null, Test.class, Test.class.getProtectionDomain())
-        );
+        ClassToJarPathSubmitter classToJarPathSubmitter = new ClassToJarPathSubmitterImpl(factory, executorService, new TestLogger());
+        InstrumentationContext ic = new InstrumentationContext(null, Test.class, Test.class.getProtectionDomain());
+        classToJarPathSubmitter.processUrl(ic.getCodeSourceLocation());
 
         ArgumentCaptor<URL> captor = ArgumentCaptor.forClass(URL.class);
         verify(factory, times(1)).createURLAnalyzer(captor.capture());
@@ -47,21 +41,15 @@ public class ClassNoticingFactoryTest {
     }
 
     @Test
-    public void noticingTestClass() throws IOException {
+    public void detectTestClassLocation() throws IOException {
         ExecutorService executorService = mock(ExecutorService.class);
 
         JarAnalystFactory factory = mock(JarAnalystFactory.class);
         when(factory.createURLAnalyzer(any(URL.class))).thenReturn(mock(Runnable.class));
 
-        ClassNoticingFactory target = new ClassNoticingFactory(factory, executorService, new TestLogger());
-
-        target.newClassMatchVisitor(
-                this.getClass().getClassLoader(),
-                this.getClass(),
-                new ClassReader(this.getClass().getName()),
-                new ClassWriter(0),
-                new InstrumentationContext(null, this.getClass(), this.getClass().getProtectionDomain())
-        );
+        ClassToJarPathSubmitter classToJarPathSubmitter = new ClassToJarPathSubmitterImpl(factory, executorService, new TestLogger());
+        InstrumentationContext ic = new InstrumentationContext(null, this.getClass(), this.getClass().getProtectionDomain());
+        classToJarPathSubmitter.processUrl(ic.getCodeSourceLocation());
 
         String codeSourceLocation = this.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
         if (codeSourceLocation.endsWith("/")) {
@@ -80,11 +68,11 @@ public class ClassNoticingFactoryTest {
         JarAnalystFactory factory = mock(JarAnalystFactory.class);
         when(factory.createURLAnalyzer(any(URL.class))).thenReturn(mock(Runnable.class));
 
-        ClassNoticingFactory target = new ClassNoticingFactory(factory, executorService, new TestLogger());
+        ClassToJarPathSubmitter classToJarPathSubmitter = new ClassToJarPathSubmitterImpl(factory, executorService, new TestLogger());
 
-        target.addURL(new URL(
+        classToJarPathSubmitter.processUrl(new URL(
                 "file:/Users/roger/webapps/java_test_webapp/WEB-INF/lib/commons-httpclient-3.1.jar!/org/apache/commons/httpclient/HttpVersion.class"));
-        target.addURL(new URL(
+        classToJarPathSubmitter.processUrl(new URL(
                 "file:/Users/roger/webapps/java_test_webapp/WEB-INF/lib/commons-httpclient-3.1.jar!/org/apache/commons/httpclient/Dude.class"));
 
         verify(factory, times(1)).createURLAnalyzer(new URL("file:/Users/roger/webapps/java_test_webapp/WEB-INF/lib/commons-httpclient-3.1.jar"));
@@ -98,10 +86,10 @@ public class ClassNoticingFactoryTest {
         JarAnalystFactory factory = mock(JarAnalystFactory.class);
         when(factory.createURLAnalyzer(any(URL.class))).thenReturn(mock(Runnable.class));
 
-        ClassNoticingFactory target = new ClassNoticingFactory(factory, executorService, new TestLogger());
+        ClassToJarPathSubmitter classToJarPathSubmitter = new ClassToJarPathSubmitterImpl(factory, executorService, new TestLogger());
 
         // jboss sends us complex urls like this
-        target.addURL(new URL(
+        classToJarPathSubmitter.processUrl(new URL(
                 "jar:file:/Users/sdaubin/servers/jboss-as-7.1.1.Final/modules/org/apache/xerces/main/xercesImpl-2.9.1-jbossas-1.jar!/"));
 
         verify(factory, times(1)).createURLAnalyzer(new URL("file:/Users/sdaubin/servers/jboss-as-7.1.1.Final/modules/org/apache/xerces/main/xercesImpl-2.9.1-jbossas-1.jar"));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorInputsTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorInputsTest.java
@@ -17,18 +17,18 @@ public class JarCollectorInputsTest {
     @Test
     public void correctInputsWhenEnabled() {
         JarCollectorInputs target = JarCollectorInputs.build(true, mock(JarAnalystFactory.class), mock(ExecutorService.class), mock(Logger.class));
-        assertTrue(target.getClassNoticingFactory() instanceof ClassNoticingFactory);
+        assertTrue(target.getClassToJarPathSubmitter() instanceof ClassToJarPathSubmitterImpl);
         assertTrue(target.getExtensionAnalysisProducer() instanceof ExtensionAnalysisProducer);
-        assertNotSame(ClassMatchVisitorFactory.NO_OP_FACTORY, target.getClassNoticingFactory());
+        assertNotSame(ClassMatchVisitorFactory.NO_OP_FACTORY, target.getClassToJarPathSubmitter());
         assertNotSame(ExtensionsLoadedListener.NOOP, target.getExtensionAnalysisProducer());
     }
 
     @Test
     public void correctInputsWhenNotEnabled() {
         JarCollectorInputs target = JarCollectorInputs.build(false, mock(JarAnalystFactory.class), mock(ExecutorService.class), mock(Logger.class));
-        assertFalse(target.getClassNoticingFactory() instanceof ClassNoticingFactory);
+        assertFalse(target.getClassToJarPathSubmitter() instanceof ClassToJarPathSubmitterImpl);
         assertFalse(target.getExtensionAnalysisProducer() instanceof ExtensionAnalysisProducer);
-        assertSame(ClassMatchVisitorFactory.NO_OP_FACTORY, target.getClassNoticingFactory());
+        assertSame(ClassMatchVisitorFactory.NO_OP_FACTORY, target.getClassToJarPathSubmitter());
         assertSame(ExtensionsLoadedListener.NOOP, target.getExtensionAnalysisProducer());
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorInputsTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorInputsTest.java
@@ -19,7 +19,7 @@ public class JarCollectorInputsTest {
         JarCollectorInputs target = JarCollectorInputs.build(true, mock(JarAnalystFactory.class), mock(ExecutorService.class), mock(Logger.class));
         assertTrue(target.getClassToJarPathSubmitter() instanceof ClassToJarPathSubmitterImpl);
         assertTrue(target.getExtensionAnalysisProducer() instanceof ExtensionAnalysisProducer);
-        assertNotSame(ClassMatchVisitorFactory.NO_OP_FACTORY, target.getClassToJarPathSubmitter());
+        assertNotSame(ClassToJarPathSubmitterImpl.NO_OP_INSTANCE, target.getClassToJarPathSubmitter());
         assertNotSame(ExtensionsLoadedListener.NOOP, target.getExtensionAnalysisProducer());
     }
 
@@ -28,7 +28,7 @@ public class JarCollectorInputsTest {
         JarCollectorInputs target = JarCollectorInputs.build(false, mock(JarAnalystFactory.class), mock(ExecutorService.class), mock(Logger.class));
         assertFalse(target.getClassToJarPathSubmitter() instanceof ClassToJarPathSubmitterImpl);
         assertFalse(target.getExtensionAnalysisProducer() instanceof ExtensionAnalysisProducer);
-        assertSame(ClassMatchVisitorFactory.NO_OP_FACTORY, target.getClassToJarPathSubmitter());
+        assertSame(ClassToJarPathSubmitterImpl.NO_OP_INSTANCE, target.getClassToJarPathSubmitter());
         assertSame(ExtensionsLoadedListener.NOOP, target.getExtensionAnalysisProducer());
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorServiceImplTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 public class JarCollectorServiceImplTest {
 
     @Mock
-    public ClassNoticingFactory classNoticingFactory;
+    public ClassToJarPathSubmitterImpl classNoticingFactory;
 
     @Mock
     public IRPMService rpmService;
@@ -179,7 +179,7 @@ public class JarCollectorServiceImplTest {
                 true,
                 shouldSendAllJars,
                 set,
-                classNoticingFactory
+                mock(ClassToJarPathSubmitter.class)
         );
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/module/JarCollectorServiceImplTest.java
@@ -33,9 +33,6 @@ import static org.mockito.Mockito.when;
 public class JarCollectorServiceImplTest {
 
     @Mock
-    public ClassToJarPathSubmitterImpl classNoticingFactory;
-
-    @Mock
     public IRPMService rpmService;
 
     @Captor


### PR DESCRIPTION
Resolves #1342 

Currently, the jar collector functionality is implemented via the ClassMatchVisitor pattern. The problem with this approach is that the registered visitors aren't executed when a class is excluded from transformation. In the case of certain jars (Spring Security for example), every single class in the jar is excluded, so the visitors are never executed, so the jar collector is never aware of the enclosing jar.

This PR keeps the exact same jar discovery logic in place, however the flow is no longer invoked after a class is transformed. Instead, all classes, prior to being checked for transformation eligibility are submitted to the jar collector. This means that no jars will be missed, even if every class within a jar is excluded, skipped, etc.