### PR TITLE
NR-134815 Treat OTel WithSpan annotation as Trace

### DIFF
--- a/functional_test/build.gradle
+++ b/functional_test/build.gradle
@@ -11,6 +11,9 @@ dependencies {
     implementation(project(":agent-bridge-datastore"))
     implementation(project(":newrelic-weaver"))
 
+    // WithSpan annotation
+    implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.33.1')
+
     testImplementation(project(":functional_test:weave_test_impl"))
 
     // the newrelic-agent test classes

--- a/functional_test/src/test/java/test/newrelic/test/agent/TraceAnnotationTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/TraceAnnotationTest.java
@@ -29,6 +29,7 @@ import com.newrelic.agent.transaction.PriorityTransactionName;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Token;
 import com.newrelic.api.agent.Trace;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -265,6 +266,19 @@ public class TraceAnnotationTest implements TransactionListener {
 
         Set<String> metrics = AgentHelper.getMetrics();
         AgentHelper.verifyMetrics(metrics, MessageFormat.format("Custom/{0}/doubleArrayArg", Simple.class.getName()));
+    }
+
+    @Test
+    public void testOTelWithSpan() {
+        withSpan();
+
+        Set<String> metrics = AgentHelper.getMetrics();
+        AgentHelper.verifyMetrics(metrics, MessageFormat.format("Custom/{0}/withSpan", Simple.class.getName()));
+    }
+
+    @WithSpan
+    private void withSpan() {
+
     }
 
     @Trace(dispatcher = true)

--- a/functional_test/src/test/java/test/newrelic/test/agent/TraceAnnotationTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/TraceAnnotationTest.java
@@ -269,6 +269,7 @@ public class TraceAnnotationTest implements TransactionListener {
     }
 
     @Test
+    @Trace(dispatcher = true)
     public void testOTelWithSpan() {
         withSpan();
 

--- a/functional_test/src/test/java/test/newrelic/test/agent/TraceAnnotationTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/TraceAnnotationTest.java
@@ -7,6 +7,7 @@
 
 package test.newrelic.test.agent;
 
+import com.newrelic.agent.Agent;
 import com.newrelic.agent.AgentHelper;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.Transaction;
@@ -269,7 +270,6 @@ public class TraceAnnotationTest implements TransactionListener {
     }
 
     @Test
-    @Trace(dispatcher = true)
     public void testOTelWithSpan() {
         withSpan();
 
@@ -277,9 +277,9 @@ public class TraceAnnotationTest implements TransactionListener {
         AgentHelper.verifyMetrics(metrics, MessageFormat.format("Custom/{0}/withSpan", Simple.class.getName()));
     }
 
-    @WithSpan
-    private void withSpan() {
-
+    @Trace(dispatcher = true)
+    static void withSpan() {
+        new Simple().withSpan();
     }
 
     @Trace(dispatcher = true)
@@ -320,7 +320,12 @@ public class TraceAnnotationTest implements TransactionListener {
         new Simple().charArray(new char[] { 6 });
     }
 
-    private class Simple {
+    private static class Simple {
+        @WithSpan
+        void withSpan() {
+            Agent.LOG.info("withSpan");
+        }
+
         @Trace
         private void foo() throws InterruptedException {
             Thread.sleep(200);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
@@ -59,6 +59,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     private static final String SYSTEM_PROPERTY_ROOT = "newrelic.config.class_transformer.";
 
     static final String NEW_RELIC_TRACE_TYPE_DESC = "Lcom/newrelic/api/agent/Trace;";
+    static final String OTEL_WITH_SPAN_TYPE_DESC = "Lio/opentelemetry/instrumentation/annotations/WithSpan;";
     static final String DEPRECATED_NEW_RELIC_TRACE_TYPE_DESC = "Lcom/newrelic/agent/Trace;";
 
     // as of JAVA-4824 the yml config file is not required, but still need to match old behavior
@@ -186,6 +187,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
         List<AnnotationMatcher> matchers = new ArrayList<>();
         matchers.add(new ClassNameAnnotationMatcher(Type.getType(DEPRECATED_NEW_RELIC_TRACE_TYPE_DESC).getDescriptor()));
         matchers.add(new ClassNameAnnotationMatcher(Type.getType(NEW_RELIC_TRACE_TYPE_DESC).getDescriptor()));
+        matchers.add(new ClassNameAnnotationMatcher(Type.getType(OTEL_WITH_SPAN_TYPE_DESC).getDescriptor()));
 
         final Collection<String> traceAnnotationClassNames = getUniqueStrings("trace_annotation_class_name");
         if (traceAnnotationClassNames.isEmpty()) {


### PR DESCRIPTION
NR-134815

### Overview

There is a java OpenTelemetry library that contains a `WithSpan` annotation designed to work the same as our `Trace` annotation.  By adding support for this annotation we increase our adoption of Otel.  It allows customers to use this open source annotation instead of our proprietary annotation (in many cases).

I think we can defer suppressing this instrumentation (`otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods`) and adding support for `otel.instrumentation.methods.include` until later.

Note that OTel properties can be set through environment or system properties, like our agent, and eventually through a config file.  We can use our existing otel instrumentation model to get access to the normalized version of the instrumentation settings to include and exclude methods and pass those to the core agent through the bridge.

https://opentelemetry.io/docs/languages/java/automatic/annotations/

### Related Github Issue
https://new-relic.atlassian.net/issues/NR-134815

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
