### PR TITLE
CSEC Version bump to 1.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The agent version.
 agentVersion=8.10.0
-securityAgentVersion=1.1.0
+securityAgentVersion=1.1.1
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -402,11 +402,6 @@ common: &default_settings
     # true, the security module will run but data will not be sent. Default is false.
     enabled: false
 
-    # Determines whether the low priority attack/vulnerability modules will instrument or not.
-    # When this is disabled instrumentation of such modules will be skipped and vice versa, default is false.
-    low-priority-instrumentation:
-      enabled: false
-
     # New Relic Security provides two modes: IAST and RASP
     # Default is IAST. Due to the invasive nature of IAST scanning, DO NOT enable this mode in either a
     # production environment or an environment where production data is processed.


### PR DESCRIPTION
CSEC Version bump to [1.1.1](https://github.com/newrelic/csec-java-agent/releases/tag/1.1.1) 
Remove config to enable/disable low-priority-instrumentation, from 1.1.1 onwards these modules are enabled by default.
