### PR TITLE
Default proxy_scheme setting to "http"

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigImpl.java
@@ -168,7 +168,7 @@ public class AgentConfigImpl extends BaseConfig implements AgentConfig {
     public static final int DEFAULT_PORT = 80;
     public static final String DEFAULT_PROXY_HOST = null;
     public static final int DEFAULT_PROXY_PORT = 8080;
-    public static final String DEFAULT_PROXY_SCHEME = null;
+    public static final String DEFAULT_PROXY_SCHEME = "http";
     public static final boolean DEFAULT_PUT_FOR_DATA_SEND_ENABLED = false;
     public static final String DEFAULT_SECURITY_POLICIES_TOKEN = "";
     public static final boolean DEFAULT_SEND_DATA_ON_EXIT = false;

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigImplTest.java
@@ -272,6 +272,21 @@ public class AgentConfigImplTest {
     }
 
     @Test
+    public void proxyScheme() {
+        Map<String, Object> localMap = new HashMap<>();
+        localMap.put(AgentConfigImpl.PROXY_SCHEME, "foo");
+        AgentConfig config = AgentConfigImpl.createAgentConfig(localMap);
+
+        assertEquals("foo", config.getProxyScheme());
+    }
+
+    @Test
+    public void proxySchemeDefault() {
+        AgentConfig config = AgentConfigImpl.createAgentConfig(new HashMap<>());
+        assertEquals(AgentConfigImpl.DEFAULT_PROXY_SCHEME, config.getProxyScheme());
+    }
+
+    @Test
     public void sendEnvironmentInfo() {
         Map<String, Object> localMap = new HashMap<>();
         localMap.put(AgentConfigImpl.SEND_ENVIRONMENT_INFO, !AgentConfigImpl.DEFAULT_SEND_ENVIRONMENT_INFO);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -59,6 +59,7 @@ public class JfrServiceTest {
         when(agentConfig.getMetricIngestUri()).thenReturn(DEFAULT_METRIC_INGEST_URI);
         when(agentConfig.getEventIngestUri()).thenReturn(DEFAULT_EVENT_INGEST_URI);
         when(agentConfig.getLicenseKey()).thenReturn("test_1234_license_key");
+        when(agentConfig.getProxyScheme()).thenReturn("http");
         when(agentConfig.getValue(eq(ThreadService.NAME_PATTERN_CFG_KEY), any(String.class)))
                 .thenReturn(ThreadNameNormalizer.DEFAULT_PATTERN);
     }
@@ -75,6 +76,7 @@ public class JfrServiceTest {
         assertEquals(DEFAULT_EVENT_INGEST_URI, daemonConfig.getEventsUri().toString());
         assertEquals(22, daemonConfig.getHarvestInterval().getSeconds());
         assertEquals(300_000, (int)daemonConfig.getQueueSize());
+        assertEquals("http", daemonConfig.getProxyScheme());
     }
 
     @Test


### PR DESCRIPTION
Resolves #2224 

Default `proxy_scheme` config setting to `http` (was previously `null`). If JFR is enabled, this will allow a proper default value to be set and sent to the underlying JFRDaemon component.

This won't effect the proxy settings in the agent itself - The proxy scheme was already being set to `http` in the underlying Apache `HttpHost` instance if the supplied scheme was null.

Update tests.