### PR TITLE
Reintroduce previously deprecated transaction/span attributes

### DIFF
--- a/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
+++ b/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
@@ -1650,7 +1650,7 @@ public class AkkaHttpRoutesTest {
         Assert.assertNotNull(transactionEvents);
         Assert.assertEquals(expectedSize, transactionEvents.size());
         for (TransactionEvent transactionEvent : transactionEvents) {
-            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("http.statusCode"));
+            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("httpResponseCode"));
             Assert.assertNotNull(httpResponseCode);
             Assert.assertEquals(expectedResponseCode, httpResponseCode);
         }

--- a/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
+++ b/instrumentation/akka-http-2.11_2.4.5/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
@@ -1650,9 +1650,11 @@ public class AkkaHttpRoutesTest {
         Assert.assertNotNull(transactionEvents);
         Assert.assertEquals(expectedSize, transactionEvents.size());
         for (TransactionEvent transactionEvent : transactionEvents) {
-            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("httpResponseCode"));
+            String httpResponseCode = (String) transactionEvent.getAttributes().get("httpResponseCode");
             Assert.assertNotNull(httpResponseCode);
             Assert.assertEquals(expectedResponseCode, httpResponseCode);
+            int statusCode = (Integer) transactionEvent.getAttributes().get("http.statusCode");
+            Assert.assertEquals(Integer.parseInt(expectedResponseCode), statusCode);
         }
     }
 

--- a/instrumentation/akka-http-2.13_10.1.8/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
+++ b/instrumentation/akka-http-2.13_10.1.8/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
@@ -1646,7 +1646,7 @@ public class AkkaHttpRoutesTest {
         Assert.assertNotNull(transactionEvents);
         Assert.assertEquals(expectedSize, transactionEvents.size());
         for (TransactionEvent transactionEvent : transactionEvents) {
-            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("http.statusCode"));
+            String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("httpResponseCode"));
             Assert.assertNotNull(httpResponseCode);
             Assert.assertEquals(expectedResponseCode, httpResponseCode);
         }

--- a/instrumentation/akka-http-2.13_10.1.8/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
+++ b/instrumentation/akka-http-2.13_10.1.8/src/test/java/com/agent/instrumentation/akka/http/AkkaHttpRoutesTest.java
@@ -1649,6 +1649,8 @@ public class AkkaHttpRoutesTest {
             String httpResponseCode = String.valueOf(transactionEvent.getAttributes().get("httpResponseCode"));
             Assert.assertNotNull(httpResponseCode);
             Assert.assertEquals(expectedResponseCode, httpResponseCode);
+            int statusCode = (Integer) transactionEvent.getAttributes().get("http.statusCode");
+            Assert.assertEquals(Integer.parseInt(expectedResponseCode), statusCode);
         }
     }
 

