### PR TITLE
adding httstatus in segment

### DIFF
--- a/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
@@ -62,7 +62,7 @@ public class Util {
                             .uri(uri)
                             .procedure("exchange")
                             .inboundHeaders(new InboundResponseWrapper(clientResponse))
-                            .status(clientResponse.statusCode().value())
+                            .status(clientResponse.statusCode().value(), "" + clientResponse.statusCode().value())
                             .build());
                     segment.end();
                 } catch (Throwable e) {

--- a/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
@@ -62,7 +62,7 @@ public class Util {
                             .uri(uri)
                             .procedure("exchange")
                             .inboundHeaders(new InboundResponseWrapper(clientResponse))
-                            .status(clientResponse.statusCode().value(), "" + clientResponse.statusCode().value())
+                            .status(clientResponse.statusCode().value(), null)
                             .build());
                     segment.end();
                 } catch (Throwable e) {

--- a/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
@@ -62,7 +62,7 @@ public class Util {
                             .uri(uri)
                             .procedure("exchange")
                             .inboundHeaders(new InboundResponseWrapper(clientResponse))
-                            .status(clientReponse.statusCode().value())
+                            .status(clientResponse.statusCode().value())
                             .build());
                     segment.end();
                 } catch (Throwable e) {

--- a/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
+++ b/instrumentation/spring-webclient-5.0/src/main/java/com/nr/agent/instrumentation/spring_webclient/Util.java
@@ -62,6 +62,7 @@ public class Util {
                             .uri(uri)
                             .procedure("exchange")
                             .inboundHeaders(new InboundResponseWrapper(clientResponse))
+                            .status(clientReponse.statusCode().value())
                             .build());
                     segment.end();
                 } catch (Throwable e) {

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -285,7 +285,7 @@ public class WebClientTest {
         assertEquals(1, introspector.getFinishedTransactionCount(TIMEOUT));
         assertTrue(introspector.getTransactionNames().contains(txnName));
 
-        Collection<ExternalExternalRequestRequest> externalRequests = introspector.getExternalRequests(txnName);
+        Collection<ExternalRequest> externalRequests = introspector.getExternalRequests(txnName);
         Assert.assertEquals(1, externalRequests.size());
         ExternalRequest externalRequest = externalRequests.iterator().next();
         Assert.assertEquals("Spring-WebClient", externalRequest.getLibrary());

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -7,9 +7,16 @@
 
 package com.nr.instrumentation;
 
-import com.newrelic.agent.introspec.*;
+import com.newrelic.agent.introspec.CatHelper;
+import com.newrelic.agent.introspec.ExternalRequest;
+import com.newrelic.agent.introspec.HttpTestServer;
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.agent.introspec.Introspector;
+import com.newrelic.agent.introspec.MetricsHelper;
+import com.newrelic.agent.introspec.TransactionEvent;
+import com.newrelic.agent.introspec.internal.HttpServerLocator;
 import com.newrelic.agent.introspec.internal.HttpServerRule;
-import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.api.agent.Trace;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -31,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(InstrumentationTestRunner.class)
-@InstrumentationTestConfig(includePrefixes = { "org.springframework" }, configName = "spans.yml")
+@InstrumentationTestConfig(includePrefixes = { "org.springframework" })
 public class WebClientTest {
 
     private static final int TIMEOUT = 3000;
@@ -170,13 +177,6 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
-
-        // span
-        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
-        assertEquals(1, externalSpanEvents.size());
-        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
-        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
-
     }
 
     @Test
@@ -276,12 +276,6 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         Assert.assertEquals("Spring-WebClient", externalRequest.getLibrary());
         Assert.assertEquals("exchange", externalRequest.getOperation());
-
-        // span
-        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
-        assertEquals(1, externalSpanEvents.size());
-        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
-        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
 
         Assert.assertEquals(1,
                 MetricsHelper.getScopedMetricCount(txnName, "External/" + host + "/Spring-WebClient/exchange"));

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -8,10 +8,8 @@
 package com.nr.instrumentation;
 
 import com.newrelic.agent.introspec.*;
-import com.newrelic.agent.introspec.internal.HttpServerLocator;
 import com.newrelic.agent.introspec.internal.HttpServerRule;
 import com.newrelic.agent.model.SpanCategory;
-import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -289,7 +287,7 @@ public class WebClientTest {
         Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
         assertEquals(1, externalSpanEvents.size());
         SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
-        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
+        assertEquals(Integer.valueOf(501), externalSpanEvent.getStatusCode());
 
         Assert.assertEquals(1,
                 MetricsHelper.getScopedMetricCount(txnName, "External/" + host + "/Spring-WebClient/exchange"));

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -9,6 +9,7 @@ package com.nr.instrumentation;
 
 import com.newrelic.agent.introspec.CatHelper;
 import com.newrelic.agent.introspec.ExternalRequest;
+import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.introspec.HttpTestServer;
 import com.newrelic.agent.introspec.InstrumentationTestConfig;
 import com.newrelic.agent.introspec.InstrumentationTestRunner;
@@ -177,6 +178,13 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+
+        // span
+        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
+        assertEquals(1, externalSpanEvents.size());
+        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
+        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
+
     }
 
     @Test
@@ -223,6 +231,12 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+
+        // span
+        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
+        assertEquals(1, externalSpanEvents.size());
+        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
+        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
     }
 
     @Trace(dispatcher = true)
@@ -271,11 +285,17 @@ public class WebClientTest {
         assertEquals(1, introspector.getFinishedTransactionCount(TIMEOUT));
         assertTrue(introspector.getTransactionNames().contains(txnName));
 
-        Collection<ExternalRequest> externalRequests = introspector.getExternalRequests(txnName);
+        Collection<ExternalExternalRequestRequest> externalRequests = introspector.getExternalRequests(txnName);
         Assert.assertEquals(1, externalRequests.size());
         ExternalRequest externalRequest = externalRequests.iterator().next();
         Assert.assertEquals("Spring-WebClient", externalRequest.getLibrary());
         Assert.assertEquals("exchange", externalRequest.getOperation());
+
+        // span
+        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
+        assertEquals(1, externalSpanEvents.size());
+        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
+        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
 
         Assert.assertEquals(1,
                 MetricsHelper.getScopedMetricCount(txnName, "External/" + host + "/Spring-WebClient/exchange"));

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -8,7 +8,7 @@
 package com.nr.instrumentation;
 
 import com.newrelic.agent.introspec.CatHelper;
-import com.newrelic.agent.introspec.ExternalRequest;
+import com.newrelic.agent.introspec.SpanEvent;
 import com.newrelic.agent.introspec.ExternalRequest;
 import com.newrelic.agent.introspec.HttpTestServer;
 import com.newrelic.agent.introspec.InstrumentationTestConfig;

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -7,16 +7,9 @@
 
 package com.nr.instrumentation;
 
-import com.newrelic.agent.introspec.CatHelper;
-import com.newrelic.agent.introspec.ExternalRequest;
-import com.newrelic.agent.introspec.HttpTestServer;
-import com.newrelic.agent.introspec.InstrumentationTestConfig;
-import com.newrelic.agent.introspec.InstrumentationTestRunner;
-import com.newrelic.agent.introspec.Introspector;
-import com.newrelic.agent.introspec.MetricsHelper;
-import com.newrelic.agent.introspec.TransactionEvent;
-import com.newrelic.agent.introspec.internal.HttpServerLocator;
+import com.newrelic.agent.introspec.*;
 import com.newrelic.agent.introspec.internal.HttpServerRule;
+import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.api.agent.Trace;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(InstrumentationTestRunner.class)
-@InstrumentationTestConfig(includePrefixes = { "org.springframework" })
+@InstrumentationTestConfig(includePrefixes = { "org.springframework" }, configName = "spans.yml")
 public class WebClientTest {
 
     private static final int TIMEOUT = 3000;
@@ -177,6 +170,13 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
+
+        // span
+        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
+        assertEquals(1, externalSpanEvents.size());
+        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
+        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
+
     }
 
     @Test
@@ -276,6 +276,12 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         Assert.assertEquals("Spring-WebClient", externalRequest.getLibrary());
         Assert.assertEquals("exchange", externalRequest.getOperation());
+
+        // span
+        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
+        assertEquals(1, externalSpanEvents.size());
+        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
+        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
 
         Assert.assertEquals(1,
                 MetricsHelper.getScopedMetricCount(txnName, "External/" + host + "/Spring-WebClient/exchange"));

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -7,17 +7,11 @@
 
 package com.nr.instrumentation;
 
-import com.newrelic.agent.introspec.CatHelper;
-import com.newrelic.agent.introspec.SpanEvent;
-import com.newrelic.agent.introspec.ExternalRequest;
-import com.newrelic.agent.introspec.HttpTestServer;
-import com.newrelic.agent.introspec.InstrumentationTestConfig;
-import com.newrelic.agent.introspec.InstrumentationTestRunner;
-import com.newrelic.agent.introspec.Introspector;
-import com.newrelic.agent.introspec.MetricsHelper;
-import com.newrelic.agent.introspec.TransactionEvent;
+import com.newrelic.agent.introspec.*;
 import com.newrelic.agent.introspec.internal.HttpServerLocator;
 import com.newrelic.agent.introspec.internal.HttpServerRule;
+import com.newrelic.agent.model.SpanCategory;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
+++ b/instrumentation/spring-webclient-5.0/src/test/java/com/nr/instrumentation/WebClientTest.java
@@ -7,9 +7,16 @@
 
 package com.nr.instrumentation;
 
-import com.newrelic.agent.introspec.*;
+import com.newrelic.agent.introspec.CatHelper;
+import com.newrelic.agent.introspec.ExternalRequest;
+import com.newrelic.agent.introspec.HttpTestServer;
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.agent.introspec.Introspector;
+import com.newrelic.agent.introspec.MetricsHelper;
+import com.newrelic.agent.introspec.TransactionEvent;
+import com.newrelic.agent.introspec.internal.HttpServerLocator;
 import com.newrelic.agent.introspec.internal.HttpServerRule;
-import com.newrelic.agent.model.SpanCategory;
 import com.newrelic.api.agent.Trace;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -170,13 +177,6 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
-
-        // span
-        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
-        assertEquals(1, externalSpanEvents.size());
-        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
-        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
-
     }
 
     @Test
@@ -223,12 +223,6 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         assertEquals(1, externalRequest.getCount());
         assertEquals(host, externalRequest.getHostname());
-
-        // span
-        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
-        assertEquals(1, externalSpanEvents.size());
-        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
-        assertEquals(Integer.valueOf(200), externalSpanEvent.getStatusCode());
     }
 
     @Trace(dispatcher = true)
