### PR TITLE
Removing use of Guava in GraphQL 17 instrumentation

### DIFF
--- a/instrumentation/graphql-java-17.0/src/main/java/com/nr/instrumentation/graphql/GraphQLObfuscator.java
+++ b/instrumentation/graphql-java-17.0/src/main/java/com/nr/instrumentation/graphql/GraphQLObfuscator.java
@@ -7,8 +7,6 @@
 
 package com.nr.instrumentation.graphql;
 
-import graphql.com.google.common.base.Joiner;
-
 import java.util.regex.Pattern;
 
 public class GraphQLObfuscator {
@@ -25,8 +23,8 @@ public class GraphQLObfuscator {
     private static final Pattern ALL_UNMATCHED_PATTERN;
 
     static {
-        String allDialectsPattern = Joiner.on("|").join(SINGLE_QUOTE, DOUBLE_QUOTE, UUID, HEX,
-                MULTILINE_COMMENT, COMMENT, NUMBER, BOOLEAN);
+        String allDialectsPattern = SINGLE_QUOTE + "|" + DOUBLE_QUOTE + "|" + UUID + "|" + HEX + "|" +
+                MULTILINE_COMMENT + "|" + COMMENT + "|" + NUMBER + "|" + BOOLEAN;
 
         ALL_DIALECTS_PATTERN = Pattern.compile(allDialectsPattern, Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
         ALL_UNMATCHED_PATTERN = Pattern.compile("'|\"|/\\*|\\*/|\\$", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
### Overview
On GraphQL 19.7 the Guava dependency was updated.
With that, a class from Guava that was used in GraphQL instrumentation is no longer available.

This PR removes the usage of that class.