### PR TITLE
vertx: decrease amount of tokens created

### DIFF
--- a/instrumentation/vertx-core-3.8.0/README.md
+++ b/instrumentation/vertx-core-3.8.0/README.md
@@ -1,0 +1,41 @@
+# vertx-core-3.8.0
+
+## FutureImpl#setHandler
+Before version 3.8.4, this method only allowed a single handler to be stored, keeping only the last one provided. On version 3.8.4 and newer, multiple can be stored in an instance of Handlers.
+
+The instrumentation for this method uses the same code as newer versions of Vert.x. And it works for both version to avoid dangling tokens. From 3.8.0 to 3.8.3, the instrumentation will create and expire tokens whenever a new Handler is set. For 3.8.4 it will at most create two Tokens.
+
+This is the relevant code.
+```java
+
+    private Handler<AsyncResult> handler = Weaver.callOriginal();
+
+    public Future setHandler(Handler<AsyncResult> handler) {
+        Handler previousHandler = this.handler;
+        // ,,,
+        Future future = Weaver.callOriginal();
+
+        if (!isComplete()) {
+            if (previousHandler != this.handler) {
+                VertxCoreUtil.storeToken(this.handler);
+                if (previousHandler != null) {
+                    VertxCoreUtil.expireToken(previousHandler);
+                }
+            }
+        }
+        return future;
+    }
+```
+
+On 3.8.0, when this method is first called, the original code will set the provided Handler in `this.handler`. The instrumentation will store the token for that handler.
+
+On the second call, the provided handler will be set in `this.handler`, a Token will be created for it. Since the first handler won't be executed, the Token for it will be expired.
+
+The same will happen for any subsequent call.
+
+
+Starting on 3.8.4, when this method is first called, the original code will set the provided Handler in `this.handler`. The instrumentation will store the token for that handler.
+
+On the second call, a Handlers instance will be created, set to `this.handler` and both provided Handlers will be put in the Handlers. At this point the instrumentation will store the token for the Handlers instance and expire the token for the first Handler.
+
+In subsequent calls, `this.handler` will be the Handlers instance throughout the execution of the method. So no further tokens will be created.

--- a/instrumentation/vertx-core-3.8.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
+++ b/instrumentation/vertx-core-3.8.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
@@ -48,6 +48,15 @@ public class VertxCoreUtil {
         }
     }
 
+    public static void expireToken(Handler handler) {
+        if (handler != null) {
+            final Token token = tokenMap.remove(handler);
+            if (token != null) {
+                token.expire();
+            }
+        }
+    }
+
     public static void processResponse(Segment segment, HttpClientResponseImpl resp, String host, int port,
             String scheme) {
         try {

--- a/instrumentation/vertx-core-3.8.0/src/test/java/io/vertx/core/impl/FutureTokenTest.java
+++ b/instrumentation/vertx-core-3.8.0/src/test/java/io/vertx/core/impl/FutureTokenTest.java
@@ -1,0 +1,73 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.vertx.core.impl;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.nr.vertx.instrumentation.VertxCoreUtil;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "io.vertx" })
+public class FutureTokenTest {
+
+    @Test
+    public void futureCreatesAtMost2Tokens() throws NoSuchFieldException, IllegalAccessException {
+        tokensTest();
+    }
+
+    @Trace(dispatcher = true)
+    private void tokensTest() throws NoSuchFieldException, IllegalAccessException {
+        Field tokenField = VertxCoreUtil.class.getDeclaredField("tokenMap");
+        tokenField.setAccessible(true);
+        Map<Object, Token> tokenMap = (Map<Object, Token>) tokenField.get(null);
+
+        Field listenerField = FutureImpl.class.getDeclaredField("handler");
+        listenerField.setAccessible(true);
+
+        FutureImpl<Object> future = new FutureImpl<>();
+        Handler<AsyncResult<Object>> listener1 = new NoopListener<>();
+        Handler<AsyncResult<Object>> listener2 = new NoopListener<>();
+        Handler<AsyncResult<Object>> listener3 = new NoopListener<>();
+
+        assertTrue(tokenMap.isEmpty());
+
+        future.setHandler(listener1);
+        assertNotNull(tokenMap.get(listener1));
+        assertEquals(1, tokenMap.size());
+
+        future.setHandler(listener2);
+        assertEquals(1, tokenMap.size());
+
+        future.setHandler(listener3);
+        assertEquals(1, tokenMap.size());
+        // tests for newer versions of this library have more assertions
+        // those assertions are not meaningful here because different supported
+        // versions of this library work slightly different
+    }
+
+    private static class NoopListener<T> implements Handler<AsyncResult<T>> {
+        @Override
+        public void handle(AsyncResult<T> tAsyncResult) {
+
+        }
+    }
+
+}

