### PR TITLE
Fix verifier range for jax-rs-3.0

### DIFF
--- a/instrumentation/jax-rs-3.0/build.gradle
+++ b/instrumentation/jax-rs-3.0/build.gradle
@@ -15,7 +15,8 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'jakarta.ws.rs:jakarta.ws.rs-api:[3.0-M1,4.0.0-M2)'
+    passesOnly 'jakarta.ws.rs:jakarta.ws.rs-api:[3.0-M1,)'
+    exclude 'jakarta.ws.rs:jakarta.ws.rs-api:4.0.0-M2'
 }
 
 compileJava {


### PR DESCRIPTION
Fixes the following verifier failure. https://github.com/newrelic/newrelic-java-agent/actions/runs/8981808490/job/24668263806

```
* What went wrong:
Execution failed for task ':instrumentation:jax-rs-3.0:verifyFail_jakarta.ws.rs_jakarta.ws.rs-api_4.0.0'.
> A failure occurred while executing com.newrelic.agent.instrumentation.verify.VerifyWorkAction
   > Verification FAILED. Instrumentation module jax-rs-3.0-1.0.jar SHOULD NOT HAVE applied to jakarta.ws.rs:jakarta.ws.rs-api:4.0.0 but it did. You may need to adjust the range "jakarta.ws.rs:jakarta.ws.rs-api:[0,)".
     Verifier output:
     Creating user classloader with custom classpath:
     	/home/runner/.gradle/caches/modules-2/files-2.1/jakarta.ws.rs/jakarta.ws.rs-api/4.0.0/c27a67f84ca491efcb3fa68f4df926e8a110069e/jakarta.ws.rs-api-4.0.0.jar
```