### PR TITLE
Memory Heap issue with ning instrumentation #783

### DIFF
--- a/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -76,6 +76,7 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
+            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
         Weaver.callOriginal();
@@ -118,6 +119,7 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
+            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
 

--- a/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -73,6 +73,7 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
+            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
         Weaver.callOriginal();
@@ -108,6 +109,7 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
+            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
 

--- a/instrumentation/ning-async-http-client-1.6.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.6.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -73,6 +73,7 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
+            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
         Weaver.callOriginal();
@@ -108,6 +109,7 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
+            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
 


### PR DESCRIPTION
### Overview
We've tried to reproduce the issue with the ning instrumentation, but were not able to.

The evidence shows that objects of the extension class that holds the new fields were left behind.
While reviewing the code for the ning instrumentation, it was noticed that one of the new fields was not nulled like the others. While this will not make the extension objects eligible for GC, it might at least make the response objects eligible, possibly lessening the problem.

### Related Github Issue
#783 

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
