### PR TITLE
CSEC Version bump to 1.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The agent version.
 agentVersion=8.13.0
-securityAgentVersion=1.3.0
+securityAgentVersion=1.4.0
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
Bump CSEC Version to [1.4.0](https://github.com/newrelic/csec-java-agent/releases/tag/1.4.0)