### PR TITLE
Refactor Agent Control config options

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentControlIntegrationConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentControlIntegrationConfig.java
@@ -31,13 +31,6 @@ public interface AgentControlIntegrationConfig {
     int getHealthReportingFrequency();
 
     /**
-     * Return the fleet id assigned by Agent Control
-     *
-     * @return the fleet id, if available
-     */
-    String getFleetId();
-
-    /**
      * Return the health client type ("file" or "noop" for example)
      *
      * @return the client type

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentControlIntegrationHealthConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentControlIntegrationHealthConfig.java
@@ -9,13 +9,26 @@ package com.newrelic.agent.config;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 public class AgentControlIntegrationHealthConfig extends BaseConfig {
     public static final String ROOT = "health";
     public static final String FREQUENCY = "frequency";
     public static final int FREQUENCY_DEFAULT = 5;  // In seconds
-    public static final String LOCATION = "delivery_location";  //URI Format; ex: file://opt/tmp/health.yml
+
+    public static final String LOCATION = "delivery_location";  //URI Format; ex: file://opt/tmp
+    public static final URI LOCATION_DEFAULT;
+
+    static {
+        URI tmpLocationDefault = null;
+        try {
+            tmpLocationDefault = new URI ("file:///newrelic/apm/health");
+        } catch (URISyntaxException ignored) {
+            // Can never happen
+        }
+        LOCATION_DEFAULT = tmpLocationDefault;
+    }
 
     private final int frequency;
     private URI deliveryLocation;
@@ -49,14 +62,15 @@ public class AgentControlIntegrationHealthConfig extends BaseConfig {
                 deliveryLocation = null;
                 return;
             }
-
-            healthClientType = deliveryLocation.getScheme();
-
-            // Ensure the URI contains the scheme and path
-            if (StringUtils.isAnyEmpty(healthClientType, deliveryLocation.getPath())) {
-                deliveryLocation = null;
-            }
+        } else {
+            deliveryLocation = LOCATION_DEFAULT;
         }
 
+        healthClientType = deliveryLocation.getScheme();
+
+        // Ensure the URI contains the scheme and path
+        if (StringUtils.isAnyEmpty(healthClientType, deliveryLocation.getPath())) {
+            deliveryLocation = null;
+        }
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -359,7 +359,7 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
         ArrayList<HealthDataProducer> healthDataProducers = new ArrayList<>();
         AgentControlIntegrationHealthClient healthClient = null;
 
-        if (config.getAgentControlIntegrationConfig() != null && StringUtils.isNotEmpty(config.getAgentControlIntegrationConfig().getFleetId())) {
+        if (config.getAgentControlIntegrationConfig() != null && config.getAgentControlIntegrationConfig().isEnabled()) {
             healthClient = AgentControlIntegrationClientFactory.createHealthClient(config.getAgentControlIntegrationConfig());
 
             healthDataProducers.add(circuitBreakerService);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentControlIntegrationConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentControlIntegrationConfigTest.java
@@ -12,36 +12,54 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class AgentControlIntegrationConfigTest {
     @Test
     public void agentControlConfig_withValidProperties_createsValidConfig() {
         Map<String, Object> agentControlConfigProps = new HashMap<>();
         Map<String, Object> healthConfigProps = new HashMap<>();
-        agentControlConfigProps.put("fleet_id", "12345");
 
+        agentControlConfigProps.put("enabled", true);
         healthConfigProps.put("delivery_location", "file:///foo/bar");
         healthConfigProps.put("frequency", 5);
         agentControlConfigProps.put("health", healthConfigProps);
 
         AgentControlIntegrationConfig config = new AgentControlIntegrationConfigImpl(agentControlConfigProps);
-        assertEquals("12345", config.getFleetId());
+        assertTrue(config.isEnabled());
         assertEquals(5, config.getHealthReportingFrequency());
         assertEquals("file", config.getHealthClientType());
         assertEquals("/foo/bar", config.getHealthDeliveryLocation().getPath());
     }
 
     @Test
-    public void agentControlConfig_withInvalidLocation_nullsFleetId() {
+    public void agentControlConfig_withEmptyLocation_usesDefault() {
         Map<String, Object> agentControlConfigProps = new HashMap<>();
         Map<String, Object> healthConfigProps = new HashMap<>();
-        agentControlConfigProps.put("fleet_id", "12345");
 
+        agentControlConfigProps.put("enabled", true);
         healthConfigProps.put("delivery_location", "");
         agentControlConfigProps.put("health", healthConfigProps);
 
         AgentControlIntegrationConfig config = new AgentControlIntegrationConfigImpl(agentControlConfigProps);
-        assertNull(config.getFleetId());
+        assertEquals("file", config.getHealthClientType());
+        assertEquals("/newrelic/apm/health", config.getHealthDeliveryLocation().getPath());
+        assertTrue(config.isEnabled());
+    }
+
+    @Test
+    public void agentControlConfig_withInvalid_returnNull() {
+        Map<String, Object> agentControlConfigProps = new HashMap<>();
+        Map<String, Object> healthConfigProps = new HashMap<>();
+
+        agentControlConfigProps.put("enabled", true);
+        healthConfigProps.put("delivery_location", "ffdfsdfdfds");
+        agentControlConfigProps.put("health", healthConfigProps);
+
+        AgentControlIntegrationConfig config = new AgentControlIntegrationConfigImpl(agentControlConfigProps);
+        assertNull(config.getHealthDeliveryLocation());
+        assertFalse(config.isEnabled());    //Since delivery location was invalid we flip enabled to false
     }
 }


### PR DESCRIPTION
Resolves #2210 

The following changes are being made to the Agent Control configuration variables:

- Removal of the agent_control.fleet_id config setting.
- Addition of agent_control.enabled to control whether health data is generated or not (replaces the fleet_id check used previously). Default value is false if not explicitly provided.
- A default value has been added for the agent_control.health.delivery_location: file:///newrelic/apm/health This value should be used if no value is supplied for the agent_control.health.delivery_location setting.

This allows all config settings to have default values if enabled is true.