### PR TITLE
SpanEventFactory - adding null check on server port

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -320,8 +320,10 @@ public class SpanEventFactory {
         return this;
     }
 
-    public SpanEventFactory setServerPort(int port) {
-        builder.putAgentAttribute(AttributeNames.SERVER_PORT, port);
+    public SpanEventFactory setServerPort(Integer port) {
+        if (port != null) {
+            builder.putAgentAttribute(AttributeNames.SERVER_PORT, port);
+        }
         return this;
     }
 


### PR DESCRIPTION
### Overview
SpanEventFactory#setServerPort received an int, but the methods that provided this int returned an Integer.
A case was found where the port received was null and caused an NPE.
Adding a null check to prevent it.