### PR TITLE
Include stack traces in client spans

### DIFF
--- a/agent-model/src/main/java/com/newrelic/agent/model/SpanEvent.java
+++ b/agent-model/src/main/java/com/newrelic/agent/model/SpanEvent.java
@@ -13,16 +13,14 @@ import org.json.simple.JSONStreamAware;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class SpanEvent extends AnalyticsEvent implements JSONStreamAware {
 
     public static final String SPAN = "Span";
-    static final String SPAN_KIND = "client";
+    static final String CLIENT_SPAN_KIND = "client";
 
     private final String appName;
     private final Map<String, Object> intrinsics;
@@ -120,6 +118,7 @@ public class SpanEvent extends AnalyticsEvent implements JSONStreamAware {
         private float priority;
         private boolean decider;
         private long timestamp;
+        private Object spanKind;
 
         public Builder appName(String appName) {
             this.appName = appName;
@@ -177,9 +176,19 @@ public class SpanEvent extends AnalyticsEvent implements JSONStreamAware {
             return this;
         }
 
+        public Builder spanKind(Object spanKind) {
+            putIntrinsic("span.kind", spanKind);
+            this.spanKind = spanKind;
+            return this;
+        }
+
+        public boolean isClientSpan() {
+            return CLIENT_SPAN_KIND.equals(spanKind);
+        }
+
         public Object getSpanKindFromUserAttributes() {
             Object result = userAttributes.get("span.kind");
-            return result == null ? SPAN_KIND : result;
+            return result == null ? CLIENT_SPAN_KIND : result;
         }
 
         public Builder decider(boolean decider) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -17,7 +17,9 @@ import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.agent.model.SpanError;
 import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.tracers.DefaultTracer;
 import com.newrelic.agent.util.ExternalsUtil;
+import com.newrelic.agent.util.StackTraces;
 import com.newrelic.api.agent.DatastoreParameters;
 import com.newrelic.api.agent.ExternalParameters;
 import com.newrelic.api.agent.HttpParameters;
@@ -25,6 +27,7 @@ import com.newrelic.api.agent.SlowQueryDatastoreParameters;
 
 import java.net.URI;
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -40,6 +43,7 @@ public class SpanEventFactory {
     private static final Joiner TRACE_STATE_VENDOR_JOINER = Joiner.on(",");
     // Truncate `db.statement` at 2000 characters
     private static final int DB_STATEMENT_TRUNCATE_LENGTH = 2000;
+    private static final int MAX_EVENT_ATTRIBUTE_STRING_LENGTH = 4095;
 
     public static final Supplier<Long> DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER = System::currentTimeMillis;
 
@@ -115,6 +119,23 @@ public class SpanEventFactory {
         return this;
     }
 
+    /**
+     * This should be called after the span kind is set.
+     */
+    public SpanEventFactory setStackTraceAttributes(Map<String, Object> agentAttributes) {
+        if (builder.isClientSpan()) {
+            final List<StackTraceElement> stackTraceList = (List<StackTraceElement>) agentAttributes.get(DefaultTracer.BACKTRACE_PARAMETER_NAME);
+            if (stackTraceList != null) {
+                final List<StackTraceElement> preStackTraces = StackTraces.scrubAndTruncate(stackTraceList);
+                final List<String> postParentRemovalTrace = StackTraces.toStringList(preStackTraces);
+
+                putAgentAttribute("code.stacktrace", truncateWithEllipsis(
+                        Joiner.on(',').join(postParentRemovalTrace), MAX_EVENT_ATTRIBUTE_STRING_LENGTH));
+            }
+        }
+        return this;
+    }
+
     public SpanEventFactory setClmAttributes(Map<String, Object> agentAttributes) {
         if (agentAttributes == null || agentAttributes.isEmpty()) {
             return this;
@@ -166,8 +187,7 @@ public class SpanEventFactory {
     }
 
     public SpanEventFactory setKindFromUserAttributes() {
-        Object spanKind = builder.getSpanKindFromUserAttributes();
-        builder.putIntrinsic("span.kind", spanKind);
+        builder.spanKind(builder.getSpanKindFromUserAttributes());
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/TracerToSpanEvent.java
@@ -94,6 +94,7 @@ public class TracerToSpanEvent {
                 .setTimestamp(tracer.getStartTimeInMillis())
                 .setPriority(transactionData.getPriority())
                 .setExternalParameterAttributes(tracer.getExternalParameters())
+                .setStackTraceAttributes(tracer.getAgentAttributes())
                 .setIsRootSpanEvent(isRoot)
                 .setDecider(inboundPayload == null || inboundPayload.priority == null);
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -7,21 +7,29 @@
 
 package com.newrelic.agent.service.analytics;
 
+import com.google.common.collect.ImmutableMap;
+import com.newrelic.agent.MockConfigService;
+import com.newrelic.agent.MockServiceManager;
+import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.model.AttributeFilter;
 import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.agent.model.SpanError;
 import com.newrelic.agent.model.SpanEvent;
+import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.tracers.DefaultTracer;
 import com.newrelic.api.agent.DatastoreParameters;
 import com.newrelic.api.agent.HttpParameters;
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
 import static com.newrelic.agent.service.analytics.SpanEventFactory.DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -174,6 +182,19 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setExternalParameterAttributes(mockParameters).build();
 
         assertEquals("database name", target.getIntrinsics().get("db.instance"));
+    }
+
+    @Test
+    public void shouldStoreStackTrace() {
+        SpanEventFactory spanEventFactory = new SpanEventFactory("MyApp", new AttributeFilter.PassEverythingAttributeFilter(), DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER);
+        spanEventFactory.setKindFromUserAttributes();
+        MockServiceManager serviceManager = new MockServiceManager();
+        serviceManager.setConfigService(new MockConfigService(mock(AgentConfig.class)));
+        ServiceFactory.setServiceManager(serviceManager);
+        spanEventFactory.setStackTraceAttributes(ImmutableMap.of(DefaultTracer.BACKTRACE_PARAMETER_NAME, Arrays.asList(Thread.currentThread().getStackTrace())));
+
+        final Object stackTrace = spanEventFactory.build().getAgentAttributes().get("code.stacktrace");
+        assertNotNull(stackTrace);
     }
 
     @Test


### PR DESCRIPTION
### Overview
This includes stack traces in client spans.  The attribute key name is `code.stacktrace`.

The DT and transaction trace UIs will be updated to display the stack traces.

![Petclinic-saxon___Petclinic-saxon___Petclinic-saxon___New_Relic_One](https://github.com/newrelic/newrelic-java-agent/assets/1627067/8fe4d8bf-d7c3-4a84-a99d-9e8c63a8b7c6)


### Testing
You can use the UI builds from [this PR](https://source.datanerd.us/app-experience/apm-nerdlets/pull/1761) to test with an agent.

The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
