### PR TITLE
Don't add null port to hostname attribute on JFR events

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -136,7 +136,11 @@ public class JfrService extends AbstractService implements AgentConfigListener {
             logger.error(e.getMessage());
             host = InetAddress.getLoopbackAddress().getHostAddress();
         }
-        return String.format("%s:%s", host, appPort);
+        if (appPort != null) {
+            return String.format("%s:%s", host, appPort);
+        } else {
+            return host;
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Fix for https://new-relic.atlassian.net/browse/NR-345540

It appears that if the Java agent cannot obtain the port associated with a host then it will set it to `null`, resulting in a `host.hostname` attribute with a value like `4326afc46b32:null` being added to JFR events (where `4326afc46b32` is the hostname and `null` is the port number). This seems to be causing errors with GraphQL queries related to the Flame graph.

The approach that we follow with other agent data forms is to omit the port if it is `null`, so this PR follows that approach rather than setting a dummy port value.