### PR TITLE
Revert "Making sure that Transaction Log reservoir is no bigger than …

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorLogSenderService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorLogSenderService.java
@@ -87,7 +87,7 @@ class IntrospectorLogSenderService implements LogSenderService {
     }
 
     @Override
-    public Logs getTransactionLogs() {
+    public Logs getTransactionLogs(AgentConfig config) {
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -620,7 +620,8 @@ public class Transaction {
     public Logs getLogEventData() {
         Logs logEventData = logEvents.get();
         if (logEventData == null) {
-            logEvents.compareAndSet(null, ServiceFactory.getServiceManager().getLogSenderService().getTransactionLogs());
+            AgentConfig defaultConfig = ServiceFactory.getConfigService().getDefaultAgentConfig();
+            logEvents.compareAndSet(null, ServiceFactory.getServiceManager().getLogSenderService().getTransactionLogs(defaultConfig));
             logEventData = logEvents.get();
         }
         return logEventData;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderService.java
@@ -24,7 +24,7 @@ public interface LogSenderService extends EventService, Logs {
      * Returns an insights instance used to track events created during a transaction. The events will be reported to
      * the Transaction's application, or to the default application if not in a transaction.
      */
-    Logs getTransactionLogs();
+    Logs getTransactionLogs(AgentConfig config);
 
     /**
      * Store event into Reservoir following usual sampling using the given appName. Preference should be given to

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
@@ -578,8 +578,8 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
     }
 
     @Override
-    public Logs getTransactionLogs() {
-        return new TransactionLogs(maxSamplesStored, contextDataKeyFilter);
+    public Logs getTransactionLogs(AgentConfig config) {
+        return new TransactionLogs(config, contextDataKeyFilter);
     }
 
     /**
@@ -589,7 +589,8 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
         private final LinkedBlockingQueue<LogEvent> events;
         private final ExcludeIncludeFilter contextDataKeyFilter;
 
-        TransactionLogs(int maxSamplesStored, ExcludeIncludeFilter contextDataKeyFilter) {
+        TransactionLogs(AgentConfig config, ExcludeIncludeFilter contextDataKeyFilter) {
+            int maxSamplesStored = config.getApplicationLoggingConfig().getMaxSamplesStored();
             events = new LinkedBlockingQueue<>(maxSamplesStored);
             this.contextDataKeyFilter = contextDataKeyFilter;
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
@@ -40,7 +40,6 @@ public class LogSenderServiceImplTest {
     private static final HarvestService harvestService = Mockito.mock(HarvestService.class);
     private static final TransactionService txService = Mockito.mock(TransactionService.class);
     private static final StatsService statsService = Mockito.mock(StatsService.class);
-    private static final int LOG_FORWARDING_MAX_SAMPLES_STORED = 100; // should be enough for testing
 
     private static LogSenderServiceImpl createService() throws Exception {
         return createService(createConfig());
@@ -90,7 +89,7 @@ public class LogSenderServiceImplTest {
         when(ServiceFactory.getTransactionService().getTransaction(false)).thenReturn(transaction);
 
         LogSenderServiceImpl.TransactionLogs logs = new LogSenderServiceImpl.TransactionLogs(
-                LOG_FORWARDING_MAX_SAMPLES_STORED, allowAllFilter());
+                AgentConfigImpl.createAgentConfig(Collections.emptyMap()), allowAllFilter());
         when(transaction.getLogEventData()).thenReturn(logs);
         when(transaction.getApplicationName()).thenReturn(appName);
         when(transaction.isInProgress()).thenReturn(true);
@@ -146,7 +145,7 @@ public class LogSenderServiceImplTest {
         when(ServiceFactory.getTransactionService().getTransaction(false)).thenReturn(transaction);
 
         LogSenderServiceImpl.TransactionLogs logs = new LogSenderServiceImpl.TransactionLogs(
-                LOG_FORWARDING_MAX_SAMPLES_STORED, allowAllFilter());
+                AgentConfigImpl.createAgentConfig(Collections.emptyMap()), allowAllFilter());
         when(transaction.getLogEventData()).thenReturn(logs);
         when(transaction.getApplicationName()).thenReturn(appName);
         when(transaction.isInProgress()).thenReturn(true);
@@ -174,7 +173,7 @@ public class LogSenderServiceImplTest {
         when(ServiceFactory.getTransactionService().getTransaction(false)).thenReturn(transaction);
 
         LogSenderServiceImpl.TransactionLogs logs = new LogSenderServiceImpl.TransactionLogs(
-                LOG_FORWARDING_MAX_SAMPLES_STORED, allowAllFilter());
+                AgentConfigImpl.createAgentConfig(Collections.emptyMap()), allowAllFilter());
         when(transaction.getLogEventData()).thenReturn(logs);
         when(transaction.getApplicationName()).thenReturn(appName);
         when(transaction.isInProgress()).thenReturn(true);


### PR DESCRIPTION
…it needs (#1728)"

This reverts commit ec31620a9d14efb81a5284297953a50f02f27790.

### Overview
The new calculation for the Transaction log reservoir size showed some strange behavior in snapshot builds of the agent.

Reverting the changes for now and will open a ticket to fix the calculation.