### PR TITLE
Force commons-codec to v1.13

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -59,6 +59,12 @@ dependencies {
     jarIntoJar("com.newrelic.agent.java.security:newrelic-security-api:${securityAgentVersion}")
     jarIntoJar("com.newrelic.agent.java.security:newrelic-security-agent:${securityAgentVersion}")
 
+    shadowIntoJar( group: 'commons-codec', name: 'commons-codec') {
+        version {
+            strictly "[1.13]"
+        }
+    }
+
     shadowIntoJar project(":agent-interfaces")
     shadowIntoJar project(":agent-model")
     shadowIntoJar(project(":newrelic-weaver"))


### PR DESCRIPTION
Resolves #1535 

Forces the `commons-codec` transitive dependency of `org.apache.httpcomponents:httpclient:4.5.13` to v1.13 to eliminate a [vulnerability](https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea).

The dependency tree of `httpclient` for the `shadowIntoJar` config now look like:
```
+--- org.apache.httpcomponents:httpclient:4.5.13
|    +--- org.apache.httpcomponents:httpcore:4.4.13
|    +--- commons-logging:commons-logging:1.2
|    \--- commons-codec:commons-codec:1.11 -> 1.13
```