### PR TITLE
MongoDB - verify instrumentation using new artifact name

### DIFF
--- a/instrumentation/mongodb-3.7/build.gradle
+++ b/instrumentation/mongodb-3.7/build.gradle
@@ -18,6 +18,7 @@ verifyInstrumentation {
     // MongoClientOptions and MongoClientSettings can be present thus both the mongodb-3.1 and mongodb-3.7
     // instrumentation modules can apply at the same time without weaving the same thing.
     passes('org.mongodb:mongo-java-driver:[3.7.0-rc0,)')
+    passes('org.mongodb:mongodb-driver-sync:[3.7.0-rc0,)')
     fails('org.mongodb:mongo-java-driver:[0.9.1,3.7.0-rc0)')
 }
 


### PR DESCRIPTION
### Overview
Verifies that the mongodb-3.7 instrumentation module applies to the new artifact name being released by Mongo.

### Related Github Issue
#2034

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
