### PR TITLE
Removing printing of stack trace in SlowTransactionManager

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/slowtransactions/SlowTransactionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/slowtransactions/SlowTransactionService.java
@@ -196,7 +196,6 @@ public class SlowTransactionService extends AbstractService implements ExtendedT
             attributes.put("code.stacktrace", stackTraceString(scrubbedStackTraceElements));
         }
 
-        new IllegalArgumentException().printStackTrace();
         return attributes;
     }
 


### PR DESCRIPTION
### Overview
Some debug code was not removed when slow transaction tracking was introduced.

Fixes #1680 