### PR TITLE
Use recordResponseTimeMetric instead recordMetric in NewRelic agent API layer

### DIFF
--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NewRelic.java
@@ -47,7 +47,7 @@ public final class NewRelic {
      * @since 1.3.0
      */
     public static void recordResponseTimeMetric(String name, long millis) {
-        getAgent().getMetricAggregator().recordMetric(name, millis);
+        getAgent().getMetricAggregator().recordResponseTimeMetric(name, millis);
     }
 
     /**


### PR DESCRIPTION
Test run PR of #2128 from @matzz

`com.newrelic.api.agent.NewRelic::recordResponseTimeMetric` is calling the wrong method on the `metricAggregator` instance:
```
    public static void recordResponseTimeMetric(String name, long millis) {
        getAgent().getMetricAggregator().recordMetric(name, millis);
    }
```
