### PR TITLE
Test to prevent adding methods to NewRelic

### DIFF
--- a/newrelic-api/src/test/java/com/newrelic/api/agent/NewRelicApiTest.java
+++ b/newrelic-api/src/test/java/com/newrelic/api/agent/NewRelicApiTest.java
@@ -1,0 +1,26 @@
+/*
+ *
+ *  * Copyright 2023 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.api.agent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+public class NewRelicApiTest {
+
+    /**
+     * This method will fail if a method is added to the NewRelic class.
+     * If your change broke this test, could you add the method to one of the interfaces that can be returned from the Agent?
+     */
+    @Test
+    public void checkMethodCount() {
+        Method[] methods = NewRelic.class.getDeclaredMethods();
+        Assert.assertEquals(34, methods.length);
+    }
+}


### PR DESCRIPTION
### Overview
Adds a test that will fail if a new method is added to NewRelic.