### PR TITLE
Comment Out Publish Step for Otel Extension

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -45,11 +45,12 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew $GRADLE_OPTIONS :agent-bridge:publish :agent-bridge-datastore:publish :newrelic-weaver:publish :newrelic-weaver-api:publish :newrelic-weaver-scala:publish :newrelic-weaver-scala-api:publish -Prelease=true
-      - name: Publish New Relic OpenTelemetry API Extension
-        env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true
+# Todo: uncomment when we fixed the issues when we manage to add sources and javadoc jars in the publish step in gradle
+#      - name: Publish New Relic OpenTelemetry API Extension
+#        env:
+#          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+#          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+#          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+#          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+#          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+#        run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true

--- a/newrelic-opentelemetry-agent-extension/build.gradle.kts
+++ b/newrelic-opentelemetry-agent-extension/build.gradle.kts
@@ -17,10 +17,11 @@ val shadowJar = tasks.getByName<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
 }
 
-java {
-    withSourcesJar()
-    withJavadocJar()
-}
+// Todo: add sources and javadoc jar to publish release
+//java {
+//    withSourcesJar()
+//    withJavadocJar()
+//}
 
 PublishConfig.config(
         project,

--- a/newrelic-opentelemetry-agent-extension/build.gradle.kts
+++ b/newrelic-opentelemetry-agent-extension/build.gradle.kts
@@ -17,6 +17,11 @@ val shadowJar = tasks.getByName<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 PublishConfig.config(
         project,
         "New Relic OpenTelemetry Java Agent Extension",


### PR DESCRIPTION
Comment out task to publish otel extensions. This is required to publish our 8.8.0 release.