--- a/instrumentation/grpc-1.22.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
+++ b/instrumentation/grpc-1.22.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
@@ -15,6 +15,16 @@ public class GrpcConfig {
 
     public static final boolean errorsEnabled = NewRelic.getAgent().getConfig().getValue("grpc.errors.enabled", true);
 
+    public static final boolean HTTP_ATTR_LEGACY;
+    public static final boolean HTTP_ATTR_STANDARD;
+
+    static {
+        String attrMode = NewRelic.getAgent().getConfig().getValue("attributes.http_attribute_mode", "both");
+        // legacy is only disabled when standard is selected.
+        HTTP_ATTR_LEGACY = !"standard".equalsIgnoreCase(attrMode);
+        // standard is only disabled when legacy is selected.
+        HTTP_ATTR_STANDARD = !"legacy".equalsIgnoreCase(attrMode);
+    }
     private GrpcConfig() {
     }
 

--- a/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -70,9 +70,15 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
-            NewRelic.addCustomParameter("http.statusCode", statusCode);
-            NewRelic.addCustomParameter("http.statusText", status.getDescription());
+            String statusMessage = status.getDescription();
+            if (GrpcConfig.HTTP_ATTR_LEGACY) {
+                NewRelic.addCustomParameter("response.status", statusCode);
+                NewRelic.addCustomParameter("response.statusMessage", statusMessage);
+            }
+            if (GrpcConfig.HTTP_ATTR_STANDARD) {
+                NewRelic.addCustomParameter("http.statusCode", statusCode);
+                NewRelic.addCustomParameter("http.statusText", statusMessage);
+            }
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.22.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,6 +39,7 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
 
@@ -69,6 +70,7 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {

--- a/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.22.0/src/test/java/ValidationHelper.java
@@ -68,6 +68,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
@@ -85,6 +86,7 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
+        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(0, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
@@ -125,6 +127,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(status, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
@@ -133,6 +136,7 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
+        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(status, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }

--- a/instrumentation/grpc-1.30.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
+++ b/instrumentation/grpc-1.30.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
@@ -15,6 +15,16 @@ public class GrpcConfig {
 
     public static final boolean errorsEnabled = NewRelic.getAgent().getConfig().getValue("grpc.errors.enabled", true);
 
+    public static final boolean HTTP_ATTR_LEGACY;
+    public static final boolean HTTP_ATTR_STANDARD;
+
+    static {
+        String attrMode = NewRelic.getAgent().getConfig().getValue("attributes.http_attribute_mode", "both");
+        // legacy is only disabled when standard is selected.
+        HTTP_ATTR_LEGACY = !"standard".equalsIgnoreCase(attrMode);
+        // standard is only disabled when legacy is selected.
+        HTTP_ATTR_STANDARD = !"legacy".equalsIgnoreCase(attrMode);
+    }
     private GrpcConfig() {
     }
 

--- a/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,9 +39,15 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
-            NewRelic.addCustomParameter("http.statusCode", statusCode);
-            NewRelic.addCustomParameter("http.statusText", status.getDescription());
+            String statusMessage = status.getDescription();
+            if (GrpcConfig.HTTP_ATTR_LEGACY) {
+                NewRelic.addCustomParameter("response.status", statusCode);
+                NewRelic.addCustomParameter("response.statusMessage", statusMessage);
+            }
+            if (GrpcConfig.HTTP_ATTR_STANDARD) {
+                NewRelic.addCustomParameter("http.statusCode", statusCode);
+                NewRelic.addCustomParameter("http.statusText", statusMessage);
+            }
 
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it

--- a/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.30.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,6 +39,7 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
 
@@ -69,6 +70,7 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {

--- a/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.30.0/src/test/java/ValidationHelper.java
@@ -68,6 +68,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
@@ -85,6 +86,7 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
+        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(0, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
@@ -125,6 +127,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(status, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
@@ -133,6 +136,7 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
+        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(status, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }

--- a/instrumentation/grpc-1.4.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
+++ b/instrumentation/grpc-1.4.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
@@ -15,6 +15,16 @@ public class GrpcConfig {
 
     public static final boolean errorsEnabled = NewRelic.getAgent().getConfig().getValue("grpc.errors.enabled", true);
 
+    public static final boolean HTTP_ATTR_LEGACY;
+    public static final boolean HTTP_ATTR_STANDARD;
+
+    static {
+        String attrMode = NewRelic.getAgent().getConfig().getValue("attributes.http_attribute_mode", "both");
+        // legacy is only disabled when standard is selected.
+        HTTP_ATTR_LEGACY = !"standard".equalsIgnoreCase(attrMode);
+        // standard is only disabled when legacy is selected.
+        HTTP_ATTR_STANDARD = !"legacy".equalsIgnoreCase(attrMode);
+    }
     private GrpcConfig() {
     }
 

--- a/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,9 +39,15 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
-            NewRelic.addCustomParameter("response.status", statusCode);
-            NewRelic.addCustomParameter("http.statusCode", statusCode);
-            NewRelic.addCustomParameter("http.statusText", status.getDescription());
+            String statusMessage = status.getDescription();
+            if (GrpcConfig.HTTP_ATTR_LEGACY) {
+                NewRelic.addCustomParameter("response.status", statusCode);
+                NewRelic.addCustomParameter("response.statusMessage", statusMessage);
+            }
+            if (GrpcConfig.HTTP_ATTR_STANDARD) {
+                NewRelic.addCustomParameter("http.statusCode", statusCode);
+                NewRelic.addCustomParameter("http.statusText", statusMessage);
+            }
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
+++ b/instrumentation/grpc-1.4.0/src/main/java/io/grpc/internal/ServerStream_Instrumentation.java
@@ -39,6 +39,7 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
@@ -68,6 +69,7 @@ public abstract class ServerStream_Instrumentation {
 
         if (status != null) {
             int statusCode = status.getCode().value();
+            NewRelic.addCustomParameter("response.status", statusCode);
             NewRelic.addCustomParameter("http.statusCode", statusCode);
             NewRelic.addCustomParameter("http.statusText", status.getDescription());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {

--- a/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.4.0/src/test/java/ValidationHelper.java
@@ -69,6 +69,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertNull(rootSegment.getTracerAttributes().get("http.statusText"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
@@ -86,6 +87,7 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
+        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(0, serverTxEvent.getAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
@@ -126,6 +128,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(status, rootSegment.getTracerAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
@@ -134,6 +137,7 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
+        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals(status, serverTxEvent.getAttributes().get(AttributeNames.HTTP_STATUS_CODE));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }

--- a/instrumentation/grpc-1.40.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
+++ b/instrumentation/grpc-1.40.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcConfig.java
@@ -15,6 +15,16 @@ public class GrpcConfig {
 
     public static final boolean errorsEnabled = NewRelic.getAgent().getConfig().getValue("grpc.errors.enabled", true);
 
+    public static final boolean HTTP_ATTR_LEGACY;
+    public static final boolean HTTP_ATTR_STANDARD;
+
+    static {
+        String attrMode = NewRelic.getAgent().getConfig().getValue("attributes.http_attribute_mode", "both");
+        // legacy is only disabled when standard is selected.
+        HTTP_ATTR_LEGACY = !"standard".equalsIgnoreCase(attrMode);
+        // standard is only disabled when legacy is selected.
+        HTTP_ATTR_STANDARD = !"legacy".equalsIgnoreCase(attrMode);
+    }
     private GrpcConfig() {
     }
 

--- a/instrumentation/grpc-1.40.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcUtil.java
+++ b/instrumentation/grpc-1.40.0/src/main/java/com/nr/agent/instrumentation/grpc/GrpcUtil.java
@@ -34,14 +34,14 @@ public class GrpcUtil {
     }
 
     /**
-     * Set the http.statusCode attribute and error cause (if applicable) on the transaction
+     * Set the response.status attribute and error cause (if applicable) on the transaction
      * when the ServerStream is closed or cancelled.
      *
      * @param status The {@link Status} of the completed/cancelled operation
      */
     public static void setServerStreamResponseStatus(Status status) {
         if (status != null) {
-            NewRelic.addCustomParameter("http.statusCode", status.getCode().value());
+            NewRelic.addCustomParameter("response.status", status.getCode().value());
             if (GrpcConfig.errorsEnabled && status.getCause() != null) {
                 // If an error occurred during the close of this server call we should record it
                 NewRelic.noticeError(status.getCause());

--- a/instrumentation/grpc-1.40.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.40.0/src/test/java/ValidationHelper.java
@@ -60,6 +60,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -75,6 +76,7 @@ class ValidationHelper {
             assertEquals(name, serverTxEvent.getAttributes().get("sayHelloAfter"));
         }
 
+        assertEquals(0, serverTxEvent.getAttributes().get("response.status"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 
@@ -114,6 +116,7 @@ class ValidationHelper {
         assertTrue(rootSegment.getName().endsWith(fullMethod));
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
+        assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -121,6 +124,7 @@ class ValidationHelper {
         assertEquals(1, serverTxEvents.size());
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
+        assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 

--- a/instrumentation/grpc-1.40.0/src/test/java/ValidationHelper.java
+++ b/instrumentation/grpc-1.40.0/src/test/java/ValidationHelper.java
@@ -61,6 +61,7 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(0, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(0, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -117,6 +118,7 @@ class ValidationHelper {
         assertEquals(1, rootSegment.getCallCount());
         assertEquals(fullMethod, rootSegment.getTracerAttributes().get("request.method"));
         assertEquals(status, rootSegment.getTracerAttributes().get("response.status"));
+        assertEquals(status, rootSegment.getTracerAttributes().get("http.statusCode"));
         assertEquals(grpcType, rootSegment.getTracerAttributes().get("grpc.type"));
 
         // Custom attributes (to test tracing into customer code)
@@ -125,6 +127,7 @@ class ValidationHelper {
         TransactionEvent serverTxEvent = serverTxEvents.iterator().next();
         assertNotNull(serverTxEvent);
         assertEquals(status, serverTxEvent.getAttributes().get("response.status"));
+        assertEquals(status, serverTxEvent.getAttributes().get("http.statusCode"));
         assertEquals("grpc://localhost:" + server.getPort() + "/" + fullMethod, serverTxEvent.getAttributes().get("request.uri"));
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AttributeNames.java
@@ -36,6 +36,8 @@ public final class AttributeNames {
     public static final String HTTP_METHOD = "http.method";
     public static final String HTTP_STATUS_CODE = "http.statusCode";
     public static final String HTTP_STATUS_TEXT = "http.statusText";
+    public static final String HTTP_STATUS = "httpResponseCode";
+    public static final String HTTP_STATUS_MESSAGE = "httpResponseMessage";
 
     public static final String LOCK_THREAD_NAME = "jvm.lock_thread_name";
     public static final String THREAD_NAME = "jvm.thread_name";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfig.java
@@ -19,4 +19,15 @@ public interface AttributesConfig {
 
     List<String> attributesRootExclude();
 
+    /**
+     * Whether the old http attributes (httpResponseCode, httpResponseMessage) should be sent.
+     * @since 8.8.1
+     */
+    boolean isLegacyHttpAttr();
+
+    /**
+     * Whether the new http attributes (http.statusCode, http.statusText) should be sent.
+     * @since 8.8.1
+     */
+    boolean isStandardHttpAttr();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfigImpl.java
@@ -46,19 +46,20 @@ public class AttributesConfigImpl extends BaseConfig implements AttributesConfig
         attributesInclude = initAttributesInclude();
         attributeExclude = initAttributesExclude();
         String httpAttributeMode = getProperty(HTTP_ATTR_MODE);
-        if (HTTP_ATTR_MODE_LEGACY.equalsIgnoreCase(httpAttributeMode)) {
-            legacyHttpAttr = true;
-            standardHttpAttr = false;
-        } else if (HTTP_ATTR_MODE_STANDARD.equalsIgnoreCase(httpAttributeMode)) {
-            legacyHttpAttr = false;
-            standardHttpAttr = true;
-        } else { // defaults to all
-            if (httpAttributeMode != null && !HTTP_ATTR_MODE_BOTH.equalsIgnoreCase(httpAttributeMode)) {
-                AgentBridge.getAgent().getLogger().log(Level.WARNING, "Invalid " + HTTP_ATTR_MODE + " config" +
-                        " encountered: " + httpAttributeMode + ". Using default :" + HTTP_ATTR_MODE_BOTH + ".");
-            }
-            legacyHttpAttr = true;
-            standardHttpAttr = true;
+
+        boolean standardMode = HTTP_ATTR_MODE_STANDARD.equalsIgnoreCase(httpAttributeMode);
+        boolean legacyMode = HTTP_ATTR_MODE_LEGACY.equalsIgnoreCase(httpAttributeMode);
+
+        // legacy is only disabled when mode is standard
+        legacyHttpAttr = !standardMode;
+        // standard is only disabled when mode is legacy
+        standardHttpAttr = !legacyMode;
+
+        // logging invalid http attr mode
+        if (httpAttributeMode != null && !legacyMode && !standardMode &&
+                !HTTP_ATTR_MODE_BOTH.equalsIgnoreCase(httpAttributeMode)) {
+            AgentBridge.getAgent().getLogger().log(Level.WARNING, "Invalid " + HTTP_ATTR_MODE + " config" +
+                    " encountered: " + httpAttributeMode + ". Using default :" + HTTP_ATTR_MODE_BOTH + ".");
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
@@ -16,8 +16,10 @@ import com.newrelic.agent.bridge.TransactionNamePriority;
 import com.newrelic.agent.bridge.WebResponse;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.AgentConfigImpl;
+import com.newrelic.agent.config.AttributesConfig;
 import com.newrelic.agent.config.CustomRequestHeaderConfig;
 import com.newrelic.agent.config.HiddenProperties;
+import com.newrelic.agent.config.TransactionEventsConfig;
 import com.newrelic.agent.config.TransactionTracerConfig;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.servlet.ServletUtils;
@@ -27,7 +29,6 @@ import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.agent.tracers.servlet.ExternalTimeTracker;
 import com.newrelic.agent.transaction.TransactionNamer;
 import com.newrelic.agent.transaction.WebTransactionNamer;
-import com.newrelic.agent.util.Strings;
 import com.newrelic.api.agent.ExtendedRequest;
 import com.newrelic.api.agent.Request;
 import com.newrelic.api.agent.Response;
@@ -104,16 +105,25 @@ public class WebRequestDispatcher extends DefaultDispatcher implements WebRespon
                 storeMethod();
                 storeResponseContentType();
 
+                AttributesConfig attributesConfig = ServiceFactory.getConfigService().getDefaultAgentConfig().getAttributesConfig();
                 if (getStatus() > 0) {
-                    // http status is now being recorded as a string
-                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS, String.valueOf(getStatus()));
-                    // http.statusCode is supposed to be an int
-                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_CODE, getStatus());
+                    if (attributesConfig.isLegacyHttpAttr()) {
+                        // http status is now being recorded as a string
+                        getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS, String.valueOf(getStatus()));
+                    }
+                    if (attributesConfig.isStandardHttpAttr()) {
+                        // http.statusCode is supposed to be an int
+                        getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_CODE, getStatus());
+                    }
                 }
 
                 if (getStatusMessage() != null) {
-                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_MESSAGE, getStatusMessage());
-                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_TEXT, getStatusMessage());
+                    if (attributesConfig.isLegacyHttpAttr()) {
+                        getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_MESSAGE, getStatusMessage());
+                    }
+                    if (attributesConfig.isStandardHttpAttr()) {
+                        getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_TEXT, getStatusMessage());
+                    }
                 }
 
                 // adding request.uri here includes it in the Transaction event, which also propagates to any Transaction error events

--- a/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java
@@ -105,11 +105,14 @@ public class WebRequestDispatcher extends DefaultDispatcher implements WebRespon
                 storeResponseContentType();
 
                 if (getStatus() > 0) {
+                    // http status is now being recorded as a string
+                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS, String.valueOf(getStatus()));
                     // http.statusCode is supposed to be an int
                     getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_CODE, getStatus());
                 }
 
                 if (getStatusMessage() != null) {
+                    getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_MESSAGE, getStatusMessage());
                     getTransaction().getAgentAttributes().put(AttributeNames.HTTP_STATUS_TEXT, getStatusMessage());
                 }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -248,8 +248,8 @@ public class SpanEventFactory {
                 filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_TEXT)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS_TEXT, statusText);
         }
-        if (attributesConfig.isStandardHttpAttr() &&
-                filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_TEXT)) {
+        if (attributesConfig.isLegacyHttpAttr() &&
+                filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_MESSAGE)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS_MESSAGE, statusText);
         }
         return this;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -231,6 +231,9 @@ public class SpanEventFactory {
         if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_CODE)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS_CODE, statusCode);
         }
+        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS)) {
+            builder.putAgentAttribute(AttributeNames.HTTP_STATUS, statusCode);
+        }
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -11,6 +11,8 @@ import com.google.common.base.Joiner;
 import com.newrelic.agent.attributes.AttributeNames;
 import com.newrelic.agent.attributes.AttributeValidator;
 import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.AttributesConfig;
+import com.newrelic.agent.config.TransactionEventsConfig;
 import com.newrelic.agent.database.SqlObfuscator;
 import com.newrelic.agent.model.AttributeFilter;
 import com.newrelic.agent.model.SpanCategory;
@@ -228,18 +230,27 @@ public class SpanEventFactory {
     }
 
     public SpanEventFactory setHttpStatusCode(Integer statusCode) {
-        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_CODE)) {
+        AttributesConfig attributesConfig = ServiceFactory.getConfigService().getDefaultAgentConfig().getAttributesConfig();
+        if (attributesConfig.isStandardHttpAttr() &&
+                filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_CODE)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS_CODE, statusCode);
         }
-        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS)) {
+        if (attributesConfig.isLegacyHttpAttr() &&
+                filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS, statusCode);
         }
         return this;
     }
 
     public SpanEventFactory setHttpStatusText(String statusText) {
-        if (filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_TEXT)) {
+        AttributesConfig attributesConfig = ServiceFactory.getConfigService().getDefaultAgentConfig().getAttributesConfig();
+        if (attributesConfig.isStandardHttpAttr() &&
+                filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_TEXT)) {
             builder.putAgentAttribute(AttributeNames.HTTP_STATUS_TEXT, statusText);
+        }
+        if (attributesConfig.isStandardHttpAttr() &&
+                filter.shouldIncludeAgentAttribute(appName, AttributeNames.HTTP_STATUS_TEXT)) {
+            builder.putAgentAttribute(AttributeNames.HTTP_STATUS_MESSAGE, statusText);
         }
         return this;
     }

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -172,6 +172,12 @@ common: &default_settings
     # not be sent to New Relic.
     #exclude:
 
+
+    # Defines which sets of http attributes the agent will send: standard, legacy or both (default).
+    # Having the agent send both sets will increase ingestion.
+    # Having the agent send only legacy may impact current or future functionality.
+    http_attribute_mode: both
+
   # Transaction tracer captures deep information about slow
   # transactions and sends this to the New Relic service once a
   # minute. Included in the transaction is the exact call sequence of

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/TracerToSpanEventTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/TracerToSpanEventTest.java
@@ -36,6 +36,8 @@ import java.util.function.Supplier;
 
 import static com.newrelic.agent.MetricNames.QUEUE_TIME;
 import static com.newrelic.agent.attributes.AttributeNames.HTTP_REQUEST_PREFIX;
+import static com.newrelic.agent.attributes.AttributeNames.HTTP_STATUS;
+import static com.newrelic.agent.attributes.AttributeNames.HTTP_STATUS_MESSAGE;
 import static com.newrelic.agent.attributes.AttributeNames.MESSAGE_REQUEST_PREFIX;
 import static com.newrelic.agent.attributes.AttributeNames.PORT;
 import static com.newrelic.agent.attributes.AttributeNames.QUEUE_DURATION;
@@ -335,10 +337,14 @@ public class TracerToSpanEventTest {
         int httpResponseCode = 404;
         String httpResponseMessage = "I cannot find that page, silly";
         String contentType = "application/vnd.ms-powerpoint ";
+        expectedAgentAttributes.put("httpResponseCode", httpResponseCode);
+        expectedAgentAttributes.put("httpResponseMessage", httpResponseMessage);
         expectedAgentAttributes.put(RESPONSE_CONTENT_TYPE_PARAMETER_NAME, contentType);
 
         SpanEvent expectedSpanEvent = buildExpectedSpanEvent();
 
+        transactionAgentAttributes.put(HTTP_STATUS, httpResponseCode);
+        transactionAgentAttributes.put(HTTP_STATUS_MESSAGE, httpResponseMessage);
         transactionAgentAttributes.put(RESPONSE_CONTENT_TYPE_PARAMETER_NAME, contentType);
 
         when(txnData.getAgentAttributes()).thenReturn(transactionAgentAttributes);


### PR DESCRIPTION
### Overview
Restores removed http attributes from Transactions and Spans under a configuration option.
By default sends both legacy and standard attributes.

### Related Github Issue
Fixes #1662 

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
