### PR TITLE
Update to JFR daemon 1.13.0

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -74,7 +74,7 @@ dependencies {
         transitive = false
     }
     shadowIntoJar("com.newrelic.agent.java:newrelic-module-util-java:2.1")
-    shadowIntoJar("com.newrelic:jfr-daemon:1.12.0")
+    shadowIntoJar("com.newrelic:jfr-daemon:1.13.0")
     shadowIntoJar "org.ow2.asm:asm:$asmVersion"
     shadowIntoJar "org.ow2.asm:asm-tree:$asmVersion"
     shadowIntoJar "org.ow2.asm:asm-commons:$asmVersion"

--- a/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
@@ -48,8 +48,7 @@ public class SourceLibraryDetectorTest {
     public void testSamplerRun() throws Exception {
         sourceLibraryDetector.run();
         ArgumentCaptor<StatsWork> captor = ArgumentCaptor.forClass(StatsWork.class);
-        //As of 7.0.0 we are pulling in kotlin as a transitive dependency of JFR-Daemon 
-        verify(ServiceFactory.getStatsService(), times(3)).doStatsWork(captor.capture(), anyString());
+        verify(ServiceFactory.getStatsService(), times(2)).doStatsWork(captor.capture(), anyString());
 
         StatsWork statsWork = captor.getValue();
 


### PR DESCRIPTION
This will update the version of the JFR daemon used by the Java agent with the changes listed here:
https://github.com/newrelic/newrelic-jfr-core/releases/tag/v1.13.0