### PR TITLE
Lambda: auto decode account id

### DIFF
--- a/instrumentation/aws-java-sdk-lambda-1.11.280/src/main/java/com/agent/instrumentation/awsjavasdk1/services/lambda/TokenLinkingAsyncHandler.java
+++ b/instrumentation/aws-java-sdk-lambda-1.11.280/src/main/java/com/agent/instrumentation/awsjavasdk1/services/lambda/TokenLinkingAsyncHandler.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.agent.instrumentation.awsjavasdk1.services.lambda;
+
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.lambda.model.InvokeRequest;
+import com.amazonaws.services.lambda.model.InvokeResult;
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+
+public class TokenLinkingAsyncHandler implements AsyncHandler<InvokeRequest, InvokeResult> {
+
+    private final AsyncHandler<InvokeRequest, InvokeResult> delegate;
+
+    private Token token;
+
+    public TokenLinkingAsyncHandler(AsyncHandler<InvokeRequest, InvokeResult> delegate) {
+        this.delegate = delegate;
+        token = NewRelic.getAgent().getTransaction().getToken();
+    }
+
+    @Override
+    @Trace(async = true)
+    public void onError(Exception e) {
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
+        NewRelic.getAgent().getTracedMethod().setMetricName("Java", delegate.getClass().getName(), "onError");
+        delegate.onError(e);
+    }
+
+    @Override
+    @Trace(async = true)
+    public void onSuccess(InvokeRequest request, InvokeResult invokeResult) {
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
+        NewRelic.getAgent().getTracedMethod().setMetricName("Java", delegate.getClass().getName(), "onSuccess");
+        delegate.onSuccess(request, invokeResult);
+    }
+}

--- a/instrumentation/aws-java-sdk-lambda-1.11.280/src/main/java/com/amazonaws/services/lambda/AWSLambdaAsyncClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-lambda-1.11.280/src/main/java/com/amazonaws/services/lambda/AWSLambdaAsyncClient_Instrumentation.java
@@ -7,14 +7,12 @@
 
 package com.amazonaws.services.lambda;
 
-import com.agent.instrumentation.awsjavasdk1.services.lambda.FunctionRawData;
 import com.agent.instrumentation.awsjavasdk1.services.lambda.LambdaUtil;
+import com.agent.instrumentation.awsjavasdk1.services.lambda.TokenLinkingAsyncHandler;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.lambda.model.InvokeRequest;
 import com.amazonaws.services.lambda.model.InvokeResult;
