### PR TITLE
httpurlconnection metric state use weakref tracers

### DIFF
--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
@@ -102,8 +102,10 @@ public class MetricState {
      */
     public void inboundPostamble(HttpURLConnection connection, int responseCode, String responseMessage, Ops operation,
             TracedMethod tracer) {
+        // So the weak reference to external tracer holds an actual tracer instance (if not null) for the duration of this method.
+        TracedMethod externalTracer = getExternalTracer();
         // make sure that only the method that first invoked inboundPreamble runs this method
-        if (externalReported || getExternalTracer() != tracer) {
+        if (externalReported || externalTracer != tracer) {
             return;
         }
         Transaction tx = AgentBridge.getAgent().getTransaction(false);

--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
@@ -158,7 +158,7 @@ public class MetricState {
      * @param responseMessage response message from HttpURLConnection
      * @param externalTracer  tracer of which the external call will be reported to
      */
-    void reportExternalCall(HttpURLConnection connection, Ops operation, int responseCode, String responseMessage, TracedMethod externalTracer) {
+    private void reportExternalCall(HttpURLConnection connection, Ops operation, int responseCode, String responseMessage, TracedMethod externalTracer) {
         if (connection != null) {
             // This conversion is necessary as it strips query parameters from the URI
             String uri = URISupport.getURI(connection.getURL());


### PR DESCRIPTION
### Overview
Within the HttpUrlConnection instrumentation module inside the Metric State class, TracedMethod member variables are replaced with weak references. This can help reduce memory usage because the TracedMethod instances can be garbage collected sooner.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2048