--- a/instrumentation/vertx-core-3.9.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
+++ b/instrumentation/vertx-core-3.9.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
@@ -48,6 +48,15 @@ public class VertxCoreUtil {
         }
     }
 
+    public static void expireToken(Handler handler) {
+        if (handler != null) {
+            final Token token = tokenMap.remove(handler);
+            if (token != null) {
+                token.expire();
+            }
+        }
+    }
+
     public static void processResponse(Segment segment, HttpClientResponseImpl resp, String host, int port,
             String scheme) {
         try {

--- a/instrumentation/vertx-core-3.9.0/src/test/java/io/vertx/core/impl/FutureTokenTest.java
+++ b/instrumentation/vertx-core-3.9.0/src/test/java/io/vertx/core/impl/FutureTokenTest.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.vertx.core.impl;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.nr.vertx.instrumentation.VertxCoreUtil;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "io.vertx" })
+public class FutureTokenTest {
+
+    @Test
+    public void futureCreatesAtMost2Tokens() throws NoSuchFieldException, IllegalAccessException {
+        tokensTest();
+    }
+
+
+    @Trace(dispatcher = true)
+    private void tokensTest() throws NoSuchFieldException, IllegalAccessException {
+        Field tokenField = VertxCoreUtil.class.getDeclaredField("tokenMap");
+        tokenField.setAccessible(true);
+        Map<Object, Token> tokenMap = (Map<Object, Token>) tokenField.get(null);
+
+        Field listenerField = FutureImpl.class.getDeclaredField("handler");
+        listenerField.setAccessible(true);
+
+        FutureImpl<Object> future = new FutureImpl<>();
+        Handler<AsyncResult<Object>> listener1 = new NoopHandler<>();
+        Handler<AsyncResult<Object>> listener2 = new NoopHandler<>();
+        Handler<AsyncResult<Object>> listener3 = new NoopHandler<>();
+
+        assertTrue(tokenMap.isEmpty());
+
+        future.onComplete(listener1);
+        assertNotNull(tokenMap.get(listener1));
+
+        future.onComplete(listener2);
+        assertNull(tokenMap.get(listener1));
+        assertNull(tokenMap.get(listener2));
+        assertEquals(1, tokenMap.size());
+        Token listenerArrayToken = tokenMap.get(listenerField.get(future));
+        assertNotNull(listenerArrayToken);
+
+        future.onComplete(listener3);
+        assertNull(tokenMap.get(listener3));
+        assertEquals(1, tokenMap.size());
+        assertSame(listenerArrayToken, tokenMap.get(listenerField.get(future)));
+    }
+
+    private static class NoopHandler<T> implements Handler<AsyncResult<T>> {
+        @Override
+        public void handle(AsyncResult<T> t) {
+
+        }
+    }
+}

--- a/instrumentation/vertx-core-4.0.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
+++ b/instrumentation/vertx-core-4.0.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
@@ -13,7 +13,6 @@ import com.newrelic.api.agent.HttpParameters;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Token;
-import com.newrelic.api.agent.Transaction;
 import com.newrelic.api.agent.weaver.Weaver;
 import io.vertx.core.Handler;
 import io.vertx.core.http.impl.HttpClientResponseImpl;
@@ -45,6 +44,15 @@ public class VertxCoreUtil {
             final Token token = tokenMap.remove(handler);
             if (token != null) {
                 token.linkAndExpire();
+            }
+        }
+    }
+
+    public static void expireToken(Handler handler) {
+        if (handler != null) {
+            final Token token = tokenMap.remove(handler);
+            if (token != null) {
+                token.expire();
             }
         }
     }

