### PR TITLE
Zio 1 update

### DIFF
--- a/instrumentation/newrelic-scala-zio-api/src/main/scala/com/newrelic/zio/api/Util.scala
+++ b/instrumentation/newrelic-scala-zio-api/src/main/scala/com/newrelic/zio/api/Util.scala
@@ -12,13 +12,14 @@ object Util {
          } else {
            body.bimap(
              error => {
+               AgentBridge.activeToken.remove()
                tracer.finish(new Throwable("ZIO txn body fail"))
                error
              },
              success => {
+               AgentBridge.activeToken.remove()
                tracer.finish(172, null)
                success
              })
          })
-
 }

--- a/instrumentation/zio/src/main/java/zio/internal/Utils.java
+++ b/instrumentation/zio/src/main/java/zio/internal/Utils.java
@@ -11,14 +11,10 @@ public class Utils {
 
   public static AgentBridge.TokenAndRefCount getThreadTokenAndRefCount() {
     AgentBridge.TokenAndRefCount tokenAndRefCount = AgentBridge.activeToken.get();
-    if (tokenAndRefCount == null) {
-      Transaction tx = AgentBridge.getAgent().getTransaction(false);
-      if (tx != null) {
-        tokenAndRefCount = new AgentBridge.TokenAndRefCount(tx.getToken(),
-                                                            AgentBridge.getAgent().getTracedMethod(), new AtomicInteger(1));
-      }
-    } else {
-      tokenAndRefCount.refCount.incrementAndGet();
+    Transaction tx = AgentBridge.getAgent().getTransaction(false);
+    if (tx != null) {
+      tokenAndRefCount = new AgentBridge.TokenAndRefCount(tx.getToken(),
+                                                          AgentBridge.getAgent().getTracedMethod(), new AtomicInteger(1));
     }
     return tokenAndRefCount;
   }

--- a/instrumentation/zio/src/main/java/zio/internal/Utils.java
+++ b/instrumentation/zio/src/main/java/zio/internal/Utils.java
@@ -28,7 +28,7 @@ public class Utils {
 
   public static void clearThreadTokenAndRefCountAndTxn(AgentBridge.TokenAndRefCount tokenAndRefCount) {
     AgentBridge.activeToken.remove();
-    if (tokenAndRefCount != null && tokenAndRefCount.refCount.decrementAndGet() == 0) {
+    if (tokenAndRefCount != null) { //removed a call to decrement the ref count as it is no longer being used
       tokenAndRefCount.token.expire();
       tokenAndRefCount.token = null;
     }


### PR DESCRIPTION
**WIP: Do not merge**

Explicitly kill the tokens when the tracer around a ZIO transaction finishes. Do not increment a refcount. 

Adds a unit test with back-to-back transactions. 