### PR TITLE
Setting thread.id as an intrinsic

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -121,7 +121,7 @@ public class SpanEventFactory {
         }
         final Object threadId = agentAttributes.get(AttributeNames.THREAD_ID);
         if (threadId != null) {
-            builder.putAgentAttribute(AttributeNames.THREAD_ID, threadId);
+            builder.putIntrinsic(AttributeNames.THREAD_ID, threadId);
         }
         if (agentAttributes.containsKey(AttributeNames.CLM_NAMESPACE) && agentAttributes.containsKey(AttributeNames.CLM_FUNCTION)) {
             builder.putAgentAttribute(AttributeNames.CLM_NAMESPACE, agentAttributes.get(AttributeNames.CLM_NAMESPACE));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -191,7 +191,7 @@ public class SpanEventFactoryTest {
 
         assertEquals("nr", target.getAgentAttributes().get(AttributeNames.CLM_NAMESPACE));
         assertEquals("process", target.getAgentAttributes().get(AttributeNames.CLM_FUNCTION));
-        assertEquals(666, target.getAgentAttributes().get(AttributeNames.THREAD_ID));
+        assertEquals(666, target.getIntrinsics().get(AttributeNames.THREAD_ID));
     }
 
     @Test


### PR DESCRIPTION
### Overview
`thread.id` was added as an agent attribute. But it was supposed to be an intrinsic attribute.