--- a/instrumentation/vertx-core-4.0.0/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.0.0/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
@@ -19,14 +19,29 @@ abstract class FutureImpl_Instrumentation {
 
     public abstract boolean isComplete();
 
+    // The 1st time this method is called, this.listener will be null.
+    // The provided listener will be assigned to this.listener and a token should be created for it.
+    // The 2nd time, the original code will create a ListenerArray and put it in this.listener.
+    // Then it will add both provided listeners to it.
+    // At this point, the first token should be expired and a token should be created for the ListenerArray.
+    // From there on, the ListenerArray will be used to store the listeners. And no token should be created.
     @Trace(async = true, excludeFromTransactionTrace = true)
     public void addListener(Listener listener) {
+        Listener previousHandler = this.listener;
         if (isComplete()) {
             VertxCoreUtil.linkAndExpireToken(listener);
-        } else {
-            VertxCoreUtil.storeToken(listener);
         }
+
         Weaver.callOriginal();
+
+        if (!isComplete()) {
+            if (previousHandler != this.listener) {
+                VertxCoreUtil.storeToken(this.listener);
+                if (previousHandler != null) {
+                    VertxCoreUtil.expireToken(previousHandler);
+                }
+            }
+        }
     }
 
     @Trace(async = true, excludeFromTransactionTrace = true)

--- a/instrumentation/vertx-core-4.0.0/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
+++ b/instrumentation/vertx-core-4.0.0/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.vertx.core.impl.future;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.nr.vertx.instrumentation.VertxCoreUtil;
+import io.vertx.core.impl.future.FutureImpl;
+import io.vertx.core.impl.future.Listener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "io.vertx" })
+public class FutureTokenTest {
+
+    @Test
+    public void futureCreatesAtMost2Tokens() throws NoSuchFieldException, IllegalAccessException {
+        tokensTest();
+    }
+
+
+    @Trace(dispatcher = true)
+    private void tokensTest() throws NoSuchFieldException, IllegalAccessException {
+        Field tokenField = VertxCoreUtil.class.getDeclaredField("tokenMap");
+        tokenField.setAccessible(true);
+        Map<Object, Token> tokenMap = (Map<Object, Token>) tokenField.get(null);
+
+        Field listenerField = FutureImpl.class.getDeclaredField("listener");
+        listenerField.setAccessible(true);
+
+        FutureImpl<Object> future = new FutureImpl<>();
+        Listener<Object> listener1 = new NoopListener<>();
+        Listener<Object> listener2 = new NoopListener<>();
+        Listener<Object> listener3 = new NoopListener<>();
+
+        assertTrue(tokenMap.isEmpty());
+
+        future.addListener(listener1);
+        assertNotNull(tokenMap.get(listener1));
+
+        future.addListener(listener2);
+        assertNull(tokenMap.get(listener1));
+        assertNull(tokenMap.get(listener2));
+        assertEquals(1, tokenMap.size());
+        Token listenerArrayToken = tokenMap.get(listenerField.get(future));
+        assertNotNull(listenerArrayToken);
+
+        future.addListener(listener3);
+        assertNull(tokenMap.get(listener3));
+        assertEquals(1, tokenMap.size());
+        assertSame(listenerArrayToken, tokenMap.get(listenerField.get(future)));
+    }
+
+    private static class NoopListener<T> implements Listener<T> {
+        @Override
+        public void onSuccess(T o) {
+
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+
+        }
+    }
+
+}

--- a/instrumentation/vertx-core-4.1.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
+++ b/instrumentation/vertx-core-4.1.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
@@ -50,6 +50,15 @@ public class VertxCoreUtil {
         }
     }
 
