### PR TITLE
Add a switch to allow the OTel SDK integration to be completely disabled

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
@@ -12,9 +12,12 @@ public class AutoConfiguredOpenTelemetrySdk {
 
     public static AutoConfiguredOpenTelemetrySdkBuilder builder() {
         final AutoConfiguredOpenTelemetrySdkBuilder builder = Weaver.callOriginal();
-        NewRelic.getAgent().getLogger().log(Level.INFO, "Appending OpenTelemetry SDK customizers");
-        builder.addPropertiesCustomizer(new PropertiesCustomizer());
-        builder.addResourceCustomizer(new ResourceCustomer());
+        Boolean autoConfigure = NewRelic.getAgent().getConfig().getValue("opentelemetry.sdk.autoconfigure");
+        if (autoConfigure == null || autoConfigure) {
+            NewRelic.getAgent().getLogger().log(Level.INFO, "Appending OpenTelemetry SDK customizers");
+            builder.addPropertiesCustomizer(new PropertiesCustomizer());
+            builder.addResourceCustomizer(new ResourceCustomer());
+        }
         return builder;
     }
 }

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
@@ -12,7 +12,7 @@ public class AutoConfiguredOpenTelemetrySdk {
 
     public static AutoConfiguredOpenTelemetrySdkBuilder builder() {
         final AutoConfiguredOpenTelemetrySdkBuilder builder = Weaver.callOriginal();
-        Boolean autoConfigure = NewRelic.getAgent().getConfig().getValue("opentelemetry.sdk.autoconfigure");
+        Boolean autoConfigure = NewRelic.getAgent().getConfig().getValue("opentelemetry.sdk.autoconfigure.enabled");
         if (autoConfigure == null || autoConfigure) {
             NewRelic.getAgent().getLogger().log(Level.INFO, "Appending OpenTelemetry SDK customizers");
             builder.addPropertiesCustomizer(new PropertiesCustomizer());


### PR DESCRIPTION

### Overview
This allows the agent's Opentelemetry SDK autoconfiguration feature to be disabled with this setting:

    opentelemetry.sdk.autoconfigure.enabled=false

For instance, start a process with this added: `-Dnewrelic.config.opentelemetry.sdk.autoconfigure.enabled=false`

This feature can currently be disabled by disabling the instrumentation, but this is a nicer looking switch.

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
