### PR TITLE
Capping jax-rs-3.0 instrumentation

### DIFF
--- a/instrumentation/jax-rs-3.0/build.gradle
+++ b/instrumentation/jax-rs-3.0/build.gradle
@@ -15,7 +15,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'jakarta.ws.rs:jakarta.ws.rs-api:[3.0-M1,)'
+    passesOnly 'jakarta.ws.rs:jakarta.ws.rs-api:[3.0-M1,4.0.0-M2)'
 }
 
 compileJava {
@@ -26,5 +26,5 @@ compileJava {
 site {
     title 'JAX-RS'
     type 'Framework'
-    versionOverride '[3.0,)'
+    versionOverride '[3.0,4.0)'
 }


### PR DESCRIPTION
### Overview
Preventing verify instrumentation from failing on unsupported jax-rs version.