### PR TITLE
Allowing TransactionLog to be instantiated with max_samples_stored = 0

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/DistributedSamplingPriorityQueue.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/DistributedSamplingPriorityQueue.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Queues;
 import com.newrelic.agent.interfaces.SamplingPriorityQueue;
 import com.newrelic.agent.model.PriorityAware;
 import com.newrelic.agent.tracing.DistributedTraceUtil;
+import com.newrelic.agent.util.NoOpQueue;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -183,108 +184,4 @@ public class DistributedSamplingPriorityQueue<E extends PriorityAware> implement
         data.clear();
     }
 
-    private static final class NoOpQueue<E extends PriorityAware> implements Queue<E> {
-        @Override
-        public boolean add(E e) {
-            return false;
-        }
-
-        @Override
-        public boolean offer(E e) {
-            return false;
-        }
-
-        @Override
-        public E remove() {
-            return null;
-        }
-
-        @Override
-        public E poll() {
-            return null;
-        }
-
-        @Override
-        public E element() {
-            return null;
-        }
-
-        @Override
-        public E peek() {
-            return null;
-        }
-
-        @Override
-        public int size() {
-            return 0;
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return true;
-        }
-
-        @Override
-        public boolean contains(Object o) {
-            return false;
-        }
-
-        @Override
-        public Iterator<E> iterator() {
-            return new Iterator<E>() {
-                @Override
-                public boolean hasNext() {
-                    return false;
-                }
-
-                @Override
-                public void remove() {
-                }
-
-                @Override
-                public E next() {
-                    return null;
-                }
-            };
-        }
-
-        @Override
-        public Object[] toArray() {
-            return new Object[0];
-        }
-
-        @Override
-        public <T> T[] toArray(T[] a) {
-            return null;
-        }
-
-        @Override
-        public boolean remove(Object o) {
-            return false;
-        }
-
-        @Override
-        public boolean containsAll(Collection<?> c) {
-            return false;
-        }
-
-        @Override
-        public boolean addAll(Collection<? extends E> c) {
-            return false;
-        }
-
-        @Override
-        public boolean removeAll(Collection<?> c) {
-            return false;
-        }
-
-        @Override
-        public boolean retainAll(Collection<?> c) {
-            return false;
-        }
-
-        @Override
-        public void clear() {
-        }
-    }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/logging/LogSenderServiceImpl.java
@@ -38,6 +38,7 @@ import com.newrelic.agent.stats.StatsWork;
 import com.newrelic.agent.stats.TransactionStats;
 import com.newrelic.agent.tracing.DistributedTraceServiceImpl;
 import com.newrelic.agent.transport.HttpError;
+import com.newrelic.agent.util.NoOpQueue;
 import com.newrelic.api.agent.Logs;
 
 import java.text.MessageFormat;
@@ -47,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -586,12 +588,12 @@ public class LogSenderServiceImpl extends AbstractService implements LogSenderSe
      * Used to record LogEvents on Transactions
      */
     public static final class TransactionLogs implements Logs {
-        private final LinkedBlockingQueue<LogEvent> events;
+        private final Queue<LogEvent> events;
         private final ExcludeIncludeFilter contextDataKeyFilter;
 
         TransactionLogs(AgentConfig config, ExcludeIncludeFilter contextDataKeyFilter) {
             int maxSamplesStored = config.getApplicationLoggingConfig().getMaxSamplesStored();
-            events = new LinkedBlockingQueue<>(maxSamplesStored);
+            events = maxSamplesStored == 0 ? NoOpQueue.getInstance() : new LinkedBlockingQueue<>(maxSamplesStored);
             this.contextDataKeyFilter = contextDataKeyFilter;
         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/NoOpQueue.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/NoOpQueue.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.util;
+
+import com.newrelic.agent.model.LogEvent;
+import com.newrelic.agent.model.PriorityAware;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Queue;
+
+public final class NoOpQueue<E extends PriorityAware> implements Queue<E> {
+    private static final Queue<? extends PriorityAware> INSTANCE = new NoOpQueue<>();
+
+    public static <T extends PriorityAware> Queue<T> getInstance() {
+        return (Queue<T>) INSTANCE;
+    }
+
+    @Override
+    public boolean add(E e) {
+        return false;
+    }
+
+    @Override
+    public boolean offer(E e) {
+        return false;
+    }
+
+    @Override
+    public E remove() {
+        return null;
+    }
+
+    @Override
+    public E poll() {
+        return null;
+    }
+
+    @Override
+    public E element() {
+        return null;
+    }
+
+    @Override
+    public E peek() {
+        return null;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return false;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return new Object[0];
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return null;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public void clear() {
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
@@ -12,6 +12,7 @@ import com.newrelic.agent.attributes.ExcludeIncludeFilter;
 import com.newrelic.agent.attributes.ExcludeIncludeFilterImpl;
 import com.newrelic.agent.bridge.logging.LogAttributeKey;
 import com.newrelic.agent.bridge.logging.LogAttributeType;
+import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.ApplicationLoggingConfigImpl;
 import com.newrelic.agent.config.ApplicationLoggingForwardingConfig;
@@ -162,6 +163,33 @@ public class LogSenderServiceImplTest {
 
         assertEquals(0, analyticsData.getEvents().size());
         assertEquals(3, logs.getEventsForTesting().size());
+    }
+
+    @Test
+    public void testTransactionLogsMaxSamplesStoredIs0() throws Exception{
+        LogSenderServiceImpl logSenderService = createService(createConfig(null, 180));
+        Transaction transaction = Mockito.mock(Transaction.class);
+        when(ServiceFactory.getTransactionService().getTransaction(false)).thenReturn(transaction);
+
+        Map<String, Object> settings = Collections.singletonMap("application_logging", Collections.singletonMap("forwarding", Collections.singletonMap("max_samples_stored", 0)));
+        AgentConfig agentConfig = AgentConfigImpl.createAgentConfig(settings);
+        LogSenderServiceImpl.TransactionLogs logs = new LogSenderServiceImpl.TransactionLogs(agentConfig, allowAllFilter());
+        when(transaction.getLogEventData()).thenReturn(logs);
+        when(transaction.getApplicationName()).thenReturn(appName);
+        when(transaction.isInProgress()).thenReturn(true);
+
+        logSenderService.recordLogEvent(createAgentLogAttrs("field", "value"));
+        logSenderService.recordLogEvent(createAgentLogAttrs("field2", "value2"));
+        logSenderService.recordLogEvent(createAgentLogAttrs("field3", "value3"));
+
+        MockRPMService analyticsData = new MockRPMService();
+        when(ServiceFactory.getServiceManager().getRPMServiceManager().getOrCreateRPMService(appName)).thenReturn(
+                analyticsData);
+
+        logSenderService.harvestHarvestables();
+
+        assertEquals(0, analyticsData.getEvents().size());
+        assertEquals(0, logs.getEventsForTesting().size());
     }
 
     @Test


### PR DESCRIPTION
### Overview
When the agent is configured to allow log forwarding but the max_samples_stored is configured to 0, a BlockingQueue was instantiated with size 0, which is illegal.

This PR changes the implementation being instantiated to a NoopQueue instead.
