### PR TITLE
Slow txn update

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SlowTransactionsConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SlowTransactionsConfig.java
@@ -22,4 +22,12 @@ public interface SlowTransactionsConfig {
      */
     long getThresholdMillis();
 
+    /**
+     * By default, only in-progress transactions are checked for exceeding the defined
+     * threshold time during a normal harvest cycle. Setting this to true will
+     * evaluate transactions as they complete and report any that exceed the defined
+     * threshold.
+     */
+    boolean evaluateCompletedTransactions();
+
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SlowTransactionsConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SlowTransactionsConfigImpl.java
@@ -15,17 +15,21 @@ public class SlowTransactionsConfigImpl extends BaseConfig implements SlowTransa
     public static final String SYSTEM_PROPERTY_ROOT = "newrelic.config." + ROOT + ".";
     public static final String ENABLED = "enabled";
     public static final String THRESHOLD = "threshold";
+    public static final String EVAL_COMPLETED_TRANSACTIONS = "evaluate_completed_transactions";
 
     public static final boolean DEFAULT_ENABLED = true;
     public static final int DEFAULT_THRESHOLD_MILLIS = 600000;
+    public static final boolean DEFAULT_EVAL_COMPLETED_TRANSACTIONS = false;
 
     private final boolean isEnabled;
     private final int thresholdMillis;
+    private final boolean evalCompletedTransactions;
 
     public SlowTransactionsConfigImpl(Map<String, Object> pProps) {
         super(pProps, SYSTEM_PROPERTY_ROOT);
         isEnabled = getProperty(ENABLED, DEFAULT_ENABLED);
         thresholdMillis = getIntProperty(THRESHOLD, DEFAULT_THRESHOLD_MILLIS);
+        evalCompletedTransactions = getProperty(EVAL_COMPLETED_TRANSACTIONS, DEFAULT_EVAL_COMPLETED_TRANSACTIONS);
     }
 
     @Override
@@ -36,6 +40,11 @@ public class SlowTransactionsConfigImpl extends BaseConfig implements SlowTransa
     @Override
     public long getThresholdMillis() {
         return thresholdMillis;
+    }
+
+    @Override
+    public boolean evaluateCompletedTransactions() {
+        return evalCompletedTransactions;
     }
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/slowtransactions/SlowTransactionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/slowtransactions/SlowTransactionService.java
@@ -36,6 +36,7 @@ public class SlowTransactionService extends AbstractService implements ExtendedT
     private final boolean isEnabled;
     private final long thresholdMillis;
     private final int maxStackTraceLines;
+    private final boolean evalCompletedTransactions;
 
     @Nullable
     private InsightsService insightsService;
@@ -52,6 +53,7 @@ public class SlowTransactionService extends AbstractService implements ExtendedT
         this.thresholdMillis = slowTransactionsConfig.getThresholdMillis();
         this.maxStackTraceLines = agentConfig.getMaxStackTraceLines();
         this.threadMXBean = threadMXBean;
+        this.evalCompletedTransactions = slowTransactionsConfig.evaluateCompletedTransactions();
 
         NewRelic.getAgent().getMetricAggregator().incrementCounter(
                 agentConfig.getSlowTransactionsConfig().isEnabled() ?
@@ -106,6 +108,14 @@ public class SlowTransactionService extends AbstractService implements ExtendedT
             getLogger().finest("Transaction finished with guid " + transactionData.getGuid());
         }
         openTransactions.remove(transactionData.getGuid());
+
+        if (evalCompletedTransactions) {
+            Transaction txn = transactionData.getTransaction();
+            long txnExecutionTimeInMs = System.currentTimeMillis() - txn.getWallClockStartTimeMs();
+            if (txnExecutionTimeInMs > this.thresholdMillis) {
+                reportSlowTransaction(txn, txnExecutionTimeInMs, true);
+            }
+        }
     }
 
     // Visible for testing
@@ -145,26 +155,11 @@ public class SlowTransactionService extends AbstractService implements ExtendedT
         }
 
         // Construct and record SlowTransaction event
