### PR TITLE
Use recordResponseTimeMetric instead recordMetric in NewRelic agent.

### DIFF
--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -47,7 +47,7 @@ public final class NewRelic {
      * @since 1.3.0
      */
     public static void recordResponseTimeMetric(String name, long millis) {
-        getAgent().getMetricAggregator().recordMetric(name, millis);
+        getAgent().getMetricAggregator().recordResponseTimeMetric(name, millis);
     }
 
     /**


### PR DESCRIPTION
It seams that 
```
    public static void recordResponseTimeMetric(String name, long millis) {
        getAgent().getMetricAggregator().recordMetric(name, millis);
    }
```
recordResponseTimeMetric calls recordMetric in MetricAggregator instead of recordResponseTimeMetric.