### PR TITLE
Don't throw if no RPMServiceManager

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
@@ -158,7 +158,11 @@ public class AgentImpl implements com.newrelic.agent.bridge.Agent {
 
     @Override
     public Map<String, String> getLinkingMetadata() {
-        return AgentLinkingMetadata.getLinkingMetadata(getTraceMetadata(), ServiceFactory.getConfigService(), ServiceFactory.getRPMService());
+        return AgentLinkingMetadata.getLinkingMetadata(
+                getTraceMetadata(),
+                ServiceFactory.getConfigService(),
+                ServiceFactory.getRPMServiceManager() != null ? ServiceFactory.getRPMServiceManager().getRPMService() : null
+        );
     }
 
 }


### PR DESCRIPTION
### Overview
We occasionally get an NPE in our logs
```
java.lang.NullPointerException: Cannot invoke "com.newrelic.agent.RPMServiceManager.getRPMService()" because the return value of "com.newrelic.agent.service.ServiceManager.getRPMServiceManager()" is null
	at com.newrelic.agent.service.ServiceFactory.getRPMService(ServiceFactory.java:103)
	at com.newrelic.agent.AgentImpl.getLinkingMetadata(AgentImpl.java:154)
	at com.newrelic.agent.bridge.logging.AppLoggingUtils.getLinkingMetadataBlob(AppLoggingUtils.java:57)
```

It looks like it comes from here, so I added a guard. `AgentLinkingMetadata.getLinkingMetadata` already handles the case if `IRPMService` is null, but I figured _some_ linking metadata was better than none.

An alternative implementation would simply bypass this entirely if there was no entity guid yet. I'm not sure which way we want to go, but _not_ getting an NPE seems preferable.

### Related Github Issue
Fixes #1553 

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