-        Map<String, Object> attributes = extractMetadata(slowestOpen, slowestOpenMillis);
-        String guid = slowestOpen.getGuid();
-        if (getLogger().isLoggable(Level.FINE)) {
-            getLogger().fine("Slowest open transaction has guid "
-                    + guid + " has been open for " + slowestOpenMillis + "ms, attributes: " + attributes);
-        }
-        if (insightsService != null) {
-            logger.fine("Sending slow transaction");
-            insightsService.storeEvent(
-                    ServiceFactory.getRPMService().getApplicationName(),
-                    new CustomInsightsEvent(
-                            "SlowTransaction",
-                            System.currentTimeMillis(),
-                            attributes,
-                            DistributedTraceServiceImpl.nextTruncatedFloat()));
-            //insightsService.recordCustomEvent("SlowTransaction", attributes);
-        }
+        reportSlowTransaction(slowestOpen, slowestOpenMillis, false);
+
         // Remove from openTransactions to ensure we don't report the same Transaction
         // multiple times
-        openTransactions.remove(guid);
+        openTransactions.remove(slowestOpen.getGuid());
     }
 
     // Visible for testing
@@ -198,6 +193,23 @@ public class SlowTransactionService extends AbstractService implements ExtendedT
 
         new IllegalArgumentException().printStackTrace();
         return attributes;
+    }
+
+    private void reportSlowTransaction(Transaction slowTxn, long txnExecutionTimeInMs, boolean isCompleted) {
+        Map<String, Object> attributes = extractMetadata(slowTxn, txnExecutionTimeInMs);
+        if (getLogger().isLoggable(Level.FINE)) {
+            getLogger().fine("Reporting " + (isCompleted ? "completed" : "in progress") + " slow transaction with guid "
+                    + slowTxn.getGuid() + " with execution time of " + txnExecutionTimeInMs + "ms, attributes: " + attributes);
+        }
+        if (insightsService != null) {
+            insightsService.storeEvent(
+                    ServiceFactory.getRPMService().getApplicationName(),
+                    new CustomInsightsEvent(
+                            "SlowTransaction",
+                            System.currentTimeMillis(),
+                            attributes,
+                            DistributedTraceServiceImpl.nextTruncatedFloat()));
+        }
     }
 
     private static String stackTraceString(List<StackTraceElement> stackTrace) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/slowtransactions/SlowTransactionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/slowtransactions/SlowTransactionService.java
@@ -107,10 +107,10 @@ public class SlowTransactionService extends AbstractService implements ExtendedT
         if (getLogger().isLoggable(Level.FINEST)) {
             getLogger().finest("Transaction finished with guid " + transactionData.getGuid());
         }
-        openTransactions.remove(transactionData.getGuid());
+        Transaction txn = openTransactions.remove(transactionData.getGuid());
 
-        if (evalCompletedTransactions) {
-            Transaction txn = transactionData.getTransaction();
+        // txn will be null if it's been reported as part of the harvest cycle.
+        if (txn != null && evalCompletedTransactions) {
             long txnExecutionTimeInMs = System.currentTimeMillis() - txn.getWallClockStartTimeMs();
             if (txnExecutionTimeInMs > this.thresholdMillis) {
                 reportSlowTransaction(txn, txnExecutionTimeInMs, true);

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -421,6 +421,11 @@ common: &default_settings
     enabled: true
     threshold: 600000
 
+    # If this is set to true, every transaction will be checked for exceeding the defined threshold on
+    # transaction completion. Note that this can be computationally expensive since a stack trace is sent
+    # with every SlowTransaction event, if a large number of transaction exceed the threshold.
+    evaluate_completed_transactions: false
+
 # Application Environments
 # ------------------------------------------
 # Environment specific settings are in this section.

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -414,7 +414,9 @@ common: &default_settings
         enabled: true
 
   # Slow transaction detection will report an event to New Relic ("SlowTransaction") whenever a Transaction's
-  # time exceeds the threshold value (in ms). A transaction will only be reported once.
+  # time exceeds the threshold value (in ms). A transaction will only be reported once and by default, only
+  # transactions that are in-process during a harvest cycle will be checked. Only the slowest single transaction
+  # will be reported even if multiple transactions exceed the threshold.
   slow_transactions:
     enabled: true
     threshold: 600000


### PR DESCRIPTION
Currently, slow transactions are only checked for during a harvest cycle. This change adds the ability to check every transaction against the defined threshold upon transaction completion. The setting to enable this is `evaluate_completed_transactions` (default is false).

```yaml
slow_transactions:
    enabled: true
    threshold: 600000

    # If this is set to true, every transaction will be checked for exceeding the defined threshold on
    # transaction completion. Note that this can be computationally expensive since a stack trace is sent
    # with every SlowTransaction event, if a large number of transaction exceed the threshold.
    evaluate_completed_transactions: false
```