### PR TITLE
Normalize CGLIB proxied class names

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/MethodInvokerPointCut.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/pointcuts/frameworks/spring/MethodInvokerPointCut.java
@@ -77,11 +77,19 @@ public abstract class MethodInvokerPointCut extends TracerFactoryPointCut {
     }
 
     private String getControllerName(String methodName, Class<?> controller) {
-        String controllerName = isUseFullPackageName() ? controller.getName() : controller.getSimpleName();
-        int indexOf = controllerName.indexOf(TO_REMOVE);
-        if (indexOf > 0) {
-            controllerName = controllerName.substring(0, indexOf);
-        }
+        Class<?> originalClass = getOriginalClassIfProxied(controller);
+        String controllerName = isUseFullPackageName() ? originalClass.getName() : originalClass.getSimpleName();
         return '/' + controllerName + '/' + methodName;
+    }
+
+    private Class<?> getOriginalClassIfProxied(Class<?> clazz) {
+        if (clazz.getName().contains("$$")) {
+            Class<?> superclass = clazz.getSuperclass();
+            if (superclass != null && superclass != Object.class) {
+                return superclass;
+            }
+        }
+
+        return clazz;
     }
 }


### PR DESCRIPTION
Resolves #1574 

With this change, transaction names that are composed of class name + method name from a controller that has a CGLIB proxy generated will no longer show the proxy class name but the original class name.  This image shows an example of transactions names with and without this change:
![Screenshot 2023-11-06 at 3 56 57 PM](https://github.com/newrelic/newrelic-java-agent/assets/5081648/2a3457e5-7315-41ab-95cd-55a68f231060)
