### PR TITLE
kafka-client-metrics-3.9.0: fixing dependency

### DIFF
--- a/instrumentation/kafka-clients-metrics-3.9.0/build.gradle
+++ b/instrumentation/kafka-clients-metrics-3.9.0/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
     implementation(project(":agent-bridge"))
-    implementation("org.apache.kafka:kafka-clients:3.7.0")
+    implementation("org.apache.kafka:kafka-clients:3.9.0")
 
     testImplementation("org.testcontainers:kafka:1.16.3")
 }


### PR DESCRIPTION
### Overview
The new Kafka module was written with the wrong dependency, causing verify instrumentation to fail on classpath.
Fixing that.
