### PR TITLE
Update class excludes list for Sonarqube9.9

### DIFF
--- a/newrelic-agent/src/main/resources/META-INF/excludes
+++ b/newrelic-agent/src/main/resources/META-INF/excludes
@@ -89,3 +89,8 @@
 ^com/ibm/ws/security/jaspi/JaspiServletFilter
 # Websphere specific servlet wrapper class
 ^com/ibm/ws/webcontainer/servlet/ServletWrapperImpl
+# Sonarqube9.9 ClassCircularityErrors 
+^java/util/AbstractList\$RandomAccessSpliterator
+^java/util/stream/MatchOps\$MatchOp
+^java/util/stream/MatchOps\$BooleanTerminalSink
+^javax/security/auth/Subject\$SecureSet\$1


### PR DESCRIPTION
fixes #1348 

This PR addresses `classCircularityError` that appeared when running the agent with Sonarqube Server v.9.9 and Java 17. 

Proposed change: add the following four classes to default excludes file: 
```
java/util/AbstractList$RandomAccessSpliterator
java/util/stream/MatchOps$MatchOp
java/util/stream/MatchOps$BooleanTerminalSink
javax/security/auth/Subject$SecureSet$1
``` 

These are not known to be weaved by the agent or security agent but appear to fix the issue on SQ. 
