### PR TITLE
Add scala3 source detection

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/language/SourceLibraryDetector.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/language/SourceLibraryDetector.java
@@ -59,6 +59,7 @@ public class SourceLibraryDetector implements Runnable {
     void detectSourceLanguages() {
         ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
         detectJava();
+        detectScala3(systemClassLoader);
         detectScala(systemClassLoader);
         detectKotlin(systemClassLoader);
         detectClojure(systemClassLoader);
@@ -86,6 +87,21 @@ public class SourceLibraryDetector implements Runnable {
             recordJvmVendorMetric("Corretto");
         } else {
             recordJvmVendorMetric("Other");
+        }
+    }
+
+    private void detectScala3(ClassLoader systemClassLoader) {
+        try {
+            //scala3-library removed all methods referencing the version number, so we just capture the major version
+            //by checking for a class introduced in the scala 3 API.
+            Class<?> aClass = Class.forName("scala.deriving.Mirror", true, systemClassLoader);
+            if (aClass != null) {
+                recordSourceLanguageMetric("scala", "3.x");
+            }
+        } catch (ClassNotFoundException cnfe){
+            Agent.LOG.log(Level.FINEST, format("Class ''{0}'' was not found; scala3 is not present in the classpath", "scala.deriving.Mirror"));
+        } catch (Exception e) {
+            Agent.LOG.log(Level.FINEST, format("Exception occurred while trying to determine scala3 version", e.getMessage()));
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/language/SourceLibraryDetector.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/language/SourceLibraryDetector.java
@@ -92,7 +92,7 @@ public class SourceLibraryDetector implements Runnable {
 
     private void detectScala3(ClassLoader systemClassLoader) {
         try {
-            //scala3-library removed all methods referencing the version number, so we just capture the major version
+            //scala3-library removed all methods referencing the version 3 number, so we only capture the major version
             //by checking for a class introduced in the scala 3 API.
             Class<?> aClass = Class.forName("scala.deriving.Mirror", true, systemClassLoader);
             if (aClass != null) {
@@ -107,7 +107,8 @@ public class SourceLibraryDetector implements Runnable {
 
     private void detectScala(ClassLoader systemClassLoader) {
         try {
-            // Scala has a static versionNumberString method that can be invoked to get the version number
+            // Scala has a static versionNumberString method that can be invoked to get the version number.
+            // A scala 3 app will also capture this metric, because scala 3 includes the scala 2.13 library.
             Class<?> aClass = Class.forName(SCALA_VERSION_CLASS, true, systemClassLoader);
             if (aClass != null) {
                 String version = (String) aClass.getMethod(SCALA_VERSION_METHOD).invoke(null);


### PR DESCRIPTION
Minor change to add a bit of detection for apps using scala 3. 

This has some significant limitations:
- **This feature detects only the major version**. Scala 3 removed the API methods exposing the version number, so we no longer can read that in-code. An app running with Scala 3.3.4 and Scala 3.5.0 will both report the same supportability metric, `Supportability/SourceVersion/scala/3.x`.
- **(Existing limitation with scala <=2.13 detection): This feature only detects scala libraries present on the system classloader**. This means that apps launched with the `sbt` and `scala` CLIs, which load core scala classes into special Scala Class Loaders, will not capture this metric. Apps launched with `java`, or any other CLI that doesn't treat scala libraries special, will be ok. 



