### PR TITLE
Add transaction GUID to all applicable TracedError instances

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/DeadlockTraceError.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/DeadlockTraceError.java
@@ -25,7 +25,7 @@ public class DeadlockTraceError extends TracedError {
             long timestampInMillis, String message, String exceptionClass, Map<String, StackTraceElement[]> stackTraces,
             Map<String, ?> errorAttributes) {
         super(errorCollectorConfig, appName, frontendMetricName, timestampInMillis, "", null, null, null,
-                errorAttributes, null, null, false);
+                errorAttributes, null, null, false, null);
         this.stackTraces = stackTraces;
         this.message = message;
         this.exceptionClass = exceptionClass;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
@@ -483,6 +483,7 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
                     .errorAttributes(td.getErrorAttributes())
                     .intrinsicAttributes(joinedIntrinsics)
                     .expected(markedExpected)
+                    .transactionGuid(td.getGuid())
                     .build();
         } else {
             error = HttpTracedError
@@ -496,6 +497,7 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
                     .errorAttributes(td.getErrorAttributes())
                     .intrinsicAttributes(joinedIntrinsics)
                     .expected(markedExpected)
+                    .transactionGuid(td.getGuid())
                     .build();
         }
         return error;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/HttpTracedError.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/HttpTracedError.java
@@ -29,9 +29,9 @@ public class HttpTracedError extends TracedError {
             long timestamp, Map<String, Map<String, String>> prefixedParams,
             Map<String, Object> userParams, Map<String, Object> agentParams,
             Map<String, ?> errorParams, Map<String, Object> intrinsics,
-            TransactionData transactionData, boolean expected) {
+            TransactionData transactionData, boolean expected, String transactionGuid) {
         super(errorCollectorConfig, appName, frontendMetricName, timestamp, requestUri, prefixedParams, userParams,
-                agentParams, errorParams, intrinsics, transactionData, expected);
+                agentParams, errorParams, intrinsics, transactionData, expected, transactionGuid);
 
         this.responseStatus = responseStatus;
         if (errorMessage == null && responseStatus != UNKNOWN_STATUS_CODE) {
@@ -67,7 +67,7 @@ public class HttpTracedError extends TracedError {
         public HttpTracedError build() {
             return new HttpTracedError(errorCollectorConfig, appName, frontendMetricName,
                     requestUri, responseStatus, errorMessage, timestampInMillis, prefixedAttributes, userAttributes,
-                    agentAttributes, errorAttributes, intrinsicAttributes, transactionData, expected);
+                    agentAttributes, errorAttributes, intrinsicAttributes, transactionData, expected, transactionGuid);
         }
 
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ThrowableError.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ThrowableError.java
@@ -38,9 +38,10 @@ public class ThrowableError extends TracedError {
             Map<String, ?> errorParams,
             Map<String, ?> intrinsics,
             TransactionData transactionData,
-            boolean expected) {
+            boolean expected,
+            String transactionGuid) {
         super(errorCollectorConfig, appName, frontendMetricName, timestamp, requestUri, prefixedParams, userParams,
-                agentParams, errorParams, intrinsics, transactionData, expected);
+                agentParams, errorParams, intrinsics, transactionData, expected, transactionGuid);
 
         this.errorMessageReplacer = errorMessageReplacer;
         this.throwable = error;
@@ -64,7 +65,7 @@ public class ThrowableError extends TracedError {
         public ThrowableError build() {
             return new ThrowableError(errorCollectorConfig, errorMessageReplacer, appName, frontendMetricName, requestUri, throwable,
                     timestampInMillis, prefixedAttributes, userAttributes, agentAttributes, errorAttributes,
-                    intrinsicAttributes, transactionData, expected);
+                    intrinsicAttributes, transactionData, expected, transactionGuid);
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/TracedError.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/TracedError.java
@@ -17,10 +17,12 @@ import org.json.simple.JSONStreamAware;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public abstract class TracedError implements Comparable<TracedError>, JSONStreamAware {
@@ -38,6 +40,8 @@ public abstract class TracedError implements Comparable<TracedError>, JSONStream
     final TransactionData transactionData;
     final boolean expected; // reported as expected error by API call
 
+    final String transactionGuid;
+
     public abstract static class Builder {
         protected final ErrorCollectorConfig errorCollectorConfig;
         protected final String appName;
@@ -53,6 +57,8 @@ public abstract class TracedError implements Comparable<TracedError>, JSONStream
         protected Map<String, Object> intrinsicAttributes = Collections.emptyMap();
 
         protected boolean expected;
+
+        protected String transactionGuid;
 
         Builder(ErrorCollectorConfig errorCollectorConfig, String appName, String frontendMetricName, long timestampInMillis) {
             this.errorCollectorConfig = errorCollectorConfig;
@@ -101,13 +107,18 @@ public abstract class TracedError implements Comparable<TracedError>, JSONStream
             return this;
         }
 
+        public Builder transactionGuid(String transactionGuid) {
+            this.transactionGuid = transactionGuid;
+            return this;
+        }
+
         public abstract TracedError build();
     }
 
     protected TracedError(ErrorCollectorConfig errorCollectorConfig, String appName, String frontendMetricName,
             long timestampInMillis, String requestUri, Map<String, Map<String, String>> prefixedParams,
             Map<String, ?> userParams, Map<String, ?> agentParams, Map<String, ?> errorParams,
-            Map<String, ?> intrinsics, TransactionData transactionData, boolean expected) {
+            Map<String, ?> intrinsics, TransactionData transactionData, boolean expected, String transactionGuid) {
         this.errorCollectorConfig = errorCollectorConfig;
         this.appName = appName;
         this.path = frontendMetricName == null ? "Unknown" : frontendMetricName;
@@ -120,6 +131,7 @@ public abstract class TracedError implements Comparable<TracedError>, JSONStream
         this.intrinsics = setAtts(intrinsics);
         this.transactionData = transactionData;
         this.expected = expected;
+        this.transactionGuid = transactionGuid;
     }
 
     private <K, V> Map<K, V> setAtts(Map<K, V> inputAtts) {
@@ -225,7 +237,13 @@ public abstract class TracedError implements Comparable<TracedError>, JSONStream
 
     @Override
     public void writeJSONString(Writer writer) throws IOException {
-        JSONArray.writeJSONString(Arrays.asList(getTimestampInMillis(), getPath(), getMessage(), getExceptionClass(), getAttributes()), writer);
+        // Wrapped in an ArrayList since Arrays.asList() returns an immutable list
+        List<Object> elements = new ArrayList<>(Arrays.asList(getTimestampInMillis(), getPath(), getMessage(), getExceptionClass(), getAttributes()));
+        // Add the transaction guid to the trace, if applicable
+        if (transactionGuid != null) {
+            elements.add(this.transactionGuid);
+        }
+        JSONArray.writeJSONString(elements, writer);
     }
 
     @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
@@ -1217,7 +1217,7 @@ public class RPMServiceTest {
                 int stackFrameCount) {
 
             super(mock(ErrorCollectorConfig.class), mock(ErrorMessageReplacer.class), appName, frontendMetricName, "", error, timestamp, prefixedParams,
-                    userParams, agentParams, errorParams, intrinsics, null, false);
+                    userParams, agentParams, errorParams, intrinsics, null, false, null);
 
             this.stackFrameCount = stackFrameCount;
         }


### PR DESCRIPTION
This will add the transaction GUID to any TracedError instance that is created as part of a transaction. This will then propagate to the backend when data is sent via the `error_data` method. The resulting JSON for the payload is below.  The GUID will show up in the 6th element of the top level JSON array. For other TracedErrors, this element will be missing (the same behavior prior to the change).

```
[
  [
    1697737126134,
    "WebTransaction/SpringController/withoutadvice (GET)",
    "Request processing failed: java.lang.IllegalArgumentException: without advice",
    "jakarta.servlet.ServletException",
    {
      "intrinsics": {
        "traceId": "5b5891157fc73f504d9b4efc60fff1aa",
        "error.expected": false,
        "guid": "4afa298e0f244149",
        "parent.transportType": "HTTP",
        "priority": 1.191872,
        "sampled": true
      },
      "agentAttributes": {
        "jvm.thread_name": "http-nio-8080-exec-2",
        "response.headers.contentType": "application/json",
        "request.uri": "/withoutadvice",
        "request.headers.accept": "*/*",
        "http.statusCode": 500,
        "request.headers.userAgent": "curl/8.1.2",
        "request.method": "GET",
        "request.headers.host": "localhost:8080"
      },
      "stack_trace": [ //Snipped ]
    },
    "4afa298e0f244149"
  ]
]
```