### PR TITLE
Non-regex SQL checks

### DIFF
--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
@@ -39,7 +39,7 @@ public class R2dbcOperation {
                     for (Pattern pattern : operation.getValue()) {
                         Matcher matcher = pattern.matcher(strippedSql);
                         if (matcher.find()) {
-                            String model = matcher.groupCount() > 0 ? removeBrackets(unquoteDatabaseName(matcher.group(1).trim())) : "unknown";
+                            String model = removeBrackets(unquoteDatabaseName(matcher.group(1).trim()));
                             return new OperationAndTableName(operation.getKey(), VALID_METRIC_NAME_MATCHER.matcher(model).matches() ? model : "ParseError");
                         }
                     }

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
@@ -7,7 +7,6 @@
 
 package com.newrelic.agent.bridge.datastore;
 
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -32,11 +31,11 @@ public class R2dbcOperation {
 
     public static OperationAndTableName extractFrom(String sql) {
         String strippedSql = COMMENT_PATTERN.matcher(sql).replaceAll("");
-        String upperCaseSql = strippedSql.toUpperCase(); //NR-262136, upper case for case-insensitive non-regex-checks
+        String upperCaseSql = strippedSql.toUpperCase(); //upper case for case-insensitive non-regex-checks
         try {
             for (Map.Entry<String, Pattern[]> operation : OPERATION_PATTERNS.entrySet()) {
                 String opName = operation.getKey();
-                if (upperCaseSql.contains(opName)) { //NR-262136, non-regex check before pattern matching
+                if (upperCaseSql.contains(opName)) { //non-regex check before pattern matching
                     for (Pattern pattern : operation.getValue()) {
                         Matcher matcher = pattern.matcher(strippedSql);
                         if (matcher.find()) {

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
@@ -7,11 +7,9 @@
 
 package com.newrelic.agent.bridge.datastore;
 
-import com.newrelic.agent.bridge.AgentBridge;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
@@ -42,9 +42,10 @@ public class R2dbcOperation {
                     for (Pattern pattern : operation.getValue()) {
                         long start = System.currentTimeMillis();
                         Matcher matcher = pattern.matcher(strippedSql);
+                        boolean foundMatch = matcher.find();
                         long matchTime = System.currentTimeMillis() - start;
-                        AgentBridge.getAgent().getLogger().log(Level.FINEST, "NR-262136: regex pattern matching for " + opName + " took " + matchTime);
-                        if (matcher.find()) {
+                        AgentBridge.getAgent().getLogger().log(Level.FINEST, "NR-262136: finding match for " + opName + " took " + matchTime);
+                        if (foundMatch) {
                             String model = matcher.groupCount() > 0 ? removeBrackets(unquoteDatabaseName(matcher.group(1).trim())) : "unknown";
                             return new OperationAndTableName(operation.getKey(), VALID_METRIC_NAME_MATCHER.matcher(model).matches() ? model : "ParseError");
                         }

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
@@ -40,12 +40,8 @@ public class R2dbcOperation {
                 String opName = operation.getKey();
                 if (upperCaseSql.contains(opName)) { //NR-262136, non-regex check before pattern matching
                     for (Pattern pattern : operation.getValue()) {
-                        long start = System.currentTimeMillis();
                         Matcher matcher = pattern.matcher(strippedSql);
-                        boolean foundMatch = matcher.find();
-                        long matchTime = System.currentTimeMillis() - start;
-                        AgentBridge.getAgent().getLogger().log(Level.FINEST, "NR-262136: finding match for " + opName + " took " + matchTime);
-                        if (foundMatch) {
+                        if (matcher.find()) {
                             String model = matcher.groupCount() > 0 ? removeBrackets(unquoteDatabaseName(matcher.group(1).trim())) : "unknown";
                             return new OperationAndTableName(operation.getKey(), VALID_METRIC_NAME_MATCHER.matcher(model).matches() ? model : "ParseError");
                         }

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/R2dbcOperation.java
@@ -40,7 +40,10 @@ public class R2dbcOperation {
                 String opName = operation.getKey();
                 if (upperCaseSql.contains(opName)) { //NR-262136, non-regex check before pattern matching
                     for (Pattern pattern : operation.getValue()) {
+                        long start = System.currentTimeMillis();
                         Matcher matcher = pattern.matcher(strippedSql);
+                        long matchTime = System.currentTimeMillis() - start;
+                        AgentBridge.getAgent().getLogger().log(Level.FINEST, "NR-262136: regex pattern matching for " + opName + " took " + matchTime);
                         if (matcher.find()) {
                             String model = matcher.groupCount() > 0 ? removeBrackets(unquoteDatabaseName(matcher.group(1).trim())) : "unknown";
                             return new OperationAndTableName(operation.getKey(), VALID_METRIC_NAME_MATCHER.matcher(model).matches() ? model : "ParseError");

--- a/instrumentation/r2dbc-mssql/src/main/java/io/r2dbc/mssql/client/R2dbcUtils.java
+++ b/instrumentation/r2dbc-mssql/src/main/java/io/r2dbc/mssql/client/R2dbcUtils.java
@@ -27,6 +27,8 @@ public class R2dbcUtils {
             Transaction transaction = NewRelic.getAgent().getTransaction();
             if(transaction != null && !(transaction instanceof NoOpTransaction)) {
                 Segment segment = transaction.startSegment("execute");
+                long wrapperTime = System.currentTimeMillis() - start;
+                AgentBridge.getAgent().getLogger().log(Level.FINEST, "NR-262136: wrapping request took " + wrapperTime);
                 return request
                         .doOnSubscribe(reportExecution(sql, client, segment))
                         .doFinally((type) -> segment.end());

--- a/instrumentation/r2dbc-mssql/src/main/java/io/r2dbc/mssql/client/R2dbcUtils.java
+++ b/instrumentation/r2dbc-mssql/src/main/java/io/r2dbc/mssql/client/R2dbcUtils.java
@@ -1,6 +1,5 @@
 package io.r2dbc.mssql.client;
 
-import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.NoOpTransaction;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
 import com.newrelic.agent.bridge.datastore.OperationAndTableName;
@@ -18,7 +17,6 @@ import reactor.netty.Connection;
 import java.net.InetSocketAddress;
 
 import java.util.function.Consumer;
-import java.util.logging.Level;
 
 public class R2dbcUtils {
     public static Flux<MssqlResult> wrapRequest(Flux<MssqlResult> request, String sql, Client client) {

--- a/instrumentation/r2dbc-mssql/src/main/java/io/r2dbc/mssql/client/R2dbcUtils.java
+++ b/instrumentation/r2dbc-mssql/src/main/java/io/r2dbc/mssql/client/R2dbcUtils.java
@@ -42,7 +42,8 @@ public class R2dbcUtils {
             long start = System.currentTimeMillis();
             OperationAndTableName sqlOperation = R2dbcOperation.extractFrom(sql);
             long sqlOpTime = System.currentTimeMillis() - start;
-            AgentBridge.getAgent().getLogger().log(Level.FINEST, "NR-262136: extracting SQL operation took " + sqlOpTime);
+            String opName = (sqlOperation != null) ? sqlOperation.getOperation() : "none";
+            AgentBridge.getAgent().getLogger().log(Level.FINEST, "NR-262136: extracting SQL operation " + opName + " took " + sqlOpTime);
             InetSocketAddress socketAddress = extractSocketAddress(client);
             if (sqlOperation != null && socketAddress != null) {
                 segment.reportAsExternal(DatastoreParameters


### PR DESCRIPTION
This PR incorporates the changes from the custom jar we built to prevent unnecessary regex checks when parsing SQL. A customer had reported latency with r2dbc drivers, and removing the extra regex checks resolved their issue. 

Instead of performing a regex check for all operations, we now do a simple String `contains` on the operation name, before continuing with the match. 
