### PR TITLE
Add new exclude to glassfish6 verify instrumentation

### DIFF
--- a/instrumentation/glassfish-6/build.gradle
+++ b/instrumentation/glassfish-6/build.gradle
@@ -19,6 +19,7 @@ verifyInstrumentation {
     exclude 'org.glassfish.main.web:web-core:8.0.0-JDK17-M5'
     exclude 'org.glassfish.main.web:web-core:8.0.0-M6'
     exclude 'org.glassfish.main.web:web-core:8.0.0-JDK17-M6'
+    exclude 'org.glassfish.main.web:web-core:8.0.0-JDK17-M7'
 }
 
 site {


### PR DESCRIPTION
### Overview
Add glassfish 8 verify instrumentation exclude: `org.glassfish.main.web:web-core:8.0.0-JDK17-M7`