### PR TITLE
Add transaction GUID to ErrorEvent instances

### DIFF
--- a/agent-model/src/main/java/com/newrelic/agent/model/ErrorEvent.java
+++ b/agent-model/src/main/java/com/newrelic/agent/model/ErrorEvent.java
@@ -247,6 +247,7 @@ public class ErrorEvent extends AnalyticsEvent implements JSONStreamAware {
         }
         if (transactionGuid != null) {
             obj.put("nr.transactionGuid", transactionGuid); // prefixed to be hidden by Insights
+            obj.put("guid", transactionGuid);
         }
         if (referringTransactionGuid != null) {
             obj.put("nr.referringTransactionGuid", referringTransactionGuid); // prefixed to be hidden by Insights

--- a/agent-model/src/test/java/com/newrelic/agent/model/ErrorEventTest.java
+++ b/agent-model/src/test/java/com/newrelic/agent/model/ErrorEventTest.java
@@ -47,6 +47,7 @@ public class ErrorEventTest {
         assertTrue(json.contains("\"externalCallCount\":16"));
         assertTrue(json.contains("\"port\":2020"));
         assertTrue(json.contains("\"priority\":1"));
+        assertTrue(json.contains("\"guid\":\"abc\""));
 
         //hidden attributes
         assertTrue(json.contains("\"nr.transactionGuid\":\"abc\""));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
@@ -465,6 +465,8 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
         DistributedTraceService distributedTraceService = ServiceFactory.getDistributedTraceService();
         DistributedTracingConfig distributedTracingConfig = ServiceFactory.getConfigService().getDefaultAgentConfig().getDistributedTracingConfig();
 
+        joinedIntrinsics.put("guid", td.getGuid());
+
         if (distributedTracingConfig.isEnabled()) {
             joinedIntrinsics.putAll(distributedTraceService.getIntrinsics(
                     td.getInboundDistributedTracePayload(), td.getGuid(), td.getTraceId(), td.getTransportType(),

--- a/newrelic-agent/src/test/java/com/newrelic/agent/errors/ErrorServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/errors/ErrorServiceTest.java
@@ -122,8 +122,7 @@ public class ErrorServiceTest {
     @Test
     public void isIgnoredErrorNone() throws Exception {
         TransactionData data = new TransactionData(Transaction.getTransaction(), 0);
-        boolean result = data.hasReportableErrorThatIsNotIgnored();
-        Assert.assertFalse(result);
+        Assert.assertFalse(data.hasReportableErrorThatIsNotIgnored());
     }
 
     @Test
@@ -131,8 +130,7 @@ public class ErrorServiceTest {
         Throwable error = new ArrayIndexOutOfBoundsException();
         Transaction.getTransaction().setThrowable(error, TransactionErrorPriority.API, false);
         TransactionData data = new TransactionData(Transaction.getTransaction(), 0);
-        boolean result = data.hasReportableErrorThatIsNotIgnored();
-        Assert.assertTrue(result);
+        Assert.assertTrue(data.hasReportableErrorThatIsNotIgnored());
     }
 
     @Test
@@ -140,8 +138,7 @@ public class ErrorServiceTest {
         Throwable error = new Exception();
         Transaction.getTransaction().setThrowable(error, TransactionErrorPriority.API, false);
         TransactionData data = new TransactionData(Transaction.getTransaction(), 0);
-        boolean result = data.hasReportableErrorThatIsNotIgnored();
-        Assert.assertFalse(result);
+        Assert.assertFalse(data.hasReportableErrorThatIsNotIgnored());
     }
 
     @Test
@@ -152,8 +149,7 @@ public class ErrorServiceTest {
         Throwable error = new Throwable(new Exception(new ArrayIndexOutOfBoundsException()));
         Transaction.getTransaction().setThrowable(error, TransactionErrorPriority.API, false);
         TransactionData data = new TransactionData(Transaction.getTransaction(), 0);
-        boolean result = data.hasReportableErrorThatIsNotIgnored();
-        Assert.assertTrue(result);
+        Assert.assertTrue(data.hasReportableErrorThatIsNotIgnored());
     }
 
     @Test
@@ -164,8 +160,7 @@ public class ErrorServiceTest {
         Throwable error = new Throwable(new Exception(new ArrayIndexOutOfBoundsException()));
         Transaction.getTransaction().setThrowable(error, TransactionErrorPriority.API, false);
         TransactionData data = new TransactionData(Transaction.getTransaction(), 0);
-        boolean result = data.hasReportableErrorThatIsNotIgnored();
-        Assert.assertFalse(result);
+        Assert.assertFalse(data.hasReportableErrorThatIsNotIgnored());
     }
 
     @Test
@@ -173,8 +168,7 @@ public class ErrorServiceTest {
         Throwable error = new Throwable(new Exception(new ArrayIndexOutOfBoundsException()));
         Transaction.getTransaction().setThrowable(error, TransactionErrorPriority.API, false);
         TransactionData data = new TransactionData(Transaction.getTransaction(), 0);
-        boolean result = data.hasReportableErrorThatIsNotIgnored();
-        Assert.assertFalse(result);
+        Assert.assertFalse(data.hasReportableErrorThatIsNotIgnored());
     }
 
     @Test
@@ -185,8 +179,7 @@ public class ErrorServiceTest {
         Throwable error = new Throwable(new Exception(new ArrayIndexOutOfBoundsException()));
         Transaction.getTransaction().setThrowable(error, TransactionErrorPriority.API, false);
         TransactionData data = new TransactionData(Transaction.getTransaction(), 0);
-        boolean result = data.hasReportableErrorThatIsNotIgnored();
-        Assert.assertFalse(result);
+        Assert.assertFalse(data.hasReportableErrorThatIsNotIgnored());
     }
 
     @Test
@@ -968,6 +961,29 @@ public class ErrorServiceTest {
         Assert.assertTrue(intrinsicAtts.containsKey("guid"));
         Assert.assertTrue(intrinsicAtts.containsKey("priority"));
         Assert.assertTrue(intrinsicAtts.containsKey("sampled"));
+    }
+
+    @Test
+    public void txnGuidIsPresentWithDistributedTracingDisabled() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        Map<String, Object> dtConfig = new HashMap<>();
+        dtConfig.put("enabled", false);
+        config.put("distributed_tracing", dtConfig);
+        Map<String, Object> spanConfig = new HashMap<>();
+        spanConfig.put("collect_span_events", true);
+        config.put("span_events", spanConfig);
+        EventTestHelper.createServiceManager(config);
+
+        TransactionData transactionData = createTransactionData(200, new Throwable("Surprising error"), false);
+        TransactionService txService = ServiceFactory.getTransactionService();
+        TransactionStats transactionStats = new TransactionStats();
+        txService.transactionFinished(transactionData, transactionStats);
+
+        List<TracedError> tracedErrors = ServiceFactory.getRPMService().getErrorService().getAndClearTracedErrors();
+        TracedError tracedError = tracedErrors.get(0);
+        Assert.assertEquals("Surprising error", tracedError.getMessage());
+        Map<String, ?> intrinsicAtts = tracedError.getIntrinsicAtts();
+        Assert.assertTrue(intrinsicAtts.containsKey("guid"));
     }
 
     @Test


### PR DESCRIPTION
Errors inbox team validated that both the `ErrorEvent` and `TracedError` payloads contain the transaction GUID in the proper spots when DT is disabled.