### PR TITLE
Making sure that Transaction Log reservoir is no bigger than it needs

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorLogSenderService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorLogSenderService.java
@@ -87,7 +87,7 @@ class IntrospectorLogSenderService implements LogSenderService {
     }
 
     @Override
-    public Logs getTransactionLogs(AgentConfig config) {
+    public Logs getTransactionLogs() {
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -620,8 +620,7 @@ public class Transaction {
     public Logs getLogEventData() {
         Logs logEventData = logEvents.get();
         if (logEventData == null) {
-            AgentConfig defaultConfig = ServiceFactory.getConfigService().getDefaultAgentConfig();
-            logEvents.compareAndSet(null, ServiceFactory.getServiceManager().getLogSenderService().getTransactionLogs(defaultConfig));
+            logEvents.compareAndSet(null, ServiceFactory.getServiceManager().getLogSenderService().getTransactionLogs());
             logEventData = logEvents.get();
         }
         return logEventData;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderService.java
@@ -24,7 +24,7 @@ public interface LogSenderService extends EventService, Logs {
      * Returns an insights instance used to track events created during a transaction. The events will be reported to
      * the Transaction's application, or to the default application if not in a transaction.
      */
-    Logs getTransactionLogs(AgentConfig config);
+    Logs getTransactionLogs();
 
     /**
      * Store event into Reservoir following usual sampling using the given appName. Preference should be given to

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
@@ -578,8 +578,8 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
     }
 
     @Override
-    public Logs getTransactionLogs(AgentConfig config) {
-        return new TransactionLogs(config, contextDataKeyFilter);
+    public Logs getTransactionLogs() {
+        return new TransactionLogs(maxSamplesStored, contextDataKeyFilter);
     }
 
     /**
@@ -589,8 +589,7 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
         private final LinkedBlockingQueue<LogEvent> events;
         private final ExcludeIncludeFilter contextDataKeyFilter;
 
-        TransactionLogs(AgentConfig config, ExcludeIncludeFilter contextDataKeyFilter) {
-            int maxSamplesStored = config.getApplicationLoggingConfig().getMaxSamplesStored();
+        TransactionLogs(int maxSamplesStored, ExcludeIncludeFilter contextDataKeyFilter) {
             events = new LinkedBlockingQueue<>(maxSamplesStored);
             this.contextDataKeyFilter = contextDataKeyFilter;
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
@@ -40,6 +40,7 @@ public class LogSenderServiceImplTest {
     private static final HarvestService harvestService = Mockito.mock(HarvestService.class);
     private static final TransactionService txService = Mockito.mock(TransactionService.class);
     private static final StatsService statsService = Mockito.mock(StatsService.class);
+    private static final int LOG_FORWARDING_MAX_SAMPLES_STORED = 100; // should be enough for testing
 
     private static LogSenderServiceImpl createService() throws Exception {
         return createService(createConfig());
@@ -89,7 +90,7 @@ public class LogSenderServiceImplTest {
         when(ServiceFactory.getTransactionService().getTransaction(false)).thenReturn(transaction);
 
         LogSenderServiceImpl.TransactionLogs logs = new LogSenderServiceImpl.TransactionLogs(
-                AgentConfigImpl.createAgentConfig(Collections.emptyMap()), allowAllFilter());
+                LOG_FORWARDING_MAX_SAMPLES_STORED, allowAllFilter());
         when(transaction.getLogEventData()).thenReturn(logs);
         when(transaction.getApplicationName()).thenReturn(appName);
         when(transaction.isInProgress()).thenReturn(true);
@@ -145,7 +146,7 @@ public class LogSenderServiceImplTest {
         when(ServiceFactory.getTransactionService().getTransaction(false)).thenReturn(transaction);
 
         LogSenderServiceImpl.TransactionLogs logs = new LogSenderServiceImpl.TransactionLogs(
-                AgentConfigImpl.createAgentConfig(Collections.emptyMap()), allowAllFilter());
+                LOG_FORWARDING_MAX_SAMPLES_STORED, allowAllFilter());
         when(transaction.getLogEventData()).thenReturn(logs);
         when(transaction.getApplicationName()).thenReturn(appName);
         when(transaction.isInProgress()).thenReturn(true);
@@ -173,7 +174,7 @@ public class LogSenderServiceImplTest {
         when(ServiceFactory.getTransactionService().getTransaction(false)).thenReturn(transaction);
 
         LogSenderServiceImpl.TransactionLogs logs = new LogSenderServiceImpl.TransactionLogs(
-                AgentConfigImpl.createAgentConfig(Collections.emptyMap()), allowAllFilter());
+                LOG_FORWARDING_MAX_SAMPLES_STORED, allowAllFilter());
         when(transaction.getLogEventData()).thenReturn(logs);
         when(transaction.getApplicationName()).thenReturn(appName);
         when(transaction.isInProgress()).thenReturn(true);


### PR DESCRIPTION
### Overview
When a transaction log reservoir is created, its max size is retrieved from `application_logging.forwarding.max_samples_stored`.

This configuration value is the number of log lines that should be sent per minute. But log events are in a fast harvest cycle and are harvested every 5 seconds.

So this PR changes the way that these reservoirs are created to use the `maxSamplesStored` in `LogSenderServiceImpl` which already has the correct value.

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
