### PR TITLE
Cap glassfish-6 instrumentation ranges

### DIFF
--- a/instrumentation/glassfish-6/build.gradle
+++ b/instrumentation/glassfish-6/build.gradle
@@ -11,12 +11,10 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.glassfish.main.web:web-core:[6.0.0-RC1,)'
+    passesOnly 'org.glassfish.main.web:web-core:[6.0.0-RC1,8.0.0-M2)'
     exclude 'org.glassfish.main.web:web-core:7.0.0-M3'
     exclude 'org.glassfish.main.web:web-core:7.0.0-M4'
     exclude 'org.glassfish.main.web:web-core:7.0.0-M10'
-    exclude 'org.glassfish.main.web:web-core:8.0.0-M2'
-    exclude 'org.glassfish.main.web:web-core:8.0.0-M3'
 }
 
 site {


### PR DESCRIPTION
The verifier has failed for the last four glassfish releases, looks like it's time to officially cap this instrumentation and create a new module.

Related: https://github.com/newrelic/newrelic-java-agent/issues/1806
