### PR TITLE
Fix an issue where the Kinesis instrumentation is generating ERROR logs due to a NullPointerException

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -854,7 +854,9 @@ public class DefaultTracer extends AbstractTracer {
 
     private void recordFaasAttributes(CloudParameters cloudParameters) {
         setAgentAttribute(AttributeNames.CLOUD_PLATFORM, cloudParameters.getPlatform());
-        setAgentAttribute(AttributeNames.CLOUD_RESOURCE_ID, cloudParameters.getResourceId());
+        if (cloudParameters.getResourceId() != null) {
+            setAgentAttribute(AttributeNames.CLOUD_RESOURCE_ID, cloudParameters.getResourceId());
+        }
     }
 
     private <T> void recordSlowQueryData(SlowQueryDatastoreParameters<T> slowQueryDatastoreParameters) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -853,7 +853,9 @@ public class DefaultTracer extends AbstractTracer {
     }
 
     private void recordFaasAttributes(CloudParameters cloudParameters) {
-        setAgentAttribute(AttributeNames.CLOUD_PLATFORM, cloudParameters.getPlatform());
+        if (cloudParameters.getPlatform() != null) {
+            setAgentAttribute(AttributeNames.CLOUD_PLATFORM, cloudParameters.getPlatform());
+        }
         if (cloudParameters.getResourceId() != null) {
             setAgentAttribute(AttributeNames.CLOUD_RESOURCE_ID, cloudParameters.getResourceId());
         }


### PR DESCRIPTION
### Overview
Fixes an issue where ERROR logs were generated by the Kinesis instrumentation due to a NullPointerException.
```
2024-09-16T13:37:08,315-0400 [10984 66] com.newrelic ERROR: An error occurred recording external metrics for class putRecord : java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "value" is null

```
