### PR TITLE
added checks for GRPC because it expects ASCIIString

### DIFF
--- a/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/Http2RequestHeaderWrapper.java
+++ b/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/Http2RequestHeaderWrapper.java
@@ -15,6 +15,7 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,12 +29,14 @@ import java.util.regex.Pattern;
 
 public class Http2RequestHeaderWrapper extends ExtendedRequest {
     private static final Pattern URL_REPLACEMENT_PATTERN = Pattern.compile("(?i)%(?![\\da-f]{2})");
+    private static final String GRPCHEADERSUTIL = "io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders";
     private final Set<Cookie> cookies;
     private final Map<String, List<String>> parameters;
     private final Http2Headers http2Headers;
     private final CharSequence method;
     private final CharSequence path;
     private final CharSequence authority;
+    private final boolean isGRPCHttp2;
 
     public Http2RequestHeaderWrapper(Http2Headers http2Headers) {
         super();
@@ -43,6 +46,7 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
         this.authority = getAuthorityHeader();
         this.cookies = getCookies();
         this.parameters = getParameters();
+        this.isGRPCHttp2 = http2Headers.getClass().getName().equals(GRPCHEADERSUTIL);
     }
 
     private Map<String, List<String>> getParameters() {
@@ -124,6 +128,13 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
     @Override
     public String getHeader(String name) {
         try {
+        	
+        	if(isGRPCHttp2) {
+        		// GRPC HTTP2 expects an AsciiString
+        		AsciiString asciiString = new AsciiString(name);
+        		return http2Headers.get(asciiString).toString();
+        		
+        	}
             // HTTP/2 only supports lowercase headers
             String lowerCaseHeaderName = name.toLowerCase();
             if (lowerCaseHeaderName.equals(HttpHeaderNames.HOST.toString())) {
@@ -134,7 +145,10 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
                 return http2Headers.get(lowerCaseHeaderName).toString();
             }
         } catch (Exception e) {
-            AgentBridge.getAgent().getLogger().log(Level.FINER, e, "Unable to get Http2Headers header: {0}", e.getMessage());
+        	String errorMsg = e.getMessage();
+        	if(!errorMsg.equals("AsciiString expected. Was: java.lang.String")) {
+        		AgentBridge.getAgent().getLogger().log(Level.FINER, e, "Unable to get Http2Headers header: {0}", e.getMessage());
+        	}
         }
         return null;
     }
@@ -205,12 +219,22 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
     public List<String> getHeaders(String name) {
         List<String> headers = new ArrayList<>();
         try {
-            // HTTP/2 only supports lowercase headers
-            String lowerCaseHeaderName = name.toLowerCase();
-            List<CharSequence> allHeaders = http2Headers.getAll(lowerCaseHeaderName);
-            for (CharSequence header : allHeaders) {
-                headers.add(header.toString());
-            }
+            if (!isGRPCHttp2) {
+				// HTTP/2 only supports lowercase headers
+				String lowerCaseHeaderName = name.toLowerCase();
+				List<CharSequence> allHeaders = http2Headers.getAll(lowerCaseHeaderName);
+				for (CharSequence header : allHeaders) {
+					headers.add(header.toString());
+				} 
+			} else {
+				// GRPC only accepts AsciiString
+				AsciiString asciiName = new AsciiString(name);
+				List<CharSequence> allHeaders = http2Headers.getAll(asciiName);
+				for (CharSequence header : allHeaders) {
+					headers.add(header.toString());
+				} 
+				
+			}
         } catch (Exception e) {
             AgentBridge.getAgent().getLogger().log(Level.FINER, e, "Unable to get Http2Headers headers: {0}", e.getMessage());
         }


### PR DESCRIPTION

### Overview
When the Java Agent attempts to read headers from io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders it throws an exception because the get method expects an io.netty.util.AsciiString input but receives a String from the agent.  

### Related Github Issue
This fixes
https://github.com/newrelic/newrelic-java-agent/issues/2177

This code check to see if the Http2Headers class that is passed into the constructor for com.agent.instrumentation.netty4116.Http2RequestHeaderWrapper is GrpcHttp2RequestHeaders.  If it is it sets a flag.   
In both the getHeader and getHeaders methods, it checks if the GRPC flag is set and if true then creates an AsciiString to use.
