### PR TITLE
Add an interface for our error API

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpAgent.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpAgent.java
@@ -8,6 +8,7 @@
 package com.newrelic.agent.bridge;
 
 import com.newrelic.api.agent.Config;
+import com.newrelic.api.agent.ErrorApi;
 import com.newrelic.api.agent.Insights;
 import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.Logs;
@@ -62,6 +63,11 @@ class NoOpAgent implements Agent {
     @Override
     public Insights getInsights() {
         return NoOpInsights.INSTANCE;
+    }
+
+    @Override
+    public ErrorApi getErrorApi() {
+        return NoOpErrorApi.INSTANCE;
     }
 
     @Override

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpErrorApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpErrorApi.java
@@ -1,0 +1,17 @@
+package com.newrelic.agent.bridge;
+
+import com.newrelic.api.agent.ErrorApi;
+
+import java.util.Map;
+
+class NoOpErrorApi implements ErrorApi {
+    static final ErrorApi INSTANCE = new NoOpErrorApi();
+
+    @Override
+    public void noticeError(Throwable throwable, Map<String, ?> params, boolean expected) {
+    }
+
+    @Override
+    public void noticeError(String message, Map<String, ?> params, boolean expected) {
+    }
+}

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpErrorApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpErrorApi.java
@@ -1,6 +1,7 @@
 package com.newrelic.agent.bridge;
 
 import com.newrelic.api.agent.ErrorApi;
+import com.newrelic.api.agent.ErrorGroupCallback;
 
 import java.util.Map;
 
@@ -13,5 +14,9 @@ class NoOpErrorApi implements ErrorApi {
 
     @Override
     public void noticeError(String message, Map<String, ?> params, boolean expected) {
+    }
+
+    @Override
+    public void setErrorGroupCallback(ErrorGroupCallback errorGroupCallback) {
     }
 }

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
@@ -16,42 +16,12 @@ import com.newrelic.api.agent.Response;
 class NoOpPublicApi implements PublicApi {
 
     @Override
-    public void noticeError(Throwable throwable, Map<String, ?> params) {
-
-    }
-
-    @Override
-    public void noticeError(Throwable throwable) {
-
-    }
-
-    @Override
-    public void noticeError(String message, Map<String, ?> params) {
-
-    }
-
-    @Override
-    public void noticeError(String message) {
-
-    }
-
-    @Override
     public void noticeError(Throwable throwable, Map<String, ?> params, boolean expected) {
 
     }
 
     @Override
-    public void noticeError(Throwable throwable, boolean expected) {
-
-    }
-
-    @Override
     public void noticeError(String message, Map<String, ?> params, boolean expected) {
-
-    }
-
-    @Override
-    public void noticeError(String message, boolean expected) {
 
     }
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
@@ -8,7 +8,6 @@
 package com.newrelic.agent.bridge;
 
 import com.newrelic.api.agent.ErrorApi;
-import com.newrelic.api.agent.ErrorGroupCallback;
 import com.newrelic.api.agent.Request;
 import com.newrelic.api.agent.Response;
 
@@ -163,15 +162,4 @@ public interface PublicApi extends ErrorApi {
      * @param instanceName the instance name to set in the environment
      */
     void setInstanceName(String instanceName);
-
-
-    /**
-     * Registers an {@link ErrorGroupCallback} that's used to generate a grouping key for the supplied
-     * error. This key will be used to group similar error messages on the Errors Inbox UI. If the
-     * errorGroupCallback instance is null no grouping key will be generated.
-     *
-     * @param errorGroupCallback the ErrorGroupCallback used to generate grouping keys for errors
-     */
-
-    void setErrorGroupCallback(ErrorGroupCallback errorGroupCallback);
 }

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/PublicApi.java
@@ -7,6 +7,7 @@
 
 package com.newrelic.agent.bridge;
 
+import com.newrelic.api.agent.ErrorApi;
 import com.newrelic.api.agent.ErrorGroupCallback;
 import com.newrelic.api.agent.Request;
 import com.newrelic.api.agent.Response;
@@ -16,113 +17,7 @@ import java.util.Map;
 /**
  * The public api interface.
  */
-public interface PublicApi {
-
-    // ************************** Error collector ***********************************//
-
-    /**
-     * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
-     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * last error will be reported.
-     *
-     * @param throwable The throwable to notice and report.
-     * @param params Custom parameters to include in the traced error. May be null.
-     */
-    void noticeError(Throwable throwable, Map<String, ?> params);
-
-    /**
-     * Report an exception to New Relic.
-     *
-     * @param throwable The throwable to report.
-     * @see #noticeError(Throwable, Map)
-     */
-    void noticeError(Throwable throwable);
-
-    /**
-     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
-     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * last error will be reported.
-     *
-     * @param message The error message to be reported.
-     * @param params Custom parameters to include in the traced error. May be null.
-     */
-    void noticeError(String message, Map<String, ?> params);
-
-    /**
-     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
-     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * last error will be reported.
-     *
-     * @param message Message to report with a transaction when it finishes.
-     */
-    void noticeError(String message);
-
-    /**
-     * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
-     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * last error will be reported.
-     *
-     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
-     *
-     * <p>
-     * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
-     * traced error if the key or value, each, cannot be encoded in 255 bytes. If key or value is over this limit, the
-     * behavior will be the same as defined in {@link #addCustomParameter(String key, String value) addCustomParameter}.
-     * </p>
-     *
-     * @param throwable The throwable to notice and report.
-     * @param params Custom parameters to include in the traced error. May be null.
-     * @param expected true if this error is expected, false otherwise.
-     */
-    void noticeError(Throwable throwable, Map<String, ?> params, boolean expected);
-
-    /**
-     * Report an exception to New Relic.
-     *
-     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
-     *
-     * @param throwable The throwable to report.
-     * @param expected true if this error is expected, false otherwise.
-     * @see #noticeError(Throwable, Map)
-     */
-    void noticeError(Throwable throwable, boolean expected);
-
-    /**
-     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
-     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * last error will be reported.
-     *
-     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
-     *
-     * <p>
-     * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
-     * traced error if the key or value, each, cannot be encoded in 255 bytes. If key or value is over this limit, the
-     * behavior will be the same as defined in {@link #addCustomParameter(String key, String value) addCustomParameter}.
-     * </p>
-     *
-     * @param message The error message to be reported.
-     * @param params Custom parameters to include in the traced error. May be null.
-     * @param expected true if this error is expected, false otherwise.
-     */
-    void noticeError(String message, Map<String, ?> params, boolean expected);
-
-    /**
-     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
-     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
-     * last error will be reported.
-     *
-     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
-     *
-     * @param message Message to report with a transaction when it finishes.
-     * @param expected true if this error is expected, false otherwise.
-     */
-    void noticeError(String message, boolean expected);
+public interface PublicApi extends ErrorApi {
 
     // **************************** Transaction APIs ********************************//
 

--- a/functional_test/src/test/java/com/newrelic/agent/extension/FakeExtensionAgent.java
+++ b/functional_test/src/test/java/com/newrelic/agent/extension/FakeExtensionAgent.java
@@ -11,6 +11,7 @@ import com.newrelic.agent.bridge.Agent;
 import com.newrelic.agent.bridge.TracedMethod;
 import com.newrelic.agent.bridge.Transaction;
 import com.newrelic.api.agent.Config;
+import com.newrelic.api.agent.ErrorApi;
 import com.newrelic.api.agent.Insights;
 import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.Logs;
@@ -36,6 +37,9 @@ public class FakeExtensionAgent implements Agent {
 
     @Override
     public Insights getInsights() { throw new RuntimeException(); }
+
+    @Override
+    public ErrorApi getErrorApi() { throw new RuntimeException(); }
 
     @Override
     public TraceMetadata getTraceMetadata() { throw new RuntimeException(); }

--- a/functional_test/src/test/java/com/newrelic/agent/instrumentation/weaver/WeaveTest.java
+++ b/functional_test/src/test/java/com/newrelic/agent/instrumentation/weaver/WeaveTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import static org.junit.Assert.fail;
 
@@ -58,7 +59,7 @@ public class WeaveTest {
             }
 
             @Override
-            public void noticeError(Throwable throwable) {
+            public void noticeError(Throwable throwable, Map<String, ?> params, boolean expected) {
                 WeaveTest.this.throwable = throwable;
             }
         };

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
@@ -7,6 +7,7 @@
 
 package com.newrelic.agent;
 
+import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.NoOpMetricAggregator;
 import com.newrelic.agent.bridge.NoOpTracedMethod;
 import com.newrelic.agent.bridge.NoOpTransaction;
@@ -14,6 +15,7 @@ import com.newrelic.agent.bridge.TracedMethod;
 import com.newrelic.agent.bridge.Transaction;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.tracers.Tracer;
+import com.newrelic.api.agent.ErrorApi;
 import com.newrelic.api.agent.Insights;
 import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.Logs;
@@ -102,6 +104,11 @@ public class AgentImpl implements com.newrelic.agent.bridge.Agent {
     @Override
     public com.newrelic.api.agent.Logger getLogger() {
         return logger;
+    }
+
+    @Override
+    public ErrorApi getErrorApi() {
+        return AgentBridge.publicApi;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
@@ -76,40 +76,6 @@ public class NewRelicApiImplementation implements PublicApi {
     public void noticeError(Throwable throwable) {
         Map<String, String> params = Collections.emptyMap();
         noticeError(throwable, params, isExpectedErrorConfigured(throwable));
-
-    }
-
-    /**
-     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
-     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-     * be created and reported to New Relic.
-     * Expecting Errors via configuration is not supported from the APIs that do not accept a Throwable as an attribute.
-     * To mark an Error that accepts a String as expected use the API that accepts a boolean.
-     * @param message the error message
-     * @param params  Custom parameters to include in the traced error. May be null. Map is copied to avoid side effects.
-     */
-    @Override
-    public void noticeError(String message, Map<String, ?> params) {
-        noticeError(message, params, false);
-    }
-
-    /**
-     * Report an error to New Relic.
-     * Expecting Errors via configuration is not supported from the APIs that do not accept a Throwable as an attribute.
-     * To mark an Error that accepts a String as expected use the API that accepts a boolean.
-     * @param message the error message
-     * @see #noticeError(String, Map)
-     */
-    @Override
-    public void noticeError(String message) {
-        Map<String, String> params = Collections.emptyMap();
-        noticeError(message, params, false);
-    }
-
-    @Override
-    public void noticeError(Throwable throwable, boolean expected) {
-        Map<String, String> params = Collections.emptyMap();
-        noticeError(throwable, params, expected);
     }
 
     public void noticeError(Throwable throwable, Map<String, ?> params, boolean expected) {
@@ -152,12 +118,6 @@ public class NewRelicApiImplementation implements PublicApi {
             String msg = MessageFormat.format("Exception reporting exception \"{0}\": {1}", message, t);
             logException(msg, t);
         }
-    }
-
-    @Override
-    public void noticeError(String message, boolean expected) {
-        Map<String, String> params = Collections.emptyMap();
-        noticeError(message, params, expected);
     }
 
     private boolean isExpectedErrorConfigured(Throwable throwable) {

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/Agent.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/Agent.java
@@ -63,6 +63,8 @@ public interface Agent {
      */
     Insights getInsights();
 
+    ErrorApi getErrorApi();
+
     /**
      * Provides access to the Trace Metadata API for details about the currently executing distributed trace.
      *

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/ErrorApi.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/ErrorApi.java
@@ -139,4 +139,14 @@ public interface ErrorApi {
     default void noticeError(String message, boolean expected) {
         noticeError(message, Collections.emptyMap(), expected);
     }
+
+    /**
+     * Registers an {@link ErrorGroupCallback} that's used to generate a grouping key for the supplied
+     * error. This key will be used to group similar error messages on the Errors Inbox UI. If the
+     * errorGroupCallback instance is null no grouping key will be generated.
+     *
+     * @param errorGroupCallback the ErrorGroupCallback used to generate grouping keys for errors
+     * @since 8.10.0
+     */
+    void setErrorGroupCallback(ErrorGroupCallback errorGroupCallback);
 }

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/ErrorApi.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/ErrorApi.java
@@ -1,0 +1,142 @@
+package com.newrelic.api.agent;
+
+import java.util.Collections;
+import java.util.Map;
+
+public interface ErrorApi {
+    /**
+     * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
+     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
+     * last error will be reported.
+     *
+     * <p>
+     * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
+     * traced error if the key or value, each, cannot be encoded in 255 bytes. If key or value is over this limit, the
+     * behavior will be the same as defined in {@link #addCustomParameter(String key, String value) addCustomParameter}.
+     * </p>
+     *
+     * @param throwable The throwable to notice and report.
+     * @param params Custom parameters to include in the traced error. May be null.
+     * @since 1.3.0
+     */
+    default void noticeError(Throwable throwable, Map<String, ?> params) {
+        noticeError(throwable, params, false);
+    }
+
+    /**
+     * Report an exception to New Relic.
+     *
+     * @param throwable The throwable to report.
+     * @see #noticeError(Throwable, Map)
+     * @since 1.3.0
+     */
+    default void noticeError(Throwable throwable) {
+        noticeError(throwable, Collections.emptyMap(), false);
+    }
+
+    /**
+     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
+     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
+     * last error will be reported.
+     *
+     * <p>
+     * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
+     * traced error if the key or value, each, cannot be encoded in 255 bytes. If key or value is over this limit, the
+     * behavior will be the same as defined in {@link #addCustomParameter(String key, String value) addCustomParameter}.
+     * </p>
+     *
+     * @param message The error message to be reported.
+     * @param params Custom parameters to include in the traced error. May be null.
+     * @since 1.3.0
+     */
+    default void noticeError(String message, Map<String, ?> params) {
+        noticeError(message, params, false);
+    }
+
+    /**
+     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
+     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
+     * last error will be reported.
+     *
+     * @param message Message to report with a transaction when it finishes.
+     * @since 2.21.0
+     */
+    default void noticeError(String message) {
+        noticeError(message, Collections.emptyMap(), false);
+    }
+
+    /**
+     * Notice an exception and report it to New Relic. If this method is called within a transaction, the exception will
+     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
+     * last error will be reported.
+     * <p>
+     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
+     *
+     * <p>
+     * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
+     * traced error if the key or value, each, cannot be encoded in 255 bytes. If key or value is over this limit, the
+     * behavior will be the same as defined in {@link #addCustomParameter(String key, String value) addCustomParameter}.
+     * </p>
+     *
+     * @param throwable The throwable to notice and report.
+     * @param params    Custom parameters to include in the traced error. May be null.
+     * @param expected  true if this error is expected, false otherwise.
+     * @since 3.38.0
+     */
+    void noticeError(Throwable throwable, Map<String, ?> params, boolean expected);
+
+    /**
+     * Report an exception to New Relic.
+     * <p>
+     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
+     *
+     * @param throwable The throwable to report.
+     * @param expected  true if this error is expected, false otherwise.
+     * @see #noticeError(Throwable, Map)
+     * @since 3.38.0
+     */
+    default void noticeError(Throwable throwable, boolean expected) {
+        noticeError(throwable, Collections.emptyMap(), expected);
+    }
+
+    /**
+     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
+     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
+     * last error will be reported.
+     * <p>
+     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
+     *
+     * <p>
+     * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
+     * traced error if the key or value, each, cannot be encoded in 255 bytes. If key or value is over this limit, the
+     * behavior will be the same as defined in {@link #addCustomParameter(String key, String value) addCustomParameter}.
+     * </p>
+     *
+     * @param message  The error message to be reported.
+     * @param params   Custom parameters to include in the traced error. May be null.
+     * @param expected true if this error is expected, false otherwise.
+     * @since 3.38.0
+     */
+    void noticeError(String message, Map<String, ?> params, boolean expected);
+
+    /**
+     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
+     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
+     * last error will be reported.
+     *
+     * Expected errors do not increment an application's error count or contribute towards its Apdex score.
+     *
+     * @param message Message to report with a transaction when it finishes.
+     * @param expected true if this error is expected, false otherwise.
+     * @since 3.38.0
+     */
+    default void noticeError(String message, boolean expected) {
+        noticeError(message, Collections.emptyMap(), expected);
+    }
+}

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -86,6 +86,7 @@ public final class NewRelic {
      * @since 1.3.0
      */
     public static void noticeError(Throwable throwable, Map<String, ?> params) {
+        getAgent().getErrorApi().noticeError(throwable, params);
     }
 
     /**
@@ -96,6 +97,7 @@ public final class NewRelic {
      * @since 1.3.0
      */
     public static void noticeError(Throwable throwable) {
+        getAgent().getErrorApi().noticeError(throwable);
     }
 
     /**
@@ -115,6 +117,7 @@ public final class NewRelic {
      * @since 1.3.0
      */
     public static void noticeError(String message, Map<String, ?> params) {
+        getAgent().getErrorApi().noticeError(message, params);
     }
 
     /**
@@ -127,6 +130,7 @@ public final class NewRelic {
      * @since 2.21.0
      */
     public static void noticeError(String message) {
+        getAgent().getErrorApi().noticeError(message);
     }
 
     /**
@@ -149,6 +153,7 @@ public final class NewRelic {
      * @since 3.38.0
      */
     public static void noticeError(Throwable throwable, Map<String, ?> params, boolean expected) {
+        getAgent().getErrorApi().noticeError(throwable, params, expected);
     }
 
     /**
@@ -162,6 +167,7 @@ public final class NewRelic {
      * @since 3.38.0
      */
     public static void noticeError(Throwable throwable, boolean expected) {
+        getAgent().getErrorApi().noticeError(throwable, expected);
     }
 
     /**
@@ -184,6 +190,7 @@ public final class NewRelic {
      * @since 3.38.0
      */
     public static void noticeError(String message, Map<String, ?> params, boolean expected) {
+        getAgent().getErrorApi().noticeError(message, params, expected);
     }
 
     /**
@@ -199,6 +206,7 @@ public final class NewRelic {
      * @since 3.38.0
      */
     public static void noticeError(String message, boolean expected) {
+        getAgent().getErrorApi().noticeError(message, expected);
     }
 
     // **************************** Transaction APIs ********************************//

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -447,7 +447,7 @@ public final class NewRelic {
      * @since 8.10.0
      */
     public static void setErrorGroupCallback(ErrorGroupCallback errorGroupCallback){
-
+        getAgent().getErrorApi().setErrorGroupCallback(errorGroupCallback);
     }
 
 }

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
@@ -205,6 +205,16 @@ class NoOpAgent implements Agent {
         }
     };
 
+    private static final ErrorApi ERROR_API = new ErrorApi() {
+        @Override
+        public void noticeError(Throwable throwable, Map<String, ?> params, boolean expected) {
+        }
+
+        @Override
+        public void noticeError(String message, Map<String, ?> params, boolean expected) {
+        }
+    };
+
     private static final Logger LOGGER = new Logger() {
 
         @Override
@@ -442,6 +452,11 @@ class NoOpAgent implements Agent {
     @Override
     public Insights getInsights() {
         return INSIGHTS;
+    }
+
+    @Override
+    public ErrorApi getErrorApi() {
+        return ERROR_API;
     }
 
     @Override

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
@@ -213,6 +213,10 @@ class NoOpAgent implements Agent {
         @Override
         public void noticeError(String message, Map<String, ?> params, boolean expected) {
         }
+
+        @Override
+        public void setErrorGroupCallback(ErrorGroupCallback errorGroupCallback) {
+        }
     };
 
     private static final Logger LOGGER = new Logger() {


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview

Years ago we refactored many of our agent APIs to have interfaces.  For example, static methods on `NewRelic` like `incrementCounter` exist on the `MetricAggregator`.  We never created an interface for our error apis.  Having an interface is helpful to customers because they can reference the interface in their code, mock it out and verify that it's called in their tests.  Multiple New Relic teams have actually created their own `ErrorApi` interface to wrap our static `NewRelic` implementation for testing purposes.

I'd like to update our `NewRelic` static apis to call `getAgent()` and the appropriate API that hangs off of that agent.  By doing that,
 * the behavior of the static class is more obvious because the code is visible
 * when intercepting and rewriting the `NewRelic` class, we could get to a point where the `getAgent()` is the only method that needs to be rewritten

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
