### PR TITLE
Bump csec version to 1.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The agent version.
 agentVersion=8.12.0
-securityAgentVersion=1.2.1
+securityAgentVersion=1.3.0
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
Bump csec version to [1.3.0](https://github.com/newrelic/csec-java-agent/releases/tag/1.3.0)
