### PR TITLE
Add null checks to vertx 4.5.1 instrumentation

### DIFF
--- a/instrumentation/vertx-core-4.5.1/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
+++ b/instrumentation/vertx-core-4.5.1/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
@@ -28,8 +28,9 @@ public class AsyncHandlerWrapper<T> implements Handler<AsyncResult<T>> {
             token.linkAndExpire();
             token = null;
         }
-
-        this.original.handle(event);
-        this.original = null;
+        if (this.original != null) {
+            this.original.handle(event);
+            this.original = null;
+        }
     }
 }

--- a/instrumentation/vertx-core-4.5.1/src/main/java/io/vertx/core/impl/ContextImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.5.1/src/main/java/io/vertx/core/impl/ContextImpl_Instrumentation.java
@@ -30,10 +30,11 @@ public abstract class ContextImpl_Instrumentation {
     }
 
     static <T> void setResultHandler(ContextInternal ctx, Future<T> fut, Handler<AsyncResult<T>> resultHandler) {
-        Transaction txn = AgentBridge.getAgent().getTransaction(false);
-        if (txn != null) {
-            resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+        if (resultHandler != null){
+            Transaction txn = AgentBridge.getAgent().getTransaction(false);
+            if (txn != null) {
+                resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+            }
         }
-        Weaver.callOriginal();
     }
 }

--- a/instrumentation/vertx-core-4.5.1/src/main/java/io/vertx/core/impl/ContextImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.5.1/src/main/java/io/vertx/core/impl/ContextImpl_Instrumentation.java
@@ -36,5 +36,6 @@ public abstract class ContextImpl_Instrumentation {
                 resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
             }
         }
+        Weaver.callOriginal();
     }
 }

--- a/instrumentation/vertx-core-4.5.1/src/test/java/com/nr/vertx/instrumentation/VertxBlockingTest.java
+++ b/instrumentation/vertx-core-4.5.1/src/test/java/com/nr/vertx/instrumentation/VertxBlockingTest.java
@@ -43,9 +43,24 @@ public class VertxBlockingTest {
             vertx.close();
         }
     }
+    @Test
+    public void executeBlocking_nullResultHandler() throws InterruptedException {
+        //Vertx allows resultHandler to be null.
+        Vertx vertx = Vertx.vertx();
+        executeBlocking_nullHandler(vertx);
+        String expectedTxnName = "OtherTransaction/Custom/com.nr.vertx.instrumentation.VertxBlockingTest/executeBlocking_nullHandler";
+        Introspector introspector = InstrumentationTestRunner.getIntrospector();
+        assertEquals(1, introspector.getFinishedTransactionCount(500));
+        assertEquals(1, introspector.getTransactionEvents(expectedTxnName).size());
+        for (TransactionEvent txnEvent: introspector.getTransactionEvents(expectedTxnName)) {
+            Map<String, Object> attributes = txnEvent.getAttributes();
+            assertTrue(attributes.containsKey("InFuture"));
+        }
+        vertx.close();
+    }
 
     @Trace(dispatcher = true)
-    void executeBlocking(Vertx vertx) throws InterruptedException {
+    void executeBlocking(Vertx vertx) throws InterruptedException{
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         vertx.executeBlocking(future -> {
             NewRelic.addCustomParameter("InFuture", "yes");
@@ -56,4 +71,16 @@ public class VertxBlockingTest {
         });
         countDownLatch.await();
     }
+
+    @Trace(dispatcher = true)
+    void executeBlocking_nullHandler(Vertx vertx) throws InterruptedException {
+        vertx.executeBlocking(future -> {
+            NewRelic.addCustomParameter("InFuture", "yes");
+            future.complete();
+        }, null);
+        //give the call to executeBlocking time to complete
+        Thread.sleep(500);
+    }
+
+
 }


### PR DESCRIPTION
Resolves #1774 

Customers were seeing NPEs after upgrading to version 8.9.0 of the agent, which added support for vertx 4.5.1. The NPEs were happening inside our `AsyncHandlerWrapper` class. 

This PR updates the instrumentation to prevent the creation of an `AsyncHandlerWrapper` if the original `resultHandler` is null. A further null check is added to `AsyncHandlerWrapper` itself to safeguard against the possibility that `handle` might get called twice somewhere later in the code. 

I added a unit test where the resultHandler is null. However, this test isn't a "true" test because the existing NPE doesn't cause the test to fail (this NPE occurs off the main thread). Instead, an ugly SEVERE message appears in the stack trace without the fix.

I wasn't able to find a way to improve the test to truly capture the NPE, but decided to leave it in just to verify that the transaction and future handling still works as expected. 
