### PR TITLE
Java HttpClient - Addition of status code to reported externals

### DIFF
--- a/instrumentation/httpclient-jdk11/src/main/java/com.nr.agent.instrumentation.httpclient/Java11HttpClientUtil.java
+++ b/instrumentation/httpclient-jdk11/src/main/java/com.nr.agent.instrumentation.httpclient/Java11HttpClientUtil.java
@@ -78,6 +78,7 @@ public class Java11HttpClientUtil {
                 .uri(uri)
                 .procedure(PROCEDURE)
                 .inboundHeaders(new InboundWrapper(httpResponse))
+                .status(httpResponse.statusCode(), null)
                 .build());
         segment.end();
     }


### PR DESCRIPTION
Resolves #2085 
Externals reported when using the Java Http Client now properly report the HTTP status code.

Note that the response text will still be null.