### PR TITLE
Check for Spring6 specific servlet attribute for advice-handled exception 

### DIFF
--- a/instrumentation/tomcat-10/src/main/java/com/nr/agent/instrumentation/tomcat10/TomcatServletRequestListener.java
+++ b/instrumentation/tomcat-10/src/main/java/com/nr/agent/instrumentation/tomcat10/TomcatServletRequestListener.java
@@ -21,7 +21,8 @@ import java.util.logging.Level;
 
 public final class TomcatServletRequestListener implements ServletRequestListener {
 
-    private static final String EXCEPTION_ATTRIBUTE_NAME = "jakarta.servlet.error.exception";
+    private static final String SERVLET_EXCEPTION_ATTRIBUTE_NAME = "jakarta.servlet.error.exception";
+    private static final String SPRING6_SERVLET_EXCEPTION_ATTRIBUTE_NAME = "org.springframework.web.servlet.DispatcherServlet.EXCEPTION";
     private static final String REQUEST_FIELD = "request";
 
     private final Field requestField;
@@ -44,8 +45,7 @@ public final class TomcatServletRequestListener implements ServletRequestListene
     @CatchAndLog
     @Override
     public void requestDestroyed(ServletRequestEvent sre) {
-
-        Throwable exception = (Throwable) sre.getServletRequest().getAttribute(EXCEPTION_ATTRIBUTE_NAME);
+        Throwable exception = retrieveExceptionFromServlet(sre);
         if (exception != null) {
             AgentBridge.privateApi.reportException(exception);
         }
@@ -97,5 +97,13 @@ public final class TomcatServletRequestListener implements ServletRequestListene
             return (Request_Weaved) httpServletRequest;
         }
         return null;
+    }
+
+    private Throwable retrieveExceptionFromServlet(ServletRequestEvent sre) {
+        //As of Spring 6, when controller advice is used for controller exception handling, the caught exception is
+        //now stored in the servlet attribute map with the "org.springframework.web.servlet.DispatcherServlet.EXCEPTION" key.
+        return (Throwable) (sre.getServletRequest().getAttribute(SERVLET_EXCEPTION_ATTRIBUTE_NAME) != null ?
+                sre.getServletRequest().getAttribute(SERVLET_EXCEPTION_ATTRIBUTE_NAME) :
+                sre.getServletRequest().getAttribute(SPRING6_SERVLET_EXCEPTION_ATTRIBUTE_NAME));
     }
 }


### PR DESCRIPTION
Resolves #1393 

As of Spring 6, when controller advice is used for controller exception handling, the caught exception is now stored in the servlet attribute map with the `org.springframework.web.servlet.DispatcherServlet.EXCEPTION` key. Other exceptions are still present in the `jakarta.servlet.error.exception` key.

With this change, exceptions now report properly to NR.

![Screenshot 2023-10-05 at 11 15 45 AM](https://github.com/newrelic/newrelic-java-agent/assets/5081648/7a3551bb-a792-4fc1-a4a6-1097c5794a62)
