### PR TITLE
Fix implementation title for the zio modules

### DIFF
--- a/instrumentation/zio-2/build.gradle
+++ b/instrumentation/zio-2/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.zio',
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.zio-2',
             'Implementation-Title-Alias': 'zio_instrumentation' }
 }
 

--- a/instrumentation/zio/build.gradle
+++ b/instrumentation/zio/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.zio-2',
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.zio',
             'Implementation-Title-Alias': 'zio_instrumentation' }
 }
 


### PR DESCRIPTION
The zio instrumentation modules have the wrong implementation titles. This PR simply fixes that so the ZIO 1 and ZIO 2 modules are compiled correctly
