### PR TITLE
Revert httpurlconnection InboundWrapper changes

### DIFF
--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/InboundWrapper.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/InboundWrapper.java
@@ -9,30 +9,26 @@ package com.nr.agent.instrumentation.httpurlconnection;
 
 import java.net.HttpURLConnection;
 import java.util.List;
-import java.util.Map;
 
 import com.newrelic.api.agent.HeaderType;
 import com.newrelic.api.agent.ExtendedInboundHeaders;
 
 public class InboundWrapper extends ExtendedInboundHeaders {
 
-    private final Map<String, List<String>> headers;
+    private final HttpURLConnection connection;
 
     public InboundWrapper(HttpURLConnection connection) {
-        this.headers = connection.getHeaderFields();
+        this.connection = connection;
     }
 
     @Override
     public String getHeader(String name) {
-        if (headers == null || name == null) return null;
-        List<String> result = headers.get(name);
-        return result == null || result.isEmpty() ? null : result.get(0);
+        return connection.getHeaderField(name);
     }
 
     @Override
     public List<String> getHeaders(String name) {
-        if (headers == null || name == null) return null;
-        return headers.get(name);
+        return connection.getHeaderFields().get(name);
     }
 
     @Override

--- a/instrumentation/httpurlconnection/src/test/java/com/nr/agent/instrumentation/httpurlconnection/InboundTest.java
+++ b/instrumentation/httpurlconnection/src/test/java/com/nr/agent/instrumentation/httpurlconnection/InboundTest.java
@@ -176,18 +176,8 @@ public class InboundTest {
     }
 
     private String fetchTransactionName(Introspector introspector, String expectedMethod) {
-        // The number 2 is a little misleading here, 1 should be the real number, but because of the way we
-        // are mocking the weaved class for testing, it will be 2 here.
-        // One comes from the InboundWrapper call to get the headers, which forces a call to getInputStream,
-        // which actually calls the the HttpServerImpl which creates the transaction.
-        // The other comes from the "call" methods in this test class
-        assertEquals(2, introspector.getFinishedTransactionCount(500));
-
-        String transactionName = introspector.getTransactionNames().stream()
-                .filter( n -> n.contains(expectedMethod))
-                .findFirst()
-                .orElse(null);
-
+        assertEquals(1, introspector.getFinishedTransactionCount(500));
+        String transactionName = introspector.getTransactionNames().iterator().next();
         boolean foundExpectedEvent = false;
         for (TransactionEvent event : introspector.getTransactionEvents(transactionName)) {
             foundExpectedEvent = foundExpectedEvent || event.getName().endsWith("/" + expectedMethod);


### PR DESCRIPTION
Reverts the `httpurlconnection` changes that went into the 8.10.0 release due to overhead issues described in https://github.com/newrelic/newrelic-java-agent/issues/1838