### PR TITLE
No dotted env vars

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
@@ -1173,6 +1173,11 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
 
     @Override
     public String getLogFileName() {
+        String classicVarValue = SystemPropertyFactory.getSystemPropertyProvider().getEnvironmentVariable("NEW_RELIC_LOG");
+        if (classicVarValue != null) {
+            return classicVarValue;
+        }
+
         return getProperty(LOG_FILE_NAME, DEFAULT_LOG_FILE_NAME);
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
@@ -21,7 +21,6 @@ public class SystemPropertyProvider {
     // environment variables
     private static final String NEW_RELIC_PREFIX_ENV = "NEW_RELIC_";
     private static final String LOG_ENV = NEW_RELIC_PREFIX_ENV + "LOG";
-    private static final String LOG_FILE_NAME = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.LOG_FILE_NAME;
     private static final String NEW_RELIC_SYSTEM_PROPERTY_ROOT = "newrelic.";
 
     private final Map<String, String> newRelicSystemProps;
@@ -87,7 +86,9 @@ public class SystemPropertyProvider {
             String envVar = entry.getKey();
             if (envVar.startsWith(NEW_RELIC_PREFIX_ENV)) {
                 if (envVar.equals(LOG_ENV)) {
-                    addPropertyWithoutSystemPropRoot(nrProps, LOG_FILE_NAME, entry.getValue());
+                    // The classic NEW_RELIC_LOG corresponds to the log_file_name property
+                    // so we use log_file_name here.
+                    nrProps.put(AgentConfigImpl.LOG_FILE_NAME, entry.getValue());
                 } else {
                     addPropertyWithoutEnvPrefix(nrProps, envVar.toLowerCase(), entry.getValue());
                 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
@@ -24,7 +24,6 @@ public class SystemPropertyProvider {
     private static final String LOG_FILE_NAME = AgentConfigImpl.SYSTEM_PROPERTY_ROOT + AgentConfigImpl.LOG_FILE_NAME;
     private static final String NEW_RELIC_SYSTEM_PROPERTY_ROOT = "newrelic.";
 
-    private final Map<String, String> envVarToSystemPropKeyMap;
     private final Map<String, String> newRelicSystemProps;
     private final Map<String, Object> newRelicPropsWithoutPrefix;
     private final Map<String, Object> newRelicEnvVarsWithoutPrefix;
@@ -38,17 +37,9 @@ public class SystemPropertyProvider {
     public SystemPropertyProvider(SystemProps sysProps, EnvironmentFacade environmentFacade) {
         systemProps = sysProps;
         this.environmentFacade = environmentFacade;
-        envVarToSystemPropKeyMap = initEnvVarToSystemPropMap();
         newRelicSystemProps = initNewRelicSystemProperties();
         newRelicPropsWithoutPrefix = createNewRelicSystemPropertiesWithoutPrefix();
         newRelicEnvVarsWithoutPrefix = createNewRelicEnvVarsWithoutPrefix();
-    }
-
-    private Map<String, String> initEnvVarToSystemPropMap() {
-        // general environment variables, originally added for Heroku
-        Map<String, String> envVars = new HashMap<>();
-        envVars.put(LOG_ENV, LOG_FILE_NAME);
-        return envVars;
     }
 
     /**
@@ -95,9 +86,8 @@ public class SystemPropertyProvider {
         for (Map.Entry<String, String> entry : allEnvVars.entrySet()) {
             String envVar = entry.getKey();
             if (envVar.startsWith(NEW_RELIC_PREFIX_ENV)) {
-                String envVarNameToReplace = envVarToSystemPropKeyMap.get(envVar);
-                if (envVarNameToReplace != null) {
-                    addPropertyWithoutSystemPropRoot(nrProps, envVarNameToReplace, entry.getValue());
+                if (envVar.equals(LOG_ENV)) {
+                    addPropertyWithoutSystemPropRoot(nrProps, LOG_FILE_NAME, entry.getValue());
                 } else {
                     addPropertyWithoutEnvPrefix(nrProps, envVar.toLowerCase(), entry.getValue());
                 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
@@ -119,22 +119,6 @@ public class SystemPropertyProvider {
     }
 
     public String getEnvironmentVariable(String key) {
-        // compatibility: map NEW_RELIC_LOG to newrelic.config.log_file_name
-        // The latter is the general name. NEW_RELIC_LOG_FILE_NAME, which
-        // also works, will be checked below.
-        if (LOG_FILE_NAME.equals(key)) {
-            String logFileVal = environmentFacade.getenv(LOG_ENV);
-            if (logFileVal != null) {
-                return logFileVal;
-            }
-        }
-
-        return getenv(key);
-    }
-
-    private String getenv(String key) {
-        //check if current key needs to be converted from NR config prop to NR env var
-
         return environmentFacade.getenv(formatNewRelicEnvVarPrefix(key));
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SystemPropertyProvider.java
@@ -137,10 +137,6 @@ public class SystemPropertyProvider {
     }
 
     private String getenv(String key) {
-        String val = environmentFacade.getenv(key);
-        if (val != null) {
-            return val;
-        }
         //check if current key needs to be converted from NR config prop to NR env var
 
         return environmentFacade.getenv(formatNewRelicEnvVarPrefix(key));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
@@ -7,7 +7,9 @@
 
 package com.newrelic.agent.config;
 
+import com.google.common.collect.ImmutableMap;
 import com.newrelic.agent.Mocks;
+import com.newrelic.agent.SaveSystemPropertyProviderRule;
 import com.newrelic.agent.config.internal.MapEnvironmentFacade;
 import com.newrelic.agent.config.internal.MapSystemProps;
 import com.newrelic.bootstrap.BootstrapAgent;
@@ -21,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static com.newrelic.agent.config.SpanEventsConfig.SERVER_SPAN_HARVEST_CONFIG;
@@ -1291,6 +1294,49 @@ public class AgentConfigImplTest {
 
         assertFalse(ApplicationLoggingConfigImpl.DEFAULT_ENABLED &&
                 config.getTransactionTracerConfig().isEnabled());
+    }
+
+    @Test
+    public void logFilePriorityOrder() {
+        // lowest priority: file property
+        Map<String, Object> prop = Collections.singletonMap("log_file_name", "propval");
+
+        AgentConfig config = AgentConfigImpl.createAgentConfig(prop);
+        assertEquals("propval", config.getLogFileName());
+
+        // next-higher priority: system property
+        Properties sysProps = new Properties();
+        sysProps.put("newrelic.config.log_file_name", "sysprop");
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new SaveSystemPropertyProviderRule.TestSystemProps(sysProps),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade()
+        ));
+
+        config = AgentConfigImpl.createAgentConfig(prop);
+        assertEquals("sysprop", config.getLogFileName());
+
+        // second-highest priority: standard environment variable
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new SaveSystemPropertyProviderRule.TestSystemProps(sysProps),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(Collections.singletonMap(
+                        "NEW_RELIC_LOG_FILE_NAME", "standard-env-var"
+                ))
+        ));
+
+        config = AgentConfigImpl.createAgentConfig(prop);
+        assertEquals("standard-env-var", config.getLogFileName());
+
+        // highest priority: classic environment variable
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new SaveSystemPropertyProviderRule.TestSystemProps(sysProps),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(ImmutableMap.of(
+                        "NEW_RELIC_LOG_FILE_NAME", "standard-env-var",
+                        "NEW_RELIC_LOG", "classic-env-var"
+                ))
+        ));
+
+        config = AgentConfigImpl.createAgentConfig(prop);
+        assertEquals("classic-env-var", config.getLogFileName());
     }
 
     private static EnvironmentFacade createEnvironmentFacade(

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/BaseConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/BaseConfigTest.java
@@ -12,10 +12,12 @@ import com.newrelic.agent.SaveSystemPropertyProviderRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static com.newrelic.agent.config.AgentConfigImpl.SYSTEM_PROPERTY_ROOT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -26,9 +28,10 @@ public class BaseConfigTest {
     // SystemProperties collections with our key value, so we need to be able to identify this magic test
     // key so we can set up and clean up using @Before and @After methods.
 
-    private static final String PREFIX = "BaseConfig";
-    private static final String KEY = "TestMagicKey";
-    private static final String FULL_KEY = PREFIX + KEY;
+    private static final String KEY_PROP = "item";
+    private static final String KEY_ENV_VAR = "NEW_RELIC_ITEM";
+    private static final String KEY_SYS_PROP = "newrelic.config.item";
+
 
     @Rule
     public SaveSystemPropertyProviderRule saveSystemPropertyProviderRule = new SaveSystemPropertyProviderRule();
@@ -43,75 +46,72 @@ public class BaseConfigTest {
     @Test
     public void getWithSyspropOverride() {
         Map<String, Object> settings = new HashMap<>();
-        settings.put(KEY, "valueInMap");
-        saveSystemPropertyProviderRule.mockSingleProperty(FULL_KEY, "valueInSystemProperties");
+        settings.put(KEY_PROP, "valueInMap");
+        saveSystemPropertyProviderRule.mockSingleProperty(KEY_SYS_PROP, "valueInSystemProperties");
 
-        BaseConfig config = new BaseConfig(settings, PREFIX);
-        assertEquals("valueInSystemProperties", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        BaseConfig config = new BaseConfig(settings, SYSTEM_PROPERTY_ROOT);
+        assertEquals("valueInSystemProperties", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_SYS_PROP));
 
         config = new BaseConfig(settings, "DoesNotMatch");
-        assertEquals("valueInMap", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        assertEquals("valueInMap", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_SYS_PROP));
 
         config = new BaseConfig(settings);
-        assertEquals("valueInMap", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        assertEquals("valueInMap", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_SYS_PROP));
     }
 
     @Test
     public void getWithEnvironmentOverride() {
         Map<String, Object> settings = new HashMap<>();
-        settings.put(KEY, "valueInMap");
+        settings.put(KEY_PROP, "valueInMap");
 
         SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
                 new SaveSystemPropertyProviderRule.TestSystemProps(),
                 new SaveSystemPropertyProviderRule.TestEnvironmentFacade(ImmutableMap.of(
-                        KEY, "keyValueInEnvironment",
-                        FULL_KEY, "fullKeyValueInEnvironment"
+                        KEY_ENV_VAR, "fullKeyValueInEnvironment"
                 ))
         ));
 
-        BaseConfig config = new BaseConfig(settings, PREFIX);
-        assertEquals("fullKeyValueInEnvironment", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        BaseConfig config = new BaseConfig(settings, SYSTEM_PROPERTY_ROOT);
+        assertEquals("fullKeyValueInEnvironment", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_SYS_PROP));
 
         config = new BaseConfig(settings, "DoesNotMatch");
-        assertEquals("valueInMap", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        assertEquals("valueInMap", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_SYS_PROP));
 
         config = new BaseConfig(settings);
-        assertEquals("valueInMap", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        assertEquals("valueInMap", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_SYS_PROP));
     }
 
     @Test
     public void getWithSyspropAndEnvironmentOverride() {
         Map<String, Object> settings = new HashMap<>();
-        settings.put(KEY, "valueInMap");
+        settings.put(KEY_PROP, "valueInMap");
 
         Properties props = new Properties();
-        props.setProperty(KEY, "keyValueInSystemProperties");
-        props.setProperty(FULL_KEY, "fullKeyValueInSystemProperties");
+        props.setProperty(KEY_SYS_PROP, "fullKeyValueInSystemProperties");
 
         SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
                 new SaveSystemPropertyProviderRule.TestSystemProps(props),
-                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(ImmutableMap.of(
-                        KEY, "keyValueInEnvironment",
-                        FULL_KEY, "fullKeyValueInEnvironment"
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(Collections.singletonMap(
+                        KEY_ENV_VAR, "fullKeyValueInEnvironment"
                 ))
         ));
 
-        BaseConfig config = new BaseConfig(settings, PREFIX);
-        assertEquals("fullKeyValueInEnvironment", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        BaseConfig config = new BaseConfig(settings, SYSTEM_PROPERTY_ROOT);
+        assertEquals("fullKeyValueInEnvironment", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_ENV_VAR));
 
         config = new BaseConfig(settings, "DoesNotMatch");
-        assertEquals("valueInMap", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        assertEquals("valueInMap", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_SYS_PROP));
 
         config = new BaseConfig(settings);
-        assertEquals("valueInMap", config.getProperty(KEY));
-        assertNull(config.getProperty(FULL_KEY));
+        assertEquals("valueInMap", config.getProperty(KEY_PROP));
+        assertNull(config.getProperty(KEY_ENV_VAR));
     }
 }


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

Resolves https://github.com/newrelic/newrelic-java-agent/issues/781

### Overview
Stop looking at env vars with dotted property names. The current warning log message is inaccurate and I have provided a repro case that illustrates it.

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

*edit* I also simplified the special case of `NEW_RELIC_LOG`. Working through the single-entry maps made the code harder to understand. I think the current code is much better.

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- Your code **does** ~not~ contain breaking changes. See below.
- [x] Your code does not introduce any new dependencies. Otherwise please describe.

### Breaking changes
This pull request removes behavior from the lower-case, dotted environment variable names (such as `newrelic.config.labels`). There are no changes to documented system property behavior (via `newrelic.config.`, server-side config, YAML, or environment variable (via `NEW_RELIC_`).

Customers relying on lower-case, dotted environment variables should switch to the standard upper-case, underscore names.