### PR TITLE
Lazy init of GUIDs on DefaultTracers

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/trace/TransactionGuidFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/trace/TransactionGuidFactory.java
@@ -10,6 +10,7 @@ package com.newrelic.agent.trace;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class TransactionGuidFactory {
+    private static final char[] hexchars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
     private TransactionGuidFactory() {
     }
@@ -21,7 +22,6 @@ public class TransactionGuidFactory {
         // return Long.toHexString(Math.abs(randomHolder.get().nextLong()))
         // In addition, this one returns 16 useful digits, while the obvious one returns slightly fewer.
         // Note that the digits are generated in "reverse order", which is perfectly fine here.
-        final char[] hexchars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
         long random = ThreadLocalRandom.current().nextLong();
         char[] result = new char[16];
         for (int i = 0; i < 16; ++i) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -145,7 +145,6 @@ public class DefaultTracer extends AbstractTracer {
         }
 
         this.tracerFlags = (byte) tracerFlags;
-        this.guid = TransactionGuidFactory.generate16CharGuid();
     }
 
     public DefaultTracer(TransactionActivity txa, ClassMethodSignature sig, Object object,
@@ -169,7 +168,11 @@ public class DefaultTracer extends AbstractTracer {
 
     @Override
     public String getGuid() {
-        return guid;
+        String theGuid = this.guid;
+        if (theGuid == null) {
+            this.guid = theGuid = TransactionGuidFactory.generate16CharGuid();
+        }
+        return theGuid;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -168,11 +168,10 @@ public class DefaultTracer extends AbstractTracer {
 
     @Override
     public String getGuid() {
-        String theGuid = this.guid;
-        if (theGuid == null) {
-            this.guid = theGuid = TransactionGuidFactory.generate16CharGuid();
+        if (this.guid == null) {
+            this.guid = TransactionGuidFactory.generate16CharGuid();
         }
-        return theGuid;
+        return this.guid;
     }
 
     @Override


### PR DESCRIPTION
Closes #2057 from @yuzawa-san 

The GUID for a tracer is only necessary if it's going to be reported up to NR. This change defers the creation of the GUID until the `getGuid()` call is made.

Another minor optimization was moving the `hexchars` const to a class level member. 
