### PR TITLE
Add work queue bound on LicenseException retries in RPMConnectionServ…

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -29,6 +29,7 @@ import com.newrelic.agent.model.LogEvent;
 import com.newrelic.agent.model.SpanEvent;
 import com.newrelic.agent.normalization.Normalizer;
 import com.newrelic.agent.profile.ProfileData;
+import com.newrelic.agent.rpm.RPMConnectionServiceImpl;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.service.analytics.TransactionEvent;
@@ -289,7 +290,9 @@ public class RPMService extends AbstractService implements IRPMService, Environm
             return dataSender.connect(getStartOptions());
         } catch (LicenseException e) {
             logLicenseException(e);
-            reconnect();
+            if (!((RPMConnectionServiceImpl) ServiceFactory.getRPMConnectionService()).shouldPreventNewConnectionTask()){
+                reconnect();
+            }
             throw e;
         } catch (ForceDisconnectException e) {
             logForceDisconnectException(e);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/rpm/RPMConnectionServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/rpm/RPMConnectionServiceImpl.java
@@ -18,8 +18,7 @@ import com.newrelic.agent.stats.StatsWorks;
 import com.newrelic.agent.util.DefaultThreadFactory;
 import com.newrelic.agent.util.SafeWrappers;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -45,12 +44,13 @@ public class RPMConnectionServiceImpl extends AbstractService implements RPMConn
     public static final long APP_SERVER_PORT_TIMEOUT = 120L;
     // interval between connection attempts
     public static final long MIN_CONNECT_ATTEMPT_INTERVAL = 5L;
-    private final ScheduledExecutorService scheduledExecutor;
+    private static final int MAX_QUEUED_CONNECT_TASKS = 5000;
+    private final ScheduledThreadPoolExecutor scheduledExecutor;
 
     public RPMConnectionServiceImpl() {
         super(RPMConnectionService.class.getSimpleName());
         ThreadFactory threadFactory = new DefaultThreadFactory(RPM_CONNECTION_THREAD_NAME, true);
-        scheduledExecutor = Executors.newSingleThreadScheduledExecutor(threadFactory);
+        scheduledExecutor = new ScheduledThreadPoolExecutor(1, threadFactory);
     }
 
     @Override
@@ -97,6 +97,14 @@ public class RPMConnectionServiceImpl extends AbstractService implements RPMConn
      */
     public long getAppServerPortTimeout() {
         return APP_SERVER_PORT_TIMEOUT;
+    }
+
+    /**
+     * Checks whether tasks have begun piling up in the scheduled executor's work queue.
+     * Used to prevent repeated reconnect attempts in the event of a LicenseException.
+     */
+    public boolean shouldPreventNewConnectionTask(){
+        return scheduledExecutor.getQueue().size() > MAX_QUEUED_CONNECT_TASKS;
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/rpm/RPMConnectionServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/rpm/RPMConnectionServiceImpl.java
@@ -19,6 +19,7 @@ import com.newrelic.agent.util.DefaultThreadFactory;
 import com.newrelic.agent.util.SafeWrappers;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,7 @@ public class RPMConnectionServiceImpl extends AbstractService implements RPMConn
     // interval between connection attempts
     public static final long MIN_CONNECT_ATTEMPT_INTERVAL = 5L;
     private static final int MAX_QUEUED_CONNECT_TASKS = 5000;
-    private final ScheduledThreadPoolExecutor scheduledExecutor;
+    private final ScheduledExecutorService scheduledExecutor;
 
     public RPMConnectionServiceImpl() {
         super(RPMConnectionService.class.getSimpleName());
@@ -104,7 +105,7 @@ public class RPMConnectionServiceImpl extends AbstractService implements RPMConn
      * Used to prevent repeated reconnect attempts in the event of a LicenseException.
      */
     public boolean shouldPreventNewConnectionTask(){
-        return scheduledExecutor.getQueue().size() > MAX_QUEUED_CONNECT_TASKS;
+        return ((ScheduledThreadPoolExecutor) scheduledExecutor).getQueue().size() > MAX_QUEUED_CONNECT_TASKS;
     }
 
     /**


### PR DESCRIPTION
Fixes #1428 

This PR addresses `OutOfMemory` exceptions that were reported during rotation to an invalid license key. The cause of the memory leak was found to be excessive creation of `RPMConnectionTasks`. To mitigate the issue, the number of `RPMConnectionTasks` created during processing of a `LicenseException` is now bounded. 

- The `ScheduledExecutorService` is replaced with a `ScheduledThreadPoolExecutor`, in order to get access to the size of its work queue. 
- The `LicenseException` handler in the `doConnect` method of `RPMService` limits `reconnect` attempts when the work queue acquires a certain number of tasks. 
- The number of tasks is bounded at 5000. 

There is no way for the agent to recover from a bad license key, so although these mitigation steps will prevent a memory leak, a JVM restart is still required to get the agent back up. 