### PR TITLE
Jetty12 missing headers impl

### DIFF
--- a/instrumentation/jetty-12/src/main/java/com/nr/agent/instrumentation/jetty12/JettyRequest.java
+++ b/instrumentation/jetty-12/src/main/java/com/nr/agent/instrumentation/jetty12/JettyRequest.java
@@ -35,6 +35,15 @@ public class JettyRequest extends ExtendedRequest {
     }
 
     @Override
+    public List<String> getHeaders(String name) {
+        Enumeration<String> headers = request.getHeaders().getValues(name);
+        if (headers == null) {
+            return Collections.emptyList();
+        }
+        return Collections.list(headers);
+    }
+
+    @Override
     public String getRequestURI() {
         return request.getHttpURI().getPath();
     }
@@ -88,4 +97,5 @@ public class JettyRequest extends ExtendedRequest {
         }
         return null;
     }
+
 }


### PR DESCRIPTION
### Overview
Resolves an issue in the Jetty 12 instrumentation module where the JettyRequest class does not have the method implementation for `String getHeader(String name)`.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2139

