### PR TITLE
Enhance Solr 7+ JMX metrics by including clustered Solr collections which include the collection name, shard name, and (replica) core

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfig.java
@@ -30,4 +30,6 @@ public interface JmxConfig {
      * MBean server.
      */
     boolean registerLinkingMetadataMBean();
+
+    boolean enableIteratedObjectNameKeys();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
@@ -16,7 +16,9 @@ class JmxConfigImpl extends BaseConfig implements JmxConfig {
     public static final String ENABLED = "enabled";
     public static final String REGISTER_LINKING_METADATA_MBEAN = "linkingMetadataMBean";
     public static final String DISABLED_JMX_FRAMEWORKS = "disabled_jmx_frameworks";
+    public static final String ENABLE_ITERATED_OBJECTNAME_KEYS = "enabledIteratedObjectNameKeys";
     public static final boolean DEFAULT_REGISTER_LINKING_METADATA_MBEAN = false;
+    public static final boolean DEFAULT_ENABLE_ITERATED_OBJECTNAME_KEYS = true;
     public static final Boolean DEFAULT_ENABLED = Boolean.TRUE;
     public static final String SYSTEM_PROPERTY_ROOT = "newrelic.config.jmx.";
 
@@ -49,5 +51,10 @@ class JmxConfigImpl extends BaseConfig implements JmxConfig {
     @Override
     public boolean registerLinkingMetadataMBean(){
         return getProperty(REGISTER_LINKING_METADATA_MBEAN, DEFAULT_REGISTER_LINKING_METADATA_MBEAN);
+    }
+
+    @Override
+    public boolean enableIteratedObjectNameKeys() {
+        return getProperty(ENABLE_ITERATED_OBJECTNAME_KEYS, DEFAULT_ENABLE_ITERATED_OBJECTNAME_KEYS);
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
@@ -16,7 +16,7 @@ class JmxConfigImpl extends BaseConfig implements JmxConfig {
     public static final String ENABLED = "enabled";
     public static final String REGISTER_LINKING_METADATA_MBEAN = "linkingMetadataMBean";
     public static final String DISABLED_JMX_FRAMEWORKS = "disabled_jmx_frameworks";
-    public static final String ENABLE_ITERATED_OBJECTNAME_KEYS = "enabledIteratedObjectNameKeys";
+    public static final String ENABLE_ITERATED_OBJECTNAME_KEYS = "enable_iterated_objectname_Keys";
     public static final boolean DEFAULT_REGISTER_LINKING_METADATA_MBEAN = false;
     public static final boolean DEFAULT_ENABLE_ITERATED_OBJECTNAME_KEYS = true;
     public static final Boolean DEFAULT_ENABLED = Boolean.TRUE;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JmxConfigImpl.java
@@ -16,7 +16,7 @@ class JmxConfigImpl extends BaseConfig implements JmxConfig {
     public static final String ENABLED = "enabled";
     public static final String REGISTER_LINKING_METADATA_MBEAN = "linkingMetadataMBean";
     public static final String DISABLED_JMX_FRAMEWORKS = "disabled_jmx_frameworks";
-    public static final String ENABLE_ITERATED_OBJECTNAME_KEYS = "enable_iterated_objectname_Keys";
+    public static final String ENABLE_ITERATED_OBJECTNAME_KEYS = "enable_iterated_objectname_keys";
     public static final boolean DEFAULT_REGISTER_LINKING_METADATA_MBEAN = false;
     public static final boolean DEFAULT_ENABLE_ITERATED_OBJECTNAME_KEYS = true;
     public static final Boolean DEFAULT_ENABLED = Boolean.TRUE;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxApiImpl.java
@@ -17,6 +17,7 @@ import com.newrelic.agent.jmx.values.Jboss7UpJmxValues;
 import com.newrelic.agent.jmx.values.JettyJmxMetrics;
 import com.newrelic.agent.jmx.values.KafkaConsumerJmxValues;
 import com.newrelic.agent.jmx.values.KafkaProducerJmxValues;
+import com.newrelic.agent.jmx.values.NonIteratedSolr7JmxValues;
 import com.newrelic.agent.jmx.values.ResinJmxValues;
 import com.newrelic.agent.jmx.values.Solr7JmxValues;
 import com.newrelic.agent.jmx.values.SolrJmxValues;
@@ -55,6 +56,7 @@ public class JmxApiImpl implements JmxApi {
     }
 
     private JmxFrameworkValues getJmxFrameworkValues(String prefixName) {
+        JmxService jmxService = ServiceFactory.getJmxService();
         if (prefixName != null) {
             switch (prefixName) {
                 case KafkaProducerJmxValues.PREFIX:
@@ -68,7 +70,9 @@ public class JmxApiImpl implements JmxApi {
                 case SolrJmxValues.PREFIX:
                     return new SolrJmxValues();
                 case Solr7JmxValues.PREFIX:
-                    return new Solr7JmxValues();
+                    return jmxService.iteratedObjectNameKeysEnabled()
+                            ? new Solr7JmxValues()
+                            : new NonIteratedSolr7JmxValues();
                 case WebsphereLibertyJmxValues.PREFIX:
                     return new WebsphereLibertyJmxValues();
                 case TomcatJmxValues.PREFIX:

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxApiImpl.java
@@ -17,7 +17,7 @@ import com.newrelic.agent.jmx.values.Jboss7UpJmxValues;
 import com.newrelic.agent.jmx.values.JettyJmxMetrics;
 import com.newrelic.agent.jmx.values.KafkaConsumerJmxValues;
 import com.newrelic.agent.jmx.values.KafkaProducerJmxValues;
-import com.newrelic.agent.jmx.values.NonIteratedSolr7JmxValues;
+import com.newrelic.agent.jmx.values.LegacySolr7JmxValues;
 import com.newrelic.agent.jmx.values.ResinJmxValues;
 import com.newrelic.agent.jmx.values.Solr7JmxValues;
 import com.newrelic.agent.jmx.values.SolrJmxValues;
@@ -72,7 +72,7 @@ public class JmxApiImpl implements JmxApi {
                 case Solr7JmxValues.PREFIX:
                     return jmxService.iteratedObjectNameKeysEnabled()
                             ? new Solr7JmxValues()
-                            : new NonIteratedSolr7JmxValues();
+                            : new LegacySolr7JmxValues();
                 case WebsphereLibertyJmxValues.PREFIX:
                     return new WebsphereLibertyJmxValues();
                 case TomcatJmxValues.PREFIX:

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/JmxService.java
@@ -166,6 +166,10 @@ public class JmxService extends AbstractService implements HarvestListener {
         }
     }
 
+    public boolean iteratedObjectNameKeysEnabled() {
+        return jmxConfig.enableIteratedObjectNameKeys();
+    }
+
     private void process(StatsEngine statsEngine, Collection<MBeanServer> srvrList, JmxGet config) {
         ObjectName name = config.getObjectName();
         if (name == null) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/create/JmxGet.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/create/JmxGet.java
@@ -39,8 +39,8 @@ public abstract class JmxGet extends JmxObject {
     private static final Pattern TYPE_QUERY_PATTERN = Pattern.compile(",(.*?)=");
     private static final Pattern PULL_VALUE_PATTERN = Pattern.compile("\\{(.*?)\\}");
     private static final Pattern PULL_ATTRIBUTE_PATTERN = Pattern.compile("\\:(.*?)\\:");
-    private static final Pattern PULL_ITER_VAL_PATTERN = Pattern.compile("for\\:(.*)\\[([0-9]+)\\:([0-9]*)\\].*");
-    private static final Pattern RANGE_PATTERN = Pattern.compile("\\[([0-9]+)\\:([0-9]*)\\]");
+    private static final Pattern PULL_ITER_VAL_PATTERN = Pattern.compile("for\\:(.*)\\[([0-9]+)\\:([0-9]*)\\:(.*)\\].*");
+    private static final Pattern RANGE_PATTERN = Pattern.compile("\\[([0-9]+)\\:([0-9]*)\\:(.*)\\]");
 
     /** This should be everything but the attribute portion of the metric. */
     private final String rootMetricName;
@@ -208,6 +208,10 @@ public abstract class JmxGet extends JmxObject {
         }
         String rangeStartStr = rangeMatcher.group(1);
         String rangeEndStr = rangeMatcher.group(2);
+        String delimiterStr = rangeMatcher.group(3);
+        if (delimiterStr == null || delimiterStr.isEmpty()) {
+            delimiterStr = "/";
+        }
         rangeMatcher.reset();
 
         int rangeStart = (rangeStartStr != null && !rangeStartStr.isEmpty()) ? Integer.parseInt(rangeStartStr): 0;
@@ -230,7 +234,7 @@ public abstract class JmxGet extends JmxObject {
             }
         }
 
-        return String.join("/", valueSequence);
+        return String.join(delimiterStr, valueSequence);
     }
 
     private String getValueFromMBeanKey(String key, Map<String, String> keyProperties,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/metrics/BaseJmxValue.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/metrics/BaseJmxValue.java
@@ -33,20 +33,120 @@ public class BaseJmxValue {
     private final JMXMetricType type;
     private final JmxMetricModifier modifier;
 
+    /**
+     * @param pObjectName
+     *  The object name query string used to search for JMX MBeans
+     * @param pObjectMetricName
+     *  A format string for agent metrics that matches against an MBean's object name.
+     *  An example format would be:
+     *
+     *  <blockquote><pre>
+     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  </pre></blockquote>
+     *
+     *  In the format we have placeholders such as:
+     *  <ul>
+     *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
+     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      sequence of keys starting from a non-negative number <i>start</i>
+     *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
+     *      The placeholder is replaced with an iterated set of values each separated by
+     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      </li>
+     *  </ul>
+     * @param pMetrics
+     */
     public BaseJmxValue(final String pObjectName, final String pObjectMetricName, JmxMetric[] pMetrics) {
         this(pObjectName, pObjectMetricName, null, null, JMXMetricType.INCREMENT_COUNT_PER_BEAN, pMetrics);
     }
 
+    /**
+     *
+     * @param pObjectName
+     *  The object name query string used to search for JMX MBeans
+     * @param pObjectMetricName
+     *  A format string for agent metrics that matches against an MBean's object name.
+     *  An example format would be:
+     *
+     *  <blockquote><pre>
+     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  </pre></blockquote>
+     *
+     *  In the format we have placeholders such as:
+     *  <ul>
+     *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
+     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      sequence of keys starting from a non-negative number <i>start</i>
+     *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
+     *      The placeholder is replaced with an iterated set of values each separated by
+     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      </li>
+     *  </ul>
+     * @param attributeFilter
+     * @param pMetrics
+     */
     public BaseJmxValue(final String pObjectName, final String pObjectMetricName, JmxAttributeFilter attributeFilter,
             JmxMetric[] pMetrics) {
         this(pObjectName, pObjectMetricName, attributeFilter, null, JMXMetricType.INCREMENT_COUNT_PER_BEAN, pMetrics);
     }
 
+    /**
+     *
+     * @param pObjectName
+     *  The object name query string used to search for JMX MBeans
+     * @param pObjectMetricName
+     *  A format string for agent metrics that matches against an MBean's object name.
+     *  An example format would be:
+     *
+     *  <blockquote><pre>
+     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  </pre></blockquote>
+     *
+     *  In the format we have placeholders such as:
+     *  <ul>
+     *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
+     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      sequence of keys starting from a non-negative number <i>start</i>
+     *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
+     *      The placeholder is replaced with an iterated set of values each separated by
+     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      </li>
+     *  </ul>
+     * @param pModifier
+     * @param pMetrics
+     */
     public BaseJmxValue(final String pObjectName, final String pObjectMetricName, JmxMetricModifier pModifier,
             JmxMetric[] pMetrics) {
         this(pObjectName, pObjectMetricName, null, pModifier, JMXMetricType.INCREMENT_COUNT_PER_BEAN, pMetrics);
     }
 
+    /**
+     *
+     * @param pObjectName
+     *  The object name query string used to search for JMX MBeans
+     * @param pObjectMetricName
+     *  A format string for agent metrics that matches against an MBean's object name.
+     *  An example format would be:
+     *
+     *  <blockquote><pre>
+     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  </pre></blockquote>
+     *
+     *  In the format we have placeholders such as:
+     *  <ul>
+     *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
+     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      sequence of keys starting from a non-negative number <i>start</i>
+     *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
+     *      The placeholder is replaced with an iterated set of values each separated by
+     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      </li>
+     *  </ul>
+     * @param attributeFilter
+     * @param pModifier
+     * @param pType
+     * @param pMetrics
+     */
     public BaseJmxValue(final String pObjectName, final String pObjectMetricName, JmxAttributeFilter attributeFilter,
             JmxMetricModifier pModifier, JMXMetricType pType, JmxMetric[] pMetrics) {
         objectNameString = pObjectName;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/metrics/BaseJmxValue.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/metrics/BaseJmxValue.java
@@ -41,17 +41,18 @@ public class BaseJmxValue {
      *  An example format would be:
      *
      *  <blockquote><pre>
-     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  "TheRoot/Wahoo/{type}/{for:key[1::.]}/{otherKey}"
      *  </pre></blockquote>
      *
      *  In the format we have placeholders such as:
      *  <ul>
      *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
-     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      <li><b>{for:%[start:end:delimiter]%}</b> which matches against an iterated
      *      sequence of keys starting from a non-negative number <i>start</i>
      *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
-     *      The placeholder is replaced with an iterated set of values each separated by
-     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      The placeholder is replaced with an iterated set of values each separated by the <i>delimiter</i> or if empty
+     *      "/" by default to follow the agent metric format.
+     *      For example: <b>{for:key[1::]}</b> and <b>{for:keyStart[1:3:.]keyEnd}</b>
      *      </li>
      *  </ul>
      * @param pMetrics
@@ -69,17 +70,18 @@ public class BaseJmxValue {
      *  An example format would be:
      *
      *  <blockquote><pre>
-     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  "TheRoot/Wahoo/{type}/{for:key[1::.]}/{otherKey}"
      *  </pre></blockquote>
      *
      *  In the format we have placeholders such as:
      *  <ul>
      *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
-     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      <li><b>{for:%[start:end:delimiter]%}</b> which matches against an iterated
      *      sequence of keys starting from a non-negative number <i>start</i>
      *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
-     *      The placeholder is replaced with an iterated set of values each separated by
-     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      The placeholder is replaced with an iterated set of values each separated by the <i>delimiter</i> or if empty
+     *      "/" by default to follow the agent metric format.
+     *      For example: <b>{for:key[1::]}</b> and <b>{for:keyStart[1:3:.]keyEnd}</b>
      *      </li>
      *  </ul>
      * @param attributeFilter
@@ -99,17 +101,18 @@ public class BaseJmxValue {
      *  An example format would be:
      *
      *  <blockquote><pre>
-     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  "TheRoot/Wahoo/{type}/{for:key[1::.]}/{otherKey}"
      *  </pre></blockquote>
      *
      *  In the format we have placeholders such as:
      *  <ul>
      *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
-     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      <li><b>{for:%[start:end:delimiter]%}</b> which matches against an iterated
      *      sequence of keys starting from a non-negative number <i>start</i>
      *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
-     *      The placeholder is replaced with an iterated set of values each separated by
-     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      The placeholder is replaced with an iterated set of values each separated by the <i>delimiter</i> or if empty
+     *      "/" by default to follow the agent metric format.
+     *      For example: <b>{for:key[1::]}</b> and <b>{for:keyStart[1:3:.]keyEnd}</b>
      *      </li>
      *  </ul>
      * @param pModifier
@@ -129,17 +132,18 @@ public class BaseJmxValue {
      *  An example format would be:
      *
      *  <blockquote><pre>
-     *  "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}"
+     *  "TheRoot/Wahoo/{type}/{for:key[1::.]}/{otherKey}"
      *  </pre></blockquote>
      *
      *  In the format we have placeholders such as:
      *  <ul>
      *      <li><b>{name}</b> which matches against a key in an object name and replaces it with a value.</li>
-     *      <li><b>{for:%[start:end]%}</b> which matches against an iterated
+     *      <li><b>{for:%[start:end:delimiter]%}</b> which matches against an iterated
      *      sequence of keys starting from a non-negative number <i>start</i>
      *      and ending it exclusively with <i>end</i> or unbounded if <i>end</i> is empty.
-     *      The placeholder is replaced with an iterated set of values each separated by
-     *      "/" to follow the agent metric format. For example: <b>{for:key[1:]}</b> and <b>{for:keyStart[1:3]keyEnd}</b>
+     *      The placeholder is replaced with an iterated set of values each separated by the <i>delimiter</i> or if empty
+     *      "/" by default to follow the agent metric format.
+     *      For example: <b>{for:key[1::]}</b> and <b>{for:keyStart[1:3:.]keyEnd}</b>
      *      </li>
      *  </ul>
      * @param attributeFilter

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/LegacySolr7JmxValues.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/LegacySolr7JmxValues.java
@@ -8,6 +8,16 @@ import com.newrelic.agent.jmx.metrics.JmxMetric;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Legacy JMX values for Solr 7_, replaced by: {@link com.newrelic.agent.jmx.values.Solr7JmxValues}
+ * If the config (via system property) <b>-Dnewrelic.config.jmx.enable_iterated_objectname_keys=false</b> is set
+ * (or the equivalent config is used via yaml or environment variables),
+ * this class has to be used instead of Solr7JmxValues for Solr 7+
+ * <br/><br/>
+ * <b>
+ *     Todo: Remove this class when the temporary config -Dnewrelic.config.jmx.enable_iterated_objectname_keys is removed.
+ * </b>
+ */
 public class LegacySolr7JmxValues extends JmxFrameworkValues {
 
     public static final String PREFIX = "solr7";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/LegacySolr7JmxValues.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/LegacySolr7JmxValues.java
@@ -8,7 +8,7 @@ import com.newrelic.agent.jmx.metrics.JmxMetric;
 import java.util.ArrayList;
 import java.util.List;
 
-public class NonIteratedSolr7JmxValues extends JmxFrameworkValues {
+public class LegacySolr7JmxValues extends JmxFrameworkValues {
 
     public static final String PREFIX = "solr7";
 
@@ -61,7 +61,7 @@ public class NonIteratedSolr7JmxValues extends JmxFrameworkValues {
 
     }
 
-    public NonIteratedSolr7JmxValues() {
+    public LegacySolr7JmxValues() {
         super();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/NonIteratedSolr7JmxValues.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/NonIteratedSolr7JmxValues.java
@@ -1,10 +1,3 @@
-/*
- *
- *  * Copyright 2020 New Relic Corporation. All rights reserved.
- *  * SPDX-License-Identifier: Apache-2.0
- *
- */
-
 package com.newrelic.agent.jmx.values;
 
 import com.newrelic.agent.jmx.JmxType;
@@ -15,7 +8,7 @@ import com.newrelic.agent.jmx.metrics.JmxMetric;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Solr7JmxValues extends JmxFrameworkValues {
+public class NonIteratedSolr7JmxValues extends JmxFrameworkValues {
 
     public static final String PREFIX = "solr7";
 
@@ -36,26 +29,26 @@ public class Solr7JmxValues extends JmxFrameworkValues {
     static {
 
         METRICS.add(new BaseJmxValue(
-                "solr:dom1=core,*,category=CACHE,scope=searcher,name=queryResultCache",
-                "JMX/solr/{for:dom[2:]}/queryResultCache/%/",
+                "solr:dom1=core,dom2=*,category=CACHE,scope=searcher,name=queryResultCache",
+                "JMX/solr/{dom2}/queryResultCache/%/",
                 createCacheMetrics()
         ));
 
         METRICS.add(new BaseJmxValue(
-                "solr:dom1=core,*,category=CACHE,scope=searcher,name=filterCache",
-                "JMX/solr/{for:dom[2:]}/filterCache/%/",
+                "solr:dom1=core,dom2=*,category=CACHE,scope=searcher,name=filterCache",
+                "JMX/solr/{dom2}/filterCache/%/",
                 createCacheMetrics()
         ));
 
         METRICS.add(new BaseJmxValue(
-                "solr:dom1=core,*,category=CACHE,scope=searcher,name=documentCache",
-                "JMX/solr/{for:dom[2:]}/documentCache/%/",
+                "solr:dom1=core,dom2=*,category=CACHE,scope=searcher,name=documentCache",
+                "JMX/solr/{dom2}/documentCache/%/",
                 createCacheMetrics()
         ));
 
         METRICS.add(new BaseJmxValue(
-                "solr:dom1=core,*,category=UPDATE,scope=updateHandler,name=*",
-                "JMX/solr/{for:dom[2:]}/updateHandler/%/{name}",
+                "solr:dom1=core,dom2=*,category=UPDATE,scope=updateHandler,name=*",
+                "JMX/solr/{dom2}/updateHandler/%/{name}",
                 new JmxMetric[] {
                         JmxMetric.create("Value", JmxType.SIMPLE),
                         JmxMetric.create("RateUnit", JmxType.SIMPLE),
@@ -68,7 +61,7 @@ public class Solr7JmxValues extends JmxFrameworkValues {
 
     }
 
-    public Solr7JmxValues() {
+    public NonIteratedSolr7JmxValues() {
         super();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/Solr7JmxValues.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jmx/values/Solr7JmxValues.java
@@ -37,25 +37,25 @@ public class Solr7JmxValues extends JmxFrameworkValues {
 
         METRICS.add(new BaseJmxValue(
                 "solr:dom1=core,*,category=CACHE,scope=searcher,name=queryResultCache",
-                "JMX/solr/{for:dom[2:]}/queryResultCache/%/",
+                "JMX/solr/{for:dom[2::.]}/queryResultCache/%/",
                 createCacheMetrics()
         ));
 
         METRICS.add(new BaseJmxValue(
                 "solr:dom1=core,*,category=CACHE,scope=searcher,name=filterCache",
-                "JMX/solr/{for:dom[2:]}/filterCache/%/",
+                "JMX/solr/{for:dom[2::.]}/filterCache/%/",
                 createCacheMetrics()
         ));
 
         METRICS.add(new BaseJmxValue(
                 "solr:dom1=core,*,category=CACHE,scope=searcher,name=documentCache",
-                "JMX/solr/{for:dom[2:]}/documentCache/%/",
+                "JMX/solr/{for:dom[2::.]}/documentCache/%/",
                 createCacheMetrics()
         ));
 
         METRICS.add(new BaseJmxValue(
                 "solr:dom1=core,*,category=UPDATE,scope=updateHandler,name=*",
-                "JMX/solr/{for:dom[2:]}/updateHandler/%/{name}",
+                "JMX/solr/{for:dom[2::.]}/updateHandler/%/{name}",
                 new JmxMetric[] {
                         JmxMetric.create("Value", JmxType.SIMPLE),
                         JmxMetric.create("RateUnit", JmxType.SIMPLE),

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/JmxApiImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/JmxApiImplTest.java
@@ -1,6 +1,5 @@
 package com.newrelic.agent.jmx;
 
-import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.newrelic.agent.bridge.JmxApi;
 import com.newrelic.agent.jmx.metrics.JmxFrameworkValues;
 import com.newrelic.agent.jmx.values.EmbeddedTomcatDataSourceJmxValues;
@@ -10,6 +9,7 @@ import com.newrelic.agent.jmx.values.Jboss7UpJmxValues;
 import com.newrelic.agent.jmx.values.JettyJmxMetrics;
 import com.newrelic.agent.jmx.values.KafkaConsumerJmxValues;
 import com.newrelic.agent.jmx.values.KafkaProducerJmxValues;
+import com.newrelic.agent.jmx.values.LegacySolr7JmxValues;
 import com.newrelic.agent.jmx.values.ResinJmxValues;
 import com.newrelic.agent.jmx.values.Solr7JmxValues;
 import com.newrelic.agent.jmx.values.SolrJmxValues;
@@ -21,9 +21,7 @@ import com.newrelic.agent.jmx.values.WebsphereLibertyJmxValues;
 import com.newrelic.agent.service.ServiceFactory;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
@@ -32,14 +30,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class JmxApiImplTest {
 
@@ -69,7 +69,7 @@ public class JmxApiImplTest {
     }
 
     @Test
-    public void addJmxMBeanGroup_addAll() {
+    public void addJmxMBeanGroup_addAll_when_iteratedObjectNames_Enabled() {
         Map<String, Class<? extends JmxFrameworkValues>> map = new HashMap<>();
         map.put(KafkaProducerJmxValues.PREFIX, KafkaProducerJmxValues.class);
         map.put(KafkaConsumerJmxValues.PREFIX, KafkaConsumerJmxValues.class);
@@ -91,25 +91,77 @@ public class JmxApiImplTest {
             JmxService jmxService = mock(JmxService.class);
             serviceFactory.when(ServiceFactory::getJmxService)
                     .thenReturn(jmxService);
+            when(jmxService.iteratedObjectNameKeysEnabled())
+                    .thenReturn(true);
 
             for (String prefix : map.keySet()) {
                 jmxApi.addJmxMBeanGroup(prefix);
             }
 
+            verify(jmxService).iteratedObjectNameKeysEnabled();
             for (Class<? extends JmxFrameworkValues> jmxValues : map.values()) {
                 verify(jmxService).addJmxFrameworkValues(any(jmxValues));
             }
+            verify(jmxService, never()).addJmxFrameworkValues(any(LegacySolr7JmxValues.class));
             verifyNoMoreInteractions(jmxService);
+
+            assertEquals(Solr7JmxValues.PREFIX, LegacySolr7JmxValues.PREFIX);
+        }
+    }
+
+    @Test
+    public void addJmxMBeanGroup_addAll_when_iteratedObjectNames_Disabled() {
+        Map<String, Class<? extends JmxFrameworkValues>> map = new HashMap<>();
+        map.put(KafkaProducerJmxValues.PREFIX, KafkaProducerJmxValues.class);
+        map.put(KafkaConsumerJmxValues.PREFIX, KafkaConsumerJmxValues.class);
+        map.put(WebSphere7JmxValues.PREFIX, WebSphere7JmxValues.class);
+        map.put(WebSphereJmxValues.PREFIX, WebSphereJmxValues.class);
+        map.put(SolrJmxValues.PREFIX, SolrJmxValues.class);
+        map.put(LegacySolr7JmxValues.PREFIX, LegacySolr7JmxValues.class);
+        map.put(WebsphereLibertyJmxValues.PREFIX, WebsphereLibertyJmxValues.class);
+        map.put(TomcatJmxValues.PREFIX, TomcatJmxValues.class);
+        map.put(EmbeddedTomcatJmxValues.PREFIX, EmbeddedTomcatJmxValues.class);
+        map.put(EmbeddedTomcatDataSourceJmxValues.PREFIX, EmbeddedTomcatDataSourceJmxValues.class);
+        map.put(JettyJmxMetrics.PREFIX, JettyJmxMetrics.class);
+        map.put(Jboss7UpJmxValues.PREFIX, Jboss7UpJmxValues.class);
+        map.put(ResinJmxValues.PREFIX, ResinJmxValues.class);
+        map.put(GlassfishJmxValues.PREFIX, GlassfishJmxValues.class);
+        map.put(WeblogicJmxValues.PREFIX, WeblogicJmxValues.class);
+
+        try (MockedStatic<ServiceFactory> serviceFactory = mockStatic(ServiceFactory.class)) {
+            JmxService jmxService = mock(JmxService.class);
+            serviceFactory.when(ServiceFactory::getJmxService)
+                    .thenReturn(jmxService);
+            when(jmxService.iteratedObjectNameKeysEnabled())
+                    .thenReturn(false);
+
+            for (String prefix : map.keySet()) {
+                jmxApi.addJmxMBeanGroup(prefix);
+            }
+
+            verify(jmxService).iteratedObjectNameKeysEnabled();
+            for (Class<? extends JmxFrameworkValues> jmxValues : map.values()) {
+                verify(jmxService).addJmxFrameworkValues(any(jmxValues));
+            }
+            verify(jmxService, never()).addJmxFrameworkValues(any(Solr7JmxValues.class));
+            verifyNoMoreInteractions(jmxService);
+
+            assertEquals(Solr7JmxValues.PREFIX, LegacySolr7JmxValues.PREFIX);
         }
     }
 
     @Test
     public void addJmxMBeanGroup_frameworkNotFound() {
         try (MockedStatic<ServiceFactory> serviceFactory = mockStatic(ServiceFactory.class)) {
+            JmxService jmxService = mock(JmxService.class);
+            serviceFactory.when(ServiceFactory::getJmxService)
+                    .thenReturn(jmxService);
 
             jmxApi.addJmxMBeanGroup("name that will not match");
 
-            serviceFactory.verifyNoInteractions();
+            serviceFactory.verify(ServiceFactory::getJmxService);
+            serviceFactory.verifyNoMoreInteractions();
+            verifyNoInteractions(jmxService);
         }
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxGetTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxGetTest.java
@@ -133,27 +133,27 @@ public class JmxGetTest {
     }
 
     @Test
-    public void testGetRootMetricWithBoundedRangePattern() throws MalformedObjectNameException {
+    public void testGetRootMetricWithNoDelimiterAndBoundedRangePattern() throws MalformedObjectNameException {
         List<JmxMetric> metrics = new ArrayList<>();
         metrics.add(JmxMetric.create("hello", JmxType.SIMPLE));
         metrics.add(JmxMetric.create("goodbye", JmxType.MONOTONICALLY_INCREASING));
         JmxGet object = new JmxSingleMBeanGet("ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*",
-                "ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*", "TheRoot/Wahoo/{type}/{for:key[1:3]}/{otherKey}", metrics, null, null);
+                "ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*", "TheRoot/Wahoo/{type}/{for:key[1:3:]}/{otherKey}", metrics, null, null);
         String root = object.getRootMetricName(new ObjectName("ThreadPool:type=rara,key1=value1,key2=value2,key3=value3,otherKey=otherValue"),
                 getServer());
         Assert.assertEquals("JMX/TheRoot/Wahoo/rara/value1/value2/otherValue/", root);
     }
 
     @Test
-    public void testGetRootMetricWithUnBoundedRangePattern() throws MalformedObjectNameException {
+    public void testGetRootMetricWithDelimiterAndUnBoundedRangePattern() throws MalformedObjectNameException {
         List<JmxMetric> metrics = new ArrayList<>();
         metrics.add(JmxMetric.create("hello", JmxType.SIMPLE));
         metrics.add(JmxMetric.create("goodbye", JmxType.MONOTONICALLY_INCREASING));
         JmxGet object = new JmxSingleMBeanGet("ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*",
-                "ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*", "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}", metrics, null, null);
+                "ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*", "TheRoot/Wahoo/{type}/{for:key[1::.]}/{otherKey}", metrics, null, null);
         String root = object.getRootMetricName(new ObjectName("ThreadPool:type=rara,key1=value1,key2=value2,key3=value3,otherKey=otherValue"),
                 getServer());
-        Assert.assertEquals("JMX/TheRoot/Wahoo/rara/value1/value2/value3/otherValue/", root);
+        Assert.assertEquals("JMX/TheRoot/Wahoo/rara/value1.value2.value3/otherValue/", root);
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxGetTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/create/JmxGetTest.java
@@ -133,6 +133,30 @@ public class JmxGetTest {
     }
 
     @Test
+    public void testGetRootMetricWithBoundedRangePattern() throws MalformedObjectNameException {
+        List<JmxMetric> metrics = new ArrayList<>();
+        metrics.add(JmxMetric.create("hello", JmxType.SIMPLE));
+        metrics.add(JmxMetric.create("goodbye", JmxType.MONOTONICALLY_INCREASING));
+        JmxGet object = new JmxSingleMBeanGet("ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*",
+                "ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*", "TheRoot/Wahoo/{type}/{for:key[1:3]}/{otherKey}", metrics, null, null);
+        String root = object.getRootMetricName(new ObjectName("ThreadPool:type=rara,key1=value1,key2=value2,key3=value3,otherKey=otherValue"),
+                getServer());
+        Assert.assertEquals("JMX/TheRoot/Wahoo/rara/value1/value2/otherValue/", root);
+    }
+
+    @Test
+    public void testGetRootMetricWithUnBoundedRangePattern() throws MalformedObjectNameException {
+        List<JmxMetric> metrics = new ArrayList<>();
+        metrics.add(JmxMetric.create("hello", JmxType.SIMPLE));
+        metrics.add(JmxMetric.create("goodbye", JmxType.MONOTONICALLY_INCREASING));
+        JmxGet object = new JmxSingleMBeanGet("ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*",
+                "ThreadPool:type=rara,key1=*,key2=*,key3=*,otherKey=*", "TheRoot/Wahoo/{type}/{for:key[1:]}/{otherKey}", metrics, null, null);
+        String root = object.getRootMetricName(new ObjectName("ThreadPool:type=rara,key1=value1,key2=value2,key3=value3,otherKey=otherValue"),
+                getServer());
+        Assert.assertEquals("JMX/TheRoot/Wahoo/rara/value1/value2/value3/otherValue/", root);
+    }
+
+    @Test
     public void testGetRootMetricWithAttributePattern() throws MalformedObjectNameException,
             AttributeNotFoundException, InstanceNotFoundException, MBeanException, ReflectionException {
         List<JmxMetric> metrics = new ArrayList<>();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/values/JmxFrameworkValueImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/values/JmxFrameworkValueImplTest.java
@@ -79,8 +79,8 @@ public class JmxFrameworkValueImplTest {
         classesUnderTest.add(new JmxFrameworkMetricsClassTestAttributes(Solr7JmxValues.class, "solr7",
                 new String[] { "solr:dom1=core,*,category=CACHE,scope=searcher,name=queryResultCache", "solr:dom1=core,*,category=CACHE,scope=searcher,name=filterCache",
                         "solr:dom1=core,*,category=CACHE,scope=searcher,name=documentCache", "solr:dom1=core,*,category=UPDATE,scope=updateHandler,name=*" },
-                new String[] { "JMX/solr/{for:dom[2:]}/queryResultCache/%/", "JMX/solr/{for:dom[2:]}/filterCache/%/",
-                        "JMX/solr/{for:dom[2:]}/documentCache/%/", "JMX/solr/{for:dom[2:]}/updateHandler/%/{name}" },
+                new String[] { "JMX/solr/{for:dom[2::.]}/queryResultCache/%/", "JMX/solr/{for:dom[2::.]}/filterCache/%/",
+                        "JMX/solr/{for:dom[2::.]}/documentCache/%/", "JMX/solr/{for:dom[2::.]}/updateHandler/%/{name}" },
                 new JMXMetricType[] { JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN }));
         classesUnderTest.add(new JmxFrameworkMetricsClassTestAttributes(SolrJmxValues.class, "solr",
                 new String[] { "solr*:type=queryResultCache,*", "solr*:type=filterCache,*", "solr*:type=documentCache,*", "solr*:type=updateHandler,*" },

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jmx/values/JmxFrameworkValueImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jmx/values/JmxFrameworkValueImplTest.java
@@ -70,11 +70,17 @@ public class JmxFrameworkValueImplTest {
                 new String[] { "resin:type=SessionManager,*", "resin:type=ConnectionPool,*", "resin:type=ThreadPool", "resin:type=TransactionManager" },
                 new String[] { "JmxBuiltIn/Session/{WebApp}/", "JmxBuiltIn/DataSources/{name}/", "JmxBuiltIn/ThreadPool/Resin/", "JmxBuiltIn/Transactions/" },
                 new JMXMetricType[] { JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN }));
-        classesUnderTest.add(new JmxFrameworkMetricsClassTestAttributes(Solr7JmxValues.class, "solr7",
+        classesUnderTest.add(new JmxFrameworkMetricsClassTestAttributes(LegacySolr7JmxValues.class, "solr7",
                 new String[] { "solr:dom1=core,dom2=*,category=CACHE,scope=searcher,name=queryResultCache", "solr:dom1=core,dom2=*,category=CACHE,scope=searcher,name=filterCache",
                         "solr:dom1=core,dom2=*,category=CACHE,scope=searcher,name=documentCache", "solr:dom1=core,dom2=*,category=UPDATE,scope=updateHandler,name=*" },
                 new String[] { "JMX/solr/{dom2}/queryResultCache/%/", "JMX/solr/{dom2}/filterCache/%/",
                         "JMX/solr/{dom2}/documentCache/%/", "JMX/solr/{dom2}/updateHandler/%/{name}" },
+                new JMXMetricType[] { JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN }));
+        classesUnderTest.add(new JmxFrameworkMetricsClassTestAttributes(Solr7JmxValues.class, "solr7",
+                new String[] { "solr:dom1=core,*,category=CACHE,scope=searcher,name=queryResultCache", "solr:dom1=core,*,category=CACHE,scope=searcher,name=filterCache",
+                        "solr:dom1=core,*,category=CACHE,scope=searcher,name=documentCache", "solr:dom1=core,*,category=UPDATE,scope=updateHandler,name=*" },
+                new String[] { "JMX/solr/{for:dom[2:]}/queryResultCache/%/", "JMX/solr/{for:dom[2:]}/filterCache/%/",
+                        "JMX/solr/{for:dom[2:]}/documentCache/%/", "JMX/solr/{for:dom[2:]}/updateHandler/%/{name}" },
                 new JMXMetricType[] { JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN, JMXMetricType.INCREMENT_COUNT_PER_BEAN }));
         classesUnderTest.add(new JmxFrameworkMetricsClassTestAttributes(SolrJmxValues.class, "solr",
                 new String[] { "solr*:type=queryResultCache,*", "solr*:type=filterCache,*", "solr*:type=documentCache,*", "solr*:type=updateHandler,*" },


### PR DESCRIPTION
### Overview
Allow the agent to capture clustered Solr cores via our JMX API . 

Single instances of Solr will contain function the same. 

In clustered Solr cores, their JMX MBeans will look like `solr:dom1=core,dom2=dummy_collection,dom3=shard2,dom4=replica_n2,category=CACHE,scope=searcher,name=documentCache` which the agent did not capture. 

Now the agent will export Solr values with nested DOM (i.e. clustered cores) in the formats:
- JMX/solr/{collection name}.{shard}.{core name}/{name_value}/%/{attribute}/
- JMX/solr/{collection name}.{shard}.{core name}/updateHandler/%/{attribute}

Fpr example: 
`JMX/solr/dummy_collection.shard2.replica_n2/documentCache/%/`

The Solr UI will recognize the cores in the format `{collection name}.{shard}.{core name}`

#### New Iteration Syntax Internal To The Agent

This is done by adding new iteration syntax for object name keys for MBeans when formatting them into agent metrics.

You may see it in any class that extends `com.newrelic.agent.jmx.metrics.JmxFrameworkValues` in the `newrelic-agent` module.

To see this in practice, we will query an MBean from JMX with Solr using the string:
```
solr:dom1=core,*,category=CACHE,scope=searcher,name=documentCache
```
which may return an MBean with an object name like:
```
solr:dom1=core,dom2=dummy_collection,dom3=shard2,dom4=replica_n2,category=CACHE,scope=searcher,name=documentCache
```

We take a metric name with the format `JMX/solr/{for:dom[2::.]}/documentCache/%/` such that it becomes the metric `JMX/solr/dummy_collection.shard2.replica_n2/documentCache/%/`

We can use this metric syntax in other ways such that `JMX/solr/{for:dom[2:4:.]}/documentCache/%/` can translate to `JMX/solr/dummy_collection.shard2.documentCache/%/`

In the format we see the following placeholder `{for:dom[start:end:delimiter]}` where `for:` indicate some iterable object name keys and `[start:end]` represents some range where `start` is the start number and `end` represents an optional exclusive end of the range. `[start::delimiter]` means the `end` is unbounded. This is similar to python syntax you may have with accessing sublists. The `delimiter` represents a string that will join the iterated values in a sequence. If left empty, it will default to `/`. 

Currently the solution will work with positive numbers for simplicity but we can eventually extend this to more characters.

Since the syntax is new and there maybe unexpected side effects, we will include new undocumented temporarily configuration to disable it for Solr:

yaml:


```yaml
# newrelic.yml snippet
common: &default_settings
  jmx:
    enable_iterated_objectname_Keys: true # default is true
```
system property:

```
-Dnewrelic.config.jmx.enable_iterated_objectname_Keys=true
```

environment variable:
```
NEW_RELIC_JMX_ENABLE_ITERATED_OBJECTNAME-KEYS=true
```
By default the configuration is true. To disable the syntax, set it to false.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/1571
