### PR TITLE
Support string formatting with JBoss Logging

### DIFF
--- a/instrumentation/jboss-logging/src/main/java/com/nr/instrumentation/jboss/AgentUtil.java
+++ b/instrumentation/jboss-logging/src/main/java/com/nr/instrumentation/jboss/AgentUtil.java
@@ -39,7 +39,7 @@ public class AgentUtil {
      */
     public static void recordNewRelicLogEvent(ExtLogRecord record) {
         if (record != null) {
-            String message = record.getMessage();
+            String message = record.getFormattedMessage();
             Throwable throwable = record.getThrown();
 
             if (shouldCreateLogEvent(message, throwable)) {


### PR DESCRIPTION
Resolves https://github.com/newrelic/newrelic-java-agent/issues/1167

When using JBoss Logging with string formatting, the substituted values will be captured in the formatted log message (e.g. `This is a INFO JBoss log string1 : string2`) instead of being reported with the replaceable parameters (e.g. `This is a INFO JBoss log %s : %s`).

```
        String s1 = "string1";
        String s2 = "string2";

        LOGGER.infof("This is a INFO JBoss log %s : %s", s1, s2);
```

<img width="1037" alt="jboss-string-format" src="https://github.com/newrelic/newrelic-java-agent/assets/3496648/ba3e78fb-6619-4d99-a1ad-38877d1635dd">