@@ -282,12 +276,6 @@ public class WebClientTest {
         ExternalRequest externalRequest = externalRequests.iterator().next();
         Assert.assertEquals("Spring-WebClient", externalRequest.getLibrary());
         Assert.assertEquals("exchange", externalRequest.getOperation());
-
-        // span
-        Collection<SpanEvent> externalSpanEvents = SpanEventsHelper.getSpanEventsByCategory(SpanCategory.http);
-        assertEquals(1, externalSpanEvents.size());
-        SpanEvent externalSpanEvent = externalSpanEvents.iterator().next();
-        assertEquals(Integer.valueOf(501), externalSpanEvent.getStatusCode());
 
         Assert.assertEquals(1,
                 MetricsHelper.getScopedMetricCount(txnName, "External/" + host + "/Spring-WebClient/exchange"));

--- a/instrumentation/spring-webclient-5.0/src/test/resources/spans.yml
+++ b/instrumentation/spring-webclient-5.0/src/test/resources/spans.yml
@@ -1,0 +1,5 @@
+common: &default_settings
+  distributed_tracing:
+    enabled: true
+  span_events:
+    enabled: true

--- a/instrumentation/spring-webclient-5.0/src/test/resources/spans.yml
+++ b/instrumentation/spring-webclient-5.0/src/test/resources/spans.yml
@@ -1,5 +1,0 @@
-common: &default_settings
-  distributed_tracing:
-    enabled: true
-  span_events:
-    enabled: true


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
In the current version, we dont have http status code for http clients using spring webclient.

![Captura de Tela 2023-11-29 às 14 56 14](https://github.com/newrelic/newrelic-java-agent/assets/114934836/9cff9ef2-5e4a-4b7c-bf36-6f9422b030e0)



### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [X] Your contributions are backwards compatible with relevant frameworks and APIs.
- [X] Your code does not contain any breaking changes. Otherwise please describe. 
- [X] Your code does not introduce any new dependencies. Otherwise please describe.
