### PR TITLE
NR-164405 Fix Package Exclusion Issue with com.nr and com.newrelic

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
@@ -800,8 +800,8 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
             securityExcludes.add("java/util/zip/InflaterInputStream");
             securityExcludes.add("java/util/zip/ZipFile$ZipFileInputStream");
             securityExcludes.add("java/util/zip/ZipFile$ZipFileInflaterInputStream");
-            securityExcludes.add("com/newrelic/.*");
-            securityExcludes.add("com/nr/.*");
+            securityExcludes.add("com/newrelic/api/agent/security/.*");
+            securityExcludes.add("com/newrelic/agent/security/.*");
 
             Object userProvidedExcludes = props.get(ClassTransformerConfigImpl.EXCLUDES);
             if (userProvidedExcludes instanceof String) {


### PR DESCRIPTION
This PR is aimed at relocating exclusion packages from "com.newrelic." and "com.nr.*" to "com.newrelic.agent.security.instrumentation.*" and "com.nr.agent.security.instrumentation.*" This change is specific to csec requirements, and it ensures that instrumentation only affects csec classes, aligning with our intended target.