### PR TITLE
Increase Size of db.statement Attribute in Span Events

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -44,7 +44,7 @@ public class SpanEventFactory {
 
     private static final Joiner TRACE_STATE_VENDOR_JOINER = Joiner.on(",");
     // Truncate `db.statement` at 2000 characters
-    private static final int DB_STATEMENT_TRUNCATE_LENGTH = 2000;
+    private static final int DB_STATEMENT_TRUNCATE_LENGTH = 4095;
     private static final int MAX_EVENT_ATTRIBUTE_STRING_LENGTH = 4095;
 
     public static final Supplier<Long> DEFAULT_SYSTEM_TIMESTAMP_SUPPLIER = System::currentTimeMillis;

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -75,13 +75,13 @@ public class SpanEventFactoryTest {
     }
 
     @Test
-    public void shouldTruncate3KDBStatementTo2K() {
-        char[] data = new char[3000];
-        String threeKStatement = new String(data);
+    public void shouldTruncate5KDBStatementTo4K() {
+        char[] data = new char[5000];
+        String fiveKStatement = new String(data);
 
-        SpanEvent target = spanEventFactory.setDatabaseStatement(threeKStatement).build();
+        SpanEvent target = spanEventFactory.setDatabaseStatement(fiveKStatement).build();
 
-        assertEquals(2000,
+        assertEquals(4095,
                 target.getAgentAttributes().get("db.statement").toString().length());
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerClmTest.java
@@ -484,7 +484,7 @@ public class DefaultSqlTracerClmTest {
         DatastoreInstanceDetection.associateAddress(connection, new InetSocketAddress("dbserver.nerd.us", 9945));
         DatastoreInstanceDetection.stopDetectingConnectionAddress();
 
-        String longQueryString = "SELECT price, name FROM BOOKS WHERE name = " + Strings.repeat("a", 4000);
+        String longQueryString = "SELECT price, name FROM BOOKS WHERE name = " + Strings.repeat("a", 5000);
         DefaultSqlTracer tracer = newInstanceDBTracer(longQueryString, connection, "MySQL", "mysql");
         tracer.finish(Opcodes.ARETURN, new DummyResultSet());
 
@@ -503,7 +503,7 @@ public class DefaultSqlTracerClmTest {
         assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
         assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
-        assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
+        assertEquals(4095, spanEvent.getAgentAttributes().get("db.statement").toString().length());
         assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("a..."));
         assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
@@ -657,7 +657,7 @@ public class DefaultSqlTracerTest {
         DatastoreInstanceDetection.associateAddress(connection, new InetSocketAddress("dbserver.nerd.us", 9945));
         DatastoreInstanceDetection.stopDetectingConnectionAddress();
 
-        String longQueryString = "SELECT price, name FROM BOOKS WHERE name = " + Strings.repeat("a", 4000);
+        String longQueryString = "SELECT price, name FROM BOOKS WHERE name = " + Strings.repeat("a", 5000);
         DefaultSqlTracer tracer = newInstanceDBTracer(longQueryString, connection, "MySQL", "mysql");
         tracer.finish(Opcodes.ARETURN, new DummyResultSet());
 
@@ -676,7 +676,7 @@ public class DefaultSqlTracerTest {
         assertEquals("MySQL", spanEvent.getAgentAttributes().get("db.system"));
         assertEquals("dbserver.nerd.us", spanEvent.getAgentAttributes().get("peer.hostname"));
         assertEquals("dbserver.nerd.us:9945", spanEvent.getAgentAttributes().get("peer.address"));
-        assertEquals(2000, spanEvent.getAgentAttributes().get("db.statement").toString().length());
+        assertEquals(4095, spanEvent.getAgentAttributes().get("db.statement").toString().length());
         assertTrue(spanEvent.getAgentAttributes().get("db.statement").toString().endsWith("a..."));
         assertEquals("books", spanEvent.getAgentAttributes().get("db.collection"));
         assertEquals("client", spanEvent.getIntrinsics().get("span.kind"));


### PR DESCRIPTION
Increases db.statement max size to reduce truncating long statements

[Issue #1486](https://github.com/newrelic/newrelic-java-agent/issues/1486)