### PR TITLE
kafka-clients-metrics: Refactor node topic metrics

### DIFF
--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/ClientType.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/ClientType.java
@@ -1,0 +1,23 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.instrumentation.kafka;
+
+public enum ClientType {
+    CONSUMER("Consume"),
+    PRODUCER("Produce");
+
+    private final String operation;
+
+    ClientType(String operation) {
+        this.operation = operation;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+}

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
@@ -78,15 +78,11 @@ public class MetricsScheduler {
                     }
                 }
 
-                for (NewRelicMetricsReporter.NodeMetricNames consumerNodeMetricNames : nrMetricsReporter.getNodes().values()) {
+                for (String nodeTopicName : nrMetricsReporter.getNodeTopicNames()) {
                     if (METRICS_AS_EVENTS) {
-                        for (String eventName : consumerNodeMetricNames.getEventNames()) {
-                            eventData.put(eventName, 1f);
-                        }
+                        eventData.put(nodeTopicName, 1f);
                     } else {
-                        for (String metricName : consumerNodeMetricNames.getMetricNames()) {
-                            NewRelic.recordMetric(metricName, 1f);
-                        }
+                        NewRelic.recordMetric(nodeTopicName, 1f);
                     }
                 }
 

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/NewRelicMetricsReporter.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/NewRelicMetricsReporter.java
@@ -8,44 +8,35 @@
 package com.nr.instrumentation.kafka;
 
 import com.newrelic.agent.bridge.AgentBridge;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
 
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 import static com.nr.instrumentation.kafka.MetricsConstants.KAFKA_METRICS_DEBUG;
-import static com.nr.instrumentation.kafka.MetricsConstants.NODE_PREFIX;
 
 public class NewRelicMetricsReporter implements MetricsReporter {
 
 
     private final Map<String, KafkaMetric> metrics = new ConcurrentHashMap<>();
 
-    private final Map<String, NodeMetricNames> nodes;
+    private final NodeTopicRegistry nodeTopicRegistry;
 
-    public NewRelicMetricsReporter() {
-        this.nodes = Collections.emptyMap();
-    }
-
-    public NewRelicMetricsReporter(Set<String> nodes, Mode mode) {
-        this.nodes = new ConcurrentHashMap<>(nodes.size());
-        for(String node: nodes) {
-            this.nodes.put(node, new NodeMetricNames(node, mode));
-        }
+    public NewRelicMetricsReporter(ClientType clientType, Collection<Node> nodes) {
+        this.nodeTopicRegistry = new NodeTopicRegistry(clientType, nodes);
     }
 
     public Map<String, KafkaMetric> getMetrics() {
         return this.metrics;
     }
 
-    public Map<String, NodeMetricNames> getNodes() {
-        return nodes;
+    public Collection<String> getNodeTopicNames() {
+        return this.nodeTopicRegistry.getNodeTopicNames();
     }
 
     @Override
@@ -56,6 +47,7 @@ public class NewRelicMetricsReporter implements MetricsReporter {
                 AgentBridge.getAgent().getLogger().log(Level.FINEST, "init(): {0} = {1}", metricGroupAndName, kafkaMetric.metricName());
             }
             metrics.put(metricGroupAndName, kafkaMetric);
+            nodeTopicRegistry.register(kafkaMetric);
         }
         MetricsScheduler.addMetricsReporter(this);
     }
@@ -63,6 +55,7 @@ public class NewRelicMetricsReporter implements MetricsReporter {
     @Override
     public void metricChange(final KafkaMetric metric) {
         String metricGroupAndName = getMetricGroupAndName(metric);
+        nodeTopicRegistry.register(metric);
         if (KAFKA_METRICS_DEBUG) {
             AgentBridge.getAgent().getLogger().log(Level.FINEST, "metricChange(): {0} = {1}", metricGroupAndName, metric.metricName());
         }
@@ -81,109 +74,20 @@ public class NewRelicMetricsReporter implements MetricsReporter {
     private String getMetricGroupAndName(final KafkaMetric metric) {
         if (metric.metricName().tags().containsKey("topic")) {
             String topic = metric.metricName().tags().get("topic");
-            addTopicToNodeMetrics(topic);
-
             // Special case for handling topic names in metrics
             return metric.metricName().group() + "/" + topic + "/" + metric.metricName().name();
         }
         return metric.metricName().group() + "/" + metric.metricName().name();
     }
 
-    private void addTopicToNodeMetrics(String topic) {
-        for (NodeMetricNames nodeMetricNames : nodes.values()) {
-            nodeMetricNames.addMetricNameForTopic(topic);
-        }
-    }
-
     @Override
     public void close() {
         MetricsScheduler.removeMetricsReporter(this);
         metrics.clear();
+        nodeTopicRegistry.close();
     }
 
     @Override
     public void configure(final Map<String, ?> configs) {
-    }
-
-    /**
-     * This class is used to track all the metric names that are related to a specific node:
-     *
-     * - MessageBroker/Kafka/Nodes/host:port
-     * - MessageBroker/Kafka/Nodes/host:port/Consume/topicName
-     * - MessageBroker/Kafka/Nodes/host:port/Produce/topicName
-     *
-     * At initialization time we only have the node and the mode (is this a metrics reporter
-     * for a Kafka consumer or for a Kafka producer?).
-     *
-     * Then, as topics are discovered through the metricChange method, the topic metric names are
-     * generated. This is the best way we have to get track of the topics since they're not
-     * available when the KafkaConsumer/KafkaProducer is initialized.
-     *
-     * For KafkaConsumer, the SubscriptionState doesn't contain the topics and partitions
-     * at initialization time because it takes time for the rebalance to happen.
-     *
-     * For KafkaProducer, topics are dynamic since a producer could send records to any
-     * topic and the concept of subscription doesn't exist there.
-     *
-     * Alternatively we could get the topics from the records in KafkaProducer.doSend or
-     * KafkaConsumer.poll, and call NewRelicMetricsReporter.addTopicToNodeMetrics from there.
-     * This approach would have a small impact in performance, and getting the topics from the
-     * KafkaMetrics is a good enough solution.
-     */
-    public static class NodeMetricNames {
-
-        private final String node;
-        private final Mode mode;
-
-        private final Set<String> topics = new HashSet<>();
-
-        private final Set<String> metricNames = new HashSet<>();
-        private final Set<String> eventNames = new HashSet<>();
-
-        public NodeMetricNames(String node, Mode mode) {
-            this.node = node;
-            this.mode = mode;
-
-            String nodeMetricName = NODE_PREFIX + node;
-            metricNames.add(nodeMetricName);
-            eventNames.add(getEventNameForMetric(nodeMetricName));
-        }
-
-        private void addMetricNameForTopic(String topic) {
-            if (!topics.contains(topic)) {
-                String nodeTopicMetricName = NODE_PREFIX + node + "/" + mode.getMetricSegmentName() + "/" + topic;
-                metricNames.add(nodeTopicMetricName);
-                eventNames.add(getEventNameForMetric(nodeTopicMetricName));
-
-                topics.add(topic);
-            }
-        }
-
-        private String getEventNameForMetric(String metricName) {
-            return metricName.replace('/', '.');
-        }
-
-        public Set<String> getMetricNames() {
-            return metricNames;
-        }
-
-        public Set<String> getEventNames() {
-            return eventNames;
-        }
-    }
-
-    public enum Mode {
-        CONSUMER("Consume"),
-        PRODUCER("Produce");
-
-        private final String metricSegmentName;
-
-        Mode(String metricSegmentName) {
-            this.metricSegmentName = metricSegmentName;
-        }
-
-        public String getMetricSegmentName() {
-            return metricSegmentName;
-        }
     }
 }

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/NodeTopicRegistry.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/com/nr/instrumentation/kafka/NodeTopicRegistry.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.instrumentation.kafka;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.metrics.KafkaMetric;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.nr.instrumentation.kafka.MetricsConstants.NODE_PREFIX;
+
+/**
+ * This class is used to track all the metric names that are related to a specific node:
+ *
+ * - MessageBroker/Kafka/Nodes/host:port
+ * - MessageBroker/Kafka/Nodes/host:port/Consume/topicName
+ * - MessageBroker/Kafka/Nodes/host:port/Produce/topicName
+ *
+ * At initialization time we only have the node and the mode (is this a metrics reporter
+ * for a Kafka consumer or for a Kafka producer?).
+ *
+ * Then, as topics are discovered through the metricChange method, the topic metric names are
+ * generated. This is the best way we have to get track of the topics since they're not
+ * available when the KafkaConsumer/KafkaProducer is initialized.
+ *
+ * For KafkaConsumer, the SubscriptionState doesn't contain the topics and partitions
+ * at initialization time because it takes time for the rebalance to happen.
+ *
+ * For KafkaProducer, topics are dynamic since a producer could send records to any
+ * topic and the concept of subscription doesn't exist there.
+ *
+ * Alternatively we could get the topics from the records in KafkaProducer.doSend or
+ * KafkaConsumer.poll, and call NewRelicMetricsReporter.addTopicToNodeMetrics from there.
+ * This approach would have a small impact in performance, and getting the topics from the
+ * KafkaMetrics is a good enough solution.
+ */
+public class NodeTopicRegistry {
+    private final Set<String> recordedTopics = ConcurrentHashMap.newKeySet();
+    // contains the registered metric or event names, according to config
+    private final Set<String> convertedNames = ConcurrentHashMap.newKeySet();
+    private final Set<String> nodes = new HashSet<>();
+    private final ClientType clientType;
+
+    public NodeTopicRegistry(ClientType clientType, Collection<Node> nodes) {
+        this.clientType = clientType;
+        for (Node node : nodes) {
+            String nodeName = node.host() + ":" + node.port();
+            this.nodes.add(nodeName);
+            this.convertedNames.add(convertName(NODE_PREFIX + nodeName));
+        }
+    }
+
+    /**
+     * @return true if the metric contains a topic and it was registered
+     */
+    public boolean register(KafkaMetric metric) {
+        String topic = metric.metricName().tags().get("topic");
+        if (topic != null && recordedTopics.add(topic)) {
+            for (String node : nodes) {
+                String metricName = NODE_PREFIX + node + "/" + clientType.getOperation() + "/" + topic;
+                this.convertedNames.add(convertName(metricName));
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public Collection<String> getNodeTopicNames() {
+        return this.convertedNames;
+    }
+
+    private String convertName(String metricName) {
+        if (MetricsConstants.METRICS_AS_EVENTS) {
+            return metricName.replace('/', '.');
+        }
+        return metricName;
+    }
+
+    public void close() {
+        recordedTopics.clear();
+        convertedNames.clear();
+        nodes.clear();
+    }
+}

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer_Instrumentation.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer_Instrumentation.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.nr.instrumentation.kafka.ClientType;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Metrics;
@@ -41,11 +42,7 @@ public class KafkaConsumer_Instrumentation<K, V> {
     public KafkaConsumer_Instrumentation() {
         if (!initialized) {
             List<Node> nodes = metadata.fetch().nodes();
-            Set<String> nodeNames = new HashSet<>(nodes.size());
-            for (Node node : nodes) {
-                nodeNames.add(node.host() + ":" + node.port());
-            }
-            metrics.addReporter(new NewRelicMetricsReporter(nodeNames, NewRelicMetricsReporter.Mode.CONSUMER));
+            metrics.addReporter(new NewRelicMetricsReporter(ClientType.CONSUMER, nodes));
             initialized = true;
         }
     }

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
@@ -7,6 +7,7 @@
 
 package org.apache.kafka.clients.producer;
 
+import com.nr.instrumentation.kafka.ClientType;
 import org.apache.kafka.clients.producer.internals.ProducerMetadata;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.Node;
@@ -44,11 +45,7 @@ public class KafkaProducer_Instrumentation<K, V> {
     public KafkaProducer_Instrumentation() {
         if (!initialized) {
             List<Node> nodes = metadata.fetch().nodes();
-            Set<String> nodeNames = new HashSet<>(nodes.size());
-            for (Node node : nodes) {
-                nodeNames.add(node.host() + ":" + node.port());
-            }
-            metrics.addReporter(new NewRelicMetricsReporter(nodeNames, NewRelicMetricsReporter.Mode.PRODUCER));
+            metrics.addReporter(new NewRelicMetricsReporter(ClientType.PRODUCER, nodes));
             initialized = true;
         }
     }

--- a/instrumentation/kafka-clients-metrics-3.0.0/src/test/java/com/nr/agent/instrumentation/kafka/NodeTopicRegistryTest.java
+++ b/instrumentation/kafka-clients-metrics-3.0.0/src/test/java/com/nr/agent/instrumentation/kafka/NodeTopicRegistryTest.java
@@ -1,0 +1,95 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.kafka;
+
+import com.nr.instrumentation.kafka.ClientType;
+import com.nr.instrumentation.kafka.NodeTopicRegistry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodeTopicRegistryTest {
+
+    @Test
+    public void singleNodeTest() {
+        NodeTopicRegistry nodeTopicRegistry = new NodeTopicRegistry(ClientType.CONSUMER, Collections.singleton(getNode("ad")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("tm")));
+        assertFalse(nodeTopicRegistry.register(kafkaMetric("tm")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("fp")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("zb")));
+
+        Collection<String> metricNames = nodeTopicRegistry.getNodeTopicNames();
+        verifyMetrics(metricNames,
+                "MessageBroker/Kafka/Nodes/ad:42/Consume/tm",
+                "MessageBroker/Kafka/Nodes/ad:42/Consume/fp",
+                "MessageBroker/Kafka/Nodes/ad:42/Consume/zb",
+                "MessageBroker/Kafka/Nodes/ad:42"
+        );
+
+        // verify nothing is reported after close
+        nodeTopicRegistry.close();
+        metricNames = nodeTopicRegistry.getNodeTopicNames();
+        assertTrue(metricNames.isEmpty());
+    }
+
+    @Test
+    public void multiNodeTest() {
+        NodeTopicRegistry nodeTopicRegistry = new NodeTopicRegistry(ClientType.PRODUCER, Arrays.asList(getNode("hh"), getNode("gg")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("vp")));
+        assertFalse(nodeTopicRegistry.register(kafkaMetric("vp")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("sep")));
+
+        Collection<String> metricNames = nodeTopicRegistry.getNodeTopicNames();
+        verifyMetrics(metricNames,
+                "MessageBroker/Kafka/Nodes/hh:42/Produce/vp",
+                "MessageBroker/Kafka/Nodes/hh:42/Produce/sep",
+                "MessageBroker/Kafka/Nodes/hh:42",
+                "MessageBroker/Kafka/Nodes/gg:42/Produce/vp",
+                "MessageBroker/Kafka/Nodes/gg:42/Produce/sep",
+                "MessageBroker/Kafka/Nodes/gg:42"
+        );
+
+        // verify nothing is reported after close
+        nodeTopicRegistry.close();
+        metricNames = nodeTopicRegistry.getNodeTopicNames();
+        assertTrue(metricNames.isEmpty());
+    }
+
+    private void verifyMetrics(Collection<String> actual, String ... expectedNames) {
+        assertEquals(expectedNames.length, actual.size());
+        for (String metricName : expectedNames) {
+            assertTrue(actual.contains(metricName));
+        }
+    }
+
+    private Node getNode(String host) {
+        Node node = Mockito.mock(Node.class);
+        when(node.host()).thenReturn(host);
+        when(node.port()).thenReturn(42);
+        return node;
+    }
+
+    private KafkaMetric kafkaMetric(String topic) {
+        Gauge<?> valueProvider = mock(Gauge.class);
+        MetricName metricName = new MetricName("name", "group", "descr", Collections.singletonMap("topic", topic));
+        return new KafkaMetric(new Object(), metricName, valueProvider, null, null);
+    }
+}

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/ClientType.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/ClientType.java
@@ -1,0 +1,23 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.instrumentation.kafka;
+
+public enum ClientType {
+    CONSUMER("Consume"),
+    PRODUCER("Produce");
+
+    private final String operation;
+
+    ClientType(String operation) {
+        this.operation = operation;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+}

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/MetricsScheduler.java
@@ -78,15 +78,11 @@ public class MetricsScheduler {
                     }
                 }
 
-                for (NewRelicMetricsReporter.NodeMetricNames consumerNodeMetricNames : nrMetricsReporter.getNodes().values()) {
+                for (String nodeTopicName : nrMetricsReporter.getNodeTopicNames()) {
                     if (METRICS_AS_EVENTS) {
-                        for (String eventName : consumerNodeMetricNames.getEventNames()) {
-                            eventData.put(eventName, 1f);
-                        }
+                        eventData.put(nodeTopicName, 1f);
                     } else {
-                        for (String metricName : consumerNodeMetricNames.getMetricNames()) {
-                            NewRelic.recordMetric(metricName, 1f);
-                        }
+                        NewRelic.recordMetric(nodeTopicName, 1f);
                     }
                 }
 

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/NewRelicMetricsReporter.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/NewRelicMetricsReporter.java
@@ -8,44 +8,35 @@
 package com.nr.instrumentation.kafka;
 
 import com.newrelic.agent.bridge.AgentBridge;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
 
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 import static com.nr.instrumentation.kafka.MetricsConstants.KAFKA_METRICS_DEBUG;
-import static com.nr.instrumentation.kafka.MetricsConstants.NODE_PREFIX;
 
 public class NewRelicMetricsReporter implements MetricsReporter {
 
 
     private final Map<String, KafkaMetric> metrics = new ConcurrentHashMap<>();
 
-    private final Map<String, NodeMetricNames> nodes;
+    private final NodeTopicRegistry nodeTopicRegistry;
 
-    public NewRelicMetricsReporter() {
-        this.nodes = Collections.emptyMap();
-    }
-
-    public NewRelicMetricsReporter(Set<String> nodes, Mode mode) {
-        this.nodes = new ConcurrentHashMap<>(nodes.size());
-        for(String node: nodes) {
-            this.nodes.put(node, new NodeMetricNames(node, mode));
-        }
+    public NewRelicMetricsReporter(ClientType clientType, Collection<Node> nodes) {
+        this.nodeTopicRegistry = new NodeTopicRegistry(clientType, nodes);
     }
 
     public Map<String, KafkaMetric> getMetrics() {
         return this.metrics;
     }
 
-    public Map<String, NodeMetricNames> getNodes() {
-        return nodes;
+    public Collection<String> getNodeTopicNames() {
+        return this.nodeTopicRegistry.getNodeTopicNames();
     }
 
     @Override
@@ -56,6 +47,7 @@ public class NewRelicMetricsReporter implements MetricsReporter {
                 AgentBridge.getAgent().getLogger().log(Level.FINEST, "init(): {0} = {1}", metricGroupAndName, kafkaMetric.metricName());
             }
             metrics.put(metricGroupAndName, kafkaMetric);
+            nodeTopicRegistry.register(kafkaMetric);
         }
         MetricsScheduler.addMetricsReporter(this);
     }
@@ -63,6 +55,7 @@ public class NewRelicMetricsReporter implements MetricsReporter {
     @Override
     public void metricChange(final KafkaMetric metric) {
         String metricGroupAndName = getMetricGroupAndName(metric);
+        nodeTopicRegistry.register(metric);
         if (KAFKA_METRICS_DEBUG) {
             AgentBridge.getAgent().getLogger().log(Level.FINEST, "metricChange(): {0} = {1}", metricGroupAndName, metric.metricName());
         }
@@ -81,109 +74,20 @@ public class NewRelicMetricsReporter implements MetricsReporter {
     private String getMetricGroupAndName(final KafkaMetric metric) {
         if (metric.metricName().tags().containsKey("topic")) {
             String topic = metric.metricName().tags().get("topic");
-            addTopicToNodeMetrics(topic);
-
             // Special case for handling topic names in metrics
             return metric.metricName().group() + "/" + topic + "/" + metric.metricName().name();
         }
         return metric.metricName().group() + "/" + metric.metricName().name();
     }
 
-    private void addTopicToNodeMetrics(String topic) {
-        for (NodeMetricNames nodeMetricNames : nodes.values()) {
-            nodeMetricNames.addMetricNameForTopic(topic);
-        }
-    }
-
     @Override
     public void close() {
         MetricsScheduler.removeMetricsReporter(this);
         metrics.clear();
+        nodeTopicRegistry.close();
     }
 
     @Override
     public void configure(final Map<String, ?> configs) {
-    }
-
-    /**
-     * This class is used to track all the metric names that are related to a specific node:
-     *
-     * - MessageBroker/Kafka/Nodes/host:port
-     * - MessageBroker/Kafka/Nodes/host:port/Consume/topicName
-     * - MessageBroker/Kafka/Nodes/host:port/Produce/topicName
-     *
-     * At initialization time we only have the node and the mode (is this a metrics reporter
-     * for a Kafka consumer or for a Kafka producer?).
-     *
-     * Then, as topics are discovered through the metricChange method, the topic metric names are
-     * generated. This is the best way we have to get track of the topics since they're not
-     * available when the KafkaConsumer/KafkaProducer is initialized.
-     *
-     * For KafkaConsumer, the SubscriptionState doesn't contain the topics and partitions
-     * at initialization time because it takes time for the rebalance to happen.
-     *
-     * For KafkaProducer, topics are dynamic since a producer could send records to any
-     * topic and the concept of subscription doesn't exist there.
-     *
-     * Alternatively we could get the topics from the records in KafkaProducer.doSend or
-     * KafkaConsumer.poll, and call NewRelicMetricsReporter.addTopicToNodeMetrics from there.
-     * This approach would have a small impact in performance, and getting the topics from the
-     * KafkaMetrics is a good enough solution.
-     */
-    public static class NodeMetricNames {
-
-        private final String node;
-        private final Mode mode;
-
-        private final Set<String> topics = new HashSet<>();
-
-        private final Set<String> metricNames = new HashSet<>();
-        private final Set<String> eventNames = new HashSet<>();
-
-        public NodeMetricNames(String node, Mode mode) {
-            this.node = node;
-            this.mode = mode;
-
-            String nodeMetricName = NODE_PREFIX + node;
-            metricNames.add(nodeMetricName);
-            eventNames.add(getEventNameForMetric(nodeMetricName));
-        }
-
-        private void addMetricNameForTopic(String topic) {
-            if (!topics.contains(topic)) {
-                String nodeTopicMetricName = NODE_PREFIX + node + "/" + mode.getMetricSegmentName() + "/" + topic;
-                metricNames.add(nodeTopicMetricName);
-                eventNames.add(getEventNameForMetric(nodeTopicMetricName));
-
-                topics.add(topic);
-            }
-        }
-
-        private String getEventNameForMetric(String metricName) {
-            return metricName.replace('/', '.');
-        }
-
-        public Set<String> getMetricNames() {
-            return metricNames;
-        }
-
-        public Set<String> getEventNames() {
-            return eventNames;
-        }
-    }
-
-    public enum Mode {
-        CONSUMER("Consume"),
-        PRODUCER("Produce");
-
-        private final String metricSegmentName;
-
-        Mode(String metricSegmentName) {
-            this.metricSegmentName = metricSegmentName;
-        }
-
-        public String getMetricSegmentName() {
-            return metricSegmentName;
-        }
     }
 }

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/NodeTopicRegistry.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/com/nr/instrumentation/kafka/NodeTopicRegistry.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.instrumentation.kafka;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.metrics.KafkaMetric;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.nr.instrumentation.kafka.MetricsConstants.NODE_PREFIX;
+
+/**
+ * This class is used to track all the metric names that are related to a specific node:
+ *
+ * - MessageBroker/Kafka/Nodes/host:port
+ * - MessageBroker/Kafka/Nodes/host:port/Consume/topicName
+ * - MessageBroker/Kafka/Nodes/host:port/Produce/topicName
+ *
+ * At initialization time we only have the node and the mode (is this a metrics reporter
+ * for a Kafka consumer or for a Kafka producer?).
+ *
+ * Then, as topics are discovered through the metricChange method, the topic metric names are
+ * generated. This is the best way we have to get track of the topics since they're not
+ * available when the KafkaConsumer/KafkaProducer is initialized.
+ *
+ * For KafkaConsumer, the SubscriptionState doesn't contain the topics and partitions
+ * at initialization time because it takes time for the rebalance to happen.
+ *
+ * For KafkaProducer, topics are dynamic since a producer could send records to any
+ * topic and the concept of subscription doesn't exist there.
+ *
+ * Alternatively we could get the topics from the records in KafkaProducer.doSend or
+ * KafkaConsumer.poll, and call NewRelicMetricsReporter.addTopicToNodeMetrics from there.
+ * This approach would have a small impact in performance, and getting the topics from the
+ * KafkaMetrics is a good enough solution.
+ */
+public class NodeTopicRegistry {
+    private final Set<String> recordedTopics = ConcurrentHashMap.newKeySet();
+    // contains the registered metric or event names, according to config
+    private final Set<String> convertedNames = ConcurrentHashMap.newKeySet();
+    private final Set<String> nodes = new HashSet<>();
+    private final ClientType clientType;
+
+    public NodeTopicRegistry(ClientType clientType, Collection<Node> nodes) {
+        this.clientType = clientType;
+        for (Node node : nodes) {
+            String nodeName = node.host() + ":" + node.port();
+            this.nodes.add(nodeName);
+            this.convertedNames.add(convertName(NODE_PREFIX + nodeName));
+        }
+    }
+
+    /**
+     * @return true if the metric contains a topic and it was registered
+     */
+    public boolean register(KafkaMetric metric) {
+        String topic = metric.metricName().tags().get("topic");
+        if (topic != null && recordedTopics.add(topic)) {
+            for (String node : nodes) {
+                String metricName = NODE_PREFIX + node + "/" + clientType.getOperation() + "/" + topic;
+                this.convertedNames.add(convertName(metricName));
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public Collection<String> getNodeTopicNames() {
+        return this.convertedNames;
+    }
+
+    private String convertName(String metricName) {
+        if (MetricsConstants.METRICS_AS_EVENTS) {
+            return metricName.replace('/', '.');
+        }
+        return metricName;
+    }
+
+    public void close() {
+        recordedTopics.clear();
+        convertedNames.clear();
+        nodes.clear();
+    }
+}

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer_Instrumentation.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer_Instrumentation.java
@@ -1,9 +1,17 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package org.apache.kafka.clients.consumer.internals;
 
 import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.WeaveAllConstructors;
 import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.instrumentation.kafka.ClientType;
 import com.nr.instrumentation.kafka.NewRelicMetricsReporter;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.metrics.Metrics;
@@ -25,11 +33,7 @@ public class AsyncKafkaConsumer_Instrumentation<K, V> {
     public AsyncKafkaConsumer_Instrumentation() {
         if (!initialized) {
             List<Node> nodes = metadata.fetch().nodes();
-            Set<String> nodeNames = new HashSet<>(nodes.size());
-            for (Node node : nodes) {
-                nodeNames.add(node.host() + ":" + node.port());
-            }
-            metrics.addReporter(new NewRelicMetricsReporter(nodeNames, NewRelicMetricsReporter.Mode.CONSUMER));
+            metrics.addReporter(new NewRelicMetricsReporter(ClientType.CONSUMER, nodes));
             initialized = true;
         }
     }

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer_Instrumentation.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer_Instrumentation.java
@@ -1,9 +1,17 @@
+/*
+ *
+ *  * Copyright 2022 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package org.apache.kafka.clients.consumer.internals;
 
 import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.WeaveAllConstructors;
 import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.instrumentation.kafka.ClientType;
 import com.nr.instrumentation.kafka.NewRelicMetricsReporter;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.metrics.Metrics;
@@ -25,11 +33,7 @@ public class LegacyKafkaConsumer_Instrumentation<K, V> {
     public LegacyKafkaConsumer_Instrumentation() {
         if (!initialized) {
             List<Node> nodes = metadata.fetch().nodes();
-            Set<String> nodeNames = new HashSet<>(nodes.size());
-            for (Node node : nodes) {
-                nodeNames.add(node.host() + ":" + node.port());
-            }
-            metrics.addReporter(new NewRelicMetricsReporter(nodeNames, NewRelicMetricsReporter.Mode.CONSUMER));
+            metrics.addReporter(new NewRelicMetricsReporter(ClientType.CONSUMER, nodes));
             initialized = true;
         }
     }

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
@@ -7,6 +7,7 @@
 
 package org.apache.kafka.clients.producer;
 
+import com.nr.instrumentation.kafka.ClientType;
 import org.apache.kafka.clients.producer.internals.ProducerMetadata;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.Node;
@@ -32,7 +33,6 @@ import java.util.List;
 
 @Weave(originalName = "org.apache.kafka.clients.producer.KafkaProducer")
 public class KafkaProducer_Instrumentation<K, V> {
-
     private final Metrics metrics = Weaver.callOriginal();
 
     private final ProducerMetadata metadata = Weaver.callOriginal();
@@ -44,11 +44,7 @@ public class KafkaProducer_Instrumentation<K, V> {
     public KafkaProducer_Instrumentation() {
         if (!initialized) {
             List<Node> nodes = metadata.fetch().nodes();
-            Set<String> nodeNames = new HashSet<>(nodes.size());
-            for (Node node : nodes) {
-                nodeNames.add(node.host() + ":" + node.port());
-            }
-            metrics.addReporter(new NewRelicMetricsReporter(nodeNames, NewRelicMetricsReporter.Mode.PRODUCER));
+            metrics.addReporter(new NewRelicMetricsReporter(ClientType.PRODUCER, nodes));
             initialized = true;
         }
     }

--- a/instrumentation/kafka-clients-metrics-3.7.0/src/test/java/com/nr/agent/instrumentation/kafka/NodeTopicRegistryTest.java
+++ b/instrumentation/kafka-clients-metrics-3.7.0/src/test/java/com/nr/agent/instrumentation/kafka/NodeTopicRegistryTest.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.kafka;
+
+import com.nr.instrumentation.kafka.ClientType;
+import com.nr.instrumentation.kafka.NodeTopicRegistry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricValueProvider;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class NodeTopicRegistryTest {
+
+    @Test
+    public void singleNodeTest() {
+        NodeTopicRegistry nodeTopicRegistry = new NodeTopicRegistry(ClientType.CONSUMER, Collections.singleton(getNode("ad")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("tm")));
+        assertFalse(nodeTopicRegistry.register(kafkaMetric("tm")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("fp")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("zb")));
+
+        Collection<String> metricNames = nodeTopicRegistry.getNodeTopicNames();
+        verifyMetrics(metricNames,
+                "MessageBroker/Kafka/Nodes/ad:42/Consume/tm",
+                "MessageBroker/Kafka/Nodes/ad:42/Consume/fp",
+                "MessageBroker/Kafka/Nodes/ad:42/Consume/zb",
+                "MessageBroker/Kafka/Nodes/ad:42"
+        );
+
+        // verify nothing is reported after close
+        nodeTopicRegistry.close();
+        metricNames = nodeTopicRegistry.getNodeTopicNames();
+        assertTrue(metricNames.isEmpty());
+    }
+
+    @Test
+    public void multiNodeTest() {
+        NodeTopicRegistry nodeTopicRegistry = new NodeTopicRegistry(ClientType.PRODUCER, Arrays.asList(getNode("hh"), getNode("gg")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("vp")));
+        assertFalse(nodeTopicRegistry.register(kafkaMetric("vp")));
+        assertTrue(nodeTopicRegistry.register(kafkaMetric("sep")));
+
+        Collection<String> metricNames = nodeTopicRegistry.getNodeTopicNames();
+        verifyMetrics(metricNames,
+                "MessageBroker/Kafka/Nodes/hh:42/Produce/vp",
+                "MessageBroker/Kafka/Nodes/hh:42/Produce/sep",
+                "MessageBroker/Kafka/Nodes/hh:42",
+                "MessageBroker/Kafka/Nodes/gg:42/Produce/vp",
+                "MessageBroker/Kafka/Nodes/gg:42/Produce/sep",
+                "MessageBroker/Kafka/Nodes/gg:42"
+        );
+
+        // verify nothing is reported after close
+        nodeTopicRegistry.close();
+        metricNames = nodeTopicRegistry.getNodeTopicNames();
+        assertTrue(metricNames.isEmpty());
+    }
+
+    private void verifyMetrics(Collection<String> actual, String ... expectedNames) {
+        assertEquals(expectedNames.length, actual.size());
+        for (String metricName : expectedNames) {
+            assertTrue(actual.contains(metricName));
+        }
+    }
+
+    private Node getNode(String host) {
+        Node node = Mockito.mock(Node.class);
+        when(node.host()).thenReturn(host);
+        when(node.port()).thenReturn(42);
+        return node;
+    }
+
+    private KafkaMetric kafkaMetric(String topic) {
+        Gauge<?> valueProvider = mock(Gauge.class);
+        MetricName metricName = new MetricName("name", "group", "descr", Collections.singletonMap("topic", topic));
+        return new KafkaMetric(new Object(), metricName, valueProvider, null, null);
+    }
+}


### PR DESCRIPTION
## Overview
The previous code executed more verifications than needed for its functionality, it also stored duplicate data for those verifications. This PR simplifies the implementation by reducing the number of verifications and data stored.

## Functionality

The functionality being altered is to generate metrics (or event attributes) with the format:

1. MessageBroker/Kafka/Nodes/<node>
2. MessageBroker/Kafka/Nodes/<node>/<Produce|Consume>/<topic>

For each node a client connects to, a metric of the first format will be created. Then for the cartesian product of the sets of node x topic, a metric of the second format will be created.

So, for a producer client connecting  to nodes (n1, n2) and producing for the topics (t1, t2), the following metrics will be created:
- MessageBroker/Kafka/Nodes/n1
- MessageBroker/Kafka/Nodes/n1/Produce/t1
- MessageBroker/Kafka/Nodes/n1/Produce/t2
- MessageBroker/Kafka/Nodes/n2
- MessageBroker/Kafka/Nodes/n2/Produce/t1
- MessageBroker/Kafka/Nodes/n2/Produce/t2

## Current implementation
For each Kafka client, a `NewRelicMetricsReporter` is instantiated. On its constructor, it creates a map with one `NodeMetricNames` (value) for each node (key) a client connects to. (The key is never used anywhere in the code. All references for this map have a `.value()` call after it).
When `NodeMetricNames` is instantiated, it creates a metric with format 1 for its node.
When a metric is registered on `NewRelicMetricsReporter`, if it has a topic, iterate thru the `NodeMetricNames` registering that topic.
In `NodeMetricNames` if the topic was not seen before, create a metric name (and an event attribute) with the format 2 and mark the topic as seen.

So for each topic, `<node count>` checks are made to create the metric with format 2, also `<node count>` sets are kept to keep the seen topics. Since a new topic will be added to all nodes, there is no reason to make the check for each node, nor keep a set of topics for each node.

Another difference of the new implementation is that it only keeps metric names or event attribute labels instead of both. Since for an agent run only one of either will ever be used, this will save a little memory.

## New implementation
A new class `NodeTopicRegistry` was created. It's functionality is similar to `NodeMetricNames`, but the newer keeps track of all nodes and topics, so only one instance of it is created for each `NewRelicMetricsReporter`.
When `NodeTopicRegistry` is instantiated, it receives all the nodes the Kafka client connects to, and creates all the metric names of format 1.
When a metric is registered with the `NewRelicMetricsReporter`, it will be passed to the `NodeTopicRegistry` and if that topic was not seen before, new metrics of format 2 will be created with the new topic for each node.

So only one check for each topic is done, as well as only one collection of seen topics is kept.


## Related Github Issue
This change was made while adding the same functionality for the `kafka-clients-node-metrics-x.y` (#2186)