### PR TITLE
NPE guard in AgentAttributeSender.removeAttribute()

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AgentAttributeSender.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AgentAttributeSender.java
@@ -34,6 +34,10 @@ public class AgentAttributeSender extends AttributeSender {
     }
 
     public void removeAttribute(String key) {
+        Map<String, Object> attributeMap = getAttributeMap();
+        if (attributeMap == null) {
+            return;
+        }
         getAttributeMap().remove(key);
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AgentAttributeSender.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/attributes/AgentAttributeSender.java
@@ -38,7 +38,7 @@ public class AgentAttributeSender extends AttributeSender {
         if (attributeMap == null) {
             return;
         }
-        getAttributeMap().remove(key);
+        attributeMap.remove(key);
     }
 
 }

--- a/newrelic-agent/src/test/java/com/newrelic/api/agent/NewRelicApiImplementationTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/api/agent/NewRelicApiImplementationTest.java
@@ -275,6 +275,21 @@ public class NewRelicApiImplementationTest {
     }
 
     @Test
+    public void setUserId_withoutActiveTxn_isNoOp() {
+        mockOutServices();
+        AttributeSender mockSender = Mockito.mock(AttributeSender.class);
+        AgentAttributeSender mockAgentSender = new AgentAttributeSender();
+        NewRelicApiImplementation target = new NewRelicApiImplementation(mockSender, mockAgentSender);
+
+        try(MockedStatic<Transaction> mockTxn = Mockito.mockStatic(Transaction.class)) {
+            mockTxn.when(() -> Transaction.getTransaction(false)).thenReturn(null);
+            //These used to throw an NPE when there was no active transaction so the "assertion" is that these method calls execute without an exception
+            target.setUserId(null);
+            target.setUserId("");
+        }
+    }
+
+    @Test
     public void setUserName_withValidName_setsNameAttribute() {
         mockOutServices();
         AttributeSender mockSender = Mockito.mock(AttributeSender.class);


### PR DESCRIPTION
Resolves #1749 

Add an NPE check prior to calling `.remove()` on the return value from `getAttributeMap()`.

This corrects the issue where `NewRelicApiImplementation.setUserId()` was throwing an exception when called outside of a transaction.