### PR TITLE
feat: add thread.id attribute to Spans

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
@@ -28,11 +28,14 @@ public final class AttributeNames {
     public static final String TIMEOUT_CAUSE = "nr.timeoutCause";
     public static final String ERROR_EXPECTED = "error.expected";
 
+    public static final String COMPONENT = "component";
+    public static final String HTTP_METHOD = "http.method";
     public static final String HTTP_STATUS_CODE = "http.statusCode";
     public static final String HTTP_STATUS_TEXT = "http.statusText";
 
     public static final String LOCK_THREAD_NAME = "jvm.lock_thread_name";
     public static final String THREAD_NAME = "jvm.thread_name";
+    public static final String THREAD_ID = "thread.id";
 
     public static final String MESSAGE_REQUEST_PREFIX = "message.parameters.";
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -17,6 +17,7 @@ import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.agent.model.SpanError;
 import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.tracers.DefaultTracer;
 import com.newrelic.agent.util.ExternalsUtil;
 import com.newrelic.api.agent.DatastoreParameters;
 import com.newrelic.api.agent.ExternalParameters;
@@ -118,6 +119,10 @@ public class SpanEventFactory {
     public SpanEventFactory setClmAttributes(Map<String, Object> agentAttributes) {
         if (agentAttributes == null || agentAttributes.isEmpty()) {
             return this;
+        }
+        final Object threadId = agentAttributes.get(DefaultTracer.THREAD_ID_PARAMETER_NAME);
+        if (threadId != null) {
+            builder.putAgentAttribute(DefaultTracer.THREAD_ID_PARAMETER_NAME, threadId);
         }
         if (agentAttributes.containsKey(AttributeNames.CLM_NAMESPACE) && agentAttributes.containsKey(AttributeNames.CLM_FUNCTION)) {
             builder.putAgentAttribute(AttributeNames.CLM_NAMESPACE, agentAttributes.get(AttributeNames.CLM_NAMESPACE));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -17,7 +17,6 @@ import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.agent.model.SpanError;
 import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.agent.service.ServiceFactory;
-import com.newrelic.agent.tracers.DefaultTracer;
 import com.newrelic.agent.util.ExternalsUtil;
 import com.newrelic.api.agent.DatastoreParameters;
 import com.newrelic.api.agent.ExternalParameters;
@@ -120,9 +119,9 @@ public class SpanEventFactory {
         if (agentAttributes == null || agentAttributes.isEmpty()) {
             return this;
         }
-        final Object threadId = agentAttributes.get(DefaultTracer.THREAD_ID_PARAMETER_NAME);
+        final Object threadId = agentAttributes.get(AttributeNames.THREAD_ID);
         if (threadId != null) {
-            builder.putAgentAttribute(DefaultTracer.THREAD_ID_PARAMETER_NAME, threadId);
+            builder.putAgentAttribute(AttributeNames.THREAD_ID, threadId);
         }
         if (agentAttributes.containsKey(AttributeNames.CLM_NAMESPACE) && agentAttributes.containsKey(AttributeNames.CLM_FUNCTION)) {
             builder.putAgentAttribute(AttributeNames.CLM_NAMESPACE, agentAttributes.get(AttributeNames.CLM_NAMESPACE));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -69,6 +69,7 @@ public class DefaultTracer extends AbstractTracer {
 
     private static final String COMPONENT_PARAMETER_NAME = "component";
     private static final String HTTP_METHOD_PARAMETER_NAME = "http.method";
+    public static final String THREAD_ID_PARAMETER_NAME = "thread.id";
 
     private final long startTime;
     private final long timestamp;
@@ -290,6 +291,7 @@ public class DefaultTracer extends AbstractTracer {
             }
 
             try {
+                setAgentAttribute(THREAD_ID_PARAMETER_NAME, getTransactionActivity().getThreadId());
                 if (classMethodSignature != null && getTransaction() != null &&
                         ServiceFactory.getConfigService().getDefaultAgentConfig().getCodeLevelMetricsConfig().isEnabled()) {
                     String className = classMethodSignature.getClassName();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -67,10 +67,6 @@ public class DefaultTracer extends AbstractTracer {
     public static final int DEFAULT_TRACER_FLAGS = TracerFlags.TRANSACTION_TRACER_SEGMENT
             | TracerFlags.GENERATE_SCOPED_METRIC;
 
-    private static final String COMPONENT_PARAMETER_NAME = "component";
-    private static final String HTTP_METHOD_PARAMETER_NAME = "http.method";
-    public static final String THREAD_ID_PARAMETER_NAME = "thread.id";
-
     private final long startTime;
     private final long timestamp;
     private long duration;
@@ -291,7 +287,7 @@ public class DefaultTracer extends AbstractTracer {
             }
 
             try {
-                setAgentAttribute(THREAD_ID_PARAMETER_NAME, getTransactionActivity().getThreadId());
+                setAgentAttribute(AttributeNames.THREAD_ID, getTransactionActivity().getThreadId());
                 if (classMethodSignature != null && getTransaction() != null &&
                         ServiceFactory.getConfigService().getDefaultAgentConfig().getCodeLevelMetricsConfig().isEnabled()) {
                     String className = classMethodSignature.getClassName();
@@ -714,9 +710,9 @@ public class DefaultTracer extends AbstractTracer {
         String uriStr = uri == null ? ExternalMetrics.UNKNOWN_HOST : uri.toString();
 
         String library = externalParameters.getLibrary();
-        setAgentAttribute(COMPONENT_PARAMETER_NAME, library);
+        setAgentAttribute(AttributeNames.COMPONENT, library);
         String procedure = externalParameters.getProcedure();
-        setAgentAttribute(HTTP_METHOD_PARAMETER_NAME, procedure);
+        setAgentAttribute(AttributeNames.HTTP_METHOD, procedure);
 
         ExternalMetrics.makeExternalComponentTrace(transaction.isWebTransaction(), this, host, library, true,
                 uriStr, procedure);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/metrics/JsonTraceSegment.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/metrics/JsonTraceSegment.java
@@ -57,8 +57,10 @@ public class JsonTraceSegment {
         seg.className = (String) segmentArray.get(5);
         seg.methodName = (String) segmentArray.get(6);
 
+        // attributes added to all traces
         seg.requestParams.put("code.namespace", seg.className);
         seg.requestParams.put("code.function", seg.methodName);
+        seg.requestParams.put("thread.id", "*");
         return seg;
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -184,14 +184,14 @@ public class SpanEventFactoryTest {
         Map<String, Object> agentAttributes = ImmutableMap.of(
                 AttributeNames.CLM_NAMESPACE, "nr",
                 AttributeNames.CLM_FUNCTION, "process",
-                DefaultTracer.THREAD_ID_PARAMETER_NAME, 666
+                AttributeNames.THREAD_ID, 666
         );
 
         SpanEvent target = spanEventFactory.setClmAttributes(agentAttributes).build();
 
         assertEquals("nr", target.getAgentAttributes().get(AttributeNames.CLM_NAMESPACE));
         assertEquals("process", target.getAgentAttributes().get(AttributeNames.CLM_FUNCTION));
-        assertEquals(666, target.getAgentAttributes().get(DefaultTracer.THREAD_ID_PARAMETER_NAME));
+        assertEquals(666, target.getAgentAttributes().get(AttributeNames.THREAD_ID));
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -7,10 +7,13 @@
 
 package com.newrelic.agent.service.analytics;
 
+import com.google.common.collect.ImmutableMap;
+import com.newrelic.agent.attributes.AttributeNames;
 import com.newrelic.agent.model.AttributeFilter;
 import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.agent.model.SpanError;
 import com.newrelic.agent.model.SpanEvent;
+import com.newrelic.agent.tracers.DefaultTracer;
 import com.newrelic.api.agent.DatastoreParameters;
 import com.newrelic.api.agent.HttpParameters;
 import org.junit.Test;
@@ -174,6 +177,21 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setExternalParameterAttributes(mockParameters).build();
 
         assertEquals("database name", target.getIntrinsics().get("db.instance"));
+    }
+
+    @Test
+    public void shouldSetCLMParameters() {
+        Map<String, Object> agentAttributes = ImmutableMap.of(
+                AttributeNames.CLM_NAMESPACE, "nr",
+                AttributeNames.CLM_FUNCTION, "process",
+                DefaultTracer.THREAD_ID_PARAMETER_NAME, 666
+        );
+
+        SpanEvent target = spanEventFactory.setClmAttributes(agentAttributes).build();
+
+        assertEquals("nr", target.getAgentAttributes().get(AttributeNames.CLM_NAMESPACE));
+        assertEquals("process", target.getAgentAttributes().get(AttributeNames.CLM_FUNCTION));
+        assertEquals(666, target.getAgentAttributes().get(DefaultTracer.THREAD_ID_PARAMETER_NAME));
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
@@ -169,7 +169,7 @@ public class DefaultSqlTracerClmTest {
         SqlObfuscator sqlObfuscator = ServiceFactory.getDatabaseService().getDefaultSqlObfuscator();
         TransactionSegment segment = new TransactionSegment(ttConfig, sqlObfuscator, 0, tracer);
 
-        assertEquals(7, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql, sql_obfuscated, host, port_path_or_id, code.namespace, code.function
+        assertEquals(8, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql, sql_obfuscated, host, port_path_or_id, code.namespace, code.function, thread.id
         assertEquals(inputSql, tracer.getAgentAttributes().get("sql")); // shouldn't be obfuscated yet
         assertClm(tracer);
 
@@ -220,7 +220,7 @@ public class DefaultSqlTracerClmTest {
         SqlObfuscator sqlObfuscator = ServiceFactory.getDatabaseService().getDefaultSqlObfuscator();
         TransactionSegment segment = new TransactionSegment(ttConfig, sqlObfuscator, 0, tracer);
 
-        assertEquals(4, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql, code.namespace, code.function
+        assertEquals(5, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql, code.namespace, code.function, thread.id
         assertEquals(inputSql, (String) tracer.getAgentAttributes().get("sql")); // shouldn't be obfuscated yet
         assertClm(tracer);
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
@@ -146,7 +146,7 @@ public class DefaultSqlTracerTest {
         SqlObfuscator sqlObfuscator = ServiceFactory.getDatabaseService().getDefaultSqlObfuscator();
         TransactionSegment segment = new TransactionSegment(ttConfig, sqlObfuscator, 0, tracer);
 
-        assertEquals(5, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql, sql_obfuscated, host, port_path_or_id
+        assertEquals(6, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql, sql_obfuscated, host, port_path_or_id, thread.id
         assertEquals(inputSql, (String) tracer.getAgentAttributes().get("sql")); // shouldn't be obfuscated yet
 
         JSONArray json = (JSONArray) AgentHelper.serializeJSON(segment);
@@ -198,7 +198,7 @@ public class DefaultSqlTracerTest {
         SqlObfuscator sqlObfuscator = ServiceFactory.getDatabaseService().getDefaultSqlObfuscator();
         TransactionSegment segment = new TransactionSegment(ttConfig, sqlObfuscator, 0, tracer);
 
-        assertEquals(2, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql
+        assertEquals(3, tracer.getAgentAttributes().size()); // exclusive_duration_millis, sql, thread.id
         assertEquals(inputSql, (String) tracer.getAgentAttributes().get("sql")); // shouldn't be obfuscated yet
 
         JSONArray json = (JSONArray) AgentHelper.serializeJSON(segment);


### PR DESCRIPTION

### Overview

Knowing the thread id of different spans allows the UI to accurately calculate the exclusive time of segments.  `thread.id` is a standard OTel attribute and they recommend that it be reported for all spans.

https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/span-general/

Attribute | Type | Description | Examples | Requirement Level
-- | -- | -- | -- | --
thread.id | int | Current “managed” thread ID (as opposed to OS thread ID). | 42 | Recommended

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

[ ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.
