### PR TITLE
Minor refactoring of daily logfile rolling job to support all platforms.

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/logging/ClearExpiredLogsRunnable.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/logging/ClearExpiredLogsRunnable.java
@@ -43,7 +43,7 @@ public class ClearExpiredLogsRunnable implements Runnable {
     public ClearExpiredLogsRunnable(int fileCount, String logfile) {
         File absoluteLogFilename = new File(logfile);
         this.daysToKeepFiles = fileCount;
-        this.logDirectoryPath = Paths.get(absoluteLogFilename.getParent());
+        this.logDirectoryPath = absoluteLogFilename.getParent() == null ? Paths.get("./") : Paths.get(absoluteLogFilename.getParent());
 
         String fileNamePrefix = absoluteLogFilename.getName();
         pattern = Pattern.compile(fileNamePrefix.replace(".", "\\.")

--- a/newrelic-agent/src/main/java/com/newrelic/agent/logging/ClearExpiredLogsRunnable.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/logging/ClearExpiredLogsRunnable.java
@@ -2,6 +2,7 @@ package com.newrelic.agent.logging;
 
 import com.newrelic.api.agent.NewRelic;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,15 +37,15 @@ public class ClearExpiredLogsRunnable implements Runnable {
     /**
      * Constructs a ClearExpiredLogFilesRunnable object.
      *
-     * @param logDirectoryPath the directory path where log files are located
-     * @param fileCount        the number of days to keep log files before deleting them
-     * @param filePrefixPath   the file prefix used to filter log files
+     * @param fileCount the number of days to keep log files before deleting them
+     * @param logfile   the full path and filename of the agent logfile
      */
-    public ClearExpiredLogsRunnable(Path logDirectoryPath, int fileCount, String filePrefixPath) {
-        this.logDirectoryPath = logDirectoryPath;
+    public ClearExpiredLogsRunnable(int fileCount, String logfile) {
+        File absoluteLogFilename = new File(logfile);
         this.daysToKeepFiles = fileCount;
+        this.logDirectoryPath = Paths.get(absoluteLogFilename.getParent());
 
-        String fileNamePrefix = extractFileNamePrefix(filePrefixPath);
+        String fileNamePrefix = absoluteLogFilename.getName();
         pattern = Pattern.compile(fileNamePrefix.replace(".", "\\.")
                 + DATE_REGEX);
     }
@@ -87,11 +88,5 @@ public class ClearExpiredLogsRunnable implements Runnable {
         // Extract the date string from the file name using the pattern
         Matcher matcher = pattern.matcher(fileName);
         return matcher.find() ? matcher.group(1) : null;
-    }
-
-    private String extractFileNamePrefix(String fileName) {
-        // Extract the file name prefix from the given file path
-        String[] parts = fileName.split("/");
-        return parts[parts.length - 1];
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/logging/FileAppenderFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/logging/FileAppenderFactory.java
@@ -136,7 +136,7 @@ public class FileAppenderFactory {
             return thread;
         });
         executorService.scheduleWithFixedDelay(
-                new ClearExpiredLogsRunnable(directory, fileCount, fileName),
+                new ClearExpiredLogsRunnable(fileCount, fileName),
                 INITIAL_DELAY_SECONDS,
                 REPEAT_INTERVAL_SECONDS,
                 TimeUnit.SECONDS


### PR DESCRIPTION
### Overview
Resolves #1884 
Refactor of the `ClearExpiredLogsRunnable` constructor to remove the Path param. Uses an alternative method for grabbing the log file name and path.

Update tests.



### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
