### PR TITLE
Updating range for otel-autoconfigure verify instrumentation

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
@@ -20,7 +20,7 @@ java {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:[1.28.0,)'
+    passesOnly 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:[1.17.0-alpha,)'
 }
 
 site {


### PR DESCRIPTION
### Overview
The original range for which the instrumentation applies was missing a few versions.
