### PR TITLE
Add pekko back to Test-AITs.yml

### DIFF
--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -67,7 +67,6 @@ jobs:
           excluded_tests=$(mktemp /tmp/excluded_tests.XXXXXXXX)
           echo "datastore/datastores.py" >> $excluded_tests
           echo "framework/jms/jms.py" >> $excluded_tests
-          echo "framework/pekko/pekko.py" >> $excluded_tests
           echo "r2dbc/mssql.py" >> $excluded_tests
           echo "server/mule.py" >> $excluded_tests
           echo "server/weblogic.py" >> $excluded_tests


### PR DESCRIPTION
Pekko was excluded because the AITs were merged too early. Adding back in. 