### PR TITLE
fix spring 6 pointcuts, after migration from javax to jakarta

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/HandleInternalInvokerPointCut.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/HandleInternalInvokerPointCut.java
@@ -32,7 +32,13 @@ public class HandleInternalInvokerPointCut extends MethodInvokerPointCut {
                                 "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lorg/springframework/web/method/HandlerMethod;)Lorg/springframework/web/servlet/ModelAndView;"),
                         createExactMethodMatcher(
                                 "invokeHandlerMethod",
-                                "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lorg/springframework/web/method/HandlerMethod;)Lorg/springframework/web/servlet/ModelAndView;")));
+                                "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Lorg/springframework/web/method/HandlerMethod;)Lorg/springframework/web/servlet/ModelAndView;"),
+                        createExactMethodMatcher(
+                                "invokeHandleMethod",
+                                "(Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lorg/springframework/web/method/HandlerMethod;)Lorg/springframework/web/servlet/ModelAndView;"),
+                        createExactMethodMatcher(
+                                "invokeHandlerMethod",
+                                "(Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Lorg/springframework/web/method/HandlerMethod;)Lorg/springframework/web/servlet/ModelAndView;")));
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/HandlerInterceptorPointCut.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/HandlerInterceptorPointCut.java
@@ -33,7 +33,15 @@ public class HandlerInterceptorPointCut extends TracerFactoryPointCut {
                                 "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Object;Lorg/springframework/web/servlet/ModelAndView;)V"),
                         new ExactMethodMatcher(
                                 "afterCompletion",
-                                "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)V")));
+                                "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)V"),
+                        new ExactMethodMatcher("preHandle",
+                                "(Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljava/lang/Object;)Z"),
+                        new ExactMethodMatcher(
+                                "postHandle",
+                                "(Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljava/lang/Object;Lorg/springframework/web/servlet/ModelAndView;)V"),
+                        new ExactMethodMatcher(
+                                "afterCompletion",
+                                "(Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)V")));
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/SpringDispatcherPointCut.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/SpringDispatcherPointCut.java
@@ -40,7 +40,12 @@ public class SpringDispatcherPointCut extends TracerFactoryPointCut {
                                 RENDER_METHOD_NAME,
                                 "(Lorg/springframework/web/servlet/ModelAndView;Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V"),
                         new ExactMethodMatcher("doDispatch",
-                                "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V")));
+                                "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V"),
+                        new ExactMethodMatcher(
+                                RENDER_METHOD_NAME,
+                                "(Lorg/springframework/web/servlet/ModelAndView;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;)V"),
+                        new ExactMethodMatcher("doDispatch",
+                                "(Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;)V")));
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/SpringExceptionHandlerPointCut.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/SpringExceptionHandlerPointCut.java
@@ -30,7 +30,13 @@ public class SpringExceptionHandlerPointCut extends AbstractExceptionHandlerPoin
                                 "(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)Lorg/springframework/web/servlet/ModelAndView;"),
                         new ExactMethodMatcher(
                                 "triggerAfterCompletion",
-                                "(Lorg/springframework/web/servlet/HandlerExecutionChain;ILjavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Exception;)V")));
+                                "(Lorg/springframework/web/servlet/HandlerExecutionChain;ILjavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Exception;)V"),
+                        new ExactMethodMatcher(
+                                PROCESS_HANDLER_EXCEPTION_METHOD_NAME,
+                                "(Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)Lorg/springframework/web/servlet/ModelAndView;"),
+                        new ExactMethodMatcher(
+                                "triggerAfterCompletion",
+                                "(Lorg/springframework/web/servlet/HandlerExecutionChain;ILjakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljava/lang/Exception;)V")));
     }
 
     @Override


### PR DESCRIPTION
I've observed that since migration to spring 6, the newrelic agent no longer sends error message when http requests fails. `SpringExceptionHandlerPointCut` used to fill error message, intercepting calls  to `org.springframework.web.servlet.DispatcherServlet#processHandlerException`.  Pointcut was defined to capture method with signature `"(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)Lorg/springframework/web/servlet/ModelAndView;"`.  Spring 6 moved to jakarta, so `jakarta` instead of `javax` is now used and method signature from `SpringExceptionHandlerPointCut` no longer captures `org.springframework.web.servlet.DispatcherServlet#processHandlerException`.

I've added new pointcuts reflecting new `jakarta` package names, used since Spring 6.0.