### PR TITLE
Bump csec agent to version 1.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The agent version.
 agentVersion=8.17.0
-securityAgentVersion=1.5.1
+securityAgentVersion=1.6.0
 
 newrelicDebug=false
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
### Overview

Update csec agent dependency to version 1.6.0