### PR TITLE
Null guard for dtTracer in httpurlconnection MetricState

### DIFF
--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
@@ -191,8 +191,11 @@ public class MetricState {
      */
     private void addOutboundHeadersIfNotAdded(HttpURLConnection connection) {
         if (getDtTracer() == null) {
-            setDtTracer(AgentBridge.getAgent().getTracedMethod());
-            getDtTracer().addOutboundRequestHeaders(new OutboundWrapper(connection));
+            TracedMethod tracedMethod = AgentBridge.getAgent().getTracedMethod();
+            if (tracedMethod != null) {
+                setDtTracer(tracedMethod);
+                tracedMethod.addOutboundRequestHeaders(new OutboundWrapper(connection));
+            }
         }
     }
 


### PR DESCRIPTION
### Overview
Continuation of the previous [PR](https://github.com/newrelic/newrelic-java-agent/pull/2082) to replace TracedMethod instances with weak references in HttpUrlConnection. This just adds an additional null guard.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2048
