### PR TITLE
Add database and external span attributes to correlate to metric data (Duplicate)

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -238,6 +238,7 @@ public class SpanEventFactory {
 
     public SpanEventFactory setServerAddress(String host) {
         builder.putAgentAttribute("server.address", host);
+        builder.putAgentAttribute("peer.hostname", host);
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -213,13 +213,13 @@ public class SpanEventFactory {
 
     // datastore parameter
     public SpanEventFactory setDatabaseName(String databaseName) {
-        builder.putIntrinsic("db.instance", databaseName);
+        builder.putAgentAttribute("db.instance", databaseName);
         return this;
     }
 
     // datastore parameter
     public SpanEventFactory setDatastoreComponent(String component) {
-        builder.putIntrinsic("db.system", component);
+        builder.putAgentAttribute("db.system", component);
         return this;
     }
 
@@ -227,7 +227,7 @@ public class SpanEventFactory {
     public SpanEventFactory setAddress(String hostName, String portPathOrId) {
         if (portPathOrId != null && hostName != null) {
             String address = MessageFormat.format("{0}:{1}", hostName, portPathOrId);
-            builder.putIntrinsic("peer.address", address);
+            builder.putAgentAttribute("peer.address", address);
         }
         return this;
     }
@@ -245,19 +245,20 @@ public class SpanEventFactory {
     // datastore parameter
     public SpanEventFactory setDatabaseStatement(String query) {
         if (query != null) {
-            builder.putIntrinsic("db.statement", truncateWithEllipsis(query, DB_STATEMENT_TRUNCATE_LENGTH));
+            builder.putAgentAttribute("db.statement", truncateWithEllipsis(query, DB_STATEMENT_TRUNCATE_LENGTH));
         }
         return this;
     }
 
     // datastore parameter
     private SpanEventFactory setDatabaseCollection(String collection) {
-        builder.putIntrinsic("db.sql.table", collection);
+        builder.putAgentAttribute("db.sql.table", collection);
         return this;
     }
 
+    // datastore parameter
     private SpanEventFactory setDatabaseOperation(String operation) {
-        builder.putIntrinsic("db.operation", operation);
+        builder.putAgentAttribute("db.operation", operation);
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -219,7 +219,7 @@ public class SpanEventFactory {
 
     // datastore parameter
     public SpanEventFactory setDatastoreComponent(String component) {
-        builder.putAgentAttribute("db.system", component);
+        builder.putIntrinsic("db.system", component);
         return this;
     }
 
@@ -233,12 +233,12 @@ public class SpanEventFactory {
     }
 
     public SpanEventFactory setServerAddress(String host) {
-        builder.putAgentAttribute("server.address", host);
+        builder.putIntrinsic("server.address", host);
         return this;
     }
 
     public SpanEventFactory setServerPort(int port) {
-        builder.putAgentAttribute("server.port", port);
+        builder.putIntrinsic("server.port", port);
         return this;
     }
 
@@ -252,13 +252,13 @@ public class SpanEventFactory {
 
     // datastore parameter
     private SpanEventFactory setDatabaseCollection(String collection) {
-        builder.putAgentAttribute("db.sql.table", collection);
+        builder.putIntrinsic("db.sql.table", collection);
         return this;
     }
 
     // datastore parameter
     private SpanEventFactory setDatabaseOperation(String operation) {
-        builder.putAgentAttribute("db.operation", operation);
+        builder.putIntrinsic("db.operation", operation);
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -223,7 +223,7 @@ public class SpanEventFactory {
 
     // datastore parameter
     public SpanEventFactory setDatastoreComponent(String component) {
-        builder.putIntrinsic("db.system", component);
+        builder.putAgentAttribute("db.system", component);
         return this;
     }
 
@@ -237,12 +237,12 @@ public class SpanEventFactory {
     }
 
     public SpanEventFactory setServerAddress(String host) {
-        builder.putIntrinsic("server.address", host);
+        builder.putAgentAttribute("server.address", host);
         return this;
     }
 
     public SpanEventFactory setServerPort(int port) {
-        builder.putIntrinsic("server.port", port);
+        builder.putAgentAttribute("server.port", port);
         return this;
     }
 
@@ -256,13 +256,13 @@ public class SpanEventFactory {
 
     // datastore parameter
     private SpanEventFactory setDatabaseCollection(String collection) {
-        builder.putIntrinsic("db.sql.table", collection);
+        builder.putAgentAttribute("db.sql.table", collection);
         return this;
     }
 
     // datastore parameter
     private SpanEventFactory setDatabaseOperation(String operation) {
-        builder.putIntrinsic("db.operation", operation);
+        builder.putAgentAttribute("db.operation", operation);
         return this;
     }
 
@@ -380,4 +380,3 @@ public class SpanEventFactory {
         return builder.build();
     }
 }
-

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -257,7 +257,7 @@ public class SpanEventFactory {
 
     // datastore parameter
     private SpanEventFactory setDatabaseCollection(String collection) {
-        builder.putAgentAttribute("db.sql.table", collection);
+        builder.putAgentAttribute("db.collection", collection);
         return this;
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -54,6 +54,7 @@ public class SpanEventFactoryTest {
 
         assertEquals("https://newrelic.com", target.getAgentAttributes().get("http.url"));
         assertEquals("newrelic.com", target.getAgentAttributes().get("server.address"));
+        assertEquals("newrelic.com", target.getAgentAttributes().get("peer.hostname"));
         assertNull(target.getAgentAttributes().get("server.port"));
     }
 
@@ -62,6 +63,7 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setServerAddress("localhost").setServerPort(3306).build();
 
         assertEquals("localhost", target.getAgentAttributes().get("server.address"));
+        assertEquals("localhost", target.getAgentAttributes().get("peer.hostname"));
         assertEquals(3306, target.getAgentAttributes().get("server.port"));
     }
 
@@ -188,6 +190,7 @@ public class SpanEventFactoryTest {
         assertEquals("select", target.getAgentAttributes().get("db.operation"));
         assertEquals("users", target.getAgentAttributes().get("db.sql.table"));
         assertEquals("MySQL", target.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver", target.getAgentAttributes().get("peer.hostname"));
         assertEquals("dbserver", target.getAgentAttributes().get("server.address"));
         assertEquals(3306, target.getAgentAttributes().get("server.port"));
         assertEquals("dbserver:3306", target.getAgentAttributes().get("peer.address"));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -50,13 +50,16 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setUri(URI.create("https://newrelic.com")).build();
 
         assertEquals("https://newrelic.com", target.getAgentAttributes().get("http.url"));
+        assertEquals("newrelic.com", target.getAgentAttributes().get("server.address"));
+        assertNull(target.getAgentAttributes().get("server.port"));
     }
 
     @Test
     public void addressShouldBeSet() {
-        SpanEvent target = spanEventFactory.setAddress("localhost", "3306").build();
+        SpanEvent target = spanEventFactory.setServerAddress("localhost").setServerPort(3306).build();
 
-        assertEquals("localhost:3306", target.getIntrinsics().get("peer.address"));
+        assertEquals("localhost", target.getAgentAttributes().get("server.address"));
+        assertEquals(3306, target.getAgentAttributes().get("server.port"));
     }
 
     @Test
@@ -170,10 +173,21 @@ public class SpanEventFactoryTest {
     public void shouldSetDataStoreParameters() {
         DatastoreParameters mockParameters = mock(DatastoreParameters.class);
         when(mockParameters.getDatabaseName()).thenReturn("database name");
+        when(mockParameters.getOperation()).thenReturn("select");
+        when(mockParameters.getCollection()).thenReturn("users");
+        when(mockParameters.getProduct()).thenReturn("MySQL");
+        when(mockParameters.getHost()).thenReturn("dbserver");
+        when(mockParameters.getPort()).thenReturn(3306);
 
         SpanEvent target = spanEventFactory.setExternalParameterAttributes(mockParameters).build();
 
         assertEquals("database name", target.getIntrinsics().get("db.instance"));
+        assertEquals("select", target.getIntrinsics().get("db.operation"));
+        assertEquals("users", target.getIntrinsics().get("db.sql.table"));
+        assertEquals("MySQL", target.getIntrinsics().get("db.system"));
+        assertEquals("dbserver", target.getAgentAttributes().get("server.address"));
+        assertEquals("dbserver:3306", target.getIntrinsics().get("peer.address"));
+        assertEquals(3306, target.getAgentAttributes().get("server.port"));
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -53,7 +53,7 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setUri(URI.create("https://newrelic.com")).build();
 
         assertEquals("https://newrelic.com", target.getAgentAttributes().get("http.url"));
-        assertEquals("newrelic.com", target.getIntrinsics().get("server.address"));
+        assertEquals("newrelic.com", target.getAgentAttributes().get("server.address"));
         assertNull(target.getAgentAttributes().get("server.port"));
     }
 
@@ -61,8 +61,8 @@ public class SpanEventFactoryTest {
     public void addressShouldBeSet() {
         SpanEvent target = spanEventFactory.setServerAddress("localhost").setServerPort(3306).build();
 
-        assertEquals("localhost", target.getIntrinsics().get("server.address"));
-        assertEquals(3306, target.getIntrinsics().get("server.port"));
+        assertEquals("localhost", target.getAgentAttributes().get("server.address"));
+        assertEquals(3306, target.getAgentAttributes().get("server.port"));
     }
 
     @Test
@@ -185,11 +185,11 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setExternalParameterAttributes(mockParameters).build();
 
         assertEquals("database name", target.getAgentAttributes().get("db.instance"));
-        assertEquals("select", target.getIntrinsics().get("db.operation"));
-        assertEquals("users", target.getIntrinsics().get("db.sql.table"));
-        assertEquals("MySQL", target.getIntrinsics().get("db.system"));
-        assertEquals("dbserver", target.getIntrinsics().get("server.address"));
-        assertEquals(3306, target.getIntrinsics().get("server.port"));
+        assertEquals("select", target.getAgentAttributes().get("db.operation"));
+        assertEquals("users", target.getAgentAttributes().get("db.sql.table"));
+        assertEquals("MySQL", target.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver", target.getAgentAttributes().get("server.address"));
+        assertEquals(3306, target.getAgentAttributes().get("server.port"));
         assertEquals("dbserver:3306", target.getAgentAttributes().get("peer.address"));
     }
 
@@ -255,7 +255,3 @@ public class SpanEventFactoryTest {
         }
     }
 }
-
-
-
-

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -188,7 +188,7 @@ public class SpanEventFactoryTest {
 
         assertEquals("database name", target.getAgentAttributes().get("db.instance"));
         assertEquals("select", target.getAgentAttributes().get("db.operation"));
-        assertEquals("users", target.getAgentAttributes().get("db.sql.table"));
+        assertEquals("users", target.getAgentAttributes().get("db.collection"));
         assertEquals("MySQL", target.getAgentAttributes().get("db.system"));
         assertEquals("dbserver", target.getAgentAttributes().get("peer.hostname"));
         assertEquals("dbserver", target.getAgentAttributes().get("server.address"));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -50,7 +50,7 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setUri(URI.create("https://newrelic.com")).build();
 
         assertEquals("https://newrelic.com", target.getAgentAttributes().get("http.url"));
-        assertEquals("newrelic.com", target.getAgentAttributes().get("server.address"));
+        assertEquals("newrelic.com", target.getIntrinsics().get("server.address"));
         assertNull(target.getAgentAttributes().get("server.port"));
     }
 
@@ -58,8 +58,8 @@ public class SpanEventFactoryTest {
     public void addressShouldBeSet() {
         SpanEvent target = spanEventFactory.setServerAddress("localhost").setServerPort(3306).build();
 
-        assertEquals("localhost", target.getAgentAttributes().get("server.address"));
-        assertEquals(3306, target.getAgentAttributes().get("server.port"));
+        assertEquals("localhost", target.getIntrinsics().get("server.address"));
+        assertEquals(3306, target.getIntrinsics().get("server.port"));
     }
 
     @Test
@@ -182,11 +182,11 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setExternalParameterAttributes(mockParameters).build();
 
         assertEquals("database name", target.getAgentAttributes().get("db.instance"));
-        assertEquals("select", target.getAgentAttributes().get("db.operation"));
-        assertEquals("users", target.getAgentAttributes().get("db.sql.table"));
-        assertEquals("MySQL", target.getAgentAttributes().get("db.system"));
-        assertEquals("dbserver", target.getAgentAttributes().get("server.address"));
-        assertEquals(3306, target.getAgentAttributes().get("server.port"));
+        assertEquals("select", target.getIntrinsics().get("db.operation"));
+        assertEquals("users", target.getIntrinsics().get("db.sql.table"));
+        assertEquals("MySQL", target.getIntrinsics().get("db.system"));
+        assertEquals("dbserver", target.getIntrinsics().get("server.address"));
+        assertEquals(3306, target.getIntrinsics().get("server.port"));
         assertEquals("dbserver:3306", target.getAgentAttributes().get("peer.address"));
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -70,7 +70,7 @@ public class SpanEventFactoryTest {
         SpanEvent target = spanEventFactory.setDatabaseStatement(threeKStatement).build();
 
         assertEquals(2000,
-                target.getIntrinsics().get("db.statement").toString().length());
+                target.getAgentAttributes().get("db.statement").toString().length());
     }
 
     @Test
@@ -181,13 +181,13 @@ public class SpanEventFactoryTest {
 
         SpanEvent target = spanEventFactory.setExternalParameterAttributes(mockParameters).build();
 
-        assertEquals("database name", target.getIntrinsics().get("db.instance"));
-        assertEquals("select", target.getIntrinsics().get("db.operation"));
-        assertEquals("users", target.getIntrinsics().get("db.sql.table"));
-        assertEquals("MySQL", target.getIntrinsics().get("db.system"));
+        assertEquals("database name", target.getAgentAttributes().get("db.instance"));
+        assertEquals("select", target.getAgentAttributes().get("db.operation"));
+        assertEquals("users", target.getAgentAttributes().get("db.sql.table"));
+        assertEquals("MySQL", target.getAgentAttributes().get("db.system"));
         assertEquals("dbserver", target.getAgentAttributes().get("server.address"));
-        assertEquals("dbserver:3306", target.getIntrinsics().get("peer.address"));
         assertEquals(3306, target.getAgentAttributes().get("server.port"));
+        assertEquals("dbserver:3306", target.getAgentAttributes().get("peer.address"));
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventsServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventsServiceTest.java
@@ -125,7 +125,7 @@ public class SpanEventsServiceTest {
                 .setDecider(true)
                 .setPriority(1.23f)
                 .setDurationInSeconds(1.3f)
-                .setHostName("yourHost")
+                .setServerAddress("yourHost")
                 .setTraceId("gnisnacirema")
                 .setGuid("globallyuniqueidentifier")
                 .setSampled(true)

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
@@ -465,11 +465,11 @@ public class DefaultSqlTracerClmTest {
         assertNotNull(spanEvent);
 
         assertEquals("datastore", spanEvent.getIntrinsics().get("category"));
-        assertEquals("MySQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("dbserver.nerd.us", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbserver.nerd.us:9945", spanEvent.getIntrinsics().get("peer.address"));
-        assertEquals("SELECT price, name FROM BOOKS WHERE price <= 79.99", spanEvent.getIntrinsics().get("db.statement"));
-        assertEquals("books", spanEvent.getIntrinsics().get("db.collection"));
+        assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
+        assertEquals("SELECT price, name FROM BOOKS WHERE price <= 79.99", spanEvent.getAgentAttributes().get("db.statement"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -500,12 +500,12 @@ public class DefaultSqlTracerClmTest {
         assertNotNull(spanEvent);
 
         assertEquals("datastore", spanEvent.getIntrinsics().get("category"));
-        assertEquals("MySQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("dbserver.nerd.us", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbserver.nerd.us:9945", spanEvent.getIntrinsics().get("peer.address"));
-        assertEquals(2000, spanEvent.getIntrinsics().get("db.statement").toString().length());
-        assertTrue(spanEvent.getIntrinsics().get("db.statement").toString().endsWith("a..."));
-        assertEquals("books", spanEvent.getIntrinsics().get("db.collection"));
+        assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
+        assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
+        assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("a..."));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -536,12 +536,13 @@ public class DefaultSqlTracerClmTest {
         assertNotNull(spanEvent);
 
         assertEquals("datastore", spanEvent.getIntrinsics().get("category"));
-        assertEquals("MySQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("dbserver.nerd.us", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbserver.nerd.us:9945", spanEvent.getIntrinsics().get("peer.address"));
-        assertEquals(2000, spanEvent.getIntrinsics().get("db.statement").toString().length());
-        assertTrue(spanEvent.getIntrinsics().get("db.statement").toString().endsWith("aaa")); // Should not end with ... since it's exactly at the limit
-        assertEquals("books", spanEvent.getIntrinsics().get("db.collection"));
+        assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("server.address"));
+        assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
+        assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
+        assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("aaa")); // Should not end with ... since it's exactly at the limit
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
@@ -469,7 +469,7 @@ public class DefaultSqlTracerClmTest {
         assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals("SELECT price, name FROM BOOKS WHERE price <= 79.99", spanEvent.getAgentAttributes().get("db.statement"));
-        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -505,7 +505,7 @@ public class DefaultSqlTracerClmTest {
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
         assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("a..."));
-        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -542,7 +542,7 @@ public class DefaultSqlTracerClmTest {
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
         assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("aaa")); // Should not end with ... since it's exactly at the limit
-        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
@@ -642,7 +642,7 @@ public class DefaultSqlTracerTest {
         assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals("SELECT price, name FROM BOOKS WHERE price <= 79.99", spanEvent.getAgentAttributes().get("db.statement"));
-        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -678,7 +678,7 @@ public class DefaultSqlTracerTest {
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
         assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("a..."));
-        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -714,7 +714,7 @@ public class DefaultSqlTracerTest {
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
         assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("aaa")); // Should not end with ... since it's exactly at the limit
-        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
@@ -638,11 +638,11 @@ public class DefaultSqlTracerTest {
         assertNotNull(spanEvent);
 
         assertEquals("datastore", spanEvent.getIntrinsics().get("category"));
-        assertEquals("MySQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("dbserver.nerd.us", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbserver.nerd.us:9945", spanEvent.getIntrinsics().get("peer.address"));
-        assertEquals("SELECT price, name FROM BOOKS WHERE price <= 79.99", spanEvent.getIntrinsics().get("db.statement"));
-        assertEquals("books", spanEvent.getIntrinsics().get("db.collection"));
+        assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
+        assertEquals("SELECT price, name FROM BOOKS WHERE price <= 79.99", spanEvent.getAgentAttributes().get("db.statement"));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -673,12 +673,12 @@ public class DefaultSqlTracerTest {
         assertNotNull(spanEvent);
 
         assertEquals("datastore", spanEvent.getIntrinsics().get("category"));
-        assertEquals("MySQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("dbserver.nerd.us", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbserver.nerd.us:9945", spanEvent.getIntrinsics().get("peer.address"));
-        assertEquals(2000, spanEvent.getIntrinsics().get("db.statement").toString().length());
-        assertTrue(spanEvent.getIntrinsics().get("db.statement").toString().endsWith("a..."));
-        assertEquals("books", spanEvent.getIntrinsics().get("db.collection"));
+        assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
+        assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
+        assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("a..."));
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());
@@ -709,12 +709,12 @@ public class DefaultSqlTracerTest {
         assertNotNull(spanEvent);
 
         assertEquals("datastore", spanEvent.getIntrinsics().get("category"));
-        assertEquals("MySQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("dbserver.nerd.us", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbserver.nerd.us:9945", spanEvent.getIntrinsics().get("peer.address"));
-        assertEquals(2000, spanEvent.getIntrinsics().get("db.statement").toString().length());
-        assertTrue(spanEvent.getIntrinsics().get("db.statement").toString().endsWith("aaa")); // Should not end with ... since it's exactly at the limit
-        assertEquals("books", spanEvent.getIntrinsics().get("db.collection"));
+        assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
+        assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
+        assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("aaa")); // Should not end with ... since it's exactly at the limit
+        assertEquals("books", spanEvent.getAgentAttributes().get("db.sql.table"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertEquals("Datastore/statement/MySQL/books/select", spanEvent.getName());
         assertNotNull(spanEvent.getTraceId());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerClmTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerClmTest.java
@@ -687,10 +687,10 @@ public class DefaultTracerClmTest {
         assertNotNull(spanEvent);
 
         assertNull(spanEvent.getParentId());
-        assertEquals("YourSQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("databaseServer", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbName", spanEvent.getIntrinsics().get("db.instance"));
-        assertEquals("databaseServer:1234", spanEvent.getIntrinsics().get("peer.address"));
+        assertEquals("YourSQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("databaseServer", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbName", spanEvent.getAgentAttributes().get("db.instance"));
+        assertEquals("databaseServer:1234", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertClm(tracer, spanEvent);
     }
@@ -829,10 +829,10 @@ public class DefaultTracerClmTest {
         assertEquals(rootSpan.getGuid(), siblingSpan.getParentId());
         assertNull(siblingSpan.getIntrinsics().get("nr.entryPoint"));
 
-        assertEquals("YourSQL", child2Span.getIntrinsics().get("component"));
-        assertEquals("databaseServer", child2Span.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbName", child2Span.getIntrinsics().get("db.instance"));
-        assertEquals("databaseServer:1234", child2Span.getIntrinsics().get("peer.address"));
+        assertEquals("YourSQL", child2Span.getAgentAttributes().get("db.system"));
+        assertEquals("databaseServer", child2Span.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbName", child2Span.getAgentAttributes().get("db.instance"));
+        assertEquals("databaseServer:1234", child2Span.getAgentAttributes().get("peer.address"));
         assertEquals("client", child2Span.getIntrinsics().get("span.kind"));
 
         assertEquals("library", siblingSpan.getIntrinsics().get("component"));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerTest.java
@@ -717,10 +717,10 @@ public class DefaultTracerTest {
         assertNotNull(spanEvent);
 
         assertNull(spanEvent.getParentId());
-        assertEquals("YourSQL", spanEvent.getIntrinsics().get("component"));
-        assertEquals("databaseServer", spanEvent.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbName", spanEvent.getIntrinsics().get("db.instance"));
-        assertEquals("databaseServer:1234", spanEvent.getIntrinsics().get("peer.address"));
+        assertEquals("YourSQL", spanEvent.getAgentAttributes().get("db.system"));
+        assertEquals("databaseServer", spanEvent.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbName", spanEvent.getAgentAttributes().get("db.instance"));
+        assertEquals("databaseServer:1234", spanEvent.getAgentAttributes().get("peer.address"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));
         assertClmAbsent(spanEvent);
     }
@@ -860,10 +860,10 @@ public class DefaultTracerTest {
         assertEquals(rootSpan.getGuid(), siblingSpan.getParentId());
         assertNull(siblingSpan.getIntrinsics().get("nr.entryPoint"));
 
-        assertEquals("YourSQL", child2Span.getIntrinsics().get("component"));
-        assertEquals("databaseServer", child2Span.getIntrinsics().get("peer.hostname"));
-        assertEquals("dbName", child2Span.getIntrinsics().get("db.instance"));
-        assertEquals("databaseServer:1234", child2Span.getIntrinsics().get("peer.address"));
+        assertEquals("YourSQL", child2Span.getAgentAttributes().get("db.system"));
+        assertEquals("databaseServer", child2Span.getAgentAttributes().get("peer.hostname"));
+        assertEquals("dbName", child2Span.getAgentAttributes().get("db.instance"));
+        assertEquals("databaseServer:1234", child2Span.getAgentAttributes().get("peer.address"));
         assertEquals("client", child2Span.getIntrinsics().get("span.kind"));
 
         assertEquals("library", siblingSpan.getIntrinsics().get("component"));


### PR DESCRIPTION
This is a duplicate of the following [PR](https://github.com/newrelic/newrelic-java-agent/pull/1504).

### Overview

This adds attributes to Spans so that we can correlate aggregate database and external metric back to their related client spans.

 * db.system
 * db.operation
 * db.collection
 * server.address
 * server.port

https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/
https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/database/

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
I added unit tests to cover the new attributes.  I can a couple of local apps with a local build and verified that the attributes were correctly added.

### Checks

[ X ] Are your contributions backwards compatible with relevant frameworks and APIs?
[ ] Does your code contain any breaking changes? Please describe. 
[ ] Does your code introduce any new dependencies? Please describe.

