### PR TITLE
Additional metrics for HikariCP module

### DIFF
--- a/instrumentation/hikaricp-2.4.0/README.md
+++ b/instrumentation/hikaricp-2.4.0/README.md
@@ -8,6 +8,14 @@ artifact should be removed from the agent's `extension` folder if present.
 
 ### Reported Metrics
 Every 5 seconds, the following metrics will be reported:
-- `Database Connection/HikariCP/{PoolName}/Busy Count[connections]`: Retrieved from the [HikariPoolMXBean](https://www.javadoc.io/doc/com.zaxxer/HikariCP/2.4.6/com/zaxxer/hikari/HikariPoolMXBean.html) instance
-- `Database Connection/HikariCP/{PoolName}/Idle Count[connections]`: Retrieved from the [HikariPoolMXBean](https://www.javadoc.io/doc/com.zaxxer/HikariCP/2.4.6/com/zaxxer/hikari/HikariPoolMXBean.html) instance
-- `Database Connection/HikariCP/{PoolName}/Max Pool Size[connections]`: Retrieved from the [HikariConfig](https://www.javadoc.io/static/com.zaxxer/HikariCP/2.4.6/index.html?com/zaxxer/hikari/pool/HikariPool.html) instance
+- `Database Connection/HikariCP/Busy Count[connections]`: Retrieved from HikariPool.getActiveConnections()
+- `Database Connection/HikariCP/Idle Count[connections]`: Retrieved from HikariPool.getIdleConnections()
+- `Database Connection/HikariCP/Total Count[connections]`: Retrieved from HikariPool.getTotalConnections()
+- `Database Connection/HikariCP/Threads Awaiting Count[connections]`: Retrieved from HikariPool.getThreadsAwaitingConnection()
+- `Database Connection/HikariCP/Max Pool Size[connections]`: Retrieved from HikariConfig.getMaximumPoolSize()
+- `Database Connection/HikariCP/Minimum Idle Size[connections]`: Retrieved from HikariConfig.getMinimumIdle()
+- `Database Connection/HikariCP/Connection Timeout`: Retrieved from HikariConfig.getConnectionTimeout()
+- `Database Connection/HikariCP/Idle Timeout`: Retrieved from HikariConfig.getIdleTimeout()
+- `Database Connection/HikariCP/Leak Detection Threshold`: Retrieved from HikariConfig.getLeakDetectionThreshold()
+- `Database Connection/HikariCP/Maximum Lifetime`: Retrieved from HikariConfig.getMaxLifetime()
+- `Database Connection/HikariCP/Validation Timeout`: Retrieved from HikariConfig.getValidationTimeout()

--- a/instrumentation/hikaricp-2.4.0/src/main/java/com/zaxxer/hikari/pool/PooledDataSourceSampler.java
+++ b/instrumentation/hikaricp-2.4.0/src/main/java/com/zaxxer/hikari/pool/PooledDataSourceSampler.java
@@ -39,6 +39,14 @@ public class PooledDataSourceSampler implements Runnable {
         MetricAggregator metricAggregator = NewRelic.getAgent().getMetricAggregator();
         metricAggregator.recordMetric(baseName + "Busy Count[connections]", hikariPool.getActiveConnections());
         metricAggregator.recordMetric(baseName + "Idle Count[connections]", hikariPool.getIdleConnections());
+        metricAggregator.recordMetric(baseName + "Total Count[connections]", hikariPool.getTotalConnections());
+        metricAggregator.recordMetric(baseName + "Threads Awaiting Count[connections]", hikariPool.getThreadsAwaitingConnection());
         metricAggregator.recordMetric(baseName + "Max Pool Size[connections]", config.getMaximumPoolSize());
+        metricAggregator.recordMetric(baseName + "Minimum Idle Size[connections]", config.getMinimumIdle());
+        metricAggregator.recordMetric(baseName + "Connection Timeout", config.getConnectionTimeout());
+        metricAggregator.recordMetric(baseName + "Idle Timeout", config.getIdleTimeout());
+        metricAggregator.recordMetric(baseName + "Leak Detection Threshold", config.getLeakDetectionThreshold());
+        metricAggregator.recordMetric(baseName + "Maximum Lifetime", config.getMaxLifetime());
+        metricAggregator.recordMetric(baseName + "Validation Timeout", config.getValidationTimeout());
     }
 }


### PR DESCRIPTION
### Overview
Resolves #1965 

Adds additional metrics pulled from the `HikariPool` and `HikariConfig` classes. The full list:

- `Database Connection/HikariCP/Busy Count[connections]`: Retrieved from HikariPool.getActiveConnections()
- `Database Connection/HikariCP/Idle Count[connections]`: Retrieved from HikariPool.getIdleConnections()
- `Database Connection/HikariCP/Total Count[connections]`: Retrieved from HikariPool.getTotalConnections()
- `Database Connection/HikariCP/Threads Awaiting Count[connections]`: Retrieved from HikariPool.getThreadsAwaitingConnection()
- `Database Connection/HikariCP/Max Pool Size[connections]`: Retrieved from HikariConfig.getMaximumPoolSize()
- `Database Connection/HikariCP/Minimum Idle Size[connections]`: Retrieved from HikariConfig.getMinimumIdle()
- `Database Connection/HikariCP/Connection Timeout`: Retrieved from HikariConfig.getConnectionTimeout()
- `Database Connection/HikariCP/Idle Timeout`: Retrieved from HikariConfig.getIdleTimeout()
- `Database Connection/HikariCP/Leak Detection Threshold`: Retrieved from HikariConfig.getLeakDetectionThreshold()
- `Database Connection/HikariCP/Maximum Lifetime`: Retrieved from HikariConfig.getMaxLifetime()
- `Database Connection/HikariCP/Validation Timeout`: Retrieved from HikariConfig.getValidationTimeout()