-import com.newrelic.api.agent.CloudParameters;
-import com.newrelic.api.agent.NewRelic;
-import com.newrelic.api.agent.Segment;
+import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
@@ -24,48 +22,12 @@ import java.util.concurrent.Future;
 @Weave(type = MatchType.ExactClass, originalName = "com.amazonaws.services.lambda.AWSLambdaAsyncClient")
 public abstract class AWSLambdaAsyncClient_Instrumentation {
 
-    protected abstract String getSigningRegion();
-
+    @Trace
     public Future<InvokeResult> invokeAsync(final InvokeRequest request, AsyncHandler<InvokeRequest, InvokeResult> asyncHandler) {
-        FunctionRawData functionRawData = new FunctionRawData(request.getFunctionName(), request.getQualifier(), this.getSigningRegion(), this);
-        CloudParameters cloudParameters = LambdaUtil.getCloudParameters(functionRawData);
-        String functionName = LambdaUtil.getSimpleFunctionName(functionRawData);
-        Segment segment = NewRelic.getAgent().getTransaction().startSegment("Lambda", "invoke/" + functionName);
-
-        try {
-            segment.reportAsExternal(cloudParameters);
-            asyncHandler = new SegmentEndingAsyncHandler(asyncHandler, segment);
-            return Weaver.callOriginal();
-        } catch (Throwable t) {
-            segment.end();
-            throw t;
+        LambdaUtil.setTokenForRequest(request);
+        if (asyncHandler != null) {
+            asyncHandler = new TokenLinkingAsyncHandler(asyncHandler);
         }
-    }
-
-    private static class SegmentEndingAsyncHandler implements AsyncHandler<InvokeRequest, InvokeResult> {
-        private final AsyncHandler<InvokeRequest, InvokeResult> originalHandler;
-        private final Segment segment;
-
-        public SegmentEndingAsyncHandler(
-                AsyncHandler<InvokeRequest, InvokeResult> asyncHandler, Segment segment) {
-            this.segment = segment;
-            this.originalHandler = asyncHandler;
-        }
-
-        @Override
-        public void onError(Exception exception) {
-            segment.end();
-            if (originalHandler != null) {
-                originalHandler.onError(exception);
-            }
-        }
-
-        @Override
-        public void onSuccess(InvokeRequest request, InvokeResult invokeResult) {
-            segment.end();
-            if (originalHandler != null) {
-                originalHandler.onSuccess(request, invokeResult);
-            }
-        }
+        return Weaver.callOriginal();
     }
 }

--- a/instrumentation/aws-java-sdk-lambda-1.11.280/src/main/java/com/amazonaws/services/lambda/AWSLambdaClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-lambda-1.11.280/src/main/java/com/amazonaws/services/lambda/AWSLambdaClient_Instrumentation.java
@@ -9,10 +9,12 @@ package com.amazonaws.services.lambda;
 
 import com.agent.instrumentation.awsjavasdk1.services.lambda.FunctionRawData;
 import com.agent.instrumentation.awsjavasdk1.services.lambda.LambdaUtil;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.lambda.model.InvokeRequest;
 import com.amazonaws.services.lambda.model.InvokeResult;
 import com.newrelic.api.agent.CloudParameters;
 import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
 import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.TracedMethod;
 import com.newrelic.api.agent.weaver.MatchType;
@@ -24,9 +26,18 @@ public abstract class AWSLambdaClient_Instrumentation {
 
     abstract protected String getSigningRegion();
 
-    @Trace(leaf = true)
-    public InvokeResult invoke(InvokeRequest invokeRequest) {
-        FunctionRawData functionRawData = new FunctionRawData(invokeRequest.getFunctionName(), invokeRequest.getQualifier(), this.getSigningRegion(), this);
+    private final AWSCredentialsProvider awsCredentialsProvider = Weaver.callOriginal();
+
+    // this method needs the async because it is invoked by the async client
+    // it is also in the path of the sync client execution
+    @Trace(async = true)
+    final InvokeResult executeInvoke(InvokeRequest invokeRequest) {
+        Token token = LambdaUtil.getToken(invokeRequest);
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
+        FunctionRawData functionRawData = new FunctionRawData(invokeRequest.getFunctionName(), invokeRequest.getQualifier(), this.getSigningRegion(), this, awsCredentialsProvider);
         CloudParameters cloudParameters = LambdaUtil.getCloudParameters(functionRawData);
         TracedMethod tracedMethod = NewRelic.getAgent().getTracedMethod();
         tracedMethod.reportAsExternal(cloudParameters);

--- a/instrumentation/aws-java-sdk-lambda-1.11.280/src/test/java/com/agent/instrumentation/awsjavasdk1/services/lambda/LambdaUtilTest.java
+++ b/instrumentation/aws-java-sdk-lambda-1.11.280/src/test/java/com/agent/instrumentation/awsjavasdk1/services/lambda/LambdaUtilTest.java
@@ -7,11 +7,11 @@
 
 package com.agent.instrumentation.awsjavasdk1.services.lambda;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.regions.Regions;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.CloudApi;
 import com.newrelic.agent.bridge.NoOpCloud;
-import com.newrelic.api.agent.CloudAccountInfo;
 import com.newrelic.api.agent.CloudParameters;
 import org.junit.After;
 import org.junit.Before;
@@ -23,13 +23,15 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class LambdaUtilTest {
+
+    private AWSCredentialsProvider credentialsProvider;
 
     @Before
     public void before() {
         AgentBridge.cloud = mock(CloudApi.class);
+        credentialsProvider = mock(AWSCredentialsProvider.class);
     }
 
     @After
@@ -65,6 +67,6 @@ public class LambdaUtilTest {
     }
 
     private FunctionRawData data(String functionRef, String qualifier) {
-        return new FunctionRawData(functionRef, qualifier, Regions.US_EAST_1.getName(), this);
+        return new FunctionRawData(functionRef, qualifier, Regions.US_EAST_1.getName(), this, credentialsProvider);
     }
 }

--- a/instrumentation/aws-java-sdk-lambda-1.11.280/src/test/java/com/agent/instrumentation/awsjavasdk1/services/lambda/LambdaUtilTest_ProcessData.java
+++ b/instrumentation/aws-java-sdk-lambda-1.11.280/src/test/java/com/agent/instrumentation/awsjavasdk1/services/lambda/LambdaUtilTest_ProcessData.java
@@ -7,6 +7,7 @@
 
 package com.agent.instrumentation.awsjavasdk1.services.lambda;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.regions.Regions;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.CloudApi;
@@ -23,12 +24,16 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(Parameterized.class)
 public class LambdaUtilTest_ProcessData {
+
+    private AWSCredentialsProvider credentialsProvider;
 
     @Parameterized.Parameter
     public String functionRef;
@@ -37,68 +42,80 @@ public class LambdaUtilTest_ProcessData {
     public String qualifier;
 
     @Parameterized.Parameter(2)
-    public boolean shouldMockCloudApi;
+    public boolean shouldMockAccountInfo;
 
     @Parameterized.Parameter(3)
-    public String expectedArn;
+    public boolean shouldDecodeArn;
 
     @Parameterized.Parameter(4)
+    public String expectedArn;
+
+    @Parameterized.Parameter(5)
     public String expectedFunctionName;
 
-    @Parameterized.Parameters(name="{0}, {1}, {2}, {3}, {4}")
+    @Parameterized.Parameters(name="{0}, {1}, {2}, {3}, {4}, {5}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            // only function name
-            {"my-function",       null,    false, "", "my-function"},
-            {"my-function:alias", null,    false, "", "my-function"},
-            {"my-function:alias", null,    true,  "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
-            {"my-function:123",   null,    false, "", "my-function"},
-            {"my-function:123",   null,    true,  "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"my-function",       "alias", false, "", "my-function"},
-            {"my-function",       "alias", true,  "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
-            {"my-function",       "123",   false, "", "my-function"},
-            {"my-function",       "123",   true,  "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                // only function name
+                {"my-function",       null,    false, false, "", "my-function"},
+                {"my-function",       null,    true,  false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"my-function",       null,    false, true,  "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"my-function:alias", null,    false, false, "", "my-function"},
+                {"my-function:alias", null,    true,  false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
+                {"my-function:123",   null,    false, false, "", "my-function"},
+                {"my-function:123",   null,    true,  false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"my-function",       "alias", false, false, "", "my-function"},
+                {"my-function",       "alias", true,  false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
+                {"my-function",       "123",   false, false, "", "my-function"},
+                {"my-function",       "123",   true,  false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
 
-            // account and function name partial ARN
-            {"123456789012:function:my-function",       null,    false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
-            {"123456789012:function:my-function:alias", null,    false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
-            {"123456789012:function:my-function:123",   null,    false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"123456789012:function:my-function",       "alias", false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
-            {"123456789012:function:my-function",       "123",   false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                // account and function name partial ARN
+                {"123456789012:function:my-function",       null,    false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"123456789012:function:my-function:alias", null,    false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
+                {"123456789012:function:my-function:123",   null,    false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"123456789012:function:my-function",       "alias", false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
+                {"123456789012:function:my-function",       "123",   false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
 
-            // full arn
-            {"arn:aws:lambda:us-east-1:123456789012:function:my-function",       null,    false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
-            {"arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", null,    false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
-            {"arn:aws:lambda:us-east-1:123456789012:function:my-function:123",   null,    false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"arn:aws:lambda:us-east-1:123456789012:function:my-function",       "alias", false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
-            {"arn:aws:lambda:us-east-1:123456789012:function:my-function",       "123",   false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"arn:aws:lambda:us-west-2:123456789012:function:my-function",       null,    false, "arn:aws:lambda:us-west-2:123456789012:function:my-function", "my-function"},
+                // full arn
+                {"arn:aws:lambda:us-east-1:123456789012:function:my-function",       null,    false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", null,    false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
+                {"arn:aws:lambda:us-east-1:123456789012:function:my-function:123",   null,    false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn:aws:lambda:us-east-1:123456789012:function:my-function",       "alias", false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias", "my-function"},
+                {"arn:aws:lambda:us-east-1:123456789012:function:my-function",       "123",   false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn:aws:lambda:us-west-2:123456789012:function:my-function",       null,    false, false, "arn:aws:lambda:us-west-2:123456789012:function:my-function", "my-function"},
 
-            // other partial arns
-            {"arn::lambda:us-east-1:123456789012:function:my-function:123", null, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"arn::lambda:us-east-1:123456789012:my-function:123", null, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"arn::lambda:us-east-1:function:my-function:123", null, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"arn::lambda:us-east-1:my-function:123", null, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"arn:aws:lambda:us-east-1:123456789012:my-function:123", null, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"arn:aws:lambda:123456789012:function:my-function", null, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
-            {"arn:aws:lambda:123456789012:my-function", null, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
-            {"us-east-1:123456789012:function:my-function:123", null, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"us-east-1:function:my-function:123", null, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
-            {"us-east-1:function:my-function:123", null, false, "", "my-function"},
-            {"us-east-1:function:my-function", null, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
-            {"us-east-1:my-function", null, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
-            {"us-east-1:my-function", null, false, "", "my-function"},
-            {"123456789012:my-function", null, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                // other partial arns
+                {"arn::lambda:us-east-1:123456789012:function:my-function:123", null, false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn::lambda:us-east-1:123456789012:my-function:123", null, false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn::lambda:us-east-1:function:my-function:123", null, true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn::lambda:us-east-1:function:my-function:123", null, false, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn::lambda:us-east-1:my-function:123", null, true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn::lambda:us-east-1:my-function:123", null, false, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn:aws:lambda:us-east-1:123456789012:my-function:123", null, false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"arn:aws:lambda:123456789012:function:my-function", null, false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"arn:aws:lambda:123456789012:my-function", null, false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"us-east-1:123456789012:function:my-function:123", null, false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"us-east-1:function:my-function:123", null, true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"us-east-1:function:my-function:123", null, true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function:123", "my-function"},
+                {"us-east-1:function:my-function:123", null, false, false, "", "my-function"},
+                {"us-east-1:function:my-function", null, true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"us-east-1:function:my-function", null, false, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"us-east-1:my-function", null, true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"us-east-1:my-function", null, false, true, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"us-east-1:my-function", null, false, false, "", "my-function"},
+                {"123456789012:my-function", null, false, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
 
-            // ignore $LATEST
-            {"my-function:$LATEST",   null,      true, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
-            {"my-function",           "$LATEST", true, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                // ignore $LATEST
+                {"my-function:$LATEST",   null,      true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
+                {"my-function",           "$LATEST", true, false, "arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"},
         });
     }
 
     @Before
     public void before() {
         AgentBridge.cloud = mock(CloudApi.class);
+        credentialsProvider = mock(AWSCredentialsProvider.class, RETURNS_DEEP_STUBS);
+        when(credentialsProvider.getCredentials().getAWSAccessKeyId()).thenReturn("accessKey");
     }
 
     @After
@@ -108,21 +125,21 @@ public class LambdaUtilTest_ProcessData {
 
     @Test
     public void test() {
-        if (shouldMockCloudApi) {
-            mockCloudApiClient();
+        if (shouldMockAccountInfo) {
+            when(AgentBridge.cloud.getAccountInfo(any(), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
+                    .thenReturn("123456789012");
+        }
+        if (shouldDecodeArn) {
+            when(AgentBridge.cloud.decodeAwsAccountId(anyString()))
+                    .thenReturn("123456789012");
         }
         FunctionProcessedData functionProcessedData = LambdaUtil.processData(data(functionRef, qualifier));
         assertEquals(expectedArn, functionProcessedData.getArn());
         assertEquals(expectedFunctionName, functionProcessedData.getFunctionName());
     }
 
-    private static void mockCloudApiClient() {
-        when(AgentBridge.cloud.getAccountInfo(any(), eq(CloudAccountInfo.AWS_ACCOUNT_ID)))
-                .thenReturn("123456789012");
-    }
-
     private FunctionRawData data(String functionRef, String qualifier) {
-        return new FunctionRawData(functionRef, qualifier, Regions.US_EAST_1.getName(), this);
+        return new FunctionRawData(functionRef, qualifier, Regions.US_EAST_1.getName(), this, credentialsProvider);
     }
 
 }

--- a/instrumentation/aws-java-sdk-lambda-2.1/src/main/java/com/agent/instrumentation/awsjavasdk2/services/lambda/FunctionRawData.java
+++ b/instrumentation/aws-java-sdk-lambda-2.1/src/main/java/com/agent/instrumentation/awsjavasdk2/services/lambda/FunctionRawData.java
@@ -7,6 +7,8 @@
 
 package com.agent.instrumentation.awsjavasdk2.services.lambda;
 
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.regions.Region;
@@ -46,6 +48,20 @@ public class FunctionRawData {
             Region region = config.option(AwsClientOption.AWS_REGION);
             if (region != null) {
                 return region.id();
+            }
+        }
+        return null;
+    }
+
+    public String getAccessKey() {
+        SdkClientConfiguration config = this.config.get();
+        if (config != null) {
+            AwsCredentialsProvider credentialsProvider = config.option(AwsClientOption.CREDENTIALS_PROVIDER);
+            if (credentialsProvider != null) {
+                AwsCredentials awsCredentials = credentialsProvider.resolveCredentials();
+                if (awsCredentials != null) {
+                    return awsCredentials.accessKeyId();
+                }
             }
         }
         return null;

--- a/instrumentation/aws-java-sdk-lambda-2.1/src/main/java/com/agent/instrumentation/awsjavasdk2/services/lambda/LambdaUtil.java
+++ b/instrumentation/aws-java-sdk-lambda-2.1/src/main/java/com/agent/instrumentation/awsjavasdk2/services/lambda/LambdaUtil.java
@@ -92,7 +92,7 @@ public class LambdaUtil {
 
         if (accountId == null) {
             // if account id is not provided, we will try to get it from the config
-            accountId = getAccountId(data.getSdkClient());
+            accountId = getAccountId(data.getSdkClient(), data.getAccessKey());
         }
 
         if (region != null && accountId != null) {
@@ -111,8 +111,12 @@ public class LambdaUtil {
         return new FunctionProcessedData(functionName, arn);
     }
 
-    private static String getAccountId(Object sdkClient) {
-        return AgentBridge.cloud.getAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID);
+    private static String getAccountId(Object sdkClient, String accessKey) {
+        String accountId = AgentBridge.cloud.getAccountInfo(sdkClient, CloudAccountInfo.AWS_ACCOUNT_ID);
+        if (accountId == null && accessKey != null) {
+            accountId = AgentBridge.cloud.decodeAwsAccountId(accessKey);
+        }
+        return accountId;
     }
 
     public static String getSimpleFunctionName(FunctionRawData functionRawData) {

--- a/instrumentation/aws-java-sdk-lambda-2.1/src/main/java/software/amazon/awssdk/services/lambda/DefaultLambdaClient_Instrumentation.java
+++ b/instrumentation/aws-java-sdk-lambda-2.1/src/main/java/software/amazon/awssdk/services/lambda/DefaultLambdaClient_Instrumentation.java
@@ -25,7 +25,7 @@ final class DefaultLambdaClient_Instrumentation {
 
     private final SdkClientConfiguration clientConfiguration = Weaver.callOriginal();
 
-    @Trace(leaf = true)
+    @Trace
     public InvokeResponse invoke(InvokeRequest invokeRequest) {
         FunctionRawData functionRawData = new FunctionRawData(invokeRequest.functionName(), invokeRequest.qualifier(), clientConfiguration, this);
         CloudParameters cloudParameters = LambdaUtil.getCloudParameters(functionRawData);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/cloud/AwsAccountDecoderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/cloud/AwsAccountDecoderImpl.java
@@ -71,7 +71,7 @@ class AwsAccountDecoderImpl implements AwsAccountDecoder {
      * AwsAccountDecoder.
      */
     static AwsAccountDecoder newInstance() {
-        if (NewRelic.getAgent().getConfig().getValue("cloud.aws.account_decoding", true)) {
+        if (NewRelic.getAgent().getConfig().getValue("cloud.aws.account_decoding.enabled", true)) {
             NewRelic.getAgent().getMetricAggregator().incrementCounter("Supportability/Aws/AccountDecode/enabled");
             return new AwsAccountDecoderImpl();
         } else {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/cloud/AwsUtilDecoderDisabledTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/cloud/AwsUtilDecoderDisabledTest.java
@@ -30,7 +30,7 @@ public class AwsUtilDecoderDisabledTest {
     @Test
     public void decodeAccount() {
         try (MockedStatic<NewRelic> newRelicMockedStatic = Mockito.mockStatic(NewRelic.class, Answers.RETURNS_DEEP_STUBS)) {
-            newRelicMockedStatic.when(() -> NewRelic.getAgent().getConfig().getValue(eq("cloud.aws.account_decoding"), any()))
+            newRelicMockedStatic.when(() -> NewRelic.getAgent().getConfig().getValue(eq("cloud.aws.account_decoding.enabled"), any()))
                     .thenReturn(false);
 
             AwsAccountDecoder decoder = AwsAccountDecoderImpl.newInstance();


### PR DESCRIPTION
### Overview
Allows `cloud.resource_id` to be populated without configuration.

### Related Github Issue
Close #2125 
