### PR TITLE
Update snakeyaml in agent build.gradle

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -98,7 +98,7 @@ dependencies {
 
     shadowIntoJar('com.github.ben-manes.caffeine:caffeine:2.9.3')
 
-    shadowIntoJar("org.yaml:snakeyaml:1.33")
+    shadowIntoJar("org.yaml:snakeyaml:2.2")
 
     implementation("javax.management.j2ee:management-api:1.1-rev-1") {
         transitive = false

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigHelper.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigHelper.java
@@ -10,6 +10,7 @@ package com.newrelic.agent.config;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.errors.ExceptionHandlerSignature;
 import com.newrelic.agent.instrumentation.methodmatchers.InvalidMethodDescriptor;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -93,6 +94,7 @@ public class AgentConfigHelper {
 
     private static class ExtensionConstructor extends SafeConstructor {
         public ExtensionConstructor() {
+            super(new LoaderOptions());
             yamlConstructors.put(new Tag("!exception_handler"), new AbstractConstruct() {
                 @Override
                 public Object construct(Node node) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionParsers.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionParsers.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 
 import com.newrelic.agent.extension.dom.ExtensionDomParser;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -25,7 +26,7 @@ public class ExtensionParsers {
     private final ExtensionParser xmlParser;
 
     public ExtensionParsers(final List<ConfigurationConstruct> constructs) {
-        SafeConstructor constructor = new SafeConstructor() {
+        SafeConstructor constructor = new SafeConstructor(new LoaderOptions()) {
             {
                 for (ConfigurationConstruct construct : constructs) {
                     this.yamlConstructors.put(new Tag(construct.getName()), construct);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/yaml/InstrumentationConstructor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/yaml/InstrumentationConstructor.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
@@ -32,6 +33,7 @@ public class InstrumentationConstructor extends SafeConstructor {
     public final Collection<ConfigurationConstruct> constructs;
 
     public InstrumentationConstructor() {
+        super(new LoaderOptions());
         constructs = Arrays.asList(new ConstructClassMethodNameFormatDescriptor(), new ConstructChildClassMatcher(),
                 new ConstructNotClassMatcher(), new ConstructAndClassMatcher(), new ConstructOrClassMatcher(),
                 new ConstructExactClassMatcher(), new ConstructInterfaceMatcher(), new ConstructAllMethodsMatcher(),

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxYmlParserTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxYmlParserTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import com.newrelic.agent.config.BaseConfig;
@@ -182,7 +183,7 @@ public class JmxYmlParserTest {
     }
 
     protected static BaseConfig readYml(File file) throws Exception {
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         try (Reader reader = new FileReader(file)) {
             Map output = (Map) yaml.load(reader);
             return new BaseConfig(output);


### PR DESCRIPTION
**WIP: do not merge**

Resolves #1725 

Upgrade snakeyaml dependency from 1.33 to 2.2 due to vulnerability `CVE-2022-1471`

Compatibility changes: A few of our config classes extend `SafeConstructor`. The default constructor for this class was previously deprecated and has been removed for snakeyaml >= 2.0:
```
@Deprecated 
SafeConstructor(){ this(new LoaderOptions()); }
```
Subclasses in the agent have been updated to explicitly call `super(new LoaderOptions())` to match this behavior. 