### PR TITLE
Exclude mssql-jdbc-12.7.0 Pre-Release From VerifyInstrumentation

### DIFF
--- a/instrumentation/jdbc-sqlserver/build.gradle
+++ b/instrumentation/jdbc-sqlserver/build.gradle
@@ -8,7 +8,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passes("com.microsoft.sqlserver:mssql-jdbc:[0,)")
+    passesOnly("com.microsoft.sqlserver:mssql-jdbc:[0,)")
     exclude("com.microsoft.sqlserver:mssql-jdbc:12.7.0") // 12.7.0 is a pre-release version
     excludeRegex(".*jre9.*")
     excludeRegex(".*jre1\\d.*")

--- a/instrumentation/jdbc-sqlserver/build.gradle
+++ b/instrumentation/jdbc-sqlserver/build.gradle
@@ -8,7 +8,8 @@ jar {
 }
 
 verifyInstrumentation {
-    passes("com.microsoft.sqlserver:mssql-jdbc:[0,12.7.0)")
+    passes("com.microsoft.sqlserver:mssql-jdbc:[0,)")
+    exclude("com.microsoft.sqlserver:mssql-jdbc:12.7.0") // 12.7.0 is a pre-release version
     excludeRegex(".*jre9.*")
     excludeRegex(".*jre1\\d.*")
     excludeRegex(".*preview.*")


### PR DESCRIPTION
Excludes `mssql-jdbc-12.7.0 Pre-Release` from being verified.
Updates the range of `mssql-jdbc` versions to be verified.

Resolves [Issue 1844](https://github.com/newrelic/newrelic-java-agent/issues/1844)