### PR TITLE
Cloud API

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/AgentBridge.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/AgentBridge.java
@@ -42,6 +42,8 @@ public final class AgentBridge {
 
     public static volatile AsyncApi asyncApi = new NoOpAsyncApi();
 
+    public static volatile CloudApi cloud = NoOpCloud.INSTANCE;
+
     public static volatile CollectionFactory collectionFactory = new DefaultCollectionFactory();
 
     /**

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/CloudApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/CloudApi.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.bridge;
+
+import com.newrelic.api.agent.Cloud;
+import com.newrelic.api.agent.CloudAccountInfo;
+
+/**
+ * Internal Cloud API. This extends the public Cloud API and adds methods
+ * for retrieving the data set by the public API methods.
+ */
+public interface CloudApi extends Cloud {
+
+    /**
+     * Return the general account information of the provided type.
+     * This data is either set by {@link Cloud#setAccountInfo(CloudAccountInfo, String)}
+     * or the agent config.
+     */
+    String getAccountInfo(CloudAccountInfo cloudAccountInfo);
+
+    /**
+     * Retrieves the account information for a cloud service SDK client.
+     * If no data was recorded for the SDK client, the general account information will be returned.
+     */
+    String getAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo);
+}

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpAgent.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpAgent.java
@@ -8,6 +8,7 @@
 package com.newrelic.agent.bridge;
 
 import com.newrelic.api.agent.AiMonitoring;
+import com.newrelic.api.agent.Cloud;
 import com.newrelic.api.agent.Config;
 import com.newrelic.api.agent.ErrorApi;
 import com.newrelic.api.agent.Insights;
@@ -71,6 +72,11 @@ class NoOpAgent implements Agent {
     @Override
     public AiMonitoring getAiMonitoring() {
         return NoOpAiMonitoring.INSTANCE;
+    }
+
+    @Override
+    public Cloud getCloud() {
+        return NoOpCloud.INSTANCE;
     }
 
     @Override

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpCloud.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpCloud.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.bridge;
+
+import com.newrelic.api.agent.CloudAccountInfo;
+
+public class NoOpCloud implements CloudApi {
+
+    public static final CloudApi INSTANCE = new NoOpCloud();
+
+    private NoOpCloud() {
+        // only instance should be the INSTANCE
+    }
+
+    @Override
+    public void setAccountInfo(CloudAccountInfo cloudAccountInfo, String value) {
+    }
+
+    @Override
+    public void setAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo, String value) {
+    }
+
+    @Override
+    public String getAccountInfo(CloudAccountInfo cloudAccountInfo) {
+        return null;
+    }
+
+    @Override
+    public String getAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo) {
+        return null;
+    }
+}

--- a/functional_test/src/test/java/com/newrelic/agent/extension/FakeExtensionAgent.java
+++ b/functional_test/src/test/java/com/newrelic/agent/extension/FakeExtensionAgent.java
@@ -11,6 +11,7 @@ import com.newrelic.agent.bridge.Agent;
 import com.newrelic.agent.bridge.TracedMethod;
 import com.newrelic.agent.bridge.Transaction;
 import com.newrelic.api.agent.AiMonitoring;
+import com.newrelic.api.agent.Cloud;
 import com.newrelic.api.agent.Config;
 import com.newrelic.api.agent.ErrorApi;
 import com.newrelic.api.agent.Insights;
@@ -41,6 +42,11 @@ public class FakeExtensionAgent implements Agent {
 
     @Override
     public AiMonitoring getAiMonitoring() {
+        return null;
+    }
+
+    @Override
+    public Cloud getCloud() {
         return null;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
@@ -17,6 +17,7 @@ import com.newrelic.agent.bridge.Transaction;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.api.agent.AiMonitoring;
+import com.newrelic.api.agent.Cloud;
 import com.newrelic.api.agent.ErrorApi;
 import com.newrelic.api.agent.Insights;
 import com.newrelic.api.agent.Logger;
@@ -142,6 +143,11 @@ public class AgentImpl implements com.newrelic.agent.bridge.Agent {
     @Override
     public AiMonitoring getAiMonitoring() {
         return new AiMonitoringImpl();
+    }
+
+    @Override
+    public Cloud getCloud() {
+        return AgentBridge.cloud;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -361,6 +361,11 @@ public class MetricNames {
     public static final String SUPPORTABILITY_API_SET_ACCOUNT_NAME = "SetAccountName";
     public static final String SUPPORTABILITY_API_SET_USER_ID = "SetUserId";
 
+    // Cloud API
+    public static final String SUPPORTABILITY_API_CLOUD_SET_ACCOUNT_INFO_CLIENT = "Cloud/SetAccountInfoClient/";
+    public static final String SUPPORTABILITY_API_CLOUD_SET_ACCOUNT_INFO = "Cloud/SetAccountInfo/";
+    public static final String SUPPORTABILITY_CONFIG_AWS_ACCOUNT_ID = "Supportability/Cloud/ConfigAccountInfo/aws_account_id";
+
     //Transaction supportability metrics
     public static final String SUPPORTABILITY_TRANSACTION_STARTED = "Supportability/Transaction/StartedCount";
     public static final String SUPPORTABILITY_TRANSACTION_FINISHED = "Supportability/Transaction/FinishedCount";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudAccountInfoCache.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudAccountInfoCache.java
@@ -49,6 +49,7 @@ public class CloudAccountInfoCache {
             if (accountInfo != null) {
                 accountInfo.remove(cloudAccountInfo);
             }
+            return;
         }
         if (CloudAccountInfoValidator.validate(cloudAccountInfo, value)) {
             Map<CloudAccountInfo, String> accountInfo = cache.get(sdkClient);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudAccountInfoCache.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudAccountInfoCache.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.cloud;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.newrelic.agent.MetricNames;
+import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.api.agent.CloudAccountInfo;
+import com.newrelic.api.agent.NewRelic;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * This class implements the account info methods from the Cloud API.
+ */
+public class CloudAccountInfoCache {
+    private final LoadingCache<Object, Map<CloudAccountInfo, String>> cache;
+    // this object is used to store data that is not related to a specific sdk client
+    private static final Object NULL_CLIENT = new Object();
+
+    CloudAccountInfoCache() {
+        cache = Caffeine.newBuilder()
+                .initialCapacity(4)
+                .weakKeys()
+                .executor(Runnable::run)
+                .build((key) -> Collections.synchronizedMap(new EnumMap<>(CloudAccountInfo.class)));
+    }
+
+    public void setAccountInfo(CloudAccountInfo cloudAccountInfo, String value) {
+        setAccountInfo(NULL_CLIENT, cloudAccountInfo, value);
+    }
+
+    public void setAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo, String value) {
+        Map<CloudAccountInfo, String> accountInfo = cache.get(sdkClient);
+        accountInfo.put(cloudAccountInfo, value);
+    }
+
+    public String getAccountInfo(CloudAccountInfo cloudAccountInfo) {
+        Map<CloudAccountInfo, String> accountInfo = cache.getIfPresent(NULL_CLIENT);
+        if (accountInfo == null) {
+            return null;
+        }
+        return accountInfo.get(cloudAccountInfo);
+    }
+
+    public String getAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo) {
+        if (sdkClient == null) {
+            return getAccountInfo(cloudAccountInfo);
+        }
+        Map<CloudAccountInfo, String> accountInfo = cache.getIfPresent(sdkClient);
+        if (accountInfo == null) {
+            return getAccountInfo(cloudAccountInfo);
+        }
+        return accountInfo.get(cloudAccountInfo);
+    }
+
+    void retrieveDataFromConfig() {
+        AgentConfig agentConfig = ServiceFactory.getConfigService().getDefaultAgentConfig();
+        Object awsAccountId = agentConfig.getValue("cloud.aws.account_id");
+        if (awsAccountId != null) {
+            NewRelic.incrementCounter(MetricNames.SUPPORTABILITY_CONFIG_AWS_ACCOUNT_ID);
+            setAccountInfo(CloudAccountInfo.AWS_ACCOUNT_ID, awsAccountId.toString());
+        }
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudAccountInfoValidator.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudAccountInfoValidator.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.cloud;
+
+import com.newrelic.api.agent.CloudAccountInfo;
+import com.newrelic.api.agent.NewRelic;
+
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+
+public class CloudAccountInfoValidator {
+
+    private static final Pattern AWS_ACCOUNT_ID_PATTERN = Pattern.compile("^\\d+$");
+    private static Level awsAccountIdLogLevel = Level.WARNING;
+
+    public static boolean validate(CloudAccountInfo cloudAccountInfo, String value) {
+        switch (cloudAccountInfo) {
+            case AWS_ACCOUNT_ID:
+                return validateAwsAccountId(value);
+            default:
+                return false;
+        }
+    }
+
+    private static boolean validateAwsAccountId(String accountId) {
+        final int AWS_ACCOUNT_ID_LENGTH = 12;
+        if (accountId == null) {
+            return false;
+        }
+        boolean valid = accountId.length() == AWS_ACCOUNT_ID_LENGTH &&
+                AWS_ACCOUNT_ID_PATTERN.matcher(accountId).matches();
+        if (!valid) {
+            NewRelic.getAgent().getLogger().log(awsAccountIdLogLevel, "AWS account ID should be a 12-digit number.");
+            awsAccountIdLogLevel = Level.FINEST;
+        }
+        return valid;
+    }
+
+    private CloudAccountInfoValidator() {
+        // prevents instantiation
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/cloud/CloudApiImpl.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.cloud;
+
+import com.newrelic.agent.MetricNames;
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.CloudApi;
+import com.newrelic.api.agent.CloudAccountInfo;
+
+/**
+ * Facade for the Cloud API.
+ */
+public class CloudApiImpl implements CloudApi {
+
+    private final CloudAccountInfoCache accountInfoCache;
+
+    private CloudApiImpl() {
+        this(new CloudAccountInfoCache());
+        accountInfoCache.retrieveDataFromConfig();
+    }
+
+    // for testing
+    CloudApiImpl(CloudAccountInfoCache accountInfoCache) {
+        this.accountInfoCache = accountInfoCache;
+    }
+
+    // calling this method more than once will invalidate any Cloud API calls to set account info
+    public static void initialize() {
+        AgentBridge.cloud = new CloudApiImpl();
+    }
+
+    @Override
+    public void setAccountInfo(CloudAccountInfo cloudAccountInfo, String value) {
+        MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_CLOUD_SET_ACCOUNT_INFO + cloudAccountInfo.toString());
+        accountInfoCache.setAccountInfo(cloudAccountInfo, value);
+    }
+
+    @Override
+    public void setAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo, String value) {
+        MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_CLOUD_SET_ACCOUNT_INFO_CLIENT + cloudAccountInfo.toString());
+        accountInfoCache.setAccountInfo(sdkClient, cloudAccountInfo, value);
+    }
+
+    @Override
+    public String getAccountInfo(CloudAccountInfo cloudAccountInfo) {
+        // not recording metrics because this is for the internal API
+        return accountInfoCache.getAccountInfo(cloudAccountInfo);
+    }
+
+    @Override
+    public String getAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo) {
+        // not recording metrics because this is for the internal API
+        return accountInfoCache.getAccountInfo(sdkClient, cloudAccountInfo);
+    }
+
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/core/CoreServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/core/CoreServiceImpl.java
@@ -13,6 +13,7 @@ import com.newrelic.agent.InstrumentationProxy;
 import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.PrivateApiImpl;
 import com.newrelic.agent.TransactionService;
+import com.newrelic.agent.cloud.CloudApiImpl;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.ConfigService;
 import com.newrelic.agent.logging.AgentLogManager;
@@ -70,6 +71,7 @@ public class CoreServiceImpl extends AbstractService implements CoreService {
     private void initializeBridgeApis() {
         NewRelicApiImplementation.initialize();
         PrivateApiImpl.initialize(Agent.LOG);
+        CloudApiImpl.initialize();
     }
 
     /**

--- a/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudAccountInfoCacheTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudAccountInfoCacheTest.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.cloud;
+
+import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.service.ServiceManager;
+import org.junit.Test;
+
+import static com.newrelic.api.agent.CloudAccountInfo.AWS_ACCOUNT_ID;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CloudAccountInfoCacheTest {
+
+    @Test
+    public void accountInfo() {
+        CloudAccountInfoCache cache = new CloudAccountInfoCache();
+
+        assertNull(cache.getAccountInfo(AWS_ACCOUNT_ID));
+
+        String accountId = "123456789";
+        cache.setAccountInfo(AWS_ACCOUNT_ID, accountId);
+
+        assertEquals(accountId, cache.getAccountInfo(AWS_ACCOUNT_ID));
+    }
+
+    @Test
+    public void accountInfoClient() {
+        CloudAccountInfoCache cache = new CloudAccountInfoCache();
+        Object sdkClient = new Object();
+
+        assertNull(cache.getAccountInfo(sdkClient, AWS_ACCOUNT_ID));
+
+        String accountId = "123456789";
+        cache.setAccountInfo(sdkClient, AWS_ACCOUNT_ID, accountId);
+
+        assertEquals(accountId, cache.getAccountInfo(sdkClient, AWS_ACCOUNT_ID));
+
+        Object anotherSdkClient = new Object();
+        assertNull(cache.getAccountInfo(anotherSdkClient, AWS_ACCOUNT_ID));
+    }
+
+    @Test
+    public void accountInfoClientFallback() {
+        CloudAccountInfoCache cache = new CloudAccountInfoCache();
+        String accountId = "123456789";
+        cache.setAccountInfo(AWS_ACCOUNT_ID, accountId);
+
+        Object sdkClient = new Object();
+        assertEquals(accountId, cache.getAccountInfo(sdkClient, AWS_ACCOUNT_ID));
+    }
+
+
+    @Test
+    public void retrieveDataFromConfigAccountInfo() {
+        CloudAccountInfoCache cache = new CloudAccountInfoCache();
+        String accountId = "123456789";
+
+        ServiceManager serviceManager = mock(ServiceManager.class, RETURNS_DEEP_STUBS);
+        ServiceFactory.setServiceManager(serviceManager);
+        when(serviceManager.getConfigService().getDefaultAgentConfig().getValue("cloud.aws.account_id"))
+                .thenReturn(accountId);
+        cache.retrieveDataFromConfig();
+
+        assertEquals(accountId, cache.getAccountInfo(AWS_ACCOUNT_ID));
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudAccountInfoCacheTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudAccountInfoCacheTest.java
@@ -25,7 +25,7 @@ public class CloudAccountInfoCacheTest {
 
         assertNull(cache.getAccountInfo(AWS_ACCOUNT_ID));
 
-        String accountId = "123456789";
+        String accountId = "123456789012";
         cache.setAccountInfo(AWS_ACCOUNT_ID, accountId);
 
         assertEquals(accountId, cache.getAccountInfo(AWS_ACCOUNT_ID));
@@ -38,7 +38,7 @@ public class CloudAccountInfoCacheTest {
 
         assertNull(cache.getAccountInfo(sdkClient, AWS_ACCOUNT_ID));
 
-        String accountId = "123456789";
+        String accountId = "123456789012";
         cache.setAccountInfo(sdkClient, AWS_ACCOUNT_ID, accountId);
 
         assertEquals(accountId, cache.getAccountInfo(sdkClient, AWS_ACCOUNT_ID));
@@ -50,7 +50,7 @@ public class CloudAccountInfoCacheTest {
     @Test
     public void accountInfoClientFallback() {
         CloudAccountInfoCache cache = new CloudAccountInfoCache();
-        String accountId = "123456789";
+        String accountId = "123456789012";
         cache.setAccountInfo(AWS_ACCOUNT_ID, accountId);
 
         Object sdkClient = new Object();
@@ -61,7 +61,7 @@ public class CloudAccountInfoCacheTest {
     @Test
     public void retrieveDataFromConfigAccountInfo() {
         CloudAccountInfoCache cache = new CloudAccountInfoCache();
-        String accountId = "123456789";
+        String accountId = "123456789012";
 
         ServiceManager serviceManager = mock(ServiceManager.class, RETURNS_DEEP_STUBS);
         ServiceFactory.setServiceManager(serviceManager);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudAccountInfoValidatorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudAccountInfoValidatorTest.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.cloud;
+
+import com.newrelic.api.agent.CloudAccountInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CloudAccountInfoValidatorTest {
+
+    @Test
+    public void testValidateAwsAccountId() {
+        assertFalse(CloudAccountInfoValidator.validate(CloudAccountInfo.AWS_ACCOUNT_ID, null));
+
+        // accountId is not 12 digits
+        assertFalse(CloudAccountInfoValidator.validate(CloudAccountInfo.AWS_ACCOUNT_ID, "12345678901"));
+
+        // accountId is not a number
+        assertFalse(CloudAccountInfoValidator.validate(CloudAccountInfo.AWS_ACCOUNT_ID, "12345678901a"));
+
+        // happy path
+        assertTrue(CloudAccountInfoValidator.validate(CloudAccountInfo.AWS_ACCOUNT_ID, "123456789012"));
+    }
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudApiImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudApiImplTest.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.cloud;
+
+import com.newrelic.api.agent.CloudAccountInfo;
+import com.newrelic.api.agent.NewRelic;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class CloudApiImplTest {
+
+    @Test
+    public void setAccountInfo() {
+        CloudAccountInfoCache cache = mock(CloudAccountInfoCache.class);
+        CloudApiImpl cloudApi = new CloudApiImpl(cache);
+
+        try (MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+
+            String accountId = "1234567890";
+            cloudApi.setAccountInfo(CloudAccountInfo.AWS_ACCOUNT_ID, accountId);
+
+            newRelic.verify(() -> NewRelic.incrementCounter("Supportability/API/Cloud/SetAccountInfo/AWS_ACCOUNT_ID/API"));
+            newRelic.verifyNoMoreInteractions();
+
+            verify(cache).setAccountInfo(eq(CloudAccountInfo.AWS_ACCOUNT_ID), eq(accountId));
+            verifyNoMoreInteractions(cache);
+        }
+    }
+
+    @Test
+    public void setAccountInfoClient() {
+        CloudAccountInfoCache cache = mock(CloudAccountInfoCache.class);
+        CloudApiImpl cloudApi = new CloudApiImpl(cache);
+
+        try (MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+
+            String accountId = "1234567890";
+            Object sdkClient = new Object();
+            cloudApi.setAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID, accountId);
+
+            newRelic.verify(() -> NewRelic.incrementCounter("Supportability/API/Cloud/SetAccountInfoClient/AWS_ACCOUNT_ID/API"));
+            newRelic.verifyNoMoreInteractions();
+
+            verify(cache).setAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID), eq(accountId));
+            verifyNoMoreInteractions(cache);
+        }
+    }
+
+    @Test
+    public void getAccountInfo() {
+        CloudAccountInfoCache cache = mock(CloudAccountInfoCache.class);
+        CloudApiImpl cloudApi = new CloudApiImpl(cache);
+
+        try (MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+
+            cloudApi.getAccountInfo(CloudAccountInfo.AWS_ACCOUNT_ID);
+
+            newRelic.verifyNoInteractions();
+
+            verify(cache).getAccountInfo(eq(CloudAccountInfo.AWS_ACCOUNT_ID));
+            verifyNoMoreInteractions(cache);
+        }
+    }
+
+    @Test
+    public void getAccountInfoClient() {
+        CloudAccountInfoCache cache = mock(CloudAccountInfoCache.class);
+        CloudApiImpl cloudApi = new CloudApiImpl(cache);
+
+        try (MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+
+            Object sdkClient = new Object();
+            cloudApi.getAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID);
+
+            newRelic.verifyNoInteractions();
+
+            verify(cache).getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID));
+            verifyNoMoreInteractions(cache);
+        }
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudApiImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/cloud/CloudApiImplTest.java
@@ -27,7 +27,7 @@ public class CloudApiImplTest {
 
         try (MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
 
-            String accountId = "1234567890";
+            String accountId = "123456789012";
             cloudApi.setAccountInfo(CloudAccountInfo.AWS_ACCOUNT_ID, accountId);
 
             newRelic.verify(() -> NewRelic.incrementCounter("Supportability/API/Cloud/SetAccountInfo/AWS_ACCOUNT_ID/API"));
@@ -45,7 +45,7 @@ public class CloudApiImplTest {
 
         try (MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
 
-            String accountId = "1234567890";
+            String accountId = "123456789012";
             Object sdkClient = new Object();
             cloudApi.setAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID, accountId);
 

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/Agent.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/Agent.java
@@ -70,6 +70,13 @@ public interface Agent {
      */
     AiMonitoring getAiMonitoring();
 
+    /**
+     * Provides access to the Cloud API.
+     *
+     * @since 8.15.0
+     */
+    Cloud getCloud();
+
     ErrorApi getErrorApi();
 
     /**

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/Cloud.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/Cloud.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.api.agent;
+
+/**
+ * This interface defines methods to pass cloud services information to the agent.
+ */
+public interface Cloud {
+
+    /**
+     * <p>
+     *     Sets the account information for a cloud service.
+     * </p>
+     * <p>
+     *     This information is used by some instrumentation modules that cannot
+     *     determine the resource id of the cloud service being invoked.
+     * </p>
+     * <p>
+     *     The value provided to this method has priority over a value set in
+     *     the agent configuration.
+     * </p>
+     * @param cloudAccountInfo the type of account information being stored
+     * @param value the value to store
+     */
+    void setAccountInfo(CloudAccountInfo cloudAccountInfo, String value);
+
+
+    /**
+     * <p>
+     *     Sets the account information for a cloud service SDK client.
+     * </p>
+     * <p>
+     *     This information is used by some instrumentation modules that cannot
+     *     determine the resource id of the cloud service being invoked.
+     * </p>
+     * <p>
+     *     The value provided to this method has priority over a value set in
+     *     the agent configuration or a value set using {@link #setAccountInfo(CloudAccountInfo, String)}.
+     * </p>
+     * @param sdkClient the SDK client object this account information is associated with
+     * @param cloudAccountInfo the type of account information being stored
+     * @param value the value to store
+     */
+    void setAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo, String value);
+}

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/Cloud.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/Cloud.java
@@ -24,6 +24,9 @@ public interface Cloud {
      *     The value provided to this method has priority over a value set in
      *     the agent configuration.
      * </p>
+     * <p>
+     *     Passing null as the value will remove the account information previously stored.
+     * </p>
      * @param cloudAccountInfo the type of account information being stored
      * @param value the value to store
      */
@@ -41,6 +44,9 @@ public interface Cloud {
      * <p>
      *     The value provided to this method has priority over a value set in
      *     the agent configuration or a value set using {@link #setAccountInfo(CloudAccountInfo, String)}.
+     * </p>
+     * <p>
+     *     Passing null as the value will remove the account information previously stored.
      * </p>
      * @param sdkClient the SDK client object this account information is associated with
      * @param cloudAccountInfo the type of account information being stored

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/CloudAccountInfo.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/CloudAccountInfo.java
@@ -1,0 +1,16 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.api.agent;
+
+/**
+ * Identifier for the type of account information.
+ */
+public enum CloudAccountInfo {
+    AWS_ACCOUNT_ID,
+    ;
+}

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
@@ -368,6 +368,14 @@ class NoOpAgent implements Agent {
         public void setLlmTokenCountCallback(LlmTokenCountCallback llmTokenCountCallback) {}
     };
 
+    private static final Cloud CLOUD = new Cloud() {
+        @Override
+        public void setAccountInfo(CloudAccountInfo cloudAccountInfo, String value) {}
+
+        @Override
+        public void setAccountInfo(Object sdkClient, CloudAccountInfo cloudAccountInfo, String value) {}
+    };
+
     private static final Segment SEGMENT = new Segment() {
         @Override
         public void setMetricName(String... metricNameParts) {
@@ -469,6 +477,11 @@ class NoOpAgent implements Agent {
     @Override
     public AiMonitoring getAiMonitoring() {
         return AI_MONITORING;
+    }
+
+    @Override
+    public Cloud getCloud() {
+        return CLOUD;
     }
 
     @Override

--- a/newrelic-opentelemetry-agent-extension/src/main/java/com/newrelic/opentelemetry/OpenTelemetryAgent.java
+++ b/newrelic-opentelemetry-agent-extension/src/main/java/com/newrelic/opentelemetry/OpenTelemetryAgent.java
@@ -9,6 +9,7 @@ package com.newrelic.opentelemetry;
 
 import com.newrelic.api.agent.Agent;
 import com.newrelic.api.agent.AiMonitoring;
+import com.newrelic.api.agent.Cloud;
 import com.newrelic.api.agent.Config;
 import com.newrelic.api.agent.Insights;
 import com.newrelic.api.agent.Logger;
@@ -76,6 +77,11 @@ public final class OpenTelemetryAgent implements Agent {
 
     @Override
     public AiMonitoring getAiMonitoring() {
+        return null;
+    }
+
+    @Override
+    public Cloud getCloud() {
         return null;
     }
 


### PR DESCRIPTION
### Overview
Introduces the Cloud API, which allows cloud account information to be passed to the agent.

This information is required by some instrumentation modules to be able to form cloud resource identifiers which are used to link a monitored application to the cloud resources it uses.

### Related Github Issue
Fixes #2003 

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
