### PR TITLE
Decrease log instrumentation overhead when log forwarding is disabled account wide #1572

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/HarvestServiceImpl.java
@@ -50,7 +50,7 @@ public class HarvestServiceImpl extends AbstractService implements HarvestServic
     private static final long INITIAL_DELAY_IN_MILLISECONDS = TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS);
     private static final long REPORTING_PERIOD_IN_MILLISECONDS = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
     private static final long MIN_HARVEST_INTERVAL_IN_NANOSECONDS = TimeUnit.NANOSECONDS.convert(55, TimeUnit.SECONDS);
-    private static final String HARVEST_LIMITS = "harvest_limits";
+    public static final String HARVEST_LIMITS = "harvest_limits";
     private static final String REPORT_PERIOD_MS = "report_period_ms";
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
@@ -9,7 +9,6 @@ package com.newrelic.agent.config;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.newrelic.agent.Agent;
 import com.newrelic.agent.HarvestServiceImpl;
 import com.newrelic.agent.browser.BrowserConfig;
 import com.newrelic.agent.config.internal.DeepMapClone;
@@ -24,7 +23,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 
 import static com.newrelic.agent.config.SpanEventsConfig.SERVER_SPAN_HARVEST_CONFIG;
 
@@ -242,7 +240,6 @@ public class AgentConfigFactory {
             if (harvestLimits instanceof Map) {
                 Object logLimit = ((Map<?,?>) harvestLimits).get(CollectorMethods.LOG_EVENT_DATA);
                 if (logLimit instanceof Number && ((Number) logLimit).intValue() == 0) {
-                    Agent.LOG.log(Level.WARNING, "Application logging forwarding is disabled in the account.");
                     String loggingForwardingEnabled = AgentConfigImpl.APPLICATION_LOGGING + "." + ApplicationLoggingConfigImpl.FORWARDING + "." +
                             ApplicationLoggingForwardingConfig.ENABLED;
                     addServerProp(loggingForwardingEnabled, false, settings);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigFactoryTest.java
@@ -7,7 +7,9 @@
 
 package com.newrelic.agent.config;
 
+import com.newrelic.agent.HarvestServiceImpl;
 import com.newrelic.agent.database.SqlObfuscator;
+import com.newrelic.agent.transport.CollectorMethods;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -218,4 +220,48 @@ public class AgentConfigFactoryTest {
         Assert.assertEquals(expected, settings.get("one"));
     }
 
+    @Test
+    public void loggingDisabledServerSideOverride() {
+        Map<String, Object> localSettings = logForwardingSettingsEnabled(true);
+        Map<String, Object> serverSettings = loggingHarvestLimit(0);
+        AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
+        Assert.assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
+    }
+
+    @Test
+    public void loggingEnabledServerSideOverride() {
+        Map<String, Object> localSettings = logForwardingSettingsEnabled(true);
+        Map<String, Object> serverSettings = loggingHarvestLimit(10);
+        AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
+        Assert.assertTrue(config.getApplicationLoggingConfig().isForwardingEnabled());
+    }
+
+    @Test
+    public void loggingDisabledLocally() {
+        Map<String, Object> localSettings = logForwardingSettingsEnabled(false);
+        Map<String, Object> serverSettings = loggingHarvestLimit(10);
+        AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
+        Assert.assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
+    }
+
+    private Map<String, Object> logForwardingSettingsEnabled(boolean enabled) {
+        Map<String, Object> localSettings = createMap();
+        Map<String, Object> loggingSettings = createMap();
+        Map<String, Object> forwardingSettings = createMap();
+
+        localSettings.put(AgentConfigImpl.APPLICATION_LOGGING, loggingSettings);
+        loggingSettings.put(ApplicationLoggingConfigImpl.FORWARDING, forwardingSettings);
+        forwardingSettings.put(ApplicationLoggingForwardingConfig.ENABLED, enabled);
+        return localSettings;
+    }
+
+    private Map<String, Object> loggingHarvestLimit(int limit) {
+        Map<String, Object> serverSettings = createMap();
+        Map<String, Object> harvestConfig = createMap();
+        Map<String, Object> harvestLimits = createMap();
+        serverSettings.put(AgentConfigFactory.EVENT_HARVEST_CONFIG, harvestConfig);
+        harvestConfig.put(HarvestServiceImpl.HARVEST_LIMITS, harvestLimits);
+        harvestLimits.put(CollectorMethods.LOG_EVENT_DATA, limit);
+        return serverSettings;
+    }
 }


### PR DESCRIPTION
### Overview
To solve the problems on #1572 this PR adds a server property to the base config. The property `application_logging.forwarding.enabled` will be set to false when the harvest limit for log events is 0.

It was added as a property rather than calculated in `ApplicationLoggingForwardingConfig` because the instrumentation modules do not have access to the config objects and have to query for the properties using the Config interface.

### Related Github Issue
Fixes #1572 

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
