### PR TITLE
dynamodb: removing reference to field only available in newer versions

### DIFF
--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtilTest.java
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/src/test/java/com/nr/instrumentation/dynamodb_v2/DynamoDBMetricUtilTest.java
@@ -46,32 +46,18 @@ public class DynamoDBMetricUtilTest {
     }
 
     @Test
-    public void testFindRegion_fromRegion() {
-        String host = "dynamodb.us-west-2.amazonaws.com";
+    public void testFindRegion() {
         SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
                 .option(AwsClientOption.AWS_REGION, Region.US_WEST_2)
-                .option(SdkClientOption.ENDPOINT, URI.create("https://" + host))
                 .build();
-        assertEquals("us-west-2", DynamoDBMetricUtil.findRegion(clientConfig, host));
-    }
-
-    @Test
-    public void testFindRegion_fromEndpoint() {
-        String host = "dynamodb.ap-east-1.amazonaws.com";
-        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
-                .option(AwsClientOption.AWS_REGION, Region.US_WEST_2)
-                .option(SdkClientOption.ENDPOINT, URI.create("https://" + host))
-                .option(SdkClientOption.ENDPOINT_OVERRIDDEN, Boolean.TRUE)
-                .build();
-        assertEquals("ap-east-1", DynamoDBMetricUtil.findRegion(clientConfig, host));
+        assertEquals("us-west-2", DynamoDBMetricUtil.findRegion(clientConfig));
     }
 
     @Test
     public void testFindRegion_fail() {
         SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
                 .build();
-        String host = null;
-        assertNull(DynamoDBMetricUtil.findRegion(clientConfig, host));
+        assertNull(DynamoDBMetricUtil.findRegion(clientConfig));
     }
 
 


### PR DESCRIPTION
### Overview
While retrieving the region for the DynamoDB table, to check whether the endpoint was custom, the field `SdkClientOption.ENDPOINT_OVERRIDDEN` was used. But this field is not available in older versions of the instrumentation.
So to increase the compatibility of the instrumentation, this verification is being dropped and the region the sdk client is configured is used instead.
