### PR TITLE
When IAST is disabled log security related env and system properties

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -10,7 +10,6 @@ package com.newrelic.agent;
 import com.google.common.collect.ImmutableMap;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.config.AgentConfig;
-import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.AgentJarHelper;
 import com.newrelic.agent.config.ConfigService;
 import com.newrelic.agent.config.ConfigServiceFactory;
@@ -29,8 +28,6 @@ import com.newrelic.agent.stats.StatsWorks;
 import com.newrelic.agent.util.UnwindableInstrumentation;
 import com.newrelic.agent.util.UnwindableInstrumentationImpl;
 import com.newrelic.agent.util.asm.ClassStructure;
-import com.newrelic.api.agent.Config;
-import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.security.NewRelicSecurity;
 import com.newrelic.bootstrap.BootstrapAgent;
 import com.newrelic.bootstrap.BootstrapLoader;
@@ -275,15 +272,8 @@ public final class Agent {
             }
         } else {
             LOG.info("New Relic Security is completely disabled by one of the user provided config `security.enabled`, `security.agent.enabled` or `high_security`. Not loading security capabilities.");
-            Config config = NewRelic.getAgent().getConfig();
-            logConfig(config, Level.FINE, AgentConfigImpl.HIGH_SECURITY);
-            logConfig(config, Level.FINE, SecurityAgentConfig.SECURITY_ENABLED);
-            logConfig(config, Level.FINE, SecurityAgentConfig.SECURITY_AGENT_ENABLED);
+            SecurityAgentConfig.logSettings(Level.FINE);
         }
-    }
-
-    private static void logConfig(Config config, Level logLevel, String key) {
-        LOG.log(logLevel, "{0} = {1}", key, config.getValue(key));
     }
 
     private static Instrumentation maybeWrapInstrumentation(Instrumentation inst) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SecurityAgentConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SecurityAgentConfig.java
@@ -9,10 +9,13 @@ package com.newrelic.agent.config;
 
 import com.google.common.collect.Sets;
 import com.newrelic.api.agent.Config;
+import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.NewRelic;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.logging.Level;
 
 /* Default config should look like:
  *
@@ -150,4 +153,27 @@ public class SecurityAgentConfig {
         return config.getValue(SECURITY_LOW_PRIORITY_INSTRUMENTATION_ENABLED, SECURITY_LOW_PRIORITY_INSTRUMENTATION_ENABLED_DEFAULT);
     }
 
+    /**
+     * Log security settings to help debug when the IAST agent is not enabled.
+     */
+    public static void logSettings(Level logLevel) {
+        final Logger logger = NewRelic.getAgent().getLogger();
+        if (logger.isLoggable(logLevel)) {
+            final Config config = NewRelic.getAgent().getConfig();
+
+            Arrays.asList(AgentConfigImpl.HIGH_SECURITY, SECURITY_ENABLED, SECURITY_AGENT_ENABLED).forEach(key ->
+                logger.log(logLevel, "{0} = {1}", key, config.getValue(key)));
+
+            System.getenv().forEach((key, value) -> {
+                if (key.contains("NEW_RELIC") && key.contains("SECURITY")) {
+                    logger.log(logLevel, "Environment {0} = {1}", key, value);
+                }
+            });
+            System.getProperties().forEach((key, value) -> {
+                if (key.toString().contains("newrelic.config.") && key.toString().contains("security")) {
+                    logger.log(logLevel, "System property {0} = {1}", key, value);
+                }
+            });
+        }
+    }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/SecurityAgentConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/SecurityAgentConfig.java
@@ -14,6 +14,7 @@ import com.newrelic.api.agent.NewRelic;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
@@ -157,19 +158,24 @@ public class SecurityAgentConfig {
      * Log security settings to help debug when the IAST agent is not enabled.
      */
     public static void logSettings(Level logLevel) {
-        final Logger logger = NewRelic.getAgent().getLogger();
+        logSettings(NewRelic.getAgent().getConfig(), NewRelic.getAgent().getLogger(), logLevel,
+                System.getenv(), System.getProperties());
+    }
+
+    static void logSettings(final Config config, final Logger logger, Level logLevel,
+                            Map<String, String> environment,
+                            Map<Object, Object> systemProperties) {
+
         if (logger.isLoggable(logLevel)) {
-            final Config config = NewRelic.getAgent().getConfig();
-
             Arrays.asList(AgentConfigImpl.HIGH_SECURITY, SECURITY_ENABLED, SECURITY_AGENT_ENABLED).forEach(key ->
-                logger.log(logLevel, "{0} = {1}", key, config.getValue(key)));
+                    logger.log(logLevel, "{0} = {1}", key, config.getValue(key)));
 
-            System.getenv().forEach((key, value) -> {
+            environment.forEach((key, value) -> {
                 if (key.contains("NEW_RELIC") && key.contains("SECURITY")) {
                     logger.log(logLevel, "Environment {0} = {1}", key, value);
                 }
             });
-            System.getProperties().forEach((key, value) -> {
+            systemProperties.forEach((key, value) -> {
                 if (key.toString().contains("newrelic.config.") && key.toString().contains("security")) {
                     logger.log(logLevel, "System property {0} = {1}", key, value);
                 }


### PR DESCRIPTION
### Overview
When IAST is disabled, this logs the following at `FINE` level:
 * Environment keys and their values when the key contains `NEW_RELIC` and `SECURITY`
 * System property keys and their values when the key contains `newrelic.config.` and `security`

I pulled all of this logging out of the main `Agent` class and into `SecurityAgentConfig`.

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
