### PR TITLE
Log IAST related config variables

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -10,11 +10,13 @@ package com.newrelic.agent;
 import com.google.common.collect.ImmutableMap;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.AgentJarHelper;
 import com.newrelic.agent.config.ConfigService;
 import com.newrelic.agent.config.ConfigServiceFactory;
 import com.newrelic.agent.config.JarResource;
 import com.newrelic.agent.config.JavaVersionUtils;
+import com.newrelic.agent.config.SecurityAgentConfig;
 import com.newrelic.agent.core.CoreService;
 import com.newrelic.agent.core.CoreServiceImpl;
 import com.newrelic.agent.logging.AgentLogManager;
@@ -27,6 +29,8 @@ import com.newrelic.agent.stats.StatsWorks;
 import com.newrelic.agent.util.UnwindableInstrumentation;
 import com.newrelic.agent.util.UnwindableInstrumentationImpl;
 import com.newrelic.agent.util.asm.ClassStructure;
+import com.newrelic.api.agent.Config;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.security.NewRelicSecurity;
 import com.newrelic.bootstrap.BootstrapAgent;
 import com.newrelic.bootstrap.BootstrapLoader;
@@ -234,10 +238,10 @@ public final class Agent {
             instrumentation.started();
         }
         lifecycleObserver.agentStarted();
-        InitialiseNewRelicSecurityIfAllowed(inst);
+        initialiseNewRelicSecurityIfAllowed(inst);
     }
 
-    private static void InitialiseNewRelicSecurityIfAllowed(Instrumentation inst) {
+    private static void initialiseNewRelicSecurityIfAllowed(Instrumentation inst) {
         // Do not initialise New Relic Security module so that it stays in NoOp mode if force disabled.
         addSecurityAgentConfigSupportabilityMetrics();
         if (shouldInitializeSecurityAgent()) {
@@ -271,7 +275,15 @@ public final class Agent {
             }
         } else {
             LOG.warning("New Relic Security is completely disabled by one of the user provided config `security.enabled`, `security.agent.enabled` or `high_security`. Not loading security capabilities.");
+            Config config = NewRelic.getAgent().getConfig();
+            logConfig(config, Level.FINE, AgentConfigImpl.HIGH_SECURITY);
+            logConfig(config, Level.FINE, SecurityAgentConfig.SECURITY_ENABLED);
+            logConfig(config, Level.FINE, SecurityAgentConfig.SECURITY_AGENT_ENABLED);
         }
+    }
+
+    private static void logConfig(Config config, Level logLevel, String key) {
+        LOG.log(logLevel, "{0} = {1}", key, config.getValue(key));
     }
 
     private static Instrumentation maybeWrapInstrumentation(Instrumentation inst) {


### PR DESCRIPTION

### Overview
Customers are seeing this message:

    New Relic Security is completely disabled by one of the user provided config `security.enabled`, `security.agent.enabled` or `high_security`. Not loading security capabilities.

But they believe they have configured the agent to enable IAST.  This PR logs `security.enabled`, `security.agent.enabled` and `high_security` at `FINE` so that the config values can be scrutinized.

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
