### PR TITLE
Add experimental config option to unsupported java version message

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -380,7 +380,7 @@ public final class Agent {
             System.out.println("----------");
             System.out.println(JavaVersionUtils.getUnsupportedAgentJavaSpecVersionMessage(javaSpecVersion));
             System.out.println("Experimental runtime mode is enabled. Usage of the agent in this mode is for experimenting with early access" +
-                    " or upcoming Java releases or at your own risk.");
+                    " or upcoming Java releases at your own risk.");
             System.out.println("----------");
         }
         if (!JavaVersionUtils.isAgentSupportedJavaSpecVersion(javaSpecVersion) && !useExperimentalRuntime) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JavaVersionUtils.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JavaVersionUtils.java
@@ -61,9 +61,13 @@ public class JavaVersionUtils {
                     .append("Please use a 6.5.3 New Relic agent or a later version of Java.");
         } else if (EXCLUSIVE_MAX_JAVA_VERSION_PATTERN.matcher(javaSpecificationVersion).matches()) {
             message.append("Java version is: ").append(javaSpecificationVersion).append(". ");
-            message.append("This version of the New Relic Agent does not support versions of Java greater than ");
+            message.append("This version of the New Relic Agent does not officially support versions of Java greater than ");
             message.append(MAX_SUPPORTED_VERSION);
-            message.append(".");
+            message.append(".\n");
+            message.append("To enable support for newer versions of Java, the following environment variable or Java system property can be set:\n");
+            message.append("\tEnvironment variable: NEW_RELIC_EXPERIMENTAL_RUNTIME=true\n");
+            message.append("\tSystem property: newrelic.config.experimental_runtime=true\n");
+            message.append("Enabling experimental mode may cause agent issues, application crashes or other problems.");
         }
         return message.toString();
     }

--- a/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/bootstrap/BootstrapAgent.java
@@ -285,7 +285,7 @@ public class BootstrapAgent {
         System.out.println("----------");
         System.out.println(JavaVersionUtils.getUnsupportedAgentJavaSpecVersionMessage(javaSpecVersion));
         System.out.println("Experimental runtime mode is enabled. Usage of the agent in this mode is for experimenting with early access" +
-                " or upcoming Java releases or at your own risk.");
+                " or upcoming Java releases at your own risk.");
         System.out.println("----------");
     }
 


### PR DESCRIPTION
Resolves #1451 
To facilitate Java 21 testing by the community, we're publicizing a config option to allow unsupported java versions to be used with the agent. To enable experimental mode, set the following environment variable or system property to true:
Env variable: NEW_RELIC_EXPERIMENTAL_RUNTIME=true
Java system property: newrelic.config.experimental_runtime=true

These config options will also be output in the stdout log when attempting to use an unsupported Java version.