### PR TITLE
Update ait cache to v4.2.0

### DIFF
--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Retrieve agent from cache
         id: retrieve-agent
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # pin@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0 # pin@v4
         with:
           path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: agent-jar-${{ github.run_id }}

--- a/.github/workflows/X-Reusable-BuildAgent.yml
+++ b/.github/workflows/X-Reusable-BuildAgent.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew $GRADLE_OPTIONS clean jar
 
       - name: Cache agent
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # pin@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0 # pin@v4
         with:
           path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: agent-jar-${{ github.run_id }}

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Retrieve agent from cache
         id: retrieve-agent
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # pin@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0 # pin@v4
         with:
           path: /home/runner/work/newrelic-java-agent/newrelic-java-agent/newrelic-agent/build/newrelicJar/newrelic.jar
           key: agent-jar-${{ github.run_id }}


### PR DESCRIPTION
### Overview
The AIT cache is updated to v4.2.0 because the older version will lose support on 2/1/2025/

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2214