### PR TITLE
glassfish-6: excluding some milestones

### DIFF
--- a/instrumentation/glassfish-6/build.gradle
+++ b/instrumentation/glassfish-6/build.gradle
@@ -15,6 +15,10 @@ verifyInstrumentation {
     exclude 'org.glassfish.main.web:web-core:7.0.0-M3'
     exclude 'org.glassfish.main.web:web-core:7.0.0-M4'
     exclude 'org.glassfish.main.web:web-core:7.0.0-M10'
+    exclude 'org.glassfish.main.web:web-core:8.0.0-M5'
+    exclude 'org.glassfish.main.web:web-core:8.0.0-JDK17-M5'
+    exclude 'org.glassfish.main.web:web-core:8.0.0-M6'
+    exclude 'org.glassfish.main.web:web-core:8.0.0-JDK17-M6'
 }
 
 site {


### PR DESCRIPTION
### Overview
Glassfish-6 instrumentation module applies to the newly released 8.0.0 milestones. Since this version of Glassfish will include a newer version of Jakarta, it is likely that we will indeed need a new instrumentation module. So for now, the milestones that allow the instrumentation module to be applied are going to be excluded.

### Related Github Issue
#1806 

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
