### PR TITLE
Updating mule verification

### DIFF
--- a/instrumentation/mule-3.7/build.gradle
+++ b/instrumentation/mule-3.7/build.gradle
@@ -24,13 +24,13 @@ jar {
                 'Implementation-Title-Alias': 'mule_instrumentation' }
 }
 
-// This will still match [3.7.1,3.7.5], and [3.8.2,3.8.7]
+// This will still match [3.7.1,3.7.5], [3.8.2,3.8.7], and 3.9.5,
 // but we can't verify that because the artifacts are enterprise only (behind auth)
 verifyInstrumentation {
     passes('org.mule:mule-core:3.7.0') {
         implementation("org.mule.modules:mule-module-http:3.7.0")
     }
-    passes('org.mule:mule-core:[3.8.0,3.8.2)') {
+    passes('org.mule:mule-core:[3.8.0,)') {
         implementation("org.mule.modules:mule-module-http:3.7.0")
     }
 
@@ -39,7 +39,8 @@ verifyInstrumentation {
     exclude 'org.mule:mule-core:3.5.4'
     exclude 'org.mule:mule-core:[3.6.2,3.7.0)'
     exclude 'org.mule:mule-core:[3.7.1,3.8.0)'
-    exclude 'org.mule:mule-core:[3.8.2,)'
+    exclude 'org.mule:mule-core:3.8.2'
+    exclude 'org.mule:mule-core:3.9.5'
 
     excludeRegex 'org.mule:mule-core:.*-(EA|HF|RC|M|rc|bighorn|cascade).*[0-9]*.*'
 }

--- a/instrumentation/mule-base/build.gradle
+++ b/instrumentation/mule-base/build.gradle
@@ -33,7 +33,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passes('org.mule:mule-core:[3.4.0,3.8.2)') {
+    passes('org.mule:mule-core:[3.4.0,)') {
         implementation("org.mule.transports:mule-transport-http:3.4.0")
         implementation("org.mule.modules:mule-module-launcher:3.4.0")
         implementation("org.mule.modules:mule-module-client:3.4.0")
@@ -45,7 +45,8 @@ verifyInstrumentation {
     exclude 'org.mule:mule-core:3.5.4'
     exclude 'org.mule:mule-core:[3.6.2,3.7.0)'
     exclude 'org.mule:mule-core:[3.7.1,3.8.0)'
-    exclude 'org.mule:mule-core:[3.8.2,)'
+    exclude 'org.mule:mule-core:3.8.2'
+    exclude 'org.mule:mule-core:3.9.5'
 
     excludeRegex 'org.mule:mule-core:.*-(EA|HF|RC|M|rc|bighorn|cascade).*[0-9]*.*'
 }

--- a/instrumentation/mule-ei1/build.gradle
+++ b/instrumentation/mule-ei1/build.gradle
@@ -29,13 +29,6 @@ verifyInstrumentation {
     passes('org.mule:mule-core:[3.4.0,3.5.2)')
     passes('org.mule:mule-core:[3.6.0,3.6.2)')
 
-    // these versions cause problems getting artifacts
-    exclude 'org.mule:mule-core:[0,3.4.0)'
-    exclude 'org.mule:mule-core:3.5.4'
-    exclude 'org.mule:mule-core:[3.6.2,3.7.0)'
-    exclude 'org.mule:mule-core:[3.7.1,3.8.0)'
-    exclude 'org.mule:mule-core:[3.8.2,)'
-
     excludeRegex 'org.mule:mule-core:.*-(EA|HF|RC|M|rc|bighorn|cascade).*[0-9]*.*'
 }
 

--- a/instrumentation/mule-ei2/build.gradle
+++ b/instrumentation/mule-ei2/build.gradle
@@ -23,18 +23,15 @@ jar {
     }
 }
 
-// This will still apply to 3.5.4, [3.6.3,3.6.4], [3.7.1,3.7.5], and [3.8.2,3.8.7]
+// This will still apply to 3.5.4, [3.6.3,3.6.4], [3.7.1,3.7.5], [3.8.2,3.8.7], and 3.9.5
 // but we can't verify that because the artifacts are enterprise only (behind auth)
 verifyInstrumentation {
     passes('org.mule:mule-core:3.7.0')
-    passes('org.mule:mule-core:[3.8.0,3.8.2)')
+    passes('org.mule:mule-core:[3.8.0,)')
 
     // these versions cause problems getting artifacts
-    exclude 'org.mule:mule-core:[0,3.4.0)'
-    exclude 'org.mule:mule-core:3.5.4'
-    exclude 'org.mule:mule-core:[3.6.2,3.7.0)'
-    exclude 'org.mule:mule-core:[3.7.1,3.8.0)'
-    exclude 'org.mule:mule-core:[3.8.2,)'
+    exclude 'org.mule:mule-core:3.8.2'
+    exclude 'org.mule:mule-core:3.9.5'
 
     excludeRegex 'org.mule:mule-core:.*-(EA|HF|RC|M|rc|bighorn|cascade).*[0-9]*.*'
 }


### PR DESCRIPTION
### Overview
The configuration for verification of some Mule instrumentation modules was too restrictive and were not testing versions it should apply to.

This PR opens up the range and adds exclusions as necessary.
