### PR TITLE
Cap mongo-reactive-4.8 module

### DIFF
--- a/instrumentation/mongodb-reactive-streams-4.8/build.gradle
+++ b/instrumentation/mongodb-reactive-streams-4.8/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 
 verifyInstrumentation {
-    passesOnly 'org.mongodb:mongodb-driver-reactivestreams:[4.8.0,)'
+    passesOnly 'org.mongodb:mongodb-driver-reactivestreams:[4.8.0,5.2.0)'
 	excludeRegex 'org.mongodb:mongodb-driver-reactivestreams:.*(alpha|beta|rc|SNAPSHOT).*'
 }
 


### PR DESCRIPTION
Cap mongo-reactive-4.8 module to exclude v5.20+