### PR TITLE
CSEC Java Agent Public Release 1.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The agent version.
 agentVersion=8.9.0
-securityAgentVersion=1.1.0-public-preview
+securityAgentVersion=1.1.0
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The agent version.
 agentVersion=8.9.0
-securityAgentVersion=1.0.7-public-preview
+securityAgentVersion=1.1.0-public-preview
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m

--- a/newrelic-agent/src/main/resources/META-INF/excludes
+++ b/newrelic-agent/src/main/resources/META-INF/excludes
@@ -6,7 +6,7 @@
 //To resolve class circularity error
 ^javax/crypto/BadPaddingException
 ^javax/crypto/SecretKey
-//This is to avoid vulnerabilities flagged in NR APM code
+//Remove ThreadLocal Weak Random Class Instrumentation
 ^java/util/concurrent/ThreadLocalRandom
 ^(org/objectweb/asm/|javax/xml/|org/apache/juli/)(.*)
 # Don't instrument agent threads

--- a/newrelic-agent/src/main/resources/META-INF/excludes
+++ b/newrelic-agent/src/main/resources/META-INF/excludes
@@ -3,6 +3,11 @@
 ^java/io/(BufferedOutputStream|ByteArrayOutputStream|DataOutputStream|FilterOutputStream|ObjectOutputStream|PipedOutputStream)
 ^java/lang/(NullOutputStream|ProcessPipeOutputStream)
 ^java/net/SocketOutputStream
+//To resolve class circularity error
+^javax/crypto/BadPaddingException
+^javax/crypto/SecretKey
+//This is to avoid vulnerabilities flagged in NR APM code
+^java/util/concurrent/ThreadLocalRandom
 ^(org/objectweb/asm/|javax/xml/|org/apache/juli/)(.*)
 # Don't instrument agent threads
 ^com/newrelic/agent/.*AgentThread.*


### PR DESCRIPTION
CSEC version bump to 1.1.0
[NR-214326]: Fix class circularity error by introducing excludes