### PR TITLE
Fix since in AttributesConfig#{isLegacyHttpAttr, isStandardHttpAttr}

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AttributesConfig.java
@@ -21,13 +21,13 @@ public interface AttributesConfig {
 
     /**
      * Whether the old http attributes (httpResponseCode, httpResponseMessage) should be sent.
-     * @since 8.8.1
+     * @since 8.8.0
      */
     boolean isLegacyHttpAttr();
 
     /**
      * Whether the new http attributes (http.statusCode, http.statusText) should be sent.
-     * @since 8.8.1
+     * @since 8.8.0
      */
     boolean isStandardHttpAttr();
 }


### PR DESCRIPTION
### Overview
Initially those methods were supposed to go into the 8.8.1 release, but they made it into the 8.8.0 release.
