### PR TITLE
AIT: clean up disk

### DIFF
--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -197,8 +197,13 @@ jobs:
 
       # looks like docker is not properly sanitized between runs in GHA
       # so its disk space may be pilling up and blows up during our tests
-      - name: Clean Docker image data
-        run: docker rmi $(docker images -q)
+      # other cleanups were suggested on runner-images repo
+      - name: Clean up disk
+        run: |
+          docker rmi $(docker images -q)
+          sudo apt clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
 
       ## JDK Installs
 


### PR DESCRIPTION
### Overview
Some AITs have failed many times in a row due to the runner running out of space.
This PR adds some clean up commands to try to free up more space.