### PR TITLE
Correct multiple traceparent header logging

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/W3CTraceParentParser.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/W3CTraceParentParser.java
@@ -21,13 +21,13 @@ public class W3CTraceParentParser {
             return null;
         }
         if (traceParentHeaders.size() > 1) {
-            ServiceFactory.getStatsService().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_TRACE_CONTEXT_INVALID_PARENT_HEADER_COUNT);
-            Agent.LOG.log(Level.WARNING, "Multiple traceparent headers found on inbound request.");
             // Multiple values ok if all are equal
             String first = traceParentHeaders.get(0);
             for (String header : traceParentHeaders) {
                 if (!header.equals(first)) {
-                   return null;
+                    ServiceFactory.getStatsService().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_TRACE_CONTEXT_INVALID_PARENT_HEADER_COUNT);
+                    Agent.LOG.log(Level.WARNING, "Multiple, different, traceparent headers found on inbound request.");
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
Resolves #2126 

Based on the logic in method and the associated comment, multiple TraceParent headers is only an issue if the headers differ. If all the headers are the same value, that's ok.

This moves the log statement and associated supportability metric to execute only if the headers are different values.