### PR TITLE
Move init container release from lambda to GHA

### DIFF
--- a/.github/workflows/Create-Release-Tags.yml
+++ b/.github/workflows/Create-Release-Tags.yml
@@ -2,10 +2,9 @@ name: Create release tags
 on:
   workflow_dispatch: # Allow manual trigger
     inputs:
-      agent-ref:
-        description: 'The ref (release tag) to create init containers for'
-        required: false
-        default: 'main'
+      agent-version:
+        description: 'The release tag to create init containers for, including the v. Eg v8.12.0’. '
+        required: true
         type: string
 jobs:
   create_release_tags:
@@ -13,9 +12,9 @@ jobs:
     steps:
       - name: Create release tags for K8s Init Container
         run: |
-          RELEASE_TITLE="New Relic Java Agent ${{ inputs.agent-ref }}.0"
-          RELEASE_TAG="${{ inputs.agent-ref }}.0_java"
-          RELEASE_NOTES="Automated release for [Java Agent ${{ inputs.agent-ref }}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${{ inputs.agent-ref }})"
+          RELEASE_TITLE="New Relic Java Agent ${{ inputs.agent-version }}.0"
+          RELEASE_TAG="${{ inputs.agent-version }}.0_java"
+          RELEASE_NOTES="Automated release for [Java Agent ${{ inputs.agent-version }}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${{ inputs.agent-version }})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
           echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"

--- a/.github/workflows/Create-Release-Tags.yml
+++ b/.github/workflows/Create-Release-Tags.yml
@@ -1,0 +1,18 @@
+name: Create release tags
+on:
+  workflow_dispatch: # Allow manual trigger
+jobs:
+  create_release_tags:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
+      - name: Create release tags for K8s Init Container
+        run: |
+          RELEASE_TITLE="New Relic Java Agent ${GITHUB_REF}.0"
+          RELEASE_TAG="${GITHUB_REF}.0_java"
+          RELEASE_NOTES="Automated release for [Java Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${GITHUB_REF})"
+          gh auth login --with-token <<< $GH_RELEASE_TOKEN
+          echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/Create-Release-Tags.yml
+++ b/.github/workflows/Create-Release-Tags.yml
@@ -2,9 +2,10 @@ name: Create release tags
 on:
   workflow_dispatch: # Allow manual trigger
     inputs:
-      releaseTag:
-        description: 'Agent release tag to create init containers for'
-        required: true
+      agent-ref:
+        description: 'The ref (release tag) to create init containers for'
+        required: false
+        default: 'main'
         type: string
 jobs:
   create_release_tags:
@@ -12,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
-          ref: ${{ inputs.releaseTag }}
+          ref: ${{ inputs.agent-ref }}
       - name: Create release tags for K8s Init Container
         run: |
           RELEASE_TITLE="New Relic Java Agent ${GITHUB_REF}.0"

--- a/.github/workflows/Create-Release-Tags.yml
+++ b/.github/workflows/Create-Release-Tags.yml
@@ -1,11 +1,18 @@
 name: Create release tags
 on:
   workflow_dispatch: # Allow manual trigger
+    inputs:
+      releaseTag:
+        description: 'Agent release tag to create init containers for'
+        required: true
+        type: string
 jobs:
   create_release_tags:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
+        with:
+          ref: ${{ inputs.releaseTag }}
       - name: Create release tags for K8s Init Container
         run: |
           RELEASE_TITLE="New Relic Java Agent ${GITHUB_REF}.0"

--- a/.github/workflows/Create-Release-Tags.yml
+++ b/.github/workflows/Create-Release-Tags.yml
@@ -11,14 +11,11 @@ jobs:
   create_release_tags:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
-        with:
-          ref: ${{ inputs.agent-ref }}
       - name: Create release tags for K8s Init Container
         run: |
-          RELEASE_TITLE="New Relic Java Agent ${GITHUB_REF}.0"
-          RELEASE_TAG="${GITHUB_REF}.0_java"
-          RELEASE_NOTES="Automated release for [Java Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${GITHUB_REF})"
+          RELEASE_TITLE="New Relic Java Agent ${{ inputs.agent-ref }}.0"
+          RELEASE_TAG="${{ inputs.agent-ref }}.0_java"
+          RELEASE_NOTES="Automated release for [Java Agent ${{ inputs.agent-ref }}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${{ inputs.agent-ref }})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
           echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -53,14 +53,3 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true
-
-      - name: Create release tags for K8s Init Container
-        run: |
-          RELEASE_TITLE="New Relic Java Agent ${GITHUB_REF}.0"
-          RELEASE_TAG="${GITHUB_REF}.0_java"
-          RELEASE_NOTES="Automated release for [Java Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${GITHUB_REF})"
-          gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
-        env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -60,7 +60,7 @@ jobs:
           RELEASE_TAG="${GITHUB_REF}.0_java"
           RELEASE_NOTES="Automated release for [Java Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${GITHUB_REF})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
+          echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
         env:
           GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -55,12 +55,12 @@ jobs:
         run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true
 
       - name: Create release tags for K8s Init Container
-        uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
-        with:
-          gh-cli-version: 2.63.2
         run: |
+          RELEASE_TITLE="New Relic Java Agent ${GITHUB_REF}.0"
+          RELEASE_TAG="${GITHUB_REF}.0_java"
+          RELEASE_NOTES="Automated release for [Java Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-java-agent/releases/tag/${GITHUB_REF})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-agent-init-container - Releasing New Relic Java Agent ${GITHUB_REF}.0 with tag ${GITHUB_REF}.0_java"
-          gh create release "${GITHUB_REF}.0_java" -t "New Relic Java Agent ${GITHUB_REF}.0" --repo=newrelic/newrelic-agent-init-container
+          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
         env:
           GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -53,3 +53,14 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true
+
+      - name: Create release tags for K8s Init Container
+        uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
+        with:
+          gh-cli-version: 2.63.2
+        run: |
+          gh auth login --with-token <<< $GH_RELEASE_TOKEN
+          echo "newrelic/newrelic-agent-init-container - Releasing New Relic Java Agent ${GITHUB_REF}.0 with tag ${GITHUB_REF}.0_java"
+          gh create release "${GITHUB_REF}.0_java" -t "New Relic Java Agent ${GITHUB_REF}.0" --repo=newrelic/newrelic-agent-init-container
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
### Overview
We are getting rid of the internal [auto-layer-releases repo](https://source.datanerd.us/aws-lambda/auto-layer-releases/blob/master/app.py) and moving creating of the release tags into each agent's GHA deploy flow.
