### PR TITLE
Correct Apdex on transaction event if an error is present

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/TransactionDataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/TransactionDataTest.java
@@ -13,6 +13,7 @@ import com.newrelic.agent.config.AgentConfigFactory;
 import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.TransactionTracerConfig;
 import com.newrelic.agent.dispatchers.Dispatcher;
+import com.newrelic.agent.model.ApdexPerfZone;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.sql.SlowQueryListener;
 import com.newrelic.agent.tracers.Tracer;
@@ -327,4 +328,21 @@ public class TransactionDataTest {
         Assert.assertEquals(MessageFormat.format(" {0}ms {1}", String.valueOf(expected), ex), result);
     }
 
+    @Test
+    public void isApdexFrustrating_returnsTrue_whenErrorIsPresent() {
+        Mockito.when(tx.isErrorReportableAndNotIgnored()).thenReturn(true);
+        Mockito.when(tx.isErrorNotExpected()).thenReturn(true);
+
+        TransactionData txd = getTxData(tx);
+        Assert.assertTrue(txd.isApdexFrustrating());
+    }
+
+    @Test
+    public void isApdexFrustrating_returnsFalse_whenNoErrorIsPresent() {
+        Mockito.when(tx.isErrorReportableAndNotIgnored()).thenReturn(false);
+        Mockito.when(tx.isErrorNotExpected()).thenReturn(false);
+
+        TransactionData txd = getTxData(tx);
+        Assert.assertFalse(txd.isApdexFrustrating());
+    }
 }


### PR DESCRIPTION
### Overview
This fix will properly assign an apdex of `Frustrating` if an non-ignored and unexpected error is present on the transaction. This mirrors the behavior of the [`WebRequestDispatcher`](https://github.com/newrelic/newrelic-java-agent/blob/070441920e3b06df69d45187588308ebb5ed56bf/newrelic-agent/src/main/java/com/newrelic/agent/dispatchers/WebRequestDispatcher.java#L453) when reporting Apdex metrics on a transaction.

### Related Github Issue
Resolves #2104 

