### PR TITLE
Update Create-Custom-Jar.yml with correct input

### DIFF
--- a/.github/workflows/Create-Custom-Jar.yml
+++ b/.github/workflows/Create-Custom-Jar.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set summary
         run: |
           echo "${{ inputs.description }}" >> $GITHUB_STEP_SUMMARY
-          echo "This jar was built from the ref (branch/tag/hash): ${{ inputs.ref }}." >> $GITHUB_STEP_SUMMARY
+          echo "This jar was built from the ref (branch/tag/hash): ${{ inputs.agent-ref }}." >> $GITHUB_STEP_SUMMARY
 
       - name: Capture custom jar
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # pin@v4


### PR DESCRIPTION
There was a little typo in the custom jar workflow. 

Apparently the summary step is supposed to show the input ref. But it hasn't been doing that. Oops
