### PR TITLE
Update lambda regex to ignore missing resource exceptions

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextClassMatcherHelper.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationContextClassMatcherHelper.java
@@ -70,7 +70,7 @@ public class InstrumentationContextClassMatcherHelper {
     }
 
     // lambda classes
-    if (className.contains("$$Lambda$") || className.contains("LambdaForm$")) {
+    if (className.contains("$$Lambda$") || className.contains("$$Lambda/") || className.contains("LambdaForm$")) {
       return true;
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/context/InstrumentationContextClassMatcherHelperTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/context/InstrumentationContextClassMatcherHelperTest.java
@@ -36,6 +36,7 @@ public class InstrumentationContextClassMatcherHelperTest {
     assertTrue(testClass.isMissingResourceExpected(
         "sun.util.locale.provider.JRELocaleProviderAdapter$$Lambda$108"));
     assertTrue(testClass.isMissingResourceExpected("java.lang.invoke.LambdaForm$MH"));
+    assertTrue(testClass.isMissingResourceExpected("java.util.stream.Collectors$$Lambda/0x800000047"));
   }
 
   @Test


### PR DESCRIPTION
Resolves #1759 

Add `$$Lambda/` to list of generated lambda class name patterns. Thrown `MissingResourceException` instances are ignored if the target class matches one of these defined patterns.