### PR TITLE
Report if agent was installed via Azure site extension

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -205,6 +205,8 @@ public class MetricNames {
 
     public static final String TIMEOUT_ASYNC = "Java/Timeout/asyncActivityNotStarted";
 
+    public static final String SUPPORTABILITY_AZURE_SITE_EXT_INSTALL_TYPE = "Supportability/Java/InstallType";
+
     public static final String SUPPORTABILITY_JAVA_AGENTVERSION = "Supportability/Java/AgentVersion/{0}";
 
     public static final String SUPPORTABILITY_HARVEST_SERVICE_RESPONSE_TIME = "Supportability/Harvest";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/environment/Environment.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/environment/Environment.java
@@ -9,8 +9,11 @@ package com.newrelic.agent.environment;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
+import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.samplers.MemorySampler;
+import com.newrelic.api.agent.NewRelic;
+import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONStreamAware;
 
@@ -38,6 +41,7 @@ public class Environment implements JSONStreamAware, Cloneable {
     private static final String LOGICAL_CORE_KEY = "Logical Processors";
     private static final String TOTAL_MEMORY_MB = "Total Physical Memory (MB)";
     private static final String SOLR_VERSION_KEY = "Solr Version";
+    private static final String AZURE_SITE_EXT_INSTALL_TYPE = "AzureSiteExtension";
     private static final Pattern JSON_WORKAROUND = Pattern.compile("\\\\+$");
 
     private final List<EnvironmentChangeListener> listeners = new CopyOnWriteArrayList<>();
@@ -121,6 +125,13 @@ public class Environment implements JSONStreamAware, Cloneable {
         }
 
         addVariable("Framework", "java");
+
+        if (isAzureSiteExtenstionInstall()) {
+            // Yes this is intentional, since we only have a single installation type for the site extension
+            addVariable(AZURE_SITE_EXT_INSTALL_TYPE, AZURE_SITE_EXT_INSTALL_TYPE);
+            NewRelic.getAgent().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_AZURE_SITE_EXT_INSTALL_TYPE + "/" +
+                    AZURE_SITE_EXT_INSTALL_TYPE);
+        }
 
         Number appServerPort = config.getProperty("appserver_port");
         Integer serverPort = null;
@@ -273,5 +284,12 @@ public class Environment implements JSONStreamAware, Cloneable {
         if (info.length == 2) {
             setServerInfo(info[0], info[1]);
         }
+    }
+
+    private boolean isAzureSiteExtenstionInstall() {
+        // Currently, the only "install type" we support is the Azure site extension, which is detected
+        // by the presence of a specific environment variable with a non-null/non-empty value
+        final String AZURE_SITE_EXT_VAR = "NEW_RELIC_METADATA_AZURE_APP_SERVICE_NAME";
+        return StringUtils.isNotBlank(System.getenv(AZURE_SITE_EXT_VAR));
     }
 }


### PR DESCRIPTION
Resolves #2092 

When the agent is installed with the Azure site extension, the following environment variable will be present: NEW_RELIC_METADATA_AZURE_APP_SERVICE_NAME
If this environment variable is present, the following must be added to the environment section of the connect payload
```
[
  "AzureSiteExtension",
  "AzureSiteExtension"
]
```
Additionally a supportability metric of `Supportability/Java/InstallType/AzureSiteExtension` must be reported.

