### PR TITLE
Refactor vertx-web to weave Http2ServerConnection

### DIFF
--- a/instrumentation/vertx-web-3.8.0/src/main/java/io/vertx/core/http/impl/HttpServerConnection_Instrumentation.java
+++ b/instrumentation/vertx-web-3.8.0/src/main/java/io/vertx/core/http/impl/HttpServerConnection_Instrumentation.java
@@ -1,27 +1,27 @@
 /*
  *
- *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
 
 package io.vertx.core.http.impl;
 
+import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.vertx.instrumentation.VertxUtil;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 
-@Weave(originalName = "io.vertx.core.http.impl.Http1xServerConnection")
-public class Http1xServerConnection_Instrumentation {
-
+// This interface has HTTP/1 and HTTP/2 implementations
+@Weave(type = MatchType.Interface, originalName = "io.vertx.core.http.impl.HttpServerConnection")
+public abstract class HttpServerConnection_Instrumentation {
     public HttpServerConnection handler(Handler<HttpServerRequest> handler) {
         if (handler != null) {
-            // Wrap the request handler so we can start the transaction and start tracking child threads
+            // Wrap the request handler, so we can start the transaction and start tracking child threads
             handler = VertxUtil.wrapRequestHandler(handler);
         }
         return Weaver.callOriginal();
     }
-
 }

--- a/instrumentation/vertx-web-3.8.3/src/main/java/io/vertx/core/http/impl/HttpServerConnection_Instrumentation.java
+++ b/instrumentation/vertx-web-3.8.3/src/main/java/io/vertx/core/http/impl/HttpServerConnection_Instrumentation.java
@@ -1,27 +1,27 @@
 /*
  *
- *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
 
 package io.vertx.core.http.impl;
 
+import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.vertx.instrumentation.VertxUtil;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 
-@Weave(originalName = "io.vertx.core.http.impl.Http1xServerConnection")
-public class Http1xServerConnection_Instrumentation {
-
+// This interface has HTTP/1 and HTTP/2 implementations
+@Weave(type = MatchType.Interface, originalName = "io.vertx.core.http.impl.HttpServerConnection")
+public abstract class HttpServerConnection_Instrumentation {
     public HttpServerConnection handler(Handler<HttpServerRequest> handler) {
         if (handler != null) {
-            // Wrap the request handler so we can start the transaction and start tracking child threads
+            // Wrap the request handler, so we can start the transaction and start tracking child threads
             handler = VertxUtil.wrapRequestHandler(handler);
         }
         return Weaver.callOriginal();
     }
-
 }


### PR DESCRIPTION
Fixes a gap in the `vertx-web` instrumentation where transactions weren't getting started when handling HTTP/2 requests.

Weaves the `io.vertx.core.http.impl.HttpServerConnection` interface instead of just the `Http1xServerConnection` implementation. This results in `Http1xServerConnection` being weaved as well as the previously un-instrumented `Http2ServerConnection` implementation.