### PR TITLE
Add sources & javadoc task to otel extension

### DIFF
--- a/newrelic-opentelemetry-agent-extension/build.gradle.kts
+++ b/newrelic-opentelemetry-agent-extension/build.gradle.kts
@@ -17,6 +17,11 @@ val shadowJar = tasks.getByName<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 PublishConfig.config(
         project,
         "New Relic OpenTelemetry Java Agent Extension",


### PR DESCRIPTION
This is required to add the javadoc and sources jar to otel extensions so we can send out a release
