### PR TITLE
Allow JFR queue size and harvest interval to be configured via agent config

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -496,6 +496,8 @@ public class MetricNames {
     public static final String SUPPORTABILITY_JFR_SERVICE_STARTED_SUCCESS = "Supportability/JfrService/Started/Success";
     public static final String SUPPORTABILITY_JFR_SERVICE_STOPPED_SUCCESS = "Supportability/JfrService/Stopped/Success";
     public static final String SUPPORTABILITY_JFR_SERVICE_STARTED_FAIL = "Supportability/JfrService/Started/Fail";
+    public static final String SUPPORTABILITY_JFR_SERVICE_CONFIGURED_QUEUE_SIZE = "Supportability/JfrService/Config/QueueSize";
+    public static final String SUPPORTABILITY_JFR_SERVICE_CONFIGURED_HARVEST_INTERVAL = "Supportability/JfrService/Config/HarvestInterval";
 
     // Error Grouping
     public static final String SUPPORTABILITY_ERROR_GROUPING_CALLBACK_ENABLED = "Supportability/ErrorGrouping/Callback/enabled";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
@@ -17,6 +17,18 @@ public interface JfrConfig {
     boolean isEnabled();
 
     /**
+     * The harvest interval to be used by the JfrController to trigger a harvest.
+     * @return the amount of seconds between two JFR data harvests
+     */
+    Integer getHarvestInterval();
+
+    /**
+     * The size of the queue that holds JFR's RecordedEvents to be processed in each harvest.
+     * @return the number of events to process
+     */
+    Integer getQueueSize();
+
+    /**
      * Set the JFR service enabled flag
      *
      * @param enabled the desired enabled flag value

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
@@ -7,6 +7,8 @@
 
 package com.newrelic.agent.config;
 
+import com.newrelic.jfr.daemon.DaemonConfig;
+
 import java.util.Collections;
 import java.util.Map;
 
@@ -18,12 +20,18 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     public static final String AUDIT_LOGGING = "audit_logging";
     public static final Boolean AUDIT_LOGGING_DEFAULT = Boolean.FALSE;
     public static final Boolean USE_LICENSE_KEY_DEFAULT = Boolean.TRUE;
+    public static final String HARVEST_INTERVAL = "harvest_interval";   //In seconds
+    public static final String QUEUE_SIZE = "queue_size";
 
     private boolean isEnabled;
+    private final Integer harvestInterval;
+    private final Integer queueSize;
 
     public JfrConfigImpl(Map<String, Object> pProps) {
         super(pProps, SYSTEM_PROPERTY_ROOT);
         isEnabled = getProperty(ENABLED, ENABLED_DEFAULT);
+        harvestInterval = getProperty(HARVEST_INTERVAL, DaemonConfig.DEFAULT_HARVEST_INTERVAL);
+        queueSize = getProperty(QUEUE_SIZE, DaemonConfig.DEFAULT_QUEUE_SIZE);
     }
 
     static JfrConfigImpl createJfrConfig(Map<String, Object> settings) {
@@ -36,6 +44,16 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     @Override
     public boolean isEnabled() {
         return isEnabled;
+    }
+
+    @Override
+    public Integer getHarvestInterval() {
+        return harvestInterval;
+    }
+
+    @Override
+    public Integer getQueueSize() {
+        return queueSize;
     }
 
     @Override
@@ -52,5 +70,4 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     public boolean useLicenseKey() {
         return USE_LICENSE_KEY_DEFAULT;
     }
-
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -51,6 +51,8 @@ public class JfrService extends AbstractService implements AgentConfigListener {
             Agent.LOG.log(Level.INFO, "Attaching New Relic JFR Monitor");
 
             NewRelic.getAgent().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_JFR_SERVICE_STARTED_SUCCESS);
+            NewRelic.getAgent().getMetricAggregator().recordMetric(MetricNames.SUPPORTABILITY_JFR_SERVICE_CONFIGURED_HARVEST_INTERVAL, jfrConfig.getHarvestInterval());
+            NewRelic.getAgent().getMetricAggregator().recordMetric(MetricNames.SUPPORTABILITY_JFR_SERVICE_CONFIGURED_QUEUE_SIZE, jfrConfig.getQueueSize());
 
             try {
                 final DaemonConfig daemonConfig = buildDaemonConfig();
@@ -147,6 +149,8 @@ public class JfrService extends AbstractService implements AgentConfigListener {
             .auditLogging(jfrConfig.auditLoggingEnabled())
             .metricsUri(URI.create(defaultAgentConfig.getMetricIngestUri()))
             .eventsUri(URI.create(defaultAgentConfig.getEventIngestUri()))
+            .harvestInterval(jfrConfig.getHarvestInterval())
+            .queueSize(jfrConfig.getQueueSize())
             .proxyHost(defaultAgentConfig.getProxyHost())
             .proxyScheme(defaultAgentConfig.getProxyScheme())
             .proxyPort(defaultAgentConfig.getProxyPort())

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -437,6 +437,18 @@ common: &default_settings
     # Default is false.
     audit_logging: false
 
+    # The time interval, in seconds, of how often JFR data is sent to New Relic.
+    # The default is 10 seconds.
+    harvest_interval: 10
+
+    # The size of the queue used to store JFR events. Increasing this can reduce gaps in JFR reported data
+    # but can also cause resource issues in the agent or cause data to be dropped if backend pipeline
+    # limits are exceeded.
+    # See: https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/#limits
+    #      https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/
+    # Default is 250000
+    queue_size: 250000
+
   # User-configurable custom labels for this agent.  Labels are name-value pairs.
   # There is a maximum of 64 labels per agent.  Names and values are limited to 255 characters.
   # Names and values may not contain colons (:) or semicolons (;).

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -53,6 +53,8 @@ public class JfrServiceTest {
         ServiceFactory.setServiceManager(manager);
 
         when(jfrConfig.useLicenseKey()).thenReturn(true);
+        when(jfrConfig.getHarvestInterval()).thenReturn(22);
+        when(jfrConfig.getQueueSize()).thenReturn(300_000);
         when(agentConfig.getApplicationName()).thenReturn("test_app_name");
         when(agentConfig.getMetricIngestUri()).thenReturn(DEFAULT_METRIC_INGEST_URI);
         when(agentConfig.getEventIngestUri()).thenReturn(DEFAULT_EVENT_INGEST_URI);
@@ -71,6 +73,8 @@ public class JfrServiceTest {
         assertEquals("test_app_name", daemonConfig.getMonitoredAppName());
         assertEquals(DEFAULT_METRIC_INGEST_URI, daemonConfig.getMetricsUri().toString());
         assertEquals(DEFAULT_EVENT_INGEST_URI, daemonConfig.getEventsUri().toString());
+        assertEquals(22, daemonConfig.getHarvestInterval().getSeconds());
+        assertEquals(300_000, (int)daemonConfig.getQueueSize());
     }
 
     @Test


### PR DESCRIPTION
Resolves #1511 

This is a continuation of @meiao 's [PR](https://github.com/newrelic/newrelic-java-agent/pull/371) to:
- Configure JFR queue size via `jfr.queue_size` - default of 250000
- Configure JFR harvest interval via `jrf.harvest_interval` - default of 10 seconds
- Send up supportability metrics with the configured JFR queue size and interval values

