### PR TITLE
1757 log sender sends too much

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Harvestable.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Harvestable.java
@@ -72,6 +72,7 @@ public abstract class Harvestable {
 
         if (maxSamplesStored != service.getMaxSamplesStored()) {
             service.setMaxSamplesStored(maxSamplesStored);
+            service.setReportPeriodInMillis(reportPeriodInMillis);
             maybeSendSpanLimitMetric(maxSamplesStored);
             service.harvestEvents(appName);
             service.clearReservoir();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/EventService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/EventService.java
@@ -58,6 +58,15 @@ public interface EventService extends Service {
     void setMaxSamplesStored(int maxSamplesStored);
 
     /**
+     * Update the reporting period for harvesting, in case it is needed for config changes.
+     *
+     * @param reportPeriodInMillis the number of millis between reporting/harvesting cycles
+     */
+    default void setReportPeriodInMillis(long reportPeriodInMillis) {
+        // do nothing
+    }
+
+    /**
      * Reset the event reservoir to allow for the next harvest to start
      */
     void clearReservoir();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/logging/LogSenderServiceImplTest.java
@@ -75,10 +75,13 @@ public class LogSenderServiceImplTest {
     public void testHarvestableConfigure() throws Exception {
         Map<String, Object> config = createConfig(true, 180);
         LogSenderServiceImpl logSenderService = createService(config);
+        assertEquals(833, logSenderService.getMaxSamplesStored());
+        assertEquals(5000, logSenderService.reportPeriodInMillis);
+
         logSenderService.addHarvestableToService(appName);
         logSenderService.configureHarvestables(60, 1);
-
         assertEquals(1, logSenderService.getMaxSamplesStored());
+        assertEquals(60, logSenderService.reportPeriodInMillis);
     }
 
     @Test


### PR DESCRIPTION
Store off the reportPeriodInMillis from the backend, and use it to calculate the proper maxSamplesStored on config file change.