### PR TITLE
Prevent license_key value from being written to the agent logs when u…

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/logging/ApacheCommonsAdaptingLogFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/logging/ApacheCommonsAdaptingLogFactory.java
@@ -16,6 +16,9 @@ import java.util.logging.Level;
 
 import static com.newrelic.agent.util.LicenseKeyUtil.obfuscateLicenseKey;
 
+/**
+ * SSL/TLS debug logging is handled by this class when using -Dnewrelic.debug=true
+ */
 public class ApacheCommonsAdaptingLogFactory extends LogFactory {
 
     public static final IAgentLogger LOG = AgentLogManager.getLogger();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/logging/ApacheCommonsAdaptingLogFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/logging/ApacheCommonsAdaptingLogFactory.java
@@ -8,14 +8,13 @@
 package com.newrelic.agent.logging;
 
 import com.newrelic.agent.Agent;
-import com.newrelic.agent.util.LicenseKeyUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogConfigurationException;
 import org.apache.commons.logging.LogFactory;
 
 import java.util.logging.Level;
 
-import static com.newrelic.agent.util.LicenseKeyUtil.*;
+import static com.newrelic.agent.util.LicenseKeyUtil.obfuscateLicenseKey;
 
 public class ApacheCommonsAdaptingLogFactory extends LogFactory {
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/logging/ApacheCommonsAdaptingLogFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/logging/ApacheCommonsAdaptingLogFactory.java
@@ -8,11 +8,14 @@
 package com.newrelic.agent.logging;
 
 import com.newrelic.agent.Agent;
+import com.newrelic.agent.util.LicenseKeyUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogConfigurationException;
 import org.apache.commons.logging.LogFactory;
 
 import java.util.logging.Level;
+
+import static com.newrelic.agent.util.LicenseKeyUtil.*;
 
 public class ApacheCommonsAdaptingLogFactory extends LogFactory {
 
@@ -98,84 +101,84 @@ public class ApacheCommonsAdaptingLogFactory extends LogFactory {
         @Override
         public void trace(Object message) {
             if (isDebugEnabled()) {
-                logger.trace(message.toString());
+                logger.trace(obfuscateLicenseKey(message.toString()));
             }
         }
 
         @Override
         public void trace(Object message, Throwable t) {
             if (isDebugEnabled()) {
-                logger.log(Level.FINEST, t, message.toString());
+                logger.log(Level.FINEST, t, obfuscateLicenseKey(message.toString()));
             }
         }
 
         @Override
         public void debug(Object message) {
             if (isDebugEnabled()) {
-                logger.debug(message.toString());
+                logger.debug(obfuscateLicenseKey(message.toString()));
             }
         }
 
         @Override
         public void debug(Object message, Throwable t) {
             if (isDebugEnabled()) {
-                logger.log(Level.FINEST, "{0} : {1}", message, t);
+                logger.log(Level.FINEST, "{0} : {1}", obfuscateLicenseKey(message.toString()), t);
             }
         }
 
         @Override
         public void info(Object message) {
             if (isDebugEnabled()) {
-                logger.info(message.toString());
+                logger.info(obfuscateLicenseKey(message.toString()));
             }
         }
 
         @Override
         public void info(Object message, Throwable t) {
             if (isDebugEnabled()) {
-                logger.log(Level.INFO, "{0} : {1}", message, t);
+                logger.log(Level.INFO, "{0} : {1}", obfuscateLicenseKey(message.toString()), t);
             }
         }
 
         @Override
         public void warn(Object message) {
             if (isDebugEnabled()) {
-                logger.warning(message.toString());
+                logger.warning(obfuscateLicenseKey(message.toString()));
             }
         }
 
         @Override
         public void warn(Object message, Throwable t) {
             if (isDebugEnabled()) {
-                logger.log(Level.WARNING, "{0} : {1}", message, t);
+                logger.log(Level.WARNING, "{0} : {1}", obfuscateLicenseKey(message.toString()), t);
             }
         }
 
         @Override
         public void error(Object message) {
             if (isDebugEnabled()) {
-                logger.error(message.toString());
+                logger.error(obfuscateLicenseKey(message.toString()));
             }
         }
 
         @Override
         public void error(Object message, Throwable t) {
             if (isDebugEnabled()) {
-                logger.log(Level.SEVERE, "{0} : {1}", message, t);
+                logger.log(Level.SEVERE, "{0} : {1}", obfuscateLicenseKey(message.toString()), t);
             }
         }
 
         @Override
         public void fatal(Object message) {
             if (isDebugEnabled()) {
-                logger.severe(message.toString());
+                logger.severe(obfuscateLicenseKey(message.toString()));
             }
         }
 
         @Override
         public void fatal(Object message, Throwable t) {
             if (isDebugEnabled()) {
-                logger.log(Level.SEVERE, "{0} : {1}", message, t);
+                logger.log(Level.SEVERE, "{0} : {1}", obfuscateLicenseKey(message.toString()), t);
             }
         }
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
@@ -61,6 +61,8 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
 
+import static com.newrelic.agent.util.LicenseKeyUtil.obfuscateLicenseKey;
+
 /**
  * A class for sending and receiving New Relic data.
  *
@@ -592,7 +594,8 @@ public class DataSenderImpl implements DataSender {
         String payloadJsonSent = DataSenderWriter.toJSONString(params);
 
         if (auditMode && methodShouldBeAudited(method)) {
-            String msg = MessageFormat.format("Sent JSON({0}) to: {1}, with payload: {2}", method, url, payloadJsonSent);
+
+            String msg = MessageFormat.format("Sent JSON({0}) to: {1}, with payload: {2}", method, obfuscateLicenseKey(url.toString()), obfuscateLicenseKey(payloadJsonSent));
             logger.info(msg);
         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  * Copyright 2023 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.util;
+
+import com.newrelic.agent.Agent;
+import com.newrelic.agent.service.ServiceFactory;
+
+public class LicenseKeyUtil {
+    private static final String OBFUSCATED_LICENSE_KEY = "obfuscated";
+
+    /**
+     * Removes the license_key value from a given string.
+     * <p>
+     * This is primarily used to prevent the license_key from being
+     * written to the agent logs when using debug and/or audit_mode logging.
+     *
+     * @param originalString String to be evaluated and obfuscated if it contains the license_key
+     * @return A modified String with the license_key value replaced, if it exists. Otherwise, the originalString is returned.
+     */
+    public static String obfuscateLicenseKey(String originalString) {
+        if (originalString == null || originalString.isEmpty()) {
+            Agent.LOG.finest("Unable to obfuscate the license_key in a null or empty string.");
+            return originalString;
+        }
+        String licenseKey = ServiceFactory.getConfigService().getDefaultAgentConfig().getLicenseKey();
+        if (licenseKey == null) {
+            Agent.LOG.finest("Unable to obfuscate a null license_key.");
+            return originalString;
+        } else {
+            return originalString.replace(licenseKey, OBFUSCATED_LICENSE_KEY);
+        }
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
@@ -1,0 +1,119 @@
+/*
+ *
+ *  * Copyright 2023 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.util;
+
+import com.newrelic.agent.MockServiceManager;
+import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.AgentConfigImpl;
+import com.newrelic.agent.config.ConfigService;
+import com.newrelic.agent.config.ConfigServiceFactory;
+import com.newrelic.agent.service.ServiceFactory;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LicenseKeyUtilTest extends TestCase {
+
+    public void testObfuscateLicenseKey() {
+        // Given
+        String originalRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghijklmonpqrstuvwxyz1234567890&marshal_format=json&protocol_version=17";
+
+        String originalJsonPayload = "[{\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}]";
+
+        MockServiceManager serviceManager = new MockServiceManager();
+        ServiceFactory.setServiceManager(serviceManager);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("license_key", "abcdefghijklmonpqrstuvwxyz1234567890");
+
+        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
+        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
+        serviceManager.setConfigService(configService);
+
+        // When
+        String actualRequestUrl = LicenseKeyUtil.obfuscateLicenseKey(originalRequestUrl);
+        String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
+
+        // Then
+        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=obfuscated&marshal_format=json&protocol_version=17";
+
+        String expectedJsonPayload = "[{\"license_key\":\"obfuscated\"}]";
+
+        Assert.assertEquals(expectedRequestUrl, actualRequestUrl);
+        Assert.assertEquals(expectedJsonPayload, actualJsonPayload);
+    }
+
+    public void testObfuscateLicenseKeyWithMultipleLicenseKeyEntries() {
+        // Given
+        String originalJsonPayload = "[" +
+                "{\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}, {\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}, {\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}, {\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}]";
+
+        MockServiceManager serviceManager = new MockServiceManager();
+        ServiceFactory.setServiceManager(serviceManager);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("license_key", "abcdefghijklmonpqrstuvwxyz1234567890");
+
+        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
+        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
+        serviceManager.setConfigService(configService);
+
+        // When
+        String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
+
+        // Then
+        String expectedJsonPayload = "[" +
+                "{\"license_key\":\"obfuscated\"}, {\"license_key\":\"obfuscated\"}, {\"license_key\":\"obfuscated\"}, {\"license_key\":\"obfuscated\"}]";
+
+        Assert.assertEquals(expectedJsonPayload, actualJsonPayload);
+    }
+
+    public void testObfuscateLicenseKeyWithNullLicenseKey() {
+        // Given
+        String originalRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghijklmonpqrstuvwxyz1234567890&marshal_format=json&protocol_version=17";
+
+        String originalJsonPayload = "[{\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}]";
+
+        MockServiceManager serviceManager = new MockServiceManager();
+        ServiceFactory.setServiceManager(serviceManager);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("license_key", null);
+
+        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
+        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
+        serviceManager.setConfigService(configService);
+
+        // When
+        String actualRequestUrl = LicenseKeyUtil.obfuscateLicenseKey(originalRequestUrl);
+        String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
+
+        // Then
+        Assert.assertEquals(originalRequestUrl, actualRequestUrl);
+        Assert.assertEquals(originalJsonPayload, actualJsonPayload);
+    }
+
+    public void testObfuscateLicenseKeyWithNullOrEmptyString() {
+        // Given
+        MockServiceManager serviceManager = new MockServiceManager();
+        ServiceFactory.setServiceManager(serviceManager);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("license_key", "abcdefghijklmonpqrstuvwxyz1234567890");
+
+        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
+        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
+        serviceManager.setConfigService(configService);
+
+        // When
+        String actualEmptyString = LicenseKeyUtil.obfuscateLicenseKey("");
+        String actualNullString = LicenseKeyUtil.obfuscateLicenseKey(null);
+
+        // Then
+        Assert.assertEquals("", actualEmptyString);
+        Assert.assertNull(actualNullString);
+    }
+}


### PR DESCRIPTION
…sing debug and/or audit_mode logging

Resolves https://github.com/newrelic/java-agent-integration-tests/issues/223

The `license_key` value will be replaced with `obfuscated` when using debug logging:

```
2023-12-08T16:25:42,436-0800 [23116 44] com.newrelic.agent.deps.org.apache.http.impl.execchain.MainClientExec DEBUG: Executing request POST /agent_listener/invoke_raw_method?method=custom_event_data&license_key=obfuscated&marshal_format=json&protocol_version=17&run_id=BcZAlFahANjoALR0JwJ7_Y HTTP/1.1
```

or audit mode logging:

```
2023-12-08T16:18:28,975-0800 [23116 1] com.newrelic INFO: Sent JSON(connect) to: https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=obfuscated&marshal_format=json&protocol_version=17, with payload: [{"settings":{...,"license_key":"obfuscated",...},...}]
```