### PR TITLE
Cap kafka-clients-metrics-3.0.0 supported version

### DIFF
--- a/instrumentation/kafka-clients-metrics-3.0.0/build.gradle
+++ b/instrumentation/kafka-clients-metrics-3.0.0/build.gradle
@@ -6,17 +6,14 @@ dependencies {
     testImplementation("org.testcontainers:kafka:1.16.3")
 }
 
-
-
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.kafka-clients-metrics-3.0.0',
             'Implementation-Title-Alias': 'kafka-clients-metrics' }
 }
 
 verifyInstrumentation {
-    passesOnly 'org.apache.kafka:kafka-clients:[3.0.0,)'
+    passesOnly 'org.apache.kafka:kafka-clients:[3.0.0,3.7.0)'
 }
-
 
 site {
     title 'Kafka'


### PR DESCRIPTION
Related verifier failures: https://github.com/newrelic/newrelic-java-agent/issues/1766
