### PR TITLE
Exclude pekko AITs

### DIFF
--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -71,6 +71,8 @@ jobs:
           echo "server/weblogic.py" >> $excluded_tests
           echo "basic_features/inf_tracing_test.py" >> $excluded_tests
           echo "security/lasp_msg_params.py" >> $excluded_tests
+          echo "framework/pekko/pekko.py" >> $excluded_tests
+          echo "framework/pekko/pekkohttp.py" >> $excluded_tests
           # The files below are not tests
           echo "trace/client.py" >> $excluded_tests
           echo "trace/server.py" >> $excluded_tests


### PR DESCRIPTION
Both pekko AIT tests are intermittently stalling after the update to GHA shas. Need to look into why. 
