### PR TITLE
Nr 180859 publish otel extension

### DIFF
--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -44,3 +44,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew $GRADLE_OPTIONS :agent-bridge:publish :agent-bridge-datastore:publish :newrelic-weaver:publish :newrelic-weaver-api:publish :newrelic-weaver-scala:publish :newrelic-weaver-scala-api:publish
+      - name: Publish snapshot for New Relic OpenTelemetry API Extension
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -45,3 +45,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew $GRADLE_OPTIONS :agent-bridge:publish :agent-bridge-datastore:publish :newrelic-weaver:publish :newrelic-weaver-api:publish :newrelic-weaver-scala:publish :newrelic-weaver-scala-api:publish -Prelease=true
+      - name: Publish New Relic OpenTelemetry API Extension
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true

--- a/newrelic-opentelemetry-agent-extension/build.gradle.kts
+++ b/newrelic-opentelemetry-agent-extension/build.gradle.kts
@@ -17,6 +17,11 @@ val shadowJar = tasks.getByName<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 PublishConfig.config(
         project,
         "New Relic OpenTelemetry Java Agent Extension",

--- a/newrelic-opentelemetry-agent-extension/build.gradle.kts
+++ b/newrelic-opentelemetry-agent-extension/build.gradle.kts
@@ -17,11 +17,6 @@ val shadowJar = tasks.getByName<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
 }
 
-java {
-    withSourcesJar()
-    withJavadocJar()
-}
-
 PublishConfig.config(
         project,
         "New Relic OpenTelemetry Java Agent Extension",

--- a/newrelic-opentelemetry-agent-extension/build.gradle.kts
+++ b/newrelic-opentelemetry-agent-extension/build.gradle.kts
@@ -32,20 +32,20 @@ PublishConfig.config(
     // Update artifact version to include "-alpha" suffix
     var artifactVersion = version
     val snapshotSuffix = "-SNAPSHOT"
-    if (artifactVersion.endsWith(snapshotSuffix)) {
-        artifactVersion = artifactVersion.removeSuffix(snapshotSuffix) + "-alpha" + snapshotSuffix
+    artifactVersion = if (artifactVersion.endsWith(snapshotSuffix)) {
+        artifactVersion.removeSuffix(snapshotSuffix) + "-alpha" + snapshotSuffix
     } else {
-        artifactVersion = artifactVersion + "-alpha"
+        "$artifactVersion-alpha"
     }
     version = artifactVersion
 }
 
 var agent = configurations.create("agent")
 
-var openTelemetryAgentVersion = "1.31.0";
-var openTelemetryInstrumentationVersion = "1.31.0-alpha";
-var openTelemetrySemConvVersion = "1.22.0-alpha";
-var openTelemetryProtoVersion = "1.0.0-alpha";
+var openTelemetryAgentVersion = "1.31.0"
+var openTelemetryInstrumentationVersion = "1.31.0-alpha"
+var openTelemetrySemConvVersion = "1.22.0-alpha"
+var openTelemetryProtoVersion = "1.0.0-alpha"
 
 dependencies {
     implementation(project(":newrelic-api"))
@@ -87,7 +87,7 @@ testing {
             targets {
                 all {
                     testTask {
-                        var extensionJar = shadowJar.archiveFile.get().toString()
+                        val extensionJar = shadowJar.archiveFile.get().toString()
                         jvmArgs("-javaagent:${agent.singleFile}",
                                 "-Dotel.javaagent.extensions=${extensionJar}",
                                 "-Dotel.javaagent.logging=none", // Disable logging to avoid connect error logs which occur when the agent has started but the mock server is not yet receiving requests. Set to "simple" to debug.


### PR DESCRIPTION
Resolves https://github.com/newrelic/newrelic-java-agent/issues/1594

Publishes `newrelic-opentelemetry-agent-extension`:
- Snapshots artifacts on merges to `main`
- Staged artifacts to Sonatype on agent release

<img width="1023" alt="Screenshot 2023-11-21 at 1 41 01 PM" src="https://github.com/newrelic/newrelic-java-agent/assets/3496648/b2119d6b-bab0-4c3b-a67b-847e3cdae273">
