### PR TITLE
DynamoDB: populate cloud.resource_id

### DIFF
--- a/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClient_Instrumentation.java
@@ -10,6 +10,7 @@ package com.amazonaws.services.dynamodbv2;
 import com.amazonaws.AmazonWebServiceClient;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
@@ -69,21 +70,21 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final CreateTableResult executeCreateTable(CreateTableRequest createTableRequest) {
         linkAndExpire(createTableRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "createTable",
-                createTableRequest.getTableName(), endpoint);
+                createTableRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
     @Trace(async = true, leaf = true)
     final BatchGetItemResult executeBatchGetItem(BatchGetItemRequest batchGetItemRequest) {
         linkAndExpire(batchGetItemRequest);
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchGetItem", "batch", endpoint);
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchGetItem", "batch", endpoint, this);
         return Weaver.callOriginal();
     }
 
     @Trace(async = true, leaf = true)
     final BatchWriteItemResult executeBatchWriteItem(BatchWriteItemRequest batchWriteItemRequest) {
         linkAndExpire(batchWriteItemRequest);
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchWriteItem", "batch", endpoint);
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchWriteItem", "batch", endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -91,7 +92,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final DeleteItemResult executeDeleteItem(DeleteItemRequest deleteItemRequest) {
         linkAndExpire(deleteItemRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteItem",
-                deleteItemRequest.getTableName(), endpoint);
+                deleteItemRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -99,14 +100,14 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final DeleteTableResult executeDeleteTable(DeleteTableRequest deleteTableRequest) {
         linkAndExpire(deleteTableRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteTable",
-                deleteTableRequest.getTableName(), endpoint);
+                deleteTableRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
     @Trace(async = true, leaf = true)
     final DescribeLimitsResult executeDescribeLimits(DescribeLimitsRequest describeLimitsRequest) {
         linkAndExpire(describeLimitsRequest);
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeLimits", null, endpoint);
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeLimits", null, endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -114,7 +115,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final DescribeTableResult executeDescribeTable(DescribeTableRequest describeTableRequest) {
         linkAndExpire(describeTableRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTable",
-                describeTableRequest.getTableName(), endpoint);
+                describeTableRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -122,7 +123,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final DescribeTimeToLiveResult executeDescribeTimeToLive(DescribeTimeToLiveRequest describeTimeToLiveRequest) {
         linkAndExpire(describeTimeToLiveRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTimeToLive",
-                describeTimeToLiveRequest.getTableName(), endpoint);
+                describeTimeToLiveRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -130,7 +131,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final GetItemResult executeGetItem(GetItemRequest getItemRequest) {
         linkAndExpire(getItemRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "getItem", getItemRequest.getTableName(),
-                endpoint);
+                endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -138,14 +139,14 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final ListTablesResult executeListTables(ListTablesRequest listTablesRequest) {
         linkAndExpire(listTablesRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTables",
-                listTablesRequest.getExclusiveStartTableName(), endpoint);
+                listTablesRequest.getExclusiveStartTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
     @Trace(async = true, leaf = true)
     final ListTagsOfResourceResult executeListTagsOfResource(ListTagsOfResourceRequest listTagsOfResourceRequest) {
         linkAndExpire(listTagsOfResourceRequest);
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTagsOfResource", null, endpoint);
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTagsOfResource", null, endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -153,7 +154,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final PutItemResult executePutItem(PutItemRequest putItemRequest) {
         linkAndExpire(putItemRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "putItem", putItemRequest.getTableName(),
-                endpoint);
+                endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -161,7 +162,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final QueryResult executeQuery(QueryRequest queryRequest) {
         linkAndExpire(queryRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "query", queryRequest.getTableName(),
-                endpoint);
+                endpoint, this);
         return Weaver.callOriginal();
 
     }
@@ -169,21 +170,21 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     @Trace(async = true, leaf = true)
     final ScanResult executeScan(ScanRequest scanRequest) {
         linkAndExpire(scanRequest);
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "scan", scanRequest.getTableName(), endpoint);
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "scan", scanRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
     @Trace(async = true, leaf = true)
     final TagResourceResult executeTagResource(TagResourceRequest tagResourceRequest) {
         linkAndExpire(tagResourceRequest);
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "tagResource", null, endpoint);
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "tagResource", null, endpoint, this);
         return Weaver.callOriginal();
     }
 
     @Trace(async = true, leaf = true)
     final UntagResourceResult executeUntagResource(UntagResourceRequest untagResourceRequest) {
         linkAndExpire(untagResourceRequest);
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "untagResource", null, endpoint);
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "untagResource", null, endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -191,7 +192,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final UpdateItemResult executeUpdateItem(UpdateItemRequest updateItemRequest) {
         linkAndExpire(updateItemRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateItem",
-                updateItemRequest.getTableName(), endpoint);
+                updateItemRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -199,7 +200,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final UpdateTableResult executeUpdateTable(UpdateTableRequest updateTableRequest) {
         linkAndExpire(updateTableRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTable",
-                updateTableRequest.getTableName(), endpoint);
+                updateTableRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 
@@ -207,7 +208,7 @@ public abstract class AmazonDynamoDBClient_Instrumentation extends AmazonWebServ
     final UpdateTimeToLiveResult executeUpdateTimeToLive(UpdateTimeToLiveRequest updateTimeToLiveRequest) {
        linkAndExpire(updateTimeToLiveRequest);
         DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTimeToLive",
-                updateTimeToLiveRequest.getTableName(), endpoint);
+                updateTimeToLiveRequest.getTableName(), endpoint, this);
         return Weaver.callOriginal();
     }
 

--- a/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtil.java
+++ b/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtil.java
@@ -51,6 +51,11 @@ public abstract class DynamoDBMetricUtil {
 
     // visible for testing
     static String getArn(String tableName, Object sdkClient, String host) {
+        if (host == null) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. Host is null.");
+            return null;
+        }
+
         String accountId = AgentBridge.cloud.getAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID);
         if (accountId == null) {
             NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. No account information provided.");

--- a/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtil.java
+++ b/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtil.java
@@ -7,6 +7,7 @@
 
 package com.nr.instrumentation.dynamodb_1_11_106;
 
+import com.amazonaws.util.AwsHostNameUtils;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
 import com.newrelic.api.agent.CloudAccountInfo;
@@ -61,7 +62,7 @@ public abstract class DynamoDBMetricUtil {
             return null;
         }
 
-        String region = getRegion(host);
+        String region = AwsHostNameUtils.parseRegion(host, "dynamodb");
         if (region == null) {
             NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. Unable to determine region.");
             return null;
@@ -69,37 +70,6 @@ public abstract class DynamoDBMetricUtil {
 
         // arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}
         return "arn:aws:dynamodb:" + region + ":" + accountId + ":table/" + tableName;
-    }
-
-    // visible for testing
-    static String getRegion(String host) {
-        if (host == null) {
-            return null;
-        }
-        if (!host.startsWith("dynamodb")) {
-            return null;
-        }
-
-        final int afterDynamoDb = 8; // "dynamodb".length()
-        if (host.charAt(afterDynamoDb) == '.') {
-            // dynamodb.{region}.amazonaws.com
-            int secondPeriod = host.indexOf('.', afterDynamoDb + 1);
-            if (secondPeriod > 0 && host.startsWith(".amazonaws.com", secondPeriod)) {
-                return host.substring(afterDynamoDb + 1, secondPeriod);
-            } else {
-                return null;
-            }
-        } else if (host.startsWith("-fips.", afterDynamoDb)) {
-            // dynamodb-fips.{region}.amazonaws.com
-            final int firstPeriod = 13; // "dynamodb-fips".length()
-            int secondPeriod = host.indexOf('.', firstPeriod + 1);
-            if (secondPeriod > 0 && host.startsWith(".amazonaws.com", secondPeriod)) {
-                return host.substring(firstPeriod + 1, secondPeriod);
-            } else {
-                return null;
-            }
-        }
-        return null;
     }
 
     private static Integer getPort(URI endpoint) {

--- a/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtil.java
+++ b/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/main/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtil.java
@@ -7,11 +7,15 @@
 
 package com.nr.instrumentation.dynamodb_1_11_106;
 
+import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.api.agent.CloudAccountInfo;
 import com.newrelic.api.agent.DatastoreParameters;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.TracedMethod;
 
 import java.net.URI;
+import java.util.logging.Level;
 
 /**
  * This uses {@link DatastoreParameters} to create external metrics for all DynamoDB calls in
@@ -21,24 +25,84 @@ public abstract class DynamoDBMetricUtil {
 
     private static final String PRODUCT = DatastoreVendor.DynamoDB.name();
     private static final String INSTANCE_HOST = "amazon";
-    private static final String INSTANCE_ID = "dynamodb";
 
-    public static void metrics(TracedMethod tracedMethod, String operation, String collection, URI endpoint) {
-        String host = endpoint == null ? INSTANCE_HOST : endpoint.getHost();
-        String port = endpoint == null ? INSTANCE_ID : String.valueOf(getPort(endpoint));
 
+    public static void metrics(TracedMethod tracedMethod, String operation, String collection, URI endpoint, Object sdkClient) {
+        String host = INSTANCE_HOST;
+        String arn = null;
+        Integer port = null;
+        if (endpoint != null) {
+            host = endpoint.getHost();
+            port = getPort(endpoint);
+            arn = getArn(collection, sdkClient, host);
+        }
         DatastoreParameters params = DatastoreParameters
                 .product(PRODUCT)
                 .collection(collection)
                 .operation(operation)
                 .instance(host, port)
                 .noDatabaseName()
+                .cloudResourceId(arn)
                 .build();
 
         tracedMethod.reportAsExternal(params);
     }
 
-    private static int getPort(URI endpoint) {
+    // visible for testing
+    static String getArn(String tableName, Object sdkClient, String host) {
+        String accountId = AgentBridge.cloud.getAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID);
+        if (accountId == null) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. No account information provided.");
+            return null;
+        }
+
+        if (tableName == null) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. Unable to determine table.");
+            return null;
+        }
+
+        String region = getRegion(host);
+        if (region == null) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. Unable to determine region.");
+            return null;
+        }
+
+        // arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}
+        return "arn:aws:dynamodb:" + region + ":" + accountId + ":table/" + tableName;
+    }
+
+    // visible for testing
+    static String getRegion(String host) {
+        if (host == null) {
+            return null;
+        }
+        if (!host.startsWith("dynamodb")) {
+            return null;
+        }
+
+        final int afterDynamoDb = 8; // "dynamodb".length()
+        if (host.charAt(afterDynamoDb) == '.') {
+            // dynamodb.{region}.amazonaws.com
+            int secondPeriod = host.indexOf('.', afterDynamoDb + 1);
+            if (secondPeriod > 0 && host.startsWith(".amazonaws.com", secondPeriod)) {
+                return host.substring(afterDynamoDb + 1, secondPeriod);
+            } else {
+                return null;
+            }
+        } else if (host.startsWith("-fips.", afterDynamoDb)) {
+            // dynamodb-fips.{region}.amazonaws.com
+            final int firstPeriod = 13; // "dynamodb-fips".length()
+            int secondPeriod = host.indexOf('.', firstPeriod + 1);
+            if (secondPeriod > 0 && host.startsWith(".amazonaws.com", secondPeriod)) {
+                return host.substring(firstPeriod + 1, secondPeriod);
+            } else {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static Integer getPort(URI endpoint) {
         if (endpoint.getPort() > 0) {
             return endpoint.getPort();
         }
@@ -49,7 +113,7 @@ public abstract class DynamoDBMetricUtil {
         } else if ("https".equalsIgnoreCase(scheme)) {
             return 443;
         }
-        return -1;
+        return null;
     }
 
 }

--- a/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/test/java/com/agent/instrumentation/awsjavasdkdynamodb1_11_106/DynamoApiTest.java
+++ b/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/test/java/com/agent/instrumentation/awsjavasdkdynamodb1_11_106/DynamoApiTest.java
@@ -56,6 +56,7 @@ import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Trace;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/test/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtilTest.java
+++ b/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/test/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtilTest.java
@@ -42,24 +42,6 @@ public class DynamoDBMetricUtilTest {
     }
 
     @Test
-    public void testFindRegionFromHost() {
-        String dynamoDbEndpoint = "dynamodb.us-west-2.amazonaws.com";
-        assertEquals("us-west-2", DynamoDBMetricUtil.getRegion(dynamoDbEndpoint));
-
-        String fipsEndpoint = "dynamodb-fips.my-region.amazonaws.com";
-        assertEquals("my-region", DynamoDBMetricUtil.getRegion(fipsEndpoint));
-
-        String localhost = "localhost";
-        assertNull(DynamoDBMetricUtil.getRegion(localhost));
-
-        // null
-        assertNull(DynamoDBMetricUtil.getRegion(null));
-        assertNull(DynamoDBMetricUtil.getRegion("dynamodb.ms-region.azure.com"));
-        assertNull(DynamoDBMetricUtil.getRegion("dynamodb-fips.gg-region.gcp.com"));
-        assertNull(DynamoDBMetricUtil.getRegion("cosmosdb.us-east-1.amazonaws.com"));
-    }
-
-    @Test
     public void testGetArn() {
         Object sdkClient = new Object();
         when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))

--- a/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/test/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtilTest.java
+++ b/instrumentation/aws-java-sdk-dynamodb-1.11.106/src/test/java/com/nr/instrumentation/dynamodb_1_11_106/DynamoDBMetricUtilTest.java
@@ -1,0 +1,131 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.instrumentation.dynamodb_1_11_106;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.CloudApi;
+import com.newrelic.api.agent.CloudAccountInfo;
+import com.newrelic.api.agent.DatastoreParameters;
+import com.newrelic.api.agent.TracedMethod;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DynamoDBMetricUtilTest {
+
+    private CloudApi previousCloudApi;
+
+    @Before
+    public void setup() {
+        previousCloudApi = AgentBridge.cloud;
+        AgentBridge.cloud = mock(CloudApi.class);
+    }
+
+    @After
+    public void tearDown() {
+        AgentBridge.cloud = previousCloudApi;
+    }
+
+    @Test
+    public void testFindRegionFromHost() {
+        String dynamoDbEndpoint = "dynamodb.us-west-2.amazonaws.com";
+        assertEquals("us-west-2", DynamoDBMetricUtil.getRegion(dynamoDbEndpoint));
+
+        String fipsEndpoint = "dynamodb-fips.my-region.amazonaws.com";
+        assertEquals("my-region", DynamoDBMetricUtil.getRegion(fipsEndpoint));
+
+        String localhost = "localhost";
+        assertNull(DynamoDBMetricUtil.getRegion(localhost));
+
+        // null
+        assertNull(DynamoDBMetricUtil.getRegion(null));
+        assertNull(DynamoDBMetricUtil.getRegion("dynamodb.ms-region.azure.com"));
+        assertNull(DynamoDBMetricUtil.getRegion("dynamodb-fips.gg-region.gcp.com"));
+        assertNull(DynamoDBMetricUtil.getRegion("cosmosdb.us-east-1.amazonaws.com"));
+    }
+
+    @Test
+    public void testGetArn() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        String table = "test";
+        String host = "dynamodb.us-east-2.amazonaws.com";
+
+        String arn = DynamoDBMetricUtil.getArn(table, sdkClient, host);
+        assertEquals("arn:aws:dynamodb:us-east-2:123456789:table/test", arn);
+    }
+
+    @Test
+    public void testGetArn_withoutAccountId() {
+        Object sdkClient = new Object();
+        String table = "test";
+        String host = "dynamodb.us-east-2.amazonaws.com";
+
+        String arn = DynamoDBMetricUtil.getArn(table, sdkClient, host);
+        assertNull(arn);
+    }
+
+    @Test
+    public void testGetArn_withoutTable() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        String host = "dynamodb.us-east-2.amazonaws.com";
+
+        String arn = DynamoDBMetricUtil.getArn(null, sdkClient, host);
+        assertNull(arn);
+    }
+
+    @Test
+    public void testGetArn_withoutHost() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        String table = "test";
+
+        String arn = DynamoDBMetricUtil.getArn(table, sdkClient, null);
+        assertNull(arn);
+    }
+
+    @Test
+    public void testMetrics() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        String table = "test";
+        TracedMethod tracedMethod = mock(TracedMethod.class);
+        String operation = "getItem";
+        URI endpoint = URI.create("https://dynamodb.us-east-2.amazonaws.com");
+
+        DynamoDBMetricUtil.metrics(tracedMethod, operation, table, endpoint, sdkClient);
+
+        ArgumentCaptor<DatastoreParameters> externalParamsCaptor = ArgumentCaptor.forClass(DatastoreParameters.class);
+        verify(tracedMethod).reportAsExternal(externalParamsCaptor.capture());
+        DatastoreParameters params = externalParamsCaptor.getValue();
+        assertEquals("DynamoDB", params.getProduct());
+        assertEquals("test", params.getCollection());
+        assertEquals("getItem", params.getOperation());
+        assertEquals("dynamodb.us-east-2.amazonaws.com", params.getHost());
+        assertEquals(Integer.valueOf(443), params.getPort());
+        assertNull(params.getPathOrId());
+        assertEquals("arn:aws:dynamodb:us-east-2:123456789:table/test", params.getCloudResourceId());
+        assertNull(params.getDatabaseName());
+    }
+
+}

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
@@ -4,7 +4,8 @@ dependencies {
 
     implementation platform('software.amazon.awssdk:bom:2.16.81')
     implementation("software.amazon.awssdk:dynamodb:2.16.81")
-    testImplementation("com.amazonaws:DynamoDBLocal:1.12.0")
+    testImplementation("com.amazonaws:DynamoDBLocal:1.25.0")
+    testImplementation("software.amazon.awssdk:url-connection-client")
     testImplementation("com.almworks.sqlite4java:sqlite4java:1.0.392")
     testImplementation("com.almworks.sqlite4java:libsqlite4java-osx:1.0.392")
     testImplementation("com.almworks.sqlite4java:libsqlite4java-linux-i386:1.0.392")

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/main/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtil.java
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/main/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtil.java
@@ -1,35 +1,122 @@
 package com.nr.instrumentation.dynamodb_v2;
 
+import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.api.agent.CloudAccountInfo;
 import com.newrelic.api.agent.DatastoreParameters;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.TracedMethod;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.regions.Region;
 
 import java.net.URI;
+import java.util.logging.Level;
 
 public abstract class DynamoDBMetricUtil {
 
     private static final String PRODUCT = DatastoreVendor.DynamoDB.name();
     private static final String INSTANCE_HOST = "amazon";
-    private static final String INSTANCE_ID = "dynamodb";
 
-    public static void metrics(TracedMethod tracedMethod, String operation, String collection, URI endpoint) {
-        String host = endpoint == null ? INSTANCE_HOST : endpoint.getHost();
-        String port = endpoint == null ? INSTANCE_ID : String.valueOf(getPort(endpoint));
+    public static void metrics(TracedMethod tracedMethod, String operation, String tableName, Object sdkClient, SdkClientConfiguration clientConfiguration) {
 
+        String host = INSTANCE_HOST;
+        Integer port = null;
+        String arn = null;
+        if (clientConfiguration != null) {
+            URI endpoint = clientConfiguration.option(SdkClientOption.ENDPOINT);
+            if (endpoint != null) {
+                host = endpoint.getHost();
+                port = getPort(endpoint);
+            }
+            arn = getArn(tableName, sdkClient, clientConfiguration, host);
+        }
         DatastoreParameters params = DatastoreParameters
                 .product(PRODUCT)
-                .collection(collection)
+                .collection(tableName)
                 .operation(operation)
                 .instance(host, port)
                 .noDatabaseName()
+                .cloudResourceId(arn)
                 .build();
 
         tracedMethod.reportAsExternal(params);
     }
 
-    private static int getPort(URI endpoint) {
-        if (endpoint.getPort() > 0) {
-            return endpoint.getPort();
+    // visible for testing
+    static String getArn(String tableName, Object sdkClient, SdkClientConfiguration clientConfiguration, String host) {
+        String accountId = AgentBridge.cloud.getAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID);
+        if (accountId == null) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. No account information provided.");
+            return null;
+        }
+
+        if (tableName == null) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. Table name is null.");
+            return null;
+        }
+
+        String region = findRegion(clientConfiguration, host);
+        if (region == null) {
+            NewRelic.getAgent().getLogger().log(Level.FINEST, "Unable to assemble ARN. Region is null.");
+            return null;
+        }
+
+        // arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}
+        return "arn:aws:dynamodb:" + region + ":" + accountId + ":table/" + tableName;
+    }
+
+    // visible for testing
+    static String findRegion(SdkClientConfiguration clientConfig, String host) {
+        Boolean endpointOverridden = clientConfig.option(SdkClientOption.ENDPOINT_OVERRIDDEN);
+        if (endpointOverridden == Boolean.TRUE) { // endpointOverridden could be null
+            return findRegionFromHost(host);
+        }
+
+        Region awsRegion = clientConfig.option(AwsClientOption.AWS_REGION);
+        if (awsRegion != null) {
+            return awsRegion.id();
+        }
+
+        return null;
+    }
+
+    // visible for testing
+    static String findRegionFromHost(String host) {
+        if (host == null) {
+            return null;
+        }
+        if (!host.startsWith("dynamodb")) {
+            return null;
+        }
+
+        final int afterDynamoDb = 8; // "dynamodb".length()
+        if (host.charAt(afterDynamoDb) == '.') {
+            // dynamodb.{region}.amazonaws.com
+            int secondPeriod = host.indexOf('.', afterDynamoDb + 1);
+            if (secondPeriod > 0 && host.startsWith(".amazonaws.com", secondPeriod)) {
+                return host.substring(afterDynamoDb + 1, secondPeriod);
+            } else {
+                return null;
+            }
+        } else if (host.startsWith("-fips.", afterDynamoDb)) {
+            // dynamodb-fips.{region}.amazonaws.com
+            final int firstPeriod = 13; // "dynamodb-fips".length()
+            int secondPeriod = host.indexOf('.', firstPeriod + 1);
+            if (secondPeriod > 0 && host.startsWith(".amazonaws.com", secondPeriod)) {
+                return host.substring(firstPeriod + 1, secondPeriod);
+            } else {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static Integer getPort(URI endpoint) {
+        int port = endpoint.getPort();
+        if (port > 0) {
+            return port;
         }
 
         final String scheme = endpoint.getScheme();
@@ -38,8 +125,7 @@ public abstract class DynamoDBMetricUtil {
         } else if ("https".equalsIgnoreCase(scheme)) {
             return 443;
         }
-        return -1;
+        return null;
     }
-
 }
 

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/main/java/software/amazon/awssdk/services/dynamodb/DefaultDynamoDbAsyncClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/main/java/software/amazon/awssdk/services/dynamodb/DefaultDynamoDbAsyncClient_Instrumentation.java
@@ -7,10 +7,8 @@ import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.instrumentation.dynamodb_v2.DynamoDBMetricUtil;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
-import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
 @Weave(originalName = "software.amazon.awssdk.services.dynamodb.DefaultDynamoDbAsyncClient", type = MatchType.ExactClass)
@@ -20,120 +18,117 @@ final class DefaultDynamoDbAsyncClient_Instrumentation {
 
     @Trace(leaf = true)
     public CompletableFuture<ScanResponse> scan(ScanRequest scanRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "scan", scanRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "scan", scanRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<PutItemResponse> putItem(PutItemRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "putItem", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "putItem", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<GetItemResponse> getItem(GetItemRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "getItem", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "getItem", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<DeleteItemResponse> deleteItem(DeleteItemRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteItem", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteItem", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<ListTablesResponse> listTables(ListTablesRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTables", request.exclusiveStartTableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTables", request.exclusiveStartTableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<DescribeTableResponse> describeTable(DescribeTableRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTable", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTable", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<CreateTableResponse> createTable(CreateTableRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "createTable", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "createTable", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<DeleteTableResponse> deleteTable(DeleteTableRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteTable", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteTable", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<BatchGetItemResponse> batchGetItem(BatchGetItemRequest batchGetItemRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchGetItem", "batch", getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchGetItem", "batch", this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<BatchWriteItemResponse> batchWriteItem(BatchWriteItemRequest batchWriteItemRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchWriteItem", "batch", getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchWriteItem", "batch", this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<ListTagsOfResourceResponse> listTagsOfResource(ListTagsOfResourceRequest listTagsOfResourceRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTagsOfResource", listTagsOfResourceRequest.resourceArn(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTagsOfResource", listTagsOfResourceRequest.resourceArn(), this,
+                clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<QueryResponse> query(QueryRequest queryRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "query", queryRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "query", queryRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
 
     @Trace(leaf = true)
     public CompletableFuture<UpdateItemResponse> updateItem(UpdateItemRequest updateItemRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateItem", updateItemRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateItem", updateItemRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<UpdateTableResponse> updateTable(UpdateTableRequest updateTableRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTable", updateTableRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTable", updateTableRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<UpdateTimeToLiveResponse> updateTimeToLive(UpdateTimeToLiveRequest updateTimeToLiveRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTimeToLive", updateTimeToLiveRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTimeToLive", updateTimeToLiveRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<DescribeLimitsResponse> describeLimits(DescribeLimitsRequest describeLimitsRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeLimits", null, getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeLimits", null, this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<UntagResourceResponse> untagResource(UntagResourceRequest untagResourceRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "untagResource", untagResourceRequest.resourceArn(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "untagResource", untagResourceRequest.resourceArn(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<TagResourceResponse> tagResource(TagResourceRequest tagResourceRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "tagResource", tagResourceRequest.resourceArn(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "tagResource", tagResourceRequest.resourceArn(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CompletableFuture<DescribeTimeToLiveResponse> describeTimeToLive(DescribeTimeToLiveRequest describeTimeToLiveRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTimeToLive", describeTimeToLiveRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTimeToLive", describeTimeToLiveRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
-
-    private URI getEndpoint() {
-        return clientConfiguration != null ? clientConfiguration.option(SdkClientOption.ENDPOINT) : null;
-    }
-}
+ }

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/main/java/software/amazon/awssdk/services/dynamodb/DefaultDynamoDbClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/main/java/software/amazon/awssdk/services/dynamodb/DefaultDynamoDbClient_Instrumentation.java
@@ -7,10 +7,7 @@ import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.instrumentation.dynamodb_v2.DynamoDBMetricUtil;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
-import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.dynamodb.model.*;
-
-import java.net.URI;
 
 @Weave(originalName = "software.amazon.awssdk.services.dynamodb.DefaultDynamoDbClient", type = MatchType.ExactClass)
 final class DefaultDynamoDbClient_Instrumentation {
@@ -18,119 +15,115 @@ final class DefaultDynamoDbClient_Instrumentation {
 
     @Trace(leaf = true)
     public GetItemResponse getItem(GetItemRequest getItemRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "getItem", getItemRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "getItem", getItemRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public ListTagsOfResourceResponse listTagsOfResource(ListTagsOfResourceRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTagsOfResource", null, getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTagsOfResource", null, this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public UntagResourceResponse untagResource(UntagResourceRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "untagResource", null, getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "untagResource", null, this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public BatchGetItemResponse batchGetItem(BatchGetItemRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchGetItem", "batch", getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchGetItem", "batch", this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public BatchWriteItemResponse batchWriteItem(BatchWriteItemRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchWriteItem", "batch", getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "batchWriteItem", "batch", this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public PutItemResponse putItem(PutItemRequest putItemRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "putItem", putItemRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "putItem", putItemRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public DeleteItemResponse deleteItem(DeleteItemRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteItem", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteItem", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public ListTablesResponse listTables(ListTablesRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTables", request.exclusiveStartTableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "listTables", request.exclusiveStartTableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public CreateTableResponse createTable(CreateTableRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "createTable", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "createTable", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public DeleteTableResponse deleteTable(DeleteTableRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteTable", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "deleteTable", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public DescribeTableResponse describeTable(DescribeTableRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTable", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTable", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public ScanResponse scan(ScanRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "scan", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "scan", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public QueryResponse query(QueryRequest queryRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "query", queryRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "query", queryRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public UpdateItemResponse updateItem(UpdateItemRequest updateItemRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateItem", updateItemRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateItem", updateItemRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public UpdateTableResponse updateTable(UpdateTableRequest updateTableRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTable", updateTableRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTable", updateTableRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public UpdateTimeToLiveResponse updateTimeToLive(UpdateTimeToLiveRequest request) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTimeToLive", request.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "updateTimeToLive", request.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public DescribeLimitsResponse describeLimits(DescribeLimitsRequest describeLimitsRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeLimits", null, getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeLimits", null, this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public TagResourceResponse tagResource(TagResourceRequest tagResourceRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "tagResource", tagResourceRequest.resourceArn(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "tagResource", tagResourceRequest.resourceArn(), this, clientConfiguration);
         return Weaver.callOriginal();
     }
 
     @Trace(leaf = true)
     public DescribeTimeToLiveResponse describeTimeToLive(DescribeTimeToLiveRequest describeTimeToLiveRequest) {
-        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTimeToLive", describeTimeToLiveRequest.tableName(), getEndpoint());
+        DynamoDBMetricUtil.metrics(NewRelic.getAgent().getTracedMethod(), "describeTimeToLive", describeTimeToLiveRequest.tableName(), this, clientConfiguration);
         return Weaver.callOriginal();
-    }
-
-    private URI getEndpoint() {
-        return clientConfiguration != null ? clientConfiguration.option(SdkClientOption.ENDPOINT) : null;
     }
 }

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/agent/instrumentation/awsjavasdkdynamodb_v2/DefaultDynamoDbClient_InstrumentationTest.java
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/agent/instrumentation/awsjavasdkdynamodb_v2/DefaultDynamoDbClient_InstrumentationTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 
 import static junit.framework.TestCase.assertEquals;
 
+// this test is ignored in instrumentation/build.gradle
 @RunWith(InstrumentationTestRunner.class)
 @InstrumentationTestConfig(includePrefixes = {"software.amazon.awssdk.services.dynamodb", "com.nr.instrumentation"})
 public class DefaultDynamoDbClient_InstrumentationTest {

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtilTest.java
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtilTest.java
@@ -1,0 +1,204 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.instrumentation.dynamodb_v2;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.CloudApi;
+import com.newrelic.api.agent.CloudAccountInfo;
+import com.newrelic.api.agent.DatastoreParameters;
+import com.newrelic.api.agent.TracedMethod;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.regions.Region;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DynamoDBMetricUtilTest {
+
+    private CloudApi previousCloudApi;
+
+    @Before
+    public void setup() {
+        previousCloudApi = AgentBridge.cloud;
+        AgentBridge.cloud = mock(CloudApi.class);
+    }
+
+    @After
+    public void tearDown() {
+        AgentBridge.cloud = previousCloudApi;
+    }
+
+    @Test
+    public void testFindRegionFromHost() {
+        String dynamoDbEndpoint = "dynamodb.us-west-2.amazonaws.com";
+        assertEquals("us-west-2", DynamoDBMetricUtil.findRegionFromHost(dynamoDbEndpoint));
+
+        String fipsEndpoint = "dynamodb-fips.my-region.amazonaws.com";
+        assertEquals("my-region", DynamoDBMetricUtil.findRegionFromHost(fipsEndpoint));
+
+        String localhost = "localhost";
+        assertNull(DynamoDBMetricUtil.findRegionFromHost(localhost));
+
+        // null
+        assertNull(DynamoDBMetricUtil.findRegionFromHost(null));
+        assertNull(DynamoDBMetricUtil.findRegionFromHost("dynamodb.ms-region.azure.com"));
+        assertNull(DynamoDBMetricUtil.findRegionFromHost("dynamodb-fips.gg-region.gcp.com"));
+        assertNull(DynamoDBMetricUtil.findRegionFromHost("cosmosdb.us-east-1.amazonaws.com"));
+    }
+
+    @Test
+    public void testFindRegion_fromRegion() {
+        String host = "dynamodb.us-west-2.amazonaws.com";
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                .option(AwsClientOption.AWS_REGION, Region.US_WEST_2)
+                .option(SdkClientOption.ENDPOINT, URI.create("https://" + host))
+                .build();
+        assertEquals("us-west-2", DynamoDBMetricUtil.findRegion(clientConfig, host));
+    }
+
+    @Test
+    public void testFindRegion_fromEndpoint() {
+        String host = "dynamodb.ap-east-1.amazonaws.com";
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                .option(AwsClientOption.AWS_REGION, Region.US_WEST_2)
+                .option(SdkClientOption.ENDPOINT, URI.create("https://" + host))
+                .option(SdkClientOption.ENDPOINT_OVERRIDDEN, Boolean.TRUE)
+                .build();
+        assertEquals("ap-east-1", DynamoDBMetricUtil.findRegion(clientConfig, host));
+    }
+
+    @Test
+    public void testFindRegion_fail() {
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                .build();
+        String host = null;
+        assertNull(DynamoDBMetricUtil.findRegion(clientConfig, host));
+    }
+
+
+    @Test
+    public void testGetArn() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        SdkClientConfiguration config = SdkClientConfiguration.builder()
+                .option(AwsClientOption.AWS_REGION, Region.US_EAST_2)
+                .build();
+        String table = "test";
+        String host = "dynamodb.us-east-2.amazonaws.com";
+
+        String arn = DynamoDBMetricUtil.getArn(table, sdkClient, config, host);
+        assertEquals("arn:aws:dynamodb:us-east-2:123456789:table/test", arn);
+    }
+
+    @Test
+    public void testGetArn_withoutAccountId() {
+        Object sdkClient = new Object();
+        SdkClientConfiguration config = SdkClientConfiguration.builder()
+                .option(AwsClientOption.AWS_REGION, Region.US_EAST_2)
+                .option(SdkClientOption.ENDPOINT, URI.create("https://dynamodb.us-east-2.amazonaws.com"))
+                .build();
+        String table = "test";
+        String host = "dynamodb.us-east-2.amazonaws.com";
+
+        String arn = DynamoDBMetricUtil.getArn(table, sdkClient, config, host);
+        assertNull(arn);
+    }
+
+    @Test
+    public void testGetArn_withoutTable() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        SdkClientConfiguration config = SdkClientConfiguration.builder()
+                .option(AwsClientOption.AWS_REGION, Region.US_EAST_2)
+                .build();
+        String host = "dynamodb.us-east-2.amazonaws.com";
+
+        String arn = DynamoDBMetricUtil.getArn(null, sdkClient, config, host);
+        assertNull(arn);
+    }
+
+    @Test
+    public void testGetArn_withoutRegion() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        SdkClientConfiguration config = SdkClientConfiguration.builder()
+                .build();
+        String table = "test";
+        String host = "dynamodb.us-east-2.amazonaws.com";
+
+        String arn = DynamoDBMetricUtil.getArn(table, sdkClient, config, host);
+        assertNull(arn);
+    }
+
+    @Test
+    public void testMetrics() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        SdkClientConfiguration config = SdkClientConfiguration.builder()
+                .option(AwsClientOption.AWS_REGION, Region.US_EAST_2)
+                .option(SdkClientOption.ENDPOINT, URI.create("https://dynamodb.us-east-2.amazonaws.com"))
+                .build();
+        String table = "test";
+        TracedMethod tracedMethod = mock(TracedMethod.class);
+        String operation = "getItem";
+
+        DynamoDBMetricUtil.metrics(tracedMethod, operation, table, sdkClient, config);
+
+        ArgumentCaptor<DatastoreParameters> externalParamsCaptor = ArgumentCaptor.forClass(DatastoreParameters.class);
+        verify(tracedMethod).reportAsExternal(externalParamsCaptor.capture());
+        DatastoreParameters params = externalParamsCaptor.getValue();
+        assertEquals("DynamoDB", params.getProduct());
+        assertEquals("test", params.getCollection());
+        assertEquals("getItem", params.getOperation());
+        assertEquals("dynamodb.us-east-2.amazonaws.com", params.getHost());
+        assertEquals(Integer.valueOf(443), params.getPort());
+        assertNull(params.getPathOrId());
+        assertEquals("arn:aws:dynamodb:us-east-2:123456789:table/test", params.getCloudResourceId());
+        assertNull(params.getDatabaseName());
+    }
+
+    @Test
+    public void testMetrics_withoutClientConfig() {
+        Object sdkClient = new Object();
+        when(AgentBridge.cloud.getAccountInfo(eq(sdkClient), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                .thenReturn("123456789");
+        String table = "test";
+        TracedMethod tracedMethod = mock(TracedMethod.class);
+        String operation = "getItem";
+
+        DynamoDBMetricUtil.metrics(tracedMethod, operation, table, sdkClient, null);
+
+        ArgumentCaptor<DatastoreParameters> externalParamsCaptor = ArgumentCaptor.forClass(DatastoreParameters.class);
+        verify(tracedMethod).reportAsExternal(externalParamsCaptor.capture());
+        DatastoreParameters params = externalParamsCaptor.getValue();
+        assertEquals("DynamoDB", params.getProduct());
+        assertEquals("test", params.getCollection());
+        assertEquals("getItem", params.getOperation());
+        assertEquals("amazon", params.getHost());
+        assertNull(params.getPort());
+        assertNull(params.getPathOrId());
+        assertNull(params.getCloudResourceId());
+        assertNull(params.getDatabaseName());
+    }
+}

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtilTest.java
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtilTest.java
@@ -46,24 +46,6 @@ public class DynamoDBMetricUtilTest {
     }
 
     @Test
-    public void testFindRegionFromHost() {
-        String dynamoDbEndpoint = "dynamodb.us-west-2.amazonaws.com";
-        assertEquals("us-west-2", DynamoDBMetricUtil.findRegionFromHost(dynamoDbEndpoint));
-
-        String fipsEndpoint = "dynamodb-fips.my-region.amazonaws.com";
-        assertEquals("my-region", DynamoDBMetricUtil.findRegionFromHost(fipsEndpoint));
-
-        String localhost = "localhost";
-        assertNull(DynamoDBMetricUtil.findRegionFromHost(localhost));
-
-        // null
-        assertNull(DynamoDBMetricUtil.findRegionFromHost(null));
-        assertNull(DynamoDBMetricUtil.findRegionFromHost("dynamodb.ms-region.azure.com"));
-        assertNull(DynamoDBMetricUtil.findRegionFromHost("dynamodb-fips.gg-region.gcp.com"));
-        assertNull(DynamoDBMetricUtil.findRegionFromHost("cosmosdb.us-east-1.amazonaws.com"));
-    }
-
-    @Test
     public void testFindRegion_fromRegion() {
         String host = "dynamodb.us-west-2.amazonaws.com";
         SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -424,6 +424,7 @@ public class SpanEventFactory {
             setDatabaseCollection(datastoreParameters.getCollection());
             setDatabaseOperation(datastoreParameters.getOperation());
             setServerAddress(datastoreParameters.getHost());
+            setCloudResourceId(datastoreParameters.getCloudResourceId());
             setKindFromUserAttributes();
             if (datastoreParameters.getPort() != null) {
                 setServerPort(datastoreParameters.getPort());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -238,6 +238,7 @@ public class SpanEventFactoryTest {
         when(mockParameters.getProduct()).thenReturn("MySQL");
         when(mockParameters.getHost()).thenReturn("dbserver");
         when(mockParameters.getPort()).thenReturn(3306);
+        when(mockParameters.getCloudResourceId()).thenReturn("123456789");
 
         SpanEvent target = spanEventFactory.setExternalParameterAttributes(mockParameters).build();
 
@@ -249,6 +250,7 @@ public class SpanEventFactoryTest {
         assertEquals("dbserver", target.getAgentAttributes().get("server.address"));
         assertEquals(3306, target.getAgentAttributes().get("server.port"));
         assertEquals("dbserver:3306", target.getAgentAttributes().get("peer.address"));
+        assertEquals("123456789", target.getAgentAttributes().get("cloud.resource_id"));
     }
 
     @Test

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/DatastoreParameters.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/DatastoreParameters.java
@@ -51,8 +51,13 @@ public class DatastoreParameters implements ExternalParameters {
      */
     private final String databaseName;
 
+    /**
+     * The cloud provider's identifier for this resource. Eg. in AWS, this should be an ARN.
+     */
+    private final String cloudResourceId;
+
     private DatastoreParameters(String product, String collection, String operation, String host, Integer port,
-            String pathOrId, String databaseName) {
+            String pathOrId, String databaseName, String cloudResourceId) {
         this.product = product;
         this.collection = collection;
         this.operation = operation;
@@ -60,6 +65,7 @@ public class DatastoreParameters implements ExternalParameters {
         this.port = port;
         this.pathOrId = pathOrId;
         this.databaseName = databaseName;
+        this.cloudResourceId = cloudResourceId;
     }
 
     protected DatastoreParameters(DatastoreParameters datastoreParameters) {
@@ -70,6 +76,7 @@ public class DatastoreParameters implements ExternalParameters {
         this.port = datastoreParameters.port;
         this.pathOrId = datastoreParameters.pathOrId;
         this.databaseName = datastoreParameters.databaseName;
+        this.cloudResourceId = datastoreParameters.cloudResourceId;
     }
 
     protected static class Builder implements CollectionParameter, OperationParameter, InstanceParameter,
@@ -81,6 +88,7 @@ public class DatastoreParameters implements ExternalParameters {
         private Integer port = null;
         private String pathOrId = null;
         private String databaseName = null;
+        private String cloudResourceId = null;
 
         /**
          * Used for {@link SlowQueryDatastoreParameters}. The builder method below gives us type safety here.
@@ -137,6 +145,12 @@ public class DatastoreParameters implements ExternalParameters {
         }
 
         @Override
+        public Build cloudResourceId(String cloudResourceId) {
+            this.cloudResourceId = cloudResourceId;
+            return this;
+        }
+
+        @Override
         public DatastoreParameters build() {
             if (inputQueryLabel != null && rawInputQuery != null && rawInputQueryConverter != null) {
                 return new SlowQueryWithInputDatastoreParameters<>(
@@ -167,7 +181,7 @@ public class DatastoreParameters implements ExternalParameters {
         }
 
         private DatastoreParameters buildRegular() {
-            return new DatastoreParameters(product, collection, operation, host, port, pathOrId, databaseName);
+            return new DatastoreParameters(product, collection, operation, host, port, pathOrId, databaseName, cloudResourceId);
         }
 
         private SlowQueryDatastoreParameters<?> buildWithSlowQuery() {
@@ -251,6 +265,13 @@ public class DatastoreParameters implements ExternalParameters {
      */
     public String getDatabaseName() {
         return databaseName;
+    }
+
+    /**
+     * @return the cloud provider's identifier for the message queue. Eg. in AWS, this should be an ARN.
+     */
+    public String getCloudResourceId() {
+        return cloudResourceId;
     }
 
     // Builder Interfaces
@@ -376,6 +397,13 @@ public class DatastoreParameters implements ExternalParameters {
     }
 
     public interface Build {
+
+        /**
+         * Set the cloud provider's id for the database.
+         * This method is optional and can be bypassed by calling build directly.
+         * @return the build object so it can be built.
+         */
+        Build cloudResourceId(String cloudResourceId);
 
         /**
          * Build the final {@link DatastoreParameters} for the API call.


### PR DESCRIPTION
### Overview
Changes to the DynamoDB instrumentation to populate the cloud.resource_id attribute.
This attribute will allow an instrumented DynamoDB table to be linked to an APM that calls it.

### Related Github Issue
Fixes #1802 

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
