### PR TITLE
R2dbc postgresql 0.9.2 memleak fix

### DIFF
--- a/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/com/nr/instrumentation/r2dbc/postgresql092/EndpointData.java
+++ b/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/com/nr/instrumentation/r2dbc/postgresql092/EndpointData.java
@@ -1,0 +1,19 @@
+package com.nr.instrumentation.r2dbc.postgresql092;
+
+public class EndpointData {
+    private final int port;
+    private final String hostName;
+
+    public EndpointData(String hostName, int port) {
+        this.port = port;
+        this.hostName = hostName;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+}

--- a/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/io/r2dbc/postgresql/R2dbcUtils.java
+++ b/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/io/r2dbc/postgresql/R2dbcUtils.java
@@ -15,16 +15,14 @@ import com.newrelic.api.agent.DatastoreParameters;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Transaction;
-import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import com.nr.instrumentation.r2dbc.postgresql092.EndpointData;
 import io.r2dbc.postgresql.api.PostgresqlResult;
 import io.r2dbc.postgresql.client.Client;
 import io.r2dbc.postgresql.client.ReactorNettyClient_Instrumentation;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
-import reactor.netty.Connection;
 import reactor.util.annotation.Nullable;
 
-import java.net.InetSocketAddress;
 import java.util.function.Consumer;
 
 public class R2dbcUtils {
@@ -44,13 +42,13 @@ public class R2dbcUtils {
     private static Consumer<Subscription> reportExecution(String sql, Client client, PostgresqlConnectionConfiguration connectionConfiguration, Segment segment) {
         return (subscription) -> {
             OperationAndTableName sqlOperation = R2dbcOperation.extractFrom(sql);
-            InetSocketAddress socketAddress = extractSocketAddress(client);
-            if (sqlOperation != null && socketAddress != null) {
+            EndpointData endpointData = extractEndpointData(client);
+            if (sqlOperation != null && endpointData != null) {
                 segment.reportAsExternal(DatastoreParameters
                         .product(DatastoreVendor.Postgres.name())
                         .collection(sqlOperation.getTableName())
                         .operation(sqlOperation.getOperation())
-                        .instance(socketAddress.getHostName(), socketAddress.getPort())
+                        .instance(endpointData.getHostName(), endpointData.getPort())
                         .databaseName(connectionConfiguration.getDatabase())
                         .slowQuery(sql, R2dbcObfuscator.POSTGRES_QUERY_CONVERTER)
                         .build());
@@ -58,14 +56,11 @@ public class R2dbcUtils {
         };
     }
 
-    public static @Nullable InetSocketAddress extractSocketAddress(Client client) {
+    public static @Nullable EndpointData extractEndpointData(Client client) {
         try {
             if(client instanceof ReactorNettyClient_Instrumentation) {
                 ReactorNettyClient_Instrumentation instrumentedClient = (ReactorNettyClient_Instrumentation) client;
-                Connection clientConnection = instrumentedClient.clientConnection;
-                if(clientConnection.channel().remoteAddress() != null && clientConnection.channel().remoteAddress() instanceof InetSocketAddress) {
-                    return (InetSocketAddress) clientConnection.channel().remoteAddress();
-                }
+                return instrumentedClient.endpointData;
             }
             return null;
         } catch(Exception exception) {

--- a/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/io/r2dbc/postgresql/R2dbcUtils.java
+++ b/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/io/r2dbc/postgresql/R2dbcUtils.java
@@ -21,29 +21,31 @@ import io.r2dbc.postgresql.client.Client;
 import io.r2dbc.postgresql.client.ReactorNettyClient_Instrumentation;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
+import reactor.netty.Connection;
 import reactor.util.annotation.Nullable;
 
+import java.net.InetSocketAddress;
 import java.util.function.Consumer;
 
 public class R2dbcUtils {
     public static Flux<PostgresqlResult> wrapRequest(Flux<PostgresqlResult> request, String sql, Client client, PostgresqlConnectionConfiguration connectionConfiguration) {
         if(request != null) {
             Transaction transaction = NewRelic.getAgent().getTransaction();
-            if(transaction != null && !(transaction instanceof NoOpTransaction)) {
+            EndpointData endpointData = extractEndpointData(client);
+            if(transaction != null && !(transaction instanceof NoOpTransaction) && endpointData != null) {
                 Segment segment = transaction.startSegment("execute");
                 return request
-                        .doOnSubscribe(reportExecution(sql, client, connectionConfiguration, segment))
+                        .doOnSubscribe(reportExecution(sql, endpointData, connectionConfiguration, segment))
                         .doFinally((type) -> segment.end());
             }
         }
         return request;
     }
 
-    private static Consumer<Subscription> reportExecution(String sql, Client client, PostgresqlConnectionConfiguration connectionConfiguration, Segment segment) {
+    private static Consumer<Subscription> reportExecution(String sql, EndpointData endpointData, PostgresqlConnectionConfiguration connectionConfiguration, Segment segment) {
         return (subscription) -> {
             OperationAndTableName sqlOperation = R2dbcOperation.extractFrom(sql);
-            EndpointData endpointData = extractEndpointData(client);
-            if (sqlOperation != null && endpointData != null) {
+            if (sqlOperation != null) {
                 segment.reportAsExternal(DatastoreParameters
                         .product(DatastoreVendor.Postgres.name())
                         .collection(sqlOperation.getTableName())

--- a/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient_Instrumentation.java
+++ b/instrumentation/r2dbc-postgresql-0.9.2/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient_Instrumentation.java
@@ -9,19 +9,24 @@ package io.r2dbc.postgresql.client;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
-import io.r2dbc.postgresql.client.ConnectionSettings;
+import com.nr.instrumentation.r2dbc.postgresql092.EndpointData;
 import reactor.netty.Connection;
 
-import java.util.Optional;
-import java.util.TimeZone;
+import java.net.InetSocketAddress;
 
 @Weave(type = MatchType.ExactClass, originalName = "io.r2dbc.postgresql.client.ReactorNettyClient")
 public abstract class ReactorNettyClient_Instrumentation {
+
     @NewField
-    public final Connection clientConnection;
+    public final EndpointData endpointData;
 
     private ReactorNettyClient_Instrumentation(Connection connection, ConnectionSettings settings) {
-        this.clientConnection = connection;
+        if(connection.channel().remoteAddress() != null && connection.channel().remoteAddress() instanceof InetSocketAddress) {
+            InetSocketAddress socketAddress = (InetSocketAddress) connection.channel().remoteAddress();
+            endpointData = new EndpointData(socketAddress.getHostName(), socketAddress.getPort());
+        } else {
+            endpointData = null;
+        }
     }
 
 }


### PR DESCRIPTION
### Overview
Changes to the Postgres R2DBC 9.2+ instrumentation that improve memory usage. In particular, runs of this branch of the agent did not cause a growth in heap usage compared to the old agent over time.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/1702
