### PR TITLE
Ning memory leak fix

### DIFF
--- a/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -65,6 +65,7 @@ public class NRAsyncHandler<T> {
     }
 
     public void onThrowable(Throwable t) {
+        responseStatus = null;
         if (segment != null) {
             segment.reportAsExternal(GenericParameters
                     .library("AsyncHttpClient")
@@ -76,7 +77,6 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
-            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
         Weaver.callOriginal();
@@ -103,6 +103,9 @@ public class NRAsyncHandler<T> {
 
     @Trace(async = true)
     public T onCompleted() throws Exception {
+        Integer statusCode = getStatusCode();
+        String reasonMessage = getReasonMessage();
+        responseStatus = null;
         if (segment != null) {
             // This keeps the transaction alive after "segment.end()" just in case there are any completion handlers
             segment.getTransaction().getToken().linkAndExpire();
@@ -112,14 +115,13 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
-                    .status(getStatusCode(), getReasonMessage())
+                    .status(statusCode, reasonMessage)
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
             segment = null;
             uri = null;
             inboundHeaders = null;
-            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
 

--- a/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.0/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -65,7 +65,6 @@ public class NRAsyncHandler<T> {
     }
 
     public void onThrowable(Throwable t) {
-        responseStatus = null;
         if (segment != null) {
             segment.reportAsExternal(GenericParameters
                     .library("AsyncHttpClient")
@@ -74,11 +73,13 @@ public class NRAsyncHandler<T> {
                     .build());
             // This used to be segment.finish(t), but the agent doesn't automatically report it.
             segment.end();
-            segment = null;
-            uri = null;
-            inboundHeaders = null;
-            userAbortedOnStatusReceived = null;
         }
+        responseStatus = null;
+        segment = null;
+        uri = null;
+        inboundHeaders = null;
+        userAbortedOnStatusReceived = null;
+
         Weaver.callOriginal();
     }
 
@@ -103,9 +104,6 @@ public class NRAsyncHandler<T> {
 
     @Trace(async = true)
     public T onCompleted() throws Exception {
-        Integer statusCode = getStatusCode();
-        String reasonMessage = getReasonMessage();
-        responseStatus = null;
         if (segment != null) {
             // This keeps the transaction alive after "segment.end()" just in case there are any completion handlers
             segment.getTransaction().getToken().linkAndExpire();
@@ -115,15 +113,16 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
-                    .status(statusCode, reasonMessage)
+                    .status(getStatusCode(), getReasonMessage())
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
-            segment = null;
-            uri = null;
-            inboundHeaders = null;
-            userAbortedOnStatusReceived = null;
         }
+        responseStatus = null;
+        segment = null;
+        uri = null;
+        inboundHeaders = null;
+        userAbortedOnStatusReceived = null;
 
         return Weaver.callOriginal();
     }

--- a/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -62,7 +62,6 @@ public class NRAsyncHandler<T> {
     }
 
     public void onThrowable(Throwable t) {
-        responseStatus = null;
         if (segment != null) {
             segment.reportAsExternal(GenericParameters
                     .library("AsyncHttpClient")
@@ -71,11 +70,13 @@ public class NRAsyncHandler<T> {
                     .build());
             // This used to be segment.finish(t), but the agent doesn't automatically report it.
             segment.end();
-            segment = null;
-            uri = null;
-            inboundHeaders = null;
-            userAbortedOnStatusReceived = null;
         }
+        responseStatus = null;
+        segment = null;
+        uri = null;
+        inboundHeaders = null;
+        userAbortedOnStatusReceived = null;
+
         Weaver.callOriginal();
     }
 
@@ -93,9 +94,6 @@ public class NRAsyncHandler<T> {
 
     @Trace(async = true)
     public T onCompleted() throws Exception {
-        Integer statusCode = getStatusCode();
-        String reasonMessage = getReasonMessage();
-        responseStatus = null;
         if (segment != null) {
             // This keeps the transaction alive after "segment.end()" just in case there are any completion handlers
             segment.getTransaction().getToken().linkAndExpire();
@@ -105,15 +103,16 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
-                    .status(statusCode, reasonMessage)
+                    .status(getStatusCode(), getReasonMessage())
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
-            segment = null;
-            uri = null;
-            inboundHeaders = null;
-            userAbortedOnStatusReceived = null;
         }
+        responseStatus = null;
+        segment = null;
+        uri = null;
+        inboundHeaders = null;
+        userAbortedOnStatusReceived = null;
 
         return Weaver.callOriginal();
     }

--- a/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -62,6 +62,7 @@ public class NRAsyncHandler<T> {
     }
 
     public void onThrowable(Throwable t) {
+        responseStatus = null;
         if (segment != null) {
             segment.reportAsExternal(GenericParameters
                     .library("AsyncHttpClient")
@@ -73,7 +74,6 @@ public class NRAsyncHandler<T> {
             segment = null;
             uri = null;
             inboundHeaders = null;
-            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
         Weaver.callOriginal();
@@ -93,6 +93,9 @@ public class NRAsyncHandler<T> {
 
     @Trace(async = true)
     public T onCompleted() throws Exception {
+        Integer statusCode = getStatusCode();
+        String reasonMessage = getReasonMessage();
+        responseStatus = null;
         if (segment != null) {
             // This keeps the transaction alive after "segment.end()" just in case there are any completion handlers
             segment.getTransaction().getToken().linkAndExpire();
@@ -102,14 +105,13 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
-                    .status(getStatusCode(), getReasonMessage())
+                    .status(statusCode, reasonMessage)
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
             segment = null;
             uri = null;
             inboundHeaders = null;
-            responseStatus = null;
             userAbortedOnStatusReceived = null;
         }
 
@@ -117,8 +119,7 @@ public class NRAsyncHandler<T> {
     }
 
     private Integer getStatusCode() {
-        if (responseStatus != null)
-        {
+        if (responseStatus != null) {
             return responseStatus.getStatusCode();
         }
         return null;

--- a/instrumentation/ning-async-http-client-1.6.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
+++ b/instrumentation/ning-async-http-client-1.6.1/src/main/java/com/nr/agent/instrumentation/asynchttpclient/NRAsyncHandler.java
@@ -62,7 +62,6 @@ public class NRAsyncHandler<T> {
     }
 
     public void onThrowable(Throwable t) {
-        responseStatus = null;
         if (segment != null) {
             segment.reportAsExternal(GenericParameters
                     .library("AsyncHttpClient")
@@ -71,11 +70,13 @@ public class NRAsyncHandler<T> {
                     .build());
             //This used to be segment.finish(t), but the agent doesn't automatically report t.
             segment.end();
-            segment = null;
-            uri = null;
-            inboundHeaders = null;
-            userAbortedOnStatusReceived = null;
         }
+        segment = null;
+        uri = null;
+        inboundHeaders = null;
+        userAbortedOnStatusReceived = null;
+        responseStatus = null;
+
         Weaver.callOriginal();
     }
 
@@ -93,9 +94,6 @@ public class NRAsyncHandler<T> {
 
     @Trace(async = true)
     public T onCompleted() throws Exception {
-        Integer statusCode = getStatusCode();
-        String reasonMessage = getReasonMessage();
-        responseStatus = null;
         if (segment != null) {
             // This keeps the transaction alive after "segment.end()" just in case there are any completion handlers
             segment.getTransaction().getToken().linkAndExpire();
@@ -105,15 +103,16 @@ public class NRAsyncHandler<T> {
                     .uri(uri)
                     .procedure("onCompleted")
                     .inboundHeaders(inboundHeaders)
-                    .status(statusCode, reasonMessage)
+                    .status(getStatusCode(), getReasonMessage())
                     .build());
             // This used to be segment.finish(t), but the agent doesn't automatically report it.
             segment.end();
-            segment = null;
-            uri = null;
-            inboundHeaders = null;
-            userAbortedOnStatusReceived = null;
         }
+        responseStatus = null;
+        segment = null;
+        uri = null;
+        inboundHeaders = null;
+        userAbortedOnStatusReceived = null;
 
         return Weaver.callOriginal();
     }


### PR DESCRIPTION
Resolves: https://github.com/newrelic/newrelic-java-agent/issues/783

Fixes a memory that could occur with the Ning async http client instrumentation. 

The leak would happen when the async client was invoked outside of an active agent transaction. This would cause the `segment` to be `null`, preventing references to the `responseStatus` and several other objects stored in `NewField`s from being released.