### PR TITLE
Adding status code to grpc-1.40.0 client instrumentation

### DIFF
--- a/instrumentation/grpc-1.40.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
+++ b/instrumentation/grpc-1.40.0/src/main/java/io/grpc/ClientCall_Instrumentation.java
@@ -108,6 +108,7 @@ public class ClientCall_Instrumentation<ReqT, RespT> {
                             .uri(uri)
                             .procedure(methodDescriptor.getFullMethodName())
                             .inboundHeaders(wrapper)
+                            .status(status.getCode().value(), status.getDescription())
                             .build();
                     if (segment != null) {
                         segment.reportAsExternal(params);


### PR DESCRIPTION
### Overview
The grpc-1.40.0 instrumentation was missing a line that set the status code/message on grpc client spans.
This PR adds that line.

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
