### PR TITLE
Excluding Glassfish milestone

### DIFF
--- a/instrumentation/glassfish-6/build.gradle
+++ b/instrumentation/glassfish-6/build.gradle
@@ -16,6 +16,7 @@ verifyInstrumentation {
     exclude 'org.glassfish.main.web:web-core:7.0.0-M4'
     exclude 'org.glassfish.main.web:web-core:7.0.0-M10'
     exclude 'org.glassfish.main.web:web-core:8.0.0-M2'
+    exclude 'org.glassfish.main.web:web-core:8.0.0-M3'
 }
 
 site {


### PR DESCRIPTION
### Overview
New Glassfish milestone is incompatible with the agent. Historically, they released some milestones that were not compatible, but later released others that were. So just leaving as a single exclude for the latest milestone.
