### PR TITLE
Lazily initiate guid on DefaultTracer

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -145,7 +145,6 @@ public class DefaultTracer extends AbstractTracer {
         }
 
         this.tracerFlags = (byte) tracerFlags;
-        this.guid = TransactionGuidFactory.generate16CharGuid();
     }
 
     public DefaultTracer(TransactionActivity txa, ClassMethodSignature sig, Object object,
@@ -169,7 +168,11 @@ public class DefaultTracer extends AbstractTracer {
 
     @Override
     public String getGuid() {
-        return guid;
+        String theGuid = this.guid;
+        if (theGuid == null) {
+            this.guid = theGuid = TransactionGuidFactory.generate16CharGuid();
+        }
+        return theGuid;
     }
 
     @Override


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
I was doing some flame graph analysis and noticed that every tracer had a guid created. However, it would appear that the guid is only really needed on demand if the trace is being reported on.

Here are the flame/icicle graphs of memory allocations from a simple Spring webflux app. Note the number of instances with byte[], char[], String, and DefaultTracer are most allocated.
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/1229a619-7fe5-4bc4-9d84-3c191beec757">
<img width="1314" alt="image" src="https://github.com/user-attachments/assets/86573412-d933-4e0c-a009-4f37dcfef188">

Unrelated (for a different issue), the reactive streams instrumentation on spring boot creates an gigantic number of tracers. I'm thinking of ways to maybe cut down on that. Or maybe DefaultTracer/AbstractTracer could be make lighter (there are a lot of fields).

NOTE: does this need to be thread safe? I could add a lock or CAS, if you want.

### Related Github Issue
none

### Testing
Normal CI suite should pass. If you run flame chart analysis the additional memory allocations should disappear.

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
