### PR TITLE
invokeSuspend edge case fix

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/language/SourceLibraryDetectorTest.java
@@ -48,7 +48,7 @@ public class SourceLibraryDetectorTest {
     public void testSamplerRun() throws Exception {
         sourceLibraryDetector.run();
         ArgumentCaptor<StatsWork> captor = ArgumentCaptor.forClass(StatsWork.class);
-        verify(ServiceFactory.getStatsService(), times(2)).doStatsWork(captor.capture(), anyString());
+        verify(ServiceFactory.getStatsService(), times(3)).doStatsWork(captor.capture(), anyString());
 
         StatsWork statsWork = captor.getValue();
 

--- a/newrelic-weaver/build.gradle
+++ b/newrelic-weaver/build.gradle
@@ -3,6 +3,7 @@ import com.nr.builder.publish.PublishConfig
 plugins {
     id("maven-publish")
     id("signing")
+    id("kotlin")
 }
 
 configurations {
@@ -35,6 +36,10 @@ dependencies {
 
     // used to test weaving java 1.4 class files
     testImplementation("org.apache.struts:struts-core:1.3.5")
+
+    //testing kotlin coroutines weaving
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.21")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 }
 
 jar {

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
@@ -265,6 +265,13 @@ public class ClassWeave {
 
         final String weaveClassName = match.getWeaveName();
         final String originalClassName = match.getOriginalName();
+
+        //EXPERIMENTAL - analyze the bytecode of the targetMethod
+//        if (targetMethod.name.equals("invokeSuspend")){
+//            WeaveUtils.printMethodNodeStackSizes(originalClassName, targetMethod);
+//            WeaveUtils.analyzeReturnStacks(originalClassName, targetMethod);
+//        }
+
         Set<MethodNode> toInline = new HashSet<>();
         if (weaveMethod.name.equals(WeaveUtils.INIT_NAME)) {
             // we weave every potential top-level constructor
@@ -280,22 +287,22 @@ public class ClassWeave {
         }
 
         // inline original invocation
-        if (weaveMethod.name.equals("invokeSuspend")) {
-            System.out.println("Composite node before inlining:");
-            WeaveUtils.printAllInstructions(composite);
-            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-
-            System.out.println("Target node before inlining:");
-            WeaveUtils.printAllInstructions(targetMethod);
-            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-        }
+//        if (weaveMethod.name.equals("invokeSuspend")) {
+//            System.out.println("Composite node before inlining:");
+//            WeaveUtils.printAllInstructions(composite);
+//            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+//
+//            System.out.println("Target node before inlining:");
+//            WeaveUtils.printAllInstructions(targetMethod);
+//            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+//        }
         composite = MethodProcessors.inlineMethods(WeaveUtils.INLINER_PREFIX + weaveClassName, toInline, target.name,
                 composite);
-        if (weaveMethod.name.equals("invokeSuspend")) {
-            System.out.println("Composite node after inlining:");
-            WeaveUtils.printAllInstructions(composite);
-            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-        }
+//        if (weaveMethod.name.equals("invokeSuspend")) {
+//            System.out.println("Composite node after inlining:");
+//            WeaveUtils.printAllInstructions(composite);
+//            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+//        }
         // the inliner sometimes like to sneak in some jsr instructions. Sneaky inliner!
         composite = MethodProcessors.removeJSRInstructions(composite);
 

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
@@ -298,11 +298,11 @@ public class ClassWeave {
 //        }
         composite = MethodProcessors.inlineMethods(WeaveUtils.INLINER_PREFIX + weaveClassName, toInline, target.name,
                 composite);
-//        if (weaveMethod.name.equals("invokeSuspend")) {
-//            System.out.println("Composite node after inlining:");
-//            WeaveUtils.printAllInstructions(composite);
-//            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-//        }
+        if (weaveMethod.name.equals("invokeSuspend")) {
+            System.out.println("Composite node after inlining:");
+            WeaveUtils.printAllInstructions(composite);
+            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+        }
         // the inliner sometimes like to sneak in some jsr instructions. Sneaky inliner!
         composite = MethodProcessors.removeJSRInstructions(composite);
 

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
@@ -265,13 +265,6 @@ public class ClassWeave {
 
         final String weaveClassName = match.getWeaveName();
         final String originalClassName = match.getOriginalName();
-
-        //EXPERIMENTAL - analyze the bytecode of the targetMethod
-//        if (targetMethod.name.equals("invokeSuspend")){
-//            WeaveUtils.printMethodNodeStackSizes(originalClassName, targetMethod);
-//            WeaveUtils.analyzeReturnStacks(originalClassName, targetMethod);
-//        }
-
         Set<MethodNode> toInline = new HashSet<>();
         if (weaveMethod.name.equals(WeaveUtils.INIT_NAME)) {
             // we weave every potential top-level constructor
@@ -287,22 +280,8 @@ public class ClassWeave {
         }
 
         // inline original invocation
-//        if (weaveMethod.name.equals("invokeSuspend")) {
-//            System.out.println("Composite node before inlining:");
-//            WeaveUtils.printAllInstructions(composite);
-//            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-//
-//            System.out.println("Target node before inlining:");
-//            WeaveUtils.printAllInstructions(targetMethod);
-//            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-//        }
         composite = MethodProcessors.inlineMethods(WeaveUtils.INLINER_PREFIX + weaveClassName, toInline, target.name,
                 composite);
-        if (weaveMethod.name.equals("invokeSuspend")) {
-            System.out.println("Composite node after inlining:");
-            WeaveUtils.printAllInstructions(composite);
-            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-        }
         // the inliner sometimes like to sneak in some jsr instructions. Sneaky inliner!
         composite = MethodProcessors.removeJSRInstructions(composite);
 

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
@@ -280,8 +280,22 @@ public class ClassWeave {
         }
 
         // inline original invocation
+        if (weaveMethod.name.equals("invokeSuspend")) {
+            System.out.println("Composite node before inlining:");
+            WeaveUtils.printAllInstructions(composite);
+            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+
+            System.out.println("Target node before inlining:");
+            WeaveUtils.printAllInstructions(targetMethod);
+            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+        }
         composite = MethodProcessors.inlineMethods(WeaveUtils.INLINER_PREFIX + weaveClassName, toInline, target.name,
                 composite);
+        if (weaveMethod.name.equals("invokeSuspend")) {
+            System.out.println("Composite node after inlining:");
+            WeaveUtils.printAllInstructions(composite);
+            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+        }
         // the inliner sometimes like to sneak in some jsr instructions. Sneaky inliner!
         composite = MethodProcessors.removeJSRInstructions(composite);
 

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -148,10 +148,11 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
     Only the invokeSuspend method of kotlin coroutines has been known to leave return stacks untidy.
      */
     private boolean shouldClearReturnStacks(String owner, String name, String desc) {
-        final String invokeSuspendOwner = WeaveUtils.INLINER_PREFIX + "kotlin/coroutines/jvm/internal/BaseContinuationImpl";
+        //owner depends on where the instrumentation is eventually implemented
+        //final String invokeSuspendOwner = WeaveUtils.INLINER_PREFIX + "kotlin/coroutines/jvm/internal/BaseContinuationImpl";
         final String invokeSuspendName = "invokeSuspend";
         final String invokeSuspendDesc = "(Ljava/lang/Object;)Ljava/lang/Object;";
-        return invokeSuspendOwner.equals(owner) && invokeSuspendName.equals(name) && invokeSuspendDesc.equals(desc);
+        return invokeSuspendName.equals(name) && invokeSuspendDesc.equals(desc);
     }
 
     class ClearReturnAdapter extends MethodNode {

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -245,9 +245,20 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
      * modify this guard to process additional methods beyond invokeSuspend.
      */
     private boolean shouldClearReturnStacks(String name, String desc) {
+        if (clearReturnStacksDisabled()) {
+            return false;
+        }
         final String invokeSuspendName = "invokeSuspend";
         final String invokeSuspendDesc = "(Ljava/lang/Object;)Ljava/lang/Object;";
         return invokeSuspendName.equals(name) && invokeSuspendDesc.equals(desc);
+    }
+
+    /**
+     * Feature flag to disable return stack processing.
+     */
+    private boolean clearReturnStacksDisabled () {
+        String sysProp = System.getProperty("newrelic.config.class_transformer.clear_return_stacks");
+        return ("false").equalsIgnoreCase(sysProp);
     }
 
     /**

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -255,6 +255,7 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
 
     /**
      * Feature flag to disable return stack processing.
+     * To use this feature flag, set -Dnewrelic.config.class_transformer.clear_return_stacks=false at JVM startup.
      */
     private boolean clearReturnStacksDisabled() {
         String enabled = System.getProperty("newrelic.config.class_transformer.clear_return_stacks", "true");

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -241,6 +241,8 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
 
     /**
      * Flags method nodes requiring additional return insn processing, which for now is only invokeSuspend.
+     * For future reference, if other code surfaces a bytecode verification failure (such as an ArrayIndexOutOfBoundsException),
+     * modify this guard to process additional methods beyond invokeSuspend.
      */
     private boolean shouldClearReturnStacks(String name, String desc) {
         final String invokeSuspendName = "invokeSuspend";

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -7,7 +7,9 @@
 
 package com.newrelic.weave;
 
+import com.newrelic.weave.utils.ReturnInsnProcessor;
 import com.newrelic.weave.utils.WeaveUtils;
+import org.objectweb.asm.tree.*;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -16,8 +18,6 @@ import org.objectweb.asm.commons.AnalyzerAdapter;
 import org.objectweb.asm.commons.LocalVariablesSorter;
 import org.objectweb.asm.commons.MethodRemapper;
 import org.objectweb.asm.commons.Remapper;
-import org.objectweb.asm.tree.MethodNode;
-import org.objectweb.asm.tree.TryCatchBlockNode;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -133,6 +133,9 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
             } else {
                 // Copy the MethodNode before modifying the instructions list (which is not thread safe)
                 MethodNode methodNodeCopy = WeaveUtils.copy(method.method);
+                if (name.equals("invokeSuspend")) {
+                    methodNodeCopy = ReturnInsnProcessor.clearReturnStacks(owner, methodNodeCopy);
+                }
                 methodNodeCopy.instructions.resetLabels();
                 InliningAdapter originalInliner = method.inliner;
 

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -256,9 +256,9 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
     /**
      * Feature flag to disable return stack processing.
      */
-    private boolean clearReturnStacksDisabled () {
-        String featFlag = System.getProperty("newrelic.config.class_transformer.clear_return_stacks");
-        return ("false").equalsIgnoreCase(featFlag);
+    private boolean clearReturnStacksDisabled() {
+        String enabled = System.getProperty("newrelic.config.class_transformer.clear_return_stacks", "true");
+        return enabled.equalsIgnoreCase("false");
     }
 
     /**

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -257,8 +257,8 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
      * Feature flag to disable return stack processing.
      */
     private boolean clearReturnStacksDisabled () {
-        String sysProp = System.getProperty("newrelic.config.class_transformer.clear_return_stacks");
-        return ("false").equalsIgnoreCase(sysProp);
+        String featFlag = System.getProperty("newrelic.config.class_transformer.clear_return_stacks");
+        return ("false").equalsIgnoreCase(featFlag);
     }
 
     /**

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/PreparedMatch.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/PreparedMatch.java
@@ -297,7 +297,11 @@ public class PreparedMatch {
     }
 
     private MethodNode prepare(ClassMatch classMatch, MethodNode matchedMethod, Map<Method, CallOriginalReplacement> callOriginalReplacementMap) {
-
+        if (matchedMethod.name.equals("invokeSuspend")) {
+            System.out.println("Weave method before prepare (in PreparedMatch):");
+            WeaveUtils.printAllInstructions(matchedMethod);
+            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+        }
         // remove JSR instructions
         MethodNode prepared = MethodProcessors.removeJSRInstructions(matchedMethod);
 
@@ -333,6 +337,11 @@ public class PreparedMatch {
                 endOfOriginal = replacementResult.getEndOfOriginalMethodLabelNode();
 
                 prepared = replacementResult.getResult();
+                if (matchedMethod.name.equals("invokeSuspend")) {
+                    System.out.println("Weave method after callOriginal() replacement (in PreparedMatch):");
+                    WeaveUtils.printAllInstructions(prepared);
+                    System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
+                }
 
                 // write the error trap
                 prepared = ErrorTrapWeaveMethodsProcessor.writeErrorTrap(prepared, errorHandleClassNode,
@@ -385,6 +394,12 @@ public class PreparedMatch {
         // rewrite new fields to use the extension class
         if (extension != null) {
             prepared = extension.rewriteNewFieldCalls(prepared);
+        }
+
+        if (matchedMethod.name.equals("invokeSuspend")) {
+            System.out.println("Weave method, fully prepared (in PreparedMatch):");
+            WeaveUtils.printAllInstructions(prepared);
+            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
         }
 
         return prepared;

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/PreparedMatch.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/PreparedMatch.java
@@ -297,11 +297,6 @@ public class PreparedMatch {
     }
 
     private MethodNode prepare(ClassMatch classMatch, MethodNode matchedMethod, Map<Method, CallOriginalReplacement> callOriginalReplacementMap) {
-        if (matchedMethod.name.equals("invokeSuspend")) {
-            System.out.println("Weave method before prepare (in PreparedMatch):");
-            WeaveUtils.printAllInstructions(matchedMethod);
-            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-        }
         // remove JSR instructions
         MethodNode prepared = MethodProcessors.removeJSRInstructions(matchedMethod);
 
@@ -337,11 +332,6 @@ public class PreparedMatch {
                 endOfOriginal = replacementResult.getEndOfOriginalMethodLabelNode();
 
                 prepared = replacementResult.getResult();
-                if (matchedMethod.name.equals("invokeSuspend")) {
-                    System.out.println("Weave method after callOriginal() replacement (in PreparedMatch):");
-                    WeaveUtils.printAllInstructions(prepared);
-                    System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
-                }
 
                 // write the error trap
                 prepared = ErrorTrapWeaveMethodsProcessor.writeErrorTrap(prepared, errorHandleClassNode,
@@ -394,12 +384,6 @@ public class PreparedMatch {
         // rewrite new fields to use the extension class
         if (extension != null) {
             prepared = extension.rewriteNewFieldCalls(prepared);
-        }
-
-        if (matchedMethod.name.equals("invokeSuspend")) {
-            System.out.println("Weave method, fully prepared (in PreparedMatch):");
-            WeaveUtils.printAllInstructions(prepared);
-            System.out.println("\n\n\n ~~~~~~~~~~~~~~~~~~~ \n\n\n");
         }
 
         return prepared;

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
@@ -1,0 +1,112 @@
+package com.newrelic.weave.utils;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+import org.objectweb.asm.tree.analysis.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReturnInsnProcessor {
+    /***
+     * Tidy up the stacks at every return instruction of a method.
+     *
+     * @param owner The owning class of the method
+     * @param mn The method
+     * @return mn, with updated instructions
+     */
+
+    public static MethodNode clearReturnStacks(String owner, MethodNode mn) {
+        int maxLocals = mn.maxLocals;
+        int nextLocalIdx = maxLocals; //create a new local variable
+        Map<AbstractInsnNode, Integer> stacks;
+        try {
+            stacks = calculateReturnStacks(owner, mn);
+        } catch (AnalyzerException e) {
+            //Something went wrong calculating return stacks, send back the method unmodified.
+            return mn;
+        }
+        for (Map.Entry<AbstractInsnNode, Integer> entry : stacks.entrySet()) {
+            AbstractInsnNode insn = entry.getKey();
+            Integer stackSize = entry.getValue();
+            InsnList clearInsns = insnsBeforeReturn(insn.getOpcode(), stackSize, nextLocalIdx);
+            mn.instructions.insertBefore(insn, clearInsns);
+        }
+        mn.maxLocals = nextLocalIdx + 1;
+        return mn;
+    }
+
+    /*
+    The issue has only been observed happening with reference (A-type) instructions in coroutines.
+    But for safety (and for reuse in future contexts), this method
+    checks the type of the return and pairs it with the appropriate store and load types.
+     */
+
+    private static InsnList insnsBeforeReturn(int opcode, int stackSize, int varIndex){
+        InsnList insns = new InsnList();
+//        if (opcode == Opcodes.RETURN) {
+//            for (int i = stackSize; i > 0; i--) {
+//                insns.add(new InsnNode(Opcodes.POP));
+//            }
+//            return insns;
+//        }
+        int store;
+        int load;
+        switch (opcode) {
+            case Opcodes.ARETURN:
+                store = Opcodes.ASTORE;
+                load = Opcodes.ALOAD;
+                break;
+            case Opcodes.IRETURN :
+                store = Opcodes.ISTORE;
+                load = Opcodes.ILOAD;
+                break;
+            case Opcodes.DRETURN:
+                store = Opcodes.DSTORE;
+                load = Opcodes.DLOAD;
+                break;
+            case Opcodes.LRETURN:
+                store = Opcodes.LSTORE;
+                load = Opcodes.LLOAD;
+                break;
+            case Opcodes.FRETURN:
+                store = Opcodes.FSTORE;
+                load = Opcodes.FLOAD;
+                break;
+            default:
+                return insns;
+        }
+        insns.add(new VarInsnNode(store, varIndex));
+        for (int i = stackSize; i > 1; i--){
+            insns.add(new InsnNode(Opcodes.POP));
+        }
+        insns.add(new VarInsnNode(load, varIndex));
+        return insns;
+    }
+
+    /***
+     * Compute the size of the operand stack at each return instruction.
+     * @param owner Owning class
+     * @param method The method to analyze
+     * @return A Map of return instruction instances and their stack sizes
+     */
+
+    private static Map<AbstractInsnNode, Integer> calculateReturnStacks(String owner, MethodNode method) throws AnalyzerException {
+        BasicInterpreter interpreter = new BasicInterpreter();
+        Analyzer<BasicValue> a = new Analyzer<>(interpreter);
+        Frame<BasicValue>[] frames;
+        frames = a.analyze(owner, method);
+        Map<AbstractInsnNode, Integer> rtStacks = new HashMap<>();
+        for (int j = 0; j < method.instructions.size(); ++j) {
+            AbstractInsnNode insn = method.instructions.get(j);
+            if (insn.getOpcode() >= Opcodes.IRETURN && insn.getOpcode() <= Opcodes.ARETURN) {
+                Frame<BasicValue> f = frames[j];
+                if (f != null && f.getStackSize() > 1) {
+                    rtStacks.put(insn, f.getStackSize());
+                }
+            }
+        }
+        return rtStacks;
+    }
+
+}

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
@@ -8,48 +8,49 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ReturnInsnProcessor {
+
+    private static final int EXPECTED_RETURN_STACK_SIZE = 1;
+
     /***
-     * Tidy up the stacks at every return instruction of a method.
+     * Clear the stacks at every A and I-type return instruction of a method, to their EXPECTED_RETURN_STACK_SIZE of 1.
+     * This mutates the given MethodNode and is not thread safe.
      *
      * @param owner The owning class of the method
-     * @param mn The method
-     * @return mn, with updated instructions
+     * @param mn MethodNode representing the method to be modified
      */
-
-    public static MethodNode clearReturnStacks(String owner, MethodNode mn) {
-        int maxLocals = mn.maxLocals;
-        int nextLocalIdx = maxLocals; //create a new local variable
+    public static void clearReturnStacks(String owner, MethodNode mn) {
         Map<AbstractInsnNode, Integer> stacks;
         try {
-            stacks = calculateReturnStacks(owner, mn);
+            stacks = getReturnStacks(owner, mn);
         } catch (AnalyzerException e) {
-            //Something went wrong calculating return stacks, send back the method unmodified.
-            return mn;
+            //Something went wrong calculating return stacks, leave the method unmodified.
+            return;
         }
-        for (Map.Entry<AbstractInsnNode, Integer> entry : stacks.entrySet()) {
-            AbstractInsnNode insn = entry.getKey();
-            Integer stackSize = entry.getValue();
-            InsnList clearInsns = insnsBeforeReturn(insn.getOpcode(), stackSize, nextLocalIdx);
-            mn.instructions.insertBefore(insn, clearInsns);
+        if (stacks != null && !stacks.isEmpty()) {
+            int maxLocals = mn.maxLocals;
+            int nextLocalIdx = maxLocals; //create a new local variable
+            for (Map.Entry<AbstractInsnNode, Integer> entry : stacks.entrySet()) {
+                AbstractInsnNode insn = entry.getKey();
+                Integer stackSize = entry.getValue();
+                InsnList clearInsns = insnsBeforeReturn(insn.getOpcode(), stackSize, nextLocalIdx);
+                mn.instructions.insertBefore(insn, clearInsns);
+            }
+            mn.maxLocals = nextLocalIdx + 1;
         }
-        mn.maxLocals = nextLocalIdx + 1;
-        return mn;
     }
 
     /*
-    The issue has only been observed happening with reference (A-type) instructions in coroutines.
+    The return insn issue has only been observed happening with reference (A-type) instructions in coroutines.
     But for safety (and for reuse in future contexts), this method
     checks the type of the return and pairs it with the appropriate store and load types.
+
+    I-type is also allowed (though it hasn't been observed in the wild before).
+
+    All other return types will return an empty InsnList.
      */
 
     private static InsnList insnsBeforeReturn(int opcode, int stackSize, int varIndex){
         InsnList insns = new InsnList();
-//        if (opcode == Opcodes.RETURN) {
-//            for (int i = stackSize; i > 0; i--) {
-//                insns.add(new InsnNode(Opcodes.POP));
-//            }
-//            return insns;
-//        }
         int store;
         int load;
         switch (opcode) {
@@ -61,52 +62,42 @@ public class ReturnInsnProcessor {
                 store = Opcodes.ISTORE;
                 load = Opcodes.ILOAD;
                 break;
-            case Opcodes.DRETURN:
-                store = Opcodes.DSTORE;
-                load = Opcodes.DLOAD;
-                break;
-            case Opcodes.LRETURN:
-                store = Opcodes.LSTORE;
-                load = Opcodes.LLOAD;
-                break;
-            case Opcodes.FRETURN:
-                store = Opcodes.FSTORE;
-                load = Opcodes.FLOAD;
-                break;
             default:
                 return insns;
         }
         insns.add(new VarInsnNode(store, varIndex));
-        for (int i = stackSize; i > 1; i--){
+        for (int i = stackSize; i > EXPECTED_RETURN_STACK_SIZE; i--){
             insns.add(new InsnNode(Opcodes.POP));
         }
         insns.add(new VarInsnNode(load, varIndex));
         return insns;
     }
 
-    /***
+    /*
      * Compute the size of the operand stack at each return instruction.
-     * @param owner Owning class
+     * Only applies to methods returning I (int type) or A (reference type).
+     *
+     * @param owner The owning class
      * @param method The method to analyze
-     * @return A Map of return instruction instances and their stack sizes
+     * @return A Map of return instructions having extra operands on the stack, whose keys are return insn instances and values are stack sizes at the insn
      */
-
-    private static Map<AbstractInsnNode, Integer> calculateReturnStacks(String owner, MethodNode method) throws AnalyzerException {
+    private static Map<AbstractInsnNode, Integer> getReturnStacks(String owner, MethodNode method) throws AnalyzerException {
         BasicInterpreter interpreter = new BasicInterpreter();
         Analyzer<BasicValue> a = new Analyzer<>(interpreter);
-        Frame<BasicValue>[] frames;
-        frames = a.analyze(owner, method);
+        Frame<BasicValue>[] frames = a.analyze(owner, method);
         Map<AbstractInsnNode, Integer> rtStacks = new HashMap<>();
         for (int j = 0; j < method.instructions.size(); ++j) {
             AbstractInsnNode insn = method.instructions.get(j);
-            if (insn.getOpcode() >= Opcodes.IRETURN && insn.getOpcode() <= Opcodes.ARETURN) {
+            if (insn.getOpcode() == Opcodes.IRETURN && insn.getOpcode() == Opcodes.ARETURN) {
                 Frame<BasicValue> f = frames[j];
-                if (f != null && f.getStackSize() > 1) {
+                if (f != null && f.getStackSize() > EXPECTED_RETURN_STACK_SIZE) {
                     rtStacks.put(insn, f.getStackSize());
                 }
             }
         }
         return rtStacks;
     }
+
+
 
 }

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
@@ -74,7 +74,7 @@ public class ReturnInsnProcessor {
     }
 
     /*
-     * Compute the size of the operand stack at each return instruction.
+     * Compute the size of the operand stack at each return instruction exceeding the EXPECTED_RETURN_STACK_SIZE of 1.
      * Only applies to methods returning I (int type) or A (reference type).
      *
      * @param owner The owning class
@@ -88,7 +88,7 @@ public class ReturnInsnProcessor {
         Map<AbstractInsnNode, Integer> rtStacks = new HashMap<>();
         for (int j = 0; j < method.instructions.size(); ++j) {
             AbstractInsnNode insn = method.instructions.get(j);
-            if (insn.getOpcode() == Opcodes.IRETURN && insn.getOpcode() == Opcodes.ARETURN) {
+            if (insn.getOpcode() == Opcodes.IRETURN || insn.getOpcode() == Opcodes.ARETURN) {
                 Frame<BasicValue> f = frames[j];
                 if (f != null && f.getStackSize() > EXPECTED_RETURN_STACK_SIZE) {
                     rtStacks.put(insn, f.getStackSize());

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
@@ -1,3 +1,10 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.weave.utils;
 
 import org.objectweb.asm.Opcodes;
@@ -32,6 +39,8 @@ public class ReturnInsnProcessor {
             stacks = getReturnStacks(owner, mn);
         } catch (AnalyzerException e) {
             //Something went wrong calculating return stacks, leave the method unmodified.
+            //This is a silent failure that indicates that the source (client) bytecode is invalid.
+            //This should never happen!
             return;
         }
         if (stacks != null && !stacks.isEmpty()) {

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/ReturnInsnProcessor.java
@@ -1,8 +1,16 @@
 package com.newrelic.weave.utils;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.*;
-import org.objectweb.asm.tree.analysis.*;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +57,7 @@ public class ReturnInsnProcessor {
     All other return types will return an empty InsnList.
      */
 
-    private static InsnList insnsBeforeReturn(int opcode, int stackSize, int varIndex){
+    private static InsnList insnsBeforeReturn(int opcode, int stackSize, int varIndex) {
         InsnList insns = new InsnList();
         int store;
         int load;
@@ -58,7 +66,7 @@ public class ReturnInsnProcessor {
                 store = Opcodes.ASTORE;
                 load = Opcodes.ALOAD;
                 break;
-            case Opcodes.IRETURN :
+            case Opcodes.IRETURN:
                 store = Opcodes.ISTORE;
                 load = Opcodes.ILOAD;
                 break;
@@ -66,7 +74,7 @@ public class ReturnInsnProcessor {
                 return insns;
         }
         insns.add(new VarInsnNode(store, varIndex));
-        for (int i = stackSize; i > EXPECTED_RETURN_STACK_SIZE; i--){
+        for (int i = stackSize; i > EXPECTED_RETURN_STACK_SIZE; i--) {
             insns.add(new InsnNode(Opcodes.POP));
         }
         insns.add(new VarInsnNode(load, varIndex));
@@ -97,7 +105,5 @@ public class ReturnInsnProcessor {
         }
         return rtStacks;
     }
-
-
 
 }

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
@@ -15,7 +15,6 @@ import com.newrelic.api.agent.weaver.WeaveIntoAllMethods;
 import com.newrelic.api.agent.weaver.WeaveWithAnnotation;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.newrelic.weave.MethodKey;
-import org.objectweb.asm.tree.analysis.*;
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.JSRInlinerAdapter;
 import org.objectweb.asm.commons.Method;
@@ -521,6 +520,11 @@ public final class WeaveUtils {
         return result;
     }
 
+    /**
+     * Utility method to print human-readable bytecode instructions of a MethodNode.
+     *
+     * @param mn the node to print
+     */
     public static void printAllInstructions(MethodNode mn) {
         for (AbstractInsnNode insn : mn.instructions) {
             System.out.println(stringifyInstruction(insn));
@@ -557,13 +561,6 @@ public final class WeaveUtils {
      * @return byte array representing the specified class node
      */
     public static byte[] convertToClassBytes(ClassNode classNode, ClassInformationFinder classInfoFinder) {
-        boolean shouldDump = classNode.name.equals("io/ktor/samples/clientmultipart/MultipartAppKt$main$1$1");
-        if (shouldDump) {
-//            Printer printer = new Textifier();
-//            PrintWriter output = new PrintWriter(System.out, true);
-//            TraceClassVisitor traceClassVisitor= new TraceClassVisitor(null, printer, output);
-//            classNode.accept(traceClassVisitor);
-        }
         ClassWriter cw = new PatchedClassWriter(ClassWriter.COMPUTE_FRAMES, classInfoFinder);
         classNode.accept(cw);
         return cw.toByteArray();

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
@@ -15,6 +15,7 @@ import com.newrelic.api.agent.weaver.WeaveIntoAllMethods;
 import com.newrelic.api.agent.weaver.WeaveWithAnnotation;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.newrelic.weave.MethodKey;
+import org.objectweb.asm.tree.analysis.*;
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.JSRInlinerAdapter;
 import org.objectweb.asm.commons.Method;

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
@@ -15,12 +15,29 @@ import com.newrelic.api.agent.weaver.WeaveIntoAllMethods;
 import com.newrelic.api.agent.weaver.WeaveWithAnnotation;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.newrelic.weave.MethodKey;
-import org.objectweb.asm.*;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.JSRInlinerAdapter;
 import org.objectweb.asm.commons.Method;
 import org.objectweb.asm.commons.Remapper;
-import org.objectweb.asm.tree.*;
-import org.objectweb.asm.util.*;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.InnerClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.util.Textifier;
+import org.objectweb.asm.util.TraceMethodVisitor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +45,14 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -196,7 +220,7 @@ public final class WeaveUtils {
      * Find a method by name and desc in the specified collection.
      *
      * @param methodNodes collection to search
-     * @param queryNode MethodNode with name and desc to search for
+     * @param queryNode   MethodNode with name and desc to search for
      * @return matched method or <code>null</code> if there was no match
      */
     public static MethodNode findMatch(Collection<MethodNode> methodNodes, MethodNode queryNode) {
@@ -218,8 +242,8 @@ public final class WeaveUtils {
      * Find a method by name and desc in the specified collection.
      *
      * @param methodNodes collection to search
-     * @param name method name to search for
-     * @param desc method desc to search for
+     * @param name        method name to search for
+     * @param desc        method desc to search for
      * @return matched method or <code>null</code> if there was no match
      */
     public static MethodNode findMatch(Collection<MethodNode> methodNodes, String name, String desc) {
@@ -235,7 +259,7 @@ public final class WeaveUtils {
      * Find a field by name and desc in the specified collection.
      *
      * @param fieldNodes collection to search
-     * @param name name to search for
+     * @param name       name to search for
      * @return matched field or <code>null</code> if there was no match
      */
     public static FieldNode findMatch(Collection<FieldNode> fieldNodes, String name) {
@@ -251,7 +275,7 @@ public final class WeaveUtils {
      * Find a required field by name and desc in the specified collection.
      *
      * @param fieldNodes collection to search
-     * @param name name to search for
+     * @param name       name to search for
      * @return matched field
      * @throws IllegalArgumentException if there was no match
      */
@@ -268,8 +292,8 @@ public final class WeaveUtils {
      * Tests whether the specified method invocation is to code>Weaver.callOriginal()</code>.
      *
      * @param owner method owner
-     * @param name method name
-     * @param desc method desc
+     * @param name  method name
+     * @param desc  method desc
      * @return <code>true</code> if owner, name, and desc correspond to <code>Weaver.callOriginal()</code>
      */
     public static boolean isOriginalMethodInvocation(String owner, String name, String desc) {
@@ -281,8 +305,8 @@ public final class WeaveUtils {
      * Tests whether the specified method invocation is to code>Weaver.getClassAnnotation()</code>.
      *
      * @param owner method owner
-     * @param name method name
-     * @param desc method desc
+     * @param name  method name
+     * @param desc  method desc
      * @return <code>true</code> if owner, name, and desc correspond to <code>Weaver.getClassAnnotation()</code>
      */
     public static boolean isClassAnnotationGetter(String owner, String name, String desc) {
@@ -294,8 +318,8 @@ public final class WeaveUtils {
      * Tests whether the specified method invocation is to <code>Weaver.getMethodAnnotation()</code>.
      *
      * @param owner method owner
-     * @param name method name
-     * @param desc method desc
+     * @param name  method name
+     * @param desc  method desc
      * @return <code>true</code> if owner, name, and desc correspond to <code>Weaver.getMethodAnnotation()</code>
      */
     public static boolean isMethodAnnotationGetter(String owner, String name, String desc) {
@@ -448,7 +472,7 @@ public final class WeaveUtils {
     /**
      * Returns a copy of the specified ClassNode with all references to the "oldName" parameter renamed to the value
      * of the "newName" parameter.
-     *
+     * <p>
      * This method is best used when a template ClassNode is available and you want to make a new copy of it every time
      * it needs to be used so it can have a unique name.
      *
@@ -556,7 +580,7 @@ public final class WeaveUtils {
     /**
      * Converts an ASM {@link ClassNode} to a byte array.
      *
-     * @param classNode class node to convert
+     * @param classNode       class node to convert
      * @param classInfoFinder the classloader used to create the {@link PatchedClassWriter}
      * @return byte array representing the specified class node
      */
@@ -571,7 +595,7 @@ public final class WeaveUtils {
      * found.
      *
      * @param classname internal class name
-     * @param finder {@link ClassFinder} implementation to get bytes from
+     * @param finder    {@link ClassFinder} implementation to get bytes from
      * @return class bytes, or <code>null</code> if the class could not be found
      * @throws IOException
      */
@@ -588,7 +612,7 @@ public final class WeaveUtils {
     /**
      * Read a ClassLoader's resource into a byte array.
      *
-     * @param classname Internal or Fully qualified name of the class
+     * @param classname   Internal or Fully qualified name of the class
      * @param classloader the classloader to read the resource from
      * @return the resource bytes (class bytes) or null if no resource was found.
      * @throws IOException
@@ -992,7 +1016,7 @@ public final class WeaveUtils {
     /**
      * Check if method has at least one of the provided required method annotations.
      *
-     * @param originalMethod the method to check
+     * @param originalMethod                     the method to check
      * @param requiredMethodAnnotationClassNames the Set of required annotation class names
      * @return true if method has at least one of the required method annotations, false otherwise.
      */

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
@@ -35,9 +35,13 @@ import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.util.ASMifier;
+import org.objectweb.asm.util.Printer;
+import org.objectweb.asm.util.TraceClassVisitor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.util.ArrayList;
@@ -546,6 +550,13 @@ public final class WeaveUtils {
      * @return byte array representing the specified class node
      */
     public static byte[] convertToClassBytes(ClassNode classNode, ClassInformationFinder classInfoFinder) {
+        boolean shouldDump = classNode.name.equals("io/ktor/samples/clientmultipart/MultipartAppKt$main$1$1");
+        if (shouldDump) {
+            Printer printer = new ASMifier();
+            PrintWriter output = new PrintWriter(System.out, true);
+            TraceClassVisitor traceClassVisitor= new TraceClassVisitor(null, printer, output);
+            classNode.accept(traceClassVisitor);
+        }
         ClassWriter cw = new PatchedClassWriter(ClassWriter.COMPUTE_FRAMES, classInfoFinder);
         classNode.accept(cw);
         return cw.toByteArray();

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveCoroutineTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveCoroutineTest.java
@@ -1,0 +1,114 @@
+package com.newrelic.weave;
+
+import com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.ClassNode;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/*
+This test checks whether weaving is successful for a class known to generate bytecode with extra operands on the stack.
+ */
+public class WeaveCoroutineTest {
+
+    private static ClassNode original1;
+    private static ClassNode composite1;
+    private static ClassNode original2;
+    private static ClassNode composite2;
+
+    @BeforeClass
+    public static void before() throws IOException{
+        original1 = WeaveTestUtils.readClass("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doOneSuspend$1$1");
+        ClassWeave weave1 = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doOneSuspend$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        composite1 = weave1.getComposite();
+
+        original2 = WeaveTestUtils.readClass("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doThreeSuspends$1$1");
+        ClassWeave weave2 = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doThreeSuspends$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        composite2 = weave2.getComposite();
+    }
+
+    //This test is the important one.
+    //If the weaver doesn't clean the return stacks of these coroutines, the test will fail with an ArrayIndexOOB Error.
+    @Test
+    public void weavedCoroutineShouldNotThrow() {
+        SampleCoroutineKt.doOneSuspend();
+        SampleCoroutineKt.doThreeSuspends();
+    }
+
+    //The original method and weaved method are hard to compare directly, because the weaved method includes
+    //a bunch of extra New Relic Stuff. This just checks we added some pops (as expected).
+    @Test
+    public void weavedCoroutineAddsOnePop(){
+        MethodNode originalInvokeSuspend = getNodeNamed(original1.methods, "invokeSuspend");
+        assertNotNull(originalInvokeSuspend);
+
+        MethodNode weavedInvokeSuspend = getNodeNamed(composite1.methods, "invokeSuspend");
+        assertNotNull(weavedInvokeSuspend);
+
+        int popsBefore = countInsnsWithOpcode(originalInvokeSuspend, Opcodes.POP);
+        int popsAfter = countInsnsWithOpcode(weavedInvokeSuspend, Opcodes.POP);
+
+        assertEquals(popsBefore + 1, popsAfter);
+    }
+
+    @Test
+    public void weavedCoroutineAddsSeveralPops() throws IOException {
+        MethodNode originalInvokeSuspend = getNodeNamed(original2.methods, "invokeSuspend");
+        assertNotNull(originalInvokeSuspend);
+
+        MethodNode weavedInvokeSuspend = getNodeNamed(composite2.methods, "invokeSuspend");
+        assertNotNull(weavedInvokeSuspend);
+
+        int popsBefore = countInsnsWithOpcode(originalInvokeSuspend, Opcodes.POP);
+        int popsAfter = countInsnsWithOpcode(weavedInvokeSuspend, Opcodes.POP);
+
+        assertEquals(popsBefore + 3, popsAfter);
+    }
+
+    @Test
+    public void weavedCoroutineAddsNoPops() throws IOException {
+        ClassNode original = WeaveTestUtils.readClass("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNoSuspends$1$1");
+        ClassWeave weave = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNoSuspends$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        ClassNode composite = weave.getComposite();
+
+        MethodNode originalInvokeSuspend = getNodeNamed(original.methods, "invokeSuspend");
+        assertNotNull(originalInvokeSuspend);
+
+        MethodNode weavedInvokeSuspend = getNodeNamed(composite.methods, "invokeSuspend");
+        assertNotNull(weavedInvokeSuspend);
+
+        int popsBefore = countInsnsWithOpcode(originalInvokeSuspend, Opcodes.POP);
+        int popsAfter = countInsnsWithOpcode(weavedInvokeSuspend, Opcodes.POP);
+
+        assertEquals(popsBefore, popsAfter);
+    }
+
+
+
+    private MethodNode getNodeNamed(List<MethodNode> methods, String targetName) {
+        for (MethodNode mn: methods) {
+            if (mn.name.equals(targetName)){
+                return mn;
+            }
+        }
+        return null;
+    }
+
+    private int countInsnsWithOpcode(MethodNode mn, int opcode) {
+        int count = 0;
+        for (AbstractInsnNode insn: mn.instructions) {
+            if (insn.getOpcode() == opcode) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+}

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveCoroutineTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveCoroutineTest.java
@@ -1,3 +1,10 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.weave;
 
 import com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt;
@@ -11,7 +18,8 @@ import org.objectweb.asm.tree.ClassNode;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /*
 This test checks whether weaving is successful for a class known to generate bytecode with extra operands on the stack.
@@ -24,13 +32,15 @@ public class WeaveCoroutineTest {
     private static ClassNode composite2;
 
     @BeforeClass
-    public static void before() throws IOException{
+    public static void before() throws IOException {
         original1 = WeaveTestUtils.readClass("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doOneSuspend$1$1");
-        ClassWeave weave1 = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doOneSuspend$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        ClassWeave weave1 = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doOneSuspend$1$1",
+                "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
         composite1 = weave1.getComposite();
 
         original2 = WeaveTestUtils.readClass("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doThreeSuspends$1$1");
-        ClassWeave weave2 = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doThreeSuspends$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        ClassWeave weave2 = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doThreeSuspends$1$1",
+                "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
         composite2 = weave2.getComposite();
     }
 
@@ -44,14 +54,15 @@ public class WeaveCoroutineTest {
 
     @Test
     public void nestedSuspendsShouldNotThrow() throws IOException {
-        WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNestedSuspends$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNestedSuspends$1$1",
+                "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
         SampleCoroutineKt.doNestedSuspends();
     }
 
     //The original method and weaved method are hard to compare directly, because the weaved method includes
     //a bunch of extra New Relic Stuff. This just checks we added some pops (as expected).
     @Test
-    public void weavedCoroutineAddsOnePop(){
+    public void weavedCoroutineAddsOnePop() {
         MethodNode originalInvokeSuspend = getNodeNamed(original1.methods, "invokeSuspend");
         assertNotNull(originalInvokeSuspend);
 
@@ -81,7 +92,8 @@ public class WeaveCoroutineTest {
     @Test
     public void weavedCoroutineAddsNoPops() throws IOException {
         ClassNode original = WeaveTestUtils.readClass("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNoSuspends$1$1");
-        ClassWeave weave = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNoSuspends$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        ClassWeave weave = WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNoSuspends$1$1",
+                "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
         ClassNode composite = weave.getComposite();
 
         MethodNode originalInvokeSuspend = getNodeNamed(original.methods, "invokeSuspend");
@@ -96,11 +108,9 @@ public class WeaveCoroutineTest {
         assertEquals(popsBefore, popsAfter);
     }
 
-
-
     private MethodNode getNodeNamed(List<MethodNode> methods, String targetName) {
-        for (MethodNode mn: methods) {
-            if (mn.name.equals(targetName)){
+        for (MethodNode mn : methods) {
+            if (mn.name.equals(targetName)) {
                 return mn;
             }
         }
@@ -109,7 +119,7 @@ public class WeaveCoroutineTest {
 
     private int countInsnsWithOpcode(MethodNode mn, int opcode) {
         int count = 0;
-        for (AbstractInsnNode insn: mn.instructions) {
+        for (AbstractInsnNode insn : mn.instructions) {
             if (insn.getOpcode() == opcode) {
                 count++;
             }

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveCoroutineTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/WeaveCoroutineTest.java
@@ -42,6 +42,12 @@ public class WeaveCoroutineTest {
         SampleCoroutineKt.doThreeSuspends();
     }
 
+    @Test
+    public void nestedSuspendsShouldNotThrow() throws IOException {
+        WeaveTestUtils.weaveAndAddToContextClassloader("com.newrelic.weave.weavepackage.testclasses.SampleCoroutineKt$doNestedSuspends$1$1", "com.newrelic.weave.weavepackage.testclasses.Weave_SampleCoroutine");
+        SampleCoroutineKt.doNestedSuspends();
+    }
+
     //The original method and weaved method are hard to compare directly, because the weaved method includes
     //a bunch of extra New Relic Stuff. This just checks we added some pops (as expected).
     @Test

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
@@ -1,0 +1,7 @@
+package com.newrelic.weave.utils;
+
+import static org.junit.Assert.*;
+
+public class ReturnInsnProcessorTest {
+
+}

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
@@ -3,51 +3,70 @@ package com.newrelic.weave.utils;
 import org.junit.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.tree.*;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodNode;
 
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
-import static org.objectweb.asm.Opcodes.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.ICONST_1;
+import static org.objectweb.asm.Opcodes.ICONST_2;
+import static org.objectweb.asm.Opcodes.ICONST_3;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.ILOAD;
+import static org.objectweb.asm.Opcodes.IRETURN;
+import static org.objectweb.asm.Opcodes.ISTORE;
+import static org.objectweb.asm.Opcodes.POP;
 
 public class ReturnInsnProcessorTest {
     //the nodes in here need to be constructed by hand since Java compilers don't have this issue
     @Test
-    public void doesNotAlterAlreadyClearStack(){
-        int[] originalSeq = {ICONST_1, DUP, POP, IRETURN};
+    public void doesNotAlterAlreadyClearStack() {
+        int[] originalSeq = { ICONST_1, DUP, POP, IRETURN };
         MethodNode mn = basicMethodFromSequence(Type.INT, originalSeq, 2);
         ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
         assertInsnSequence(originalSeq, mn.instructions);
 
-        int[] originalSeqRefType = {ACONST_NULL, ARETURN};
+        int[] originalSeqRefType = { ACONST_NULL, ARETURN };
         MethodNode mn2 = basicMethodFromSequence(Type.OBJECT, originalSeqRefType, 1);
         ReturnInsnProcessor.clearReturnStacks("MyClazz", mn2);
         assertInsnSequence(originalSeqRefType, mn2.instructions);
     }
 
     @Test
-    public void addsPopsForIntReturnType(){
-        int[] originalInsnSequence = {ICONST_2, ICONST_1, DUP, DUP, ICONST_3, IRETURN};
+    public void addsPopsForIntReturnType() {
+        int[] originalInsnSequence = { ICONST_2, ICONST_1, DUP, DUP, ICONST_3, IRETURN };
         MethodNode mn = basicMethodFromSequence(Type.INT, originalInsnSequence, 5);
 
         ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
-        int[] expectedInsnSequence = {ICONST_2, ICONST_1, DUP, DUP, ICONST_3, ISTORE, POP, POP, POP, POP, ILOAD, IRETURN};
+        int[] expectedInsnSequence = { ICONST_2, ICONST_1, DUP, DUP, ICONST_3, ISTORE, POP, POP,
+                POP, POP, ILOAD, IRETURN };
         assertInsnSequence(expectedInsnSequence, mn.instructions);
     }
 
     @Test
-    public void addsPopsForReferenceReturnType(){
-        int[] originalInsnSequence = {ACONST_NULL, DUP, DUP, DUP, ARETURN};
+    public void addsPopsForReferenceReturnType() {
+        int[] originalInsnSequence = { ACONST_NULL, DUP, DUP, DUP, ARETURN };
         MethodNode mn = basicMethodFromSequence(Type.OBJECT, originalInsnSequence, 4);
 
         ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
-        int[] expectedInsnSequence = {ACONST_NULL, DUP, DUP, DUP, ASTORE, POP, POP, POP, ALOAD, ARETURN};
+        int[] expectedInsnSequence = { ACONST_NULL, DUP, DUP, DUP, ASTORE, POP, POP, POP,
+                ALOAD, ARETURN };
         assertInsnSequence(expectedInsnSequence, mn.instructions);
     }
 
     @Test
-    public void handlesMultipleReturns(){
+    public void handlesMultipleReturns() {
         //This Insn List is more complicated, so we have to build it directly here
         InsnList insns = new InsnList();
         insns.add(new InsnNode(ICONST_1));
@@ -64,20 +83,21 @@ public class ReturnInsnProcessorTest {
         mn.maxStack = 2;
 
         ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
-        int[] expectedInsns = {ICONST_1, DUP, IFEQ, IRETURN, -1, DUP, ISTORE, POP, ILOAD, IRETURN};
+        int[] expectedInsns = { ICONST_1, DUP, IFEQ, IRETURN, -1, DUP, ISTORE, POP, ILOAD,
+                IRETURN };
         assertInsnSequence(expectedInsns, mn.instructions);
     }
 
     @Test
     public void failedAnalyzerDoesNothing() {
         //these instructions are bad and will fail the analyzer - we shouldn't touch them.
-        int[] originalInsns = {ICONST_1, POP, POP, IRETURN};
+        int[] originalInsns = { ICONST_1, POP, POP, IRETURN };
         MethodNode mn = basicMethodFromSequence(Type.INT, originalInsns, 1);
         ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
         assertInsnSequence(originalInsns, mn.instructions);
     }
 
-    private void assertInsnSequence( int[] expectedSequence, InsnList insns) {
+    private void assertInsnSequence(int[] expectedSequence, InsnList insns) {
         Iterator<AbstractInsnNode> it = insns.iterator();
         int i = 0;
         while (it.hasNext()) {
@@ -90,7 +110,7 @@ public class ReturnInsnProcessorTest {
 
     private MethodNode basicMethodFromSequence(int type, int[] insnSequence, int maxStack) {
         MethodNode mn = buildMethodNode(type);
-        for(int opcode: insnSequence){
+        for (int opcode : insnSequence) {
             mn.instructions.add(new InsnNode(opcode));
         }
         mn.maxStack = maxStack;
@@ -110,7 +130,7 @@ public class ReturnInsnProcessorTest {
             default:
                 fail();
         }
-        MethodNode mn = new MethodNode(Opcodes.ASM9, ACC_PUBLIC, "myMethod", desc, null, null);
+        MethodNode mn = new MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC, "myMethod", desc, null, null);
         return mn;
     }
 }

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
@@ -1,74 +1,117 @@
 package com.newrelic.weave.utils;
 
-import com.sun.org.apache.bcel.internal.generic.ALOAD;
+import net.bytebuddy.asm.Advice;
 import org.junit.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
 
+import java.util.Iterator;
+
 import static org.junit.Assert.*;
-import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static org.objectweb.asm.Type.DOUBLE_TYPE;
-import static org.objectweb.asm.Type.INT_TYPE;
+import static org.objectweb.asm.Opcodes.*;
+
 
 public class ReturnInsnProcessorTest {
-
-
-
     //the nodes in here need to be constructed by hand since Java compilers don't have this issue
-
     @Test
-    public void singleReturnStackClears() {
-       MethodNode mn = buildMethodNode(INT_TYPE);
-       buildOneUntidyReturn(mn);
-       WeaveUtils.printAllInstructions(mn);
+    public void doesNotAlterAlreadyClearStack(){
+        int[] originalSeq = {ICONST_1, DUP, POP, IRETURN};
+        MethodNode mn = basicMethodFromSequence(Type.INT, originalSeq, 2);
+        ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
+        assertInsnSequence(originalSeq, mn.instructions);
 
-       ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
-       WeaveUtils.printAllInstructions(mn);
+        int[] originalSeqRefType = {ACONST_NULL, ARETURN};
+        MethodNode mn2 = basicMethodFromSequence(Type.OBJECT, originalSeqRefType, 1);
+        ReturnInsnProcessor.clearReturnStacks("MyClazz", mn2);
+        assertInsnSequence(originalSeqRefType, mn2.instructions);
     }
 
     @Test
-    public void stackAlreadyClearDoesNothing() {
+    public void addsPopsForIntReturnType(){
+        int[] originalInsnSequence = {ICONST_2, ICONST_1, DUP, DUP, ICONST_3, IRETURN};
+        MethodNode mn = basicMethodFromSequence(Type.INT, originalInsnSequence, 5);
 
+        ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
+        int[] expectedInsnSequence = {ICONST_2, ICONST_1, DUP, DUP, ICONST_3, ISTORE, POP, POP, POP, POP, ILOAD, IRETURN};
+        assertInsnSequence(expectedInsnSequence, mn.instructions);
     }
 
+    @Test
+    public void addsPopsForReferenceReturnType(){
+        int[] originalInsnSequence = {ACONST_NULL, DUP, DUP, DUP, ARETURN};
+        MethodNode mn = basicMethodFromSequence(Type.OBJECT, originalInsnSequence, 4);
 
-    public MethodNode buildMethodNode(Type type) {
-        String desc = "";
-        desc = "()" + type.getDescriptor();
-        MethodNode mn = new MethodNode(Opcodes.ASM9, ACC_PUBLIC, "myMethod", desc, null, null);
+        ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
+        int[] expectedInsnSequence = {ACONST_NULL, DUP, DUP, DUP, ASTORE, POP, POP, POP, ALOAD, ARETURN};
+        assertInsnSequence(expectedInsnSequence, mn.instructions);
+    }
+
+    @Test
+    public void handlesMultipleReturns(){
+        //This Insn List is more complicated, so we have to build it directly here
+        InsnList insns = new InsnList();
+        insns.add(new InsnNode(ICONST_1));
+        insns.add(new InsnNode(DUP));
+        LabelNode label = new LabelNode();
+        insns.add(new JumpInsnNode(IFEQ, label));
+        insns.add(new InsnNode(IRETURN));
+        insns.add(label);
+        insns.add(new InsnNode(DUP));
+        insns.add(new InsnNode(IRETURN));
+        MethodNode mn = buildMethodNode(Type.INT);
+        mn.instructions.add(insns);
+        mn.maxLocals = 1;
+        mn.maxStack = 2;
+
+        ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
+        int[] expectedInsns = {ICONST_1, DUP, IFEQ, IRETURN, -1, DUP, ISTORE, POP, ILOAD, IRETURN};
+        assertInsnSequence(expectedInsns, mn.instructions);
+    }
+
+    @Test
+    public void failedAnalyzerDoesNothing() {
+        //these instructions are bad and will fail the analyzer - we shouldn't touch them.
+        int[] originalInsns = {ICONST_1, POP, POP, IRETURN};
+        MethodNode mn = basicMethodFromSequence(Type.INT, originalInsns, 1);
+        ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
+        assertInsnSequence(originalInsns, mn.instructions);
+    }
+
+    private void assertInsnSequence( int[] expectedSequence, InsnList insns) {
+        Iterator<AbstractInsnNode> it = insns.iterator();
+        int i = 0;
+        while (it.hasNext()) {
+            AbstractInsnNode insn = it.next();
+            int expectedOpcode = expectedSequence[i];
+            assertEquals(expectedOpcode, insn.getOpcode());
+            i++;
+        }
+    }
+
+    private MethodNode basicMethodFromSequence(int type, int[] insnSequence, int maxStack) {
+        MethodNode mn = buildMethodNode(type);
+        for(int opcode: insnSequence){
+            mn.instructions.add(new InsnNode(opcode));
+        }
+        mn.maxStack = maxStack;
+        mn.maxLocals = 1;
         return mn;
     }
 
-    private void buildOneUntidyReturn(MethodNode mn) {
-        //Java compilers will resist untidy return stacks.
-        //But we can generate unnecessary bytecode using ASM if we want to!
-        InsnList insns = new InsnList();
-        //setup insns
-        insns.add(new LabelNode());
-        insns.add(new InsnNode(Opcodes.DCONST_1));
-        insns.add(new VarInsnNode(Opcodes.DSTORE, 1));
-        insns.add(new InsnNode(Opcodes.DCONST_0));
-        insns.add(new InsnNode(Opcodes.DUP2));
-        insns.add(new InsnNode(Opcodes.DRETURN));
-
-        mn.instructions.add(insns);
-        mn.maxLocals += 4;
-        mn.maxStack += 4;
+    public MethodNode buildMethodNode(int type) {
+        String desc = "";
+        switch (type) {
+            case Type.INT:
+                desc = "()I";
+                break;
+            case Type.OBJECT:
+                desc = "()L";
+                break;
+            default:
+                fail();
+        }
+        MethodNode mn = new MethodNode(Opcodes.ASM9, ACC_PUBLIC, "myMethod", desc, null, null);
+        return mn;
     }
-
-    private void buildOneTidyReturn(MethodNode mn) {
-        InsnList insns = new InsnList();
-        //setup insns
-        insns.add(new InsnNode(Opcodes.ICONST_3));
-        insns.add(new VarInsnNode(Opcodes.ISTORE, 1));
-        insns.add(new InsnNode(Opcodes.ICONST_4));
-        insns.add(new InsnNode(Opcodes.IRETURN));
-
-        mn.instructions.add(insns);
-    }
-
-
-
-
 }

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
@@ -1,3 +1,10 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.weave.utils;
 
 import org.junit.Test;

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
@@ -1,6 +1,5 @@
 package com.newrelic.weave.utils;
 
-import net.bytebuddy.asm.Advice;
 import org.junit.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/ReturnInsnProcessorTest.java
@@ -1,7 +1,74 @@
 package com.newrelic.weave.utils;
 
+import com.sun.org.apache.bcel.internal.generic.ALOAD;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+
 import static org.junit.Assert.*;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Type.DOUBLE_TYPE;
+import static org.objectweb.asm.Type.INT_TYPE;
 
 public class ReturnInsnProcessorTest {
+
+
+
+    //the nodes in here need to be constructed by hand since Java compilers don't have this issue
+
+    @Test
+    public void singleReturnStackClears() {
+       MethodNode mn = buildMethodNode(INT_TYPE);
+       buildOneUntidyReturn(mn);
+       WeaveUtils.printAllInstructions(mn);
+
+       ReturnInsnProcessor.clearReturnStacks("MyClazz", mn);
+       WeaveUtils.printAllInstructions(mn);
+    }
+
+    @Test
+    public void stackAlreadyClearDoesNothing() {
+
+    }
+
+
+    public MethodNode buildMethodNode(Type type) {
+        String desc = "";
+        desc = "()" + type.getDescriptor();
+        MethodNode mn = new MethodNode(Opcodes.ASM9, ACC_PUBLIC, "myMethod", desc, null, null);
+        return mn;
+    }
+
+    private void buildOneUntidyReturn(MethodNode mn) {
+        //Java compilers will resist untidy return stacks.
+        //But we can generate unnecessary bytecode using ASM if we want to!
+        InsnList insns = new InsnList();
+        //setup insns
+        insns.add(new LabelNode());
+        insns.add(new InsnNode(Opcodes.DCONST_1));
+        insns.add(new VarInsnNode(Opcodes.DSTORE, 1));
+        insns.add(new InsnNode(Opcodes.DCONST_0));
+        insns.add(new InsnNode(Opcodes.DUP2));
+        insns.add(new InsnNode(Opcodes.DRETURN));
+
+        mn.instructions.add(insns);
+        mn.maxLocals += 4;
+        mn.maxStack += 4;
+    }
+
+    private void buildOneTidyReturn(MethodNode mn) {
+        InsnList insns = new InsnList();
+        //setup insns
+        insns.add(new InsnNode(Opcodes.ICONST_3));
+        insns.add(new VarInsnNode(Opcodes.ISTORE, 1));
+        insns.add(new InsnNode(Opcodes.ICONST_4));
+        insns.add(new InsnNode(Opcodes.IRETURN));
+
+        mn.instructions.add(insns);
+    }
+
+
+
 
 }

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/WeaveUtilsTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/WeaveUtilsTest.java
@@ -21,6 +21,12 @@ import java.io.PrintStream;
 
 import org.objectweb.asm.Opcodes;
 
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.ICONST_1;
+import static org.objectweb.asm.Opcodes.ICONST_2;
+import static org.objectweb.asm.Opcodes.IRETURN;
+import static org.objectweb.asm.Opcodes.POP;
+
 public class WeaveUtilsTest {
 
     @Test
@@ -69,16 +75,16 @@ public class WeaveUtilsTest {
     }
 
     @Test
-    public void testPrintAllInstructions(){
+    public void testPrintAllInstructions() {
         //intercept std out
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         PrintStream originalOut = System.out;
         System.setOut(new PrintStream(outContent));
 
-        int[] opcodeList = {Opcodes.ICONST_1, Opcodes.POP, Opcodes.ICONST_2, Opcodes.DUP, Opcodes.DUP, Opcodes.IRETURN};
+        int[] opcodeList = { ICONST_1, POP, ICONST_2, DUP, DUP, IRETURN };
         MethodNode mn = new MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC, "myMethod", "()I", null, null);
         InsnList insns = mn.instructions;
-        for (int opcode: opcodeList) {
+        for (int opcode : opcodeList) {
             insns.add(new InsnNode(opcode));
         }
         WeaveUtils.printAllInstructions(mn);

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/utils/WeaveUtilsTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/utils/WeaveUtilsTest.java
@@ -11,9 +11,15 @@ import com.newrelic.weave.WeaveTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodNode;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+
+import org.objectweb.asm.Opcodes;
 
 public class WeaveUtilsTest {
 
@@ -62,4 +68,26 @@ public class WeaveUtilsTest {
         Assert.assertFalse(WeaveUtils.isEmptyConstructor(generatedNonEmptyInnerCtor));
     }
 
+    @Test
+    public void testPrintAllInstructions(){
+        //intercept std out
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(outContent));
+
+        int[] opcodeList = {Opcodes.ICONST_1, Opcodes.POP, Opcodes.ICONST_2, Opcodes.DUP, Opcodes.DUP, Opcodes.IRETURN};
+        MethodNode mn = new MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC, "myMethod", "()I", null, null);
+        InsnList insns = mn.instructions;
+        for (int opcode: opcodeList) {
+            insns.add(new InsnNode(opcode));
+        }
+        WeaveUtils.printAllInstructions(mn);
+
+        String actual = outContent.toString().trim().replaceAll("\\s+", " ");
+        String expected = "ICONST_1 POP ICONST_2 DUP DUP IRETURN";
+        Assert.assertEquals(expected, actual);
+
+        //replace std out
+        System.setOut(originalOut);
+    }
 }

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
@@ -32,6 +32,12 @@ fun doNoSuspends() = runBlocking {
     }
 }
 
+fun doExpectedErrorSuspend() = runBlocking {
+    launch {
+        doWorld();
+    }
+}
+
 fun doNestedSuspends() = runBlocking{
     launch {
         nested()

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
@@ -1,6 +1,16 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.weave.weavepackage.testclasses
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
+
 
 fun doOneSuspend() = runBlocking{
     launch {

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
@@ -1,0 +1,32 @@
+package com.newrelic.weave.weavepackage.testclasses
+
+import kotlinx.coroutines.*
+
+fun doOneSuspend() = runBlocking{
+    launch {
+        doWorld();
+    }
+}
+
+fun doThreeSuspends() = runBlocking {
+    launch {
+        doWorld();
+        doWorld();
+        doWorld();
+    }
+}
+
+fun doNoSuspends() = runBlocking {
+    launch {
+        doOtherWorld();
+    }
+}
+
+suspend fun doWorld() {
+    println("World!")
+}
+
+fun doOtherWorld() {
+    print("Non-suspending world!")
+}
+

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/SampleCoroutine.kt
@@ -22,11 +22,21 @@ fun doNoSuspends() = runBlocking {
     }
 }
 
+fun doNestedSuspends() = runBlocking{
+    launch {
+        nested()
+    }
+}
 suspend fun doWorld() {
     println("World!")
 }
 
 fun doOtherWorld() {
     print("Non-suspending world!")
+}
+
+suspend fun nested(){
+    delay(1000L)
+    doWorld()
 }
 

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/Weave_SampleCoroutine.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/Weave_SampleCoroutine.java
@@ -1,3 +1,10 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.weave.weavepackage.testclasses;
 
 import com.newrelic.api.agent.weaver.MatchType;

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/Weave_SampleCoroutine.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/testclasses/Weave_SampleCoroutine.java
@@ -1,0 +1,12 @@
+package com.newrelic.weave.weavepackage.testclasses;
+
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+
+@Weave(type = MatchType.BaseClass, originalName = "kotlin.coroutines.jvm.internal.BaseContinuationImpl")
+class Weave_SampleCoroutine {
+    public Object invokeSuspend(Object obj) {
+        return Weaver.callOriginal();
+    }
+}


### PR DESCRIPTION
Resolves #2201 

## Description

This PR addresses a bug we found when attempting to weave `invokeSuspend` in Kotlin Coroutines. 

The weaver replaces RETURN instructions with GOTO instructions. This replacement can be unsafe if the operand stack prior to the RETURN instruction is not tidied up (ie, has more operands than needed to perform the return). This issue was previously unknown to us, because most compilers already clear their return stacks. However, the Kotlin compiler intentionally adds extra operands to Coroutines methods (for debugging purposes) and doesn't clean them up. 

The purpose of this PR is to check the offending method (`invokeSuspend`) and tidy up its return stacks before the return instructions are replaced with gotos.  

## Structure

Here is how a method will be processed with this fix:

1. The method is intercepted in `getInliner` of `MethodCallInlinerAdapter`. At this point, the method's bytecode has not been modified. 
2. If the method’s name is `invokeSuspend`, it is visited with a `ClearReturnAdapter`.
3. The adapter calls `ReturnInsnProcessor.clearReturnStacks()`, which :
    -  Computes the operand stacks for the entire method, locates the return instructions, and stores their stack sizes
    -  Adds a STORE - n-many POPs - LOAD sequence to the instructions list, where n is the number of pops needed to tidy the stack. To perform the STORE and LOAD, it creates a new local variable slot. 
4. Returns the method to the normal weaver execution flow. 

## Issues

One issue that I couldn't figure out how to address is how to handle failures of the frame analyzer (will leave a comment on the code). Unfortunately, the weaver can't log anything, and propagating an error upwards is also probably not feasible. That means it is currently a silent failure. 

Another issue we should take seriously whenever bytecode is being modified is thread safety. I have left several comments in the code about this. 

## Testing

New tests can be found in` ReturnInsnProcessorTest` and `WeaveCoroutineTest`. A test dependency on coroutines has been added to the weaver, because coroutines are the only known way to get the compiler to make the weird bytecode. 

## Other

Some utility methods are added to `WeaveUtils`, which I developed during the debugging of this fix and think would be helpful to keep for the future. 

## Feature Flag

I added a non-public system property to disable this feature:

`-Dnewrelic.config.class_transformer.clear_return_stacks=false`

Setting this property to false will allow the AIOOB error through as before. 