+    public static void expireToken(Listener listener) {
+        if (listener != null) {
+            final Token token = tokenMap.remove(listener);
+            if (token != null) {
+                token.expire();
+            }
+        }
+    }
+
     public static void processResponse(Segment segment, HttpClientResponseImpl resp, String host, int port,
             String scheme) {
         try {

--- a/instrumentation/vertx-core-4.1.0/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.1.0/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
@@ -19,15 +19,31 @@ abstract class FutureImpl_Instrumentation {
 
     public abstract boolean isComplete();
 
+    // The 1st time this method is called, this.listener will be null.
+    // The provided listener will be assigned to this.listener and a token should be created for it.
+    // The 2nd time, the original code will create a ListenerArray and put it in this.listener.
+    // Then it will add both provided listeners to it.
+    // At this point, the first token should be expired and a token should be created for the ListenerArray.
+    // From there on, the ListenerArray will be used to store the listeners. And no token should be created.
     @Trace(async = true, excludeFromTransactionTrace = true)
     public void addListener(Listener listener) {
+        Listener previousHandler = this.listener;
         if (isComplete()) {
             VertxCoreUtil.linkAndExpireToken(listener);
-        } else {
-            VertxCoreUtil.storeToken(listener);
         }
+
         Weaver.callOriginal();
+
+        if (!isComplete()) {
+            if (previousHandler != this.listener) {
+                VertxCoreUtil.storeToken(this.listener);
+                if (previousHandler != null) {
+                    VertxCoreUtil.expireToken(previousHandler);
+                }
+            }
+        }
     }
+
 
     @Trace(async = true, excludeFromTransactionTrace = true)
     public boolean tryComplete(Object result) {

--- a/instrumentation/vertx-core-4.1.0/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
+++ b/instrumentation/vertx-core-4.1.0/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.vertx.core.impl.future;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.nr.vertx.instrumentation.VertxCoreUtil;
+import io.vertx.core.impl.future.FutureImpl;
+import io.vertx.core.impl.future.Listener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "io.vertx" })
+public class FutureTokenTest {
+
+    @Test
+    public void futureCreatesAtMost2Tokens() throws NoSuchFieldException, IllegalAccessException {
+        tokensTest();
+    }
+
+
+    @Trace(dispatcher = true)
+    private void tokensTest() throws NoSuchFieldException, IllegalAccessException {
+        Field tokenField = VertxCoreUtil.class.getDeclaredField("tokenMap");
+        tokenField.setAccessible(true);
+        Map<Object, Token> tokenMap = (Map<Object, Token>) tokenField.get(null);
+
+        Field listenerField = FutureImpl.class.getDeclaredField("listener");
+        listenerField.setAccessible(true);
+
+        FutureImpl<Object> future = new FutureImpl<>();
+        Listener<Object> listener1 = new NoopListener<>();
+        Listener<Object> listener2 = new NoopListener<>();
+        Listener<Object> listener3 = new NoopListener<>();
+
+        assertTrue(tokenMap.isEmpty());
+
+        future.addListener(listener1);
+        assertNotNull(tokenMap.get(listener1));
+
+        future.addListener(listener2);
+        assertNull(tokenMap.get(listener1));
+        assertNull(tokenMap.get(listener2));
+        assertEquals(1, tokenMap.size());
+        Token listenerArrayToken = tokenMap.get(listenerField.get(future));
+        assertNotNull(listenerArrayToken);
+
+        future.addListener(listener3);
+        assertNull(tokenMap.get(listener3));
+        assertEquals(1, tokenMap.size());
+        assertSame(listenerArrayToken, tokenMap.get(listenerField.get(future)));
+    }
+
+    private static class NoopListener<T> implements Listener<T> {
+        @Override
+        public void onSuccess(T o) {
+
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+
+        }
+    }
+
+}

--- a/instrumentation/vertx-core-4.3.2/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
+++ b/instrumentation/vertx-core-4.3.2/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
@@ -49,6 +49,15 @@ public class VertxCoreUtil {
         }
     }
 
+    public static void expireToken(Listener listener) {
+        if (listener != null) {
+            final Token token = tokenMap.remove(listener);
+            if (token != null) {
+                token.expire();
+            }
+        }
+    }
+
     public static void processResponse(Segment segment, HttpClientResponseImpl resp, String host, int port,
             String scheme) {
         try {

--- a/instrumentation/vertx-core-4.3.2/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.3.2/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
@@ -19,14 +19,29 @@ abstract class FutureImpl_Instrumentation {
 
     public abstract boolean isComplete();
 
+    // The 1st time this method is called, this.listener will be null.
+    // The provided listener will be assigned to this.listener and a token should be created for it.
+    // The 2nd time, the original code will create a ListenerArray and put it in this.listener.
+    // Then it will add both provided listeners to it.
+    // At this point, the first token should be expired and a token should be created for the ListenerArray.
+    // From there on, the ListenerArray will be used to store the listeners. And no token should be created.
     @Trace(async = true, excludeFromTransactionTrace = true)
     public void addListener(Listener listener) {
+        Listener previousHandler = this.listener;
         if (isComplete()) {
             VertxCoreUtil.linkAndExpireToken(listener);
-        } else {
-            VertxCoreUtil.storeToken(listener);
         }
+
         Weaver.callOriginal();
+
+        if (!isComplete()) {
+            if (previousHandler != this.listener) {
+                VertxCoreUtil.storeToken(this.listener);
+                if (previousHandler != null) {
+                    VertxCoreUtil.expireToken(previousHandler);
+                }
+            }
+        }
     }
 
     @Trace(async = true, excludeFromTransactionTrace = true)

--- a/instrumentation/vertx-core-4.3.2/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
+++ b/instrumentation/vertx-core-4.3.2/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.vertx.core.impl.future;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.nr.vertx.instrumentation.VertxCoreUtil;
+import io.vertx.core.impl.future.FutureImpl;
+import io.vertx.core.impl.future.Listener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "io.vertx" })
+public class FutureTokenTest {
+
+    @Test
+    public void futureCreatesAtMost2Tokens() throws NoSuchFieldException, IllegalAccessException {
+        tokensTest();
+    }
+
+
+    @Trace(dispatcher = true)
+    private void tokensTest() throws NoSuchFieldException, IllegalAccessException {
+        Field tokenField = VertxCoreUtil.class.getDeclaredField("tokenMap");
+        tokenField.setAccessible(true);
+        Map<Object, Token> tokenMap = (Map<Object, Token>) tokenField.get(null);
+
+        Field listenerField = FutureImpl.class.getDeclaredField("listener");
+        listenerField.setAccessible(true);
+
+        FutureImpl<Object> future = new FutureImpl<>();
+        Listener<Object> listener1 = new NoopListener<>();
+        Listener<Object> listener2 = new NoopListener<>();
+        Listener<Object> listener3 = new NoopListener<>();
+
+        assertTrue(tokenMap.isEmpty());
+
+        future.addListener(listener1);
+        assertNotNull(tokenMap.get(listener1));
+
+        future.addListener(listener2);
+        assertNull(tokenMap.get(listener1));
+        assertNull(tokenMap.get(listener2));
+        assertEquals(1, tokenMap.size());
+        Token listenerArrayToken = tokenMap.get(listenerField.get(future));
+        assertNotNull(listenerArrayToken);
+
+        future.addListener(listener3);
+        assertNull(tokenMap.get(listener3));
+        assertEquals(1, tokenMap.size());
+        assertSame(listenerArrayToken, tokenMap.get(listenerField.get(future)));
+    }
+
+    private static class NoopListener<T> implements Listener<T> {
+        @Override
+        public void onSuccess(T o) {
+
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+
+        }
+    }
+
+}

--- a/instrumentation/vertx-core-4.5.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
+++ b/instrumentation/vertx-core-4.5.0/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
@@ -49,6 +49,14 @@ public class VertxCoreUtil {
         }
     }
 
+    public static void expireToken(Listener listener) {
+        if (listener != null) {
+            final Token token = tokenMap.remove(listener);
+            if (token != null) {
+                token.expire();
+            }
+        }
+    }
     public static void processResponse(Segment segment, HttpClientResponseImpl resp, String host, int port,
             String scheme) {
         try {

--- a/instrumentation/vertx-core-4.5.0/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.5.0/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
@@ -19,14 +19,29 @@ abstract class FutureImpl_Instrumentation {
 
     public abstract boolean isComplete();
 
+    // The 1st time this method is called, this.listener will be null.
+    // The provided listener will be assigned to this.listener and a token should be created for it.
+    // The 2nd time, the original code will create a ListenerArray and put it in this.listener.
+    // Then it will add both provided listeners to it.
+    // At this point, the first token should be expired and a token should be created for the ListenerArray.
+    // From there on, the ListenerArray will be used to store the listeners. And no token should be created.
     @Trace(async = true, excludeFromTransactionTrace = true)
     public void addListener(Listener listener) {
+        Listener previousHandler = this.listener;
         if (isComplete()) {
             VertxCoreUtil.linkAndExpireToken(listener);
-        } else {
-            VertxCoreUtil.storeToken(listener);
         }
+
         Weaver.callOriginal();
+
+        if (!isComplete()) {
+            if (previousHandler != this.listener) {
+                VertxCoreUtil.storeToken(this.listener);
+                if (previousHandler != null) {
+                    VertxCoreUtil.expireToken(previousHandler);
+                }
+            }
+        }
     }
 
     @Trace(async = true, excludeFromTransactionTrace = true)

--- a/instrumentation/vertx-core-4.5.0/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
+++ b/instrumentation/vertx-core-4.5.0/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.vertx.core.impl.future;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.nr.vertx.instrumentation.VertxCoreUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "io.vertx" })
+public class FutureTokenTest {
+
+    @Test
+    public void futureCreatesAtMost2Tokens() throws NoSuchFieldException, IllegalAccessException {
+        tokensTest();
+    }
+
+
+    @Trace(dispatcher = true)
+    private void tokensTest() throws NoSuchFieldException, IllegalAccessException {
+        Field tokenField = VertxCoreUtil.class.getDeclaredField("tokenMap");
+        tokenField.setAccessible(true);
+        Map<Object, Token> tokenMap = (Map<Object, Token>) tokenField.get(null);
+
+        Field listenerField = FutureImpl.class.getDeclaredField("listener");
+        listenerField.setAccessible(true);
+
+        FutureImpl<Object> future = new FutureImpl<>();
+        Listener<Object> listener1 = new NoopListener<>();
+        Listener<Object> listener2 = new NoopListener<>();
+        Listener<Object> listener3 = new NoopListener<>();
+
+        assertTrue(tokenMap.isEmpty());
+
+        future.addListener(listener1);
+        assertNotNull(tokenMap.get(listener1));
+
+        future.addListener(listener2);
+        assertNull(tokenMap.get(listener1));
+        assertNull(tokenMap.get(listener2));
+        assertEquals(1, tokenMap.size());
+        Token listenerArrayToken = tokenMap.get(listenerField.get(future));
+        assertNotNull(listenerArrayToken);
+
+        future.addListener(listener3);
+        assertNull(tokenMap.get(listener3));
+        assertEquals(1, tokenMap.size());
+        assertSame(listenerArrayToken, tokenMap.get(listenerField.get(future)));
+    }
+
+    private static class NoopListener<T> implements Listener<T> {
+        @Override
+        public void onSuccess(T o) {
+
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+
+        }
+    }
+
+}

--- a/instrumentation/vertx-core-4.5.1/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
+++ b/instrumentation/vertx-core-4.5.1/src/main/java/com/nr/vertx/instrumentation/VertxCoreUtil.java
@@ -49,6 +49,15 @@ public class VertxCoreUtil {
         }
     }
 
+    public static void expireToken(Listener listener) {
+        if (listener != null) {
+            final Token token = tokenMap.remove(listener);
+            if (token != null) {
+                token.expire();
+            }
+        }
+    }
+
     public static void processResponse(Segment segment, HttpClientResponseImpl resp, String host, int port,
             String scheme) {
         try {

--- a/instrumentation/vertx-core-4.5.1/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.5.1/src/main/java/io/vertx/core/impl/future/FutureImpl_Instrumentation.java
@@ -8,9 +8,12 @@
 package io.vertx.core.impl.future;
 
 import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.vertx.instrumentation.VertxCoreUtil;
+
+import java.util.ArrayList;
 
 @Weave(originalName = "io.vertx.core.impl.future.FutureImpl")
 public abstract class FutureImpl_Instrumentation {
@@ -19,14 +22,29 @@ public abstract class FutureImpl_Instrumentation {
 
     public abstract boolean isComplete();
 
+    // The 1st time this method is called, this.listener will be null.
+    // The provided listener will be assigned to this.listener and a token should be created for it.
+    // The 2nd time, the original code will create a ListenerArray and put it in this.listener.
+    // Then it will add both provided listeners to it.
+    // At this point, the first token should be expired and a token should be created for the ListenerArray.
+    // From there on, the ListenerArray will be used to store the listeners. And no token should be created.
     @Trace(async = true, excludeFromTransactionTrace = true)
     public void addListener(Listener listener) {
+        Listener previousHandler = this.listener;
         if (isComplete()) {
             VertxCoreUtil.linkAndExpireToken(listener);
-        } else {
-            VertxCoreUtil.storeToken(listener);
         }
+
         Weaver.callOriginal();
+
+        if (!isComplete()) {
+            if (previousHandler != this.listener) {
+                VertxCoreUtil.storeToken(this.listener);
+                if (previousHandler != null) {
+                    VertxCoreUtil.expireToken(previousHandler);
+                }
+            }
+        }
     }
 
     @Trace(async = true, excludeFromTransactionTrace = true)

--- a/instrumentation/vertx-core-4.5.1/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
+++ b/instrumentation/vertx-core-4.5.1/src/test/java/io/vertx/core/impl/future/FutureTokenTest.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *  * Copyright 2024 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.vertx.core.impl.future;
+
+import com.newrelic.agent.introspec.InstrumentationTestConfig;
+import com.newrelic.agent.introspec.InstrumentationTestRunner;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+import com.nr.vertx.instrumentation.VertxCoreUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(InstrumentationTestRunner.class)
+@InstrumentationTestConfig(includePrefixes = { "io.vertx" })
+public class FutureTokenTest {
+
+    @Test
+    public void futureCreatesAtMost2Tokens() throws NoSuchFieldException, IllegalAccessException {
+        tokensTest();
+    }
+
+
+    @Trace(dispatcher = true)
+    private void tokensTest() throws NoSuchFieldException, IllegalAccessException {
+        Field tokenField = VertxCoreUtil.class.getDeclaredField("tokenMap");
+        tokenField.setAccessible(true);
+        Map<Object, Token> tokenMap = (Map<Object, Token>) tokenField.get(null);
+
+        Field listenerField = FutureImpl.class.getDeclaredField("listener");
+        listenerField.setAccessible(true);
+
+        FutureImpl<Object> future = new FutureImpl<>();
+        Listener<Object> listener1 = new NoopListener<>();
+        Listener<Object> listener2 = new NoopListener<>();
+        Listener<Object> listener3 = new NoopListener<>();
+
+        assertTrue(tokenMap.isEmpty());
+
+        future.addListener(listener1);
+        assertNotNull(tokenMap.get(listener1));
+
+        future.addListener(listener2);
+        assertNull(tokenMap.get(listener1));
+        assertNull(tokenMap.get(listener2));
+        assertEquals(1, tokenMap.size());
+        Token listenerArrayToken = tokenMap.get(listenerField.get(future));
+        assertNotNull(listenerArrayToken);
+
+        future.addListener(listener3);
+        assertNull(tokenMap.get(listener3));
+        assertEquals(1, tokenMap.size());
+        assertSame(listenerArrayToken, tokenMap.get(listenerField.get(future)));
+    }
+
+    private static class NoopListener<T> implements Listener<T> {
+        @Override
+        public void onSuccess(T o) {
+
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+
+        }
+    }
+
+}


### PR DESCRIPTION
### Overview
When a FutureImpl receives its first listener, it adds it to it's listener reference. When a second listener is received, it creates a ListenerArray, that will hold both received listeners and all future ones, and sets in its listener reference.

The agent used to create a token for each received listener. With this PR, it will create one token for the first listener, then if a second one is added, the first token will be expired and a new one will be created for the ListenerArray. Then if any other listener is received, no new tokens will be created.

The token linking will work as it used to, but now there is only the token from the ListenerArray to be linked. Thus preventing multiple linkings.

### Related Github Issue
Closes #2171 
