### PR TITLE
Support Adding Labels to APM Forwarded Logs

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -228,6 +228,8 @@ public class MetricNames {
     public static final String SUPPORTABILITY_LOGGING_METRICS_JAVA_DISABLED = "Supportability/Logging/Metrics/Java/disabled";
     public static final String SUPPORTABILITY_LOGGING_FORWARDING_JAVA_ENABLED = "Supportability/Logging/Forwarding/Java/enabled";
     public static final String SUPPORTABILITY_LOGGING_FORWARDING_JAVA_DISABLED = "Supportability/Logging/Forwarding/Java/disabled";
+    public static final String SUPPORTABILITY_LOGGING_LABELS_JAVA_ENABLED = "Supportability/Logging/Labels/Java/enabled";
+    public static final String SUPPORTABILITY_LOGGING_LABELS_JAVA_DISABLED = "Supportability/Logging/Labels/Java/disabled";
     public static final String SUPPORTABILITY_LOGGING_LOCAL_DECORATING_JAVA_ENABLED = "Supportability/Logging/LocalDecorating/Java/enabled";
     public static final String SUPPORTABILITY_LOGGING_LOCAL_DECORATING_JAVA_DISABLED = "Supportability/Logging/LocalDecorating/Java/disabled";
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfig.java
@@ -8,6 +8,8 @@
 package com.newrelic.agent.config;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Configuration for application logging features. These settings do not pertain to agent logs.
@@ -69,4 +71,26 @@ public interface ApplicationLoggingConfig {
      * @return a list of Strings
      */
     List<String> getForwardingContextDataExclude();
+
+    /**
+     * Allow the agent to add labels to application logs.
+     *
+     * @return true if logging labels are enabled, false otherwise
+     */
+    boolean isLogLabelsEnabled();
+
+    /**
+     * Removes excluded labels from the labels map.
+     *
+     * @return a map of filtered log labels
+     */
+
+    Map<String, String> removeExcludedLogLabels(Map<String, String> labels);
+
+    /**
+     * Get the set of excluded labels.
+     *
+     * @return a Set of excluded labels
+     */
+    Set<String> getLogLabelsExcludeSet();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
@@ -131,7 +131,7 @@ public class ApplicationLoggingConfigImpl extends BaseConfig implements Applicat
 
     @Override
     public Set<String> getLogLabelsExcludeSet() {
-        return applicationLoggingForwardingConfig.getLoggingLabelsExcludes();
+        return applicationLoggingForwardingConfig.getLoggingLabelsExcludeSet();
     }
 }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
@@ -10,6 +10,7 @@ package com.newrelic.agent.config;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.newrelic.agent.config.AgentConfigImpl.APPLICATION_LOGGING;
 
@@ -24,6 +25,9 @@ import static com.newrelic.agent.config.AgentConfigImpl.APPLICATION_LOGGING;
  *     context_data:
  *       enabled: false
  *       include:
+ *       exclude:
+ *     labels:
+ *       enabled: false
  *       exclude:
  *   metrics:
  *     enabled: true
@@ -114,4 +118,20 @@ public class ApplicationLoggingConfigImpl extends BaseConfig implements Applicat
     public List<String> getForwardingContextDataExclude() {
         return applicationLoggingForwardingConfig.contextDataExclude();
     }
+
+    @Override
+    public boolean isLogLabelsEnabled() {
+        return applicationLoggingEnabled && applicationLoggingForwardingConfig.isLogLabelsEnabled();
+    }
+
+    @Override
+    public Map<String, String> removeExcludedLogLabels(Map<String, String> labels) {
+        return applicationLoggingForwardingConfig.removeExcludedLabels(labels);
+    }
+
+    @Override
+    public Set<String> getLogLabelsExcludeSet() {
+        return applicationLoggingForwardingConfig.getLoggingLabelsExcludes();
+    }
 }
+

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfig.java
@@ -85,7 +85,7 @@ public class ApplicationLoggingForwardingConfig extends BaseConfig {
         return loggingLabelsConfig.removeExcludedLabels(labels);
     }
 
-    public Set<String> getLoggingLabelsExcludes() {
+    public Set<String> getLoggingLabelsExcludeSet() {
         return loggingLabelsConfig.getExcludeSet();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingForwardingConfig.java
@@ -7,13 +7,12 @@
 
 package com.newrelic.agent.config;
 
-import com.google.common.collect.Sets;
 import com.newrelic.agent.Agent;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 
 public class ApplicationLoggingForwardingConfig extends BaseConfig {
@@ -27,6 +26,7 @@ public class ApplicationLoggingForwardingConfig extends BaseConfig {
     private final boolean enabled;
     private final int maxSamplesStored;
     private final ApplicationLoggingContextDataConfig contextDataConfig;
+    private final ApplicationLoggingLabelsConfig loggingLabelsConfig;
 
     public ApplicationLoggingForwardingConfig(Map<String, Object> props, String parentRoot, boolean highSecurity) {
         super(props, parentRoot + ROOT + ".");
@@ -34,6 +34,7 @@ public class ApplicationLoggingForwardingConfig extends BaseConfig {
         boolean storedMoreThan0 = maxSamplesStored > 0;
         enabled = storedMoreThan0 && !highSecurity && getProperty(ENABLED, DEFAULT_ENABLED);
         contextDataConfig = createContextDataConfig(highSecurity);
+        loggingLabelsConfig = createLoggingLabelsConfig();
     }
 
     private int initMaxSamplesStored() {
@@ -49,6 +50,11 @@ public class ApplicationLoggingForwardingConfig extends BaseConfig {
     private ApplicationLoggingContextDataConfig createContextDataConfig(boolean highSecurity) {
         Map<String, Object> contextDataProps = getProperty(ApplicationLoggingContextDataConfig.ROOT, Collections.emptyMap());
         return new ApplicationLoggingContextDataConfig(contextDataProps, systemPropertyPrefix, highSecurity);
+    }
+
+    private ApplicationLoggingLabelsConfig createLoggingLabelsConfig() {
+        Map<String, Object> labelsProps = getProperty(ApplicationLoggingLabelsConfig.ROOT, Collections.emptyMap());
+        return new ApplicationLoggingLabelsConfig(labelsProps, systemPropertyPrefix);
     }
 
     public boolean getEnabled() {
@@ -69,5 +75,17 @@ public class ApplicationLoggingForwardingConfig extends BaseConfig {
 
     public List<String> contextDataExclude() {
         return contextDataConfig.getExclude();
+    }
+
+    public boolean isLogLabelsEnabled() {
+        return enabled && loggingLabelsConfig.getEnabled();
+    }
+
+    public Map<String, String> removeExcludedLabels(Map<String, String> labels) {
+        return loggingLabelsConfig.removeExcludedLabels(labels);
+    }
+
+    public Set<String> getLoggingLabelsExcludes() {
+        return loggingLabelsConfig.getExcludeSet();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfig.java
@@ -1,0 +1,59 @@
+package com.newrelic.agent.config;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ApplicationLoggingLabelsConfig extends BaseConfig {
+    public static final String ROOT = "labels";
+    public static final String ENABLED = "enabled";
+    public static final String EXCLUDE = "exclude";
+
+    private final boolean enabled;
+    private final Set<String> excludeSet;
+
+    /**
+     * Constructor to initialize LogLabelsConfig from configuration properties.
+     *
+     * @param props Map containing configuration properties.
+     */
+    public ApplicationLoggingLabelsConfig(Map<String, Object> props, String parentRoot) {
+        super(props, parentRoot + ROOT + ".");
+        enabled = props.containsKey(ENABLED) && (boolean) props.get(ENABLED);
+        excludeSet = initExcludes(props);
+    }
+
+    private Set<String> initExcludes(Map<String, Object> props) {
+        List<String> excludeList = (List<String>) props.getOrDefault(EXCLUDE, Collections.emptyList());
+        if (excludeList == null) {
+            return Collections.emptySet();
+        }
+        Set<String> excludeSet = new HashSet<>();
+        for (String exclude : excludeList) {
+            String trimmedExclude = exclude.trim();
+            if (!trimmedExclude.isEmpty()) {
+                excludeSet.add(trimmedExclude);
+            }
+        }
+        return excludeSet;
+    }
+
+    public boolean getEnabled() { return enabled; }
+
+    public Set<String> getExcludeSet() { return excludeSet; }
+
+    public boolean isExcluded(String label) { return getExcludeSet().contains(label); }
+
+    public Map<String, String> removeExcludedLabels(Map<String, String> labels) {
+        Map<String, String> filteredLabels = new HashMap<>();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            if (!isExcluded(entry.getKey())) {
+                filteredLabels.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return filteredLabels;
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfig.java
@@ -1,6 +1,12 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.agent.config;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfig.java
@@ -13,6 +13,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Configuration class for adding tags to application logs.
+ * <p>
+ * This class is used to parse configuration properties, applying tag exclusions
+ * and managing feature enablement.
+ */
+
 public class ApplicationLoggingLabelsConfig extends BaseConfig {
     public static final String ROOT = "labels";
     public static final String ENABLED = "enabled";

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
@@ -2,7 +2,9 @@ package com.newrelic.agent.config;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
@@ -27,6 +29,21 @@ public class ApplicationLoggingLabelsConfigTest {
         Map<String, Object> props = new HashMap<>();
         ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT + LABELS);
         assertFalse(config.getEnabled());
+    }
+
+    @Test
+    public void testLabelsExcludeConfig() {
+        Map<String, Object> props = new HashMap<>();
+        List<String> exclude = new ArrayList<>();
+        exclude.add("test1");
+        exclude.add("test2");
+        props.put("exclude", exclude);
+
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT + LABELS);
+
+        assertTrue(config.isExcluded("test1"));
+        assertTrue(config.isExcluded("test2"));
+        assertFalse(config.isExcluded("test3"));
     }
 
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
@@ -46,4 +46,15 @@ public class ApplicationLoggingLabelsConfigTest {
         assertFalse(config.isExcluded("test3"));
     }
 
+    @Test
+    public void testLabelsIsDisabledByDefault() {
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(new HashMap<>(), PARENT_ROOT + LABELS);
+        assertFalse( "Labels should set to false by default", config.getEnabled());
+    }
+
+    @Test
+    public void testLabelsExcludeDefaultsToEmptySet() {
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(new HashMap<>(), PARENT_ROOT + LABELS);
+        assertTrue("Excluded set should be empty by default", config.getExcludeSet().isEmpty());
+    }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
@@ -1,0 +1,32 @@
+package com.newrelic.agent.config;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ApplicationLoggingLabelsConfigTest {
+
+    private static final String PARENT_ROOT = "newrelic.config.application_logging.forwarding.labels.";
+    private static final String LABELS = "labels";
+
+    @Test
+    public void testApplicationLoggingLabelsConfigEnabled() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("enabled", true);
+
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT + LABELS);
+        assertTrue(config.getEnabled());
+    }
+
+    @Test
+    public void testLabelCOnfigDisabledByDefault() {
+        Map<String, Object> props = new HashMap<>();
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT + LABELS);
+        assertFalse(config.getEnabled());
+    }
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ApplicationLoggingLabelsConfigTest.java
@@ -1,60 +1,246 @@
 package com.newrelic.agent.config;
 
+import com.newrelic.agent.SaveSystemPropertyProviderRule;
+import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.Properties;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ApplicationLoggingLabelsConfigTest {
 
-    private static final String PARENT_ROOT = "newrelic.config.application_logging.forwarding.labels.";
-    private static final String LABELS = "labels";
+    @Rule
+    public SaveSystemPropertyProviderRule saveSystemPropertyProviderRule = new SaveSystemPropertyProviderRule();
+
+    public static final String ENV_VAR_ENABLE = "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED";
+    public static final String ENV_VAR_EXCLUDE = "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE";
+    private static final String PARENT_ROOT = "newrelic.config.application_logging.";
 
     @Test
-    public void testApplicationLoggingLabelsConfigEnabled() {
+    public void testDefaultLabelsConfig() {
         Map<String, Object> props = new HashMap<>();
-        props.put("enabled", true);
 
-        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT + LABELS);
-        assertTrue(config.getEnabled());
+        ApplicationLoggingLabelsConfig labelsConfig = new ApplicationLoggingLabelsConfig(props, ApplicationLoggingConfigImpl.SYSTEM_PROPERTY_ROOT);
+
+        assertFalse(labelsConfig.getEnabled());
+        assertTrue(labelsConfig.getExcludeSet().isEmpty());
     }
 
     @Test
-    public void testLabelCOnfigDisabledByDefault() {
-        Map<String, Object> props = new HashMap<>();
-        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT + LABELS);
-        assertFalse(config.getEnabled());
+    public void testSettingExcludeViaSystemProps() {
+        Properties props = new Properties();
+        props.put("newrelic.config.application_logging.forwarding.labels.exclude", "test1, test2");
+
+        SystemPropertyFactory.setSystemPropertyProvider(
+                new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(props), //only test the system property
+                        new SaveSystemPropertyProviderRule.TestEnvironmentFacade()));
+
+        ApplicationLoggingForwardingConfig config = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
+
+        assertTrue(config.getLoggingLabelsExcludeSet().contains("test1"));
+        assertTrue(config.getLoggingLabelsExcludeSet().contains("test2"));
+        assertFalse(config.getLoggingLabelsExcludeSet().contains("test3"));
     }
 
     @Test
-    public void testLabelsExcludeConfig() {
-        Map<String, Object> props = new HashMap<>();
-        List<String> exclude = new ArrayList<>();
-        exclude.add("test1");
-        exclude.add("test2");
-        props.put("exclude", exclude);
+    public void testSettingExcludesViaEnvVars() {
+        Map<String, String> envVars = Collections.singletonMap(ENV_VAR_EXCLUDE, "test1,test2");
 
-        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT + LABELS);
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(envVars)));
 
-        assertTrue(config.isExcluded("test1"));
-        assertTrue(config.isExcluded("test2"));
-        assertFalse(config.isExcluded("test3"));
-    }
+        ApplicationLoggingForwardingConfig config = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
 
-    @Test
-    public void testLabelsIsDisabledByDefault() {
-        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(new HashMap<>(), PARENT_ROOT + LABELS);
-        assertFalse( "Labels should set to false by default", config.getEnabled());
+        assertTrue(config.getLoggingLabelsExcludeSet().contains("test1"));
+        assertTrue(config.getLoggingLabelsExcludeSet().contains("test2"));
+        assertFalse(config.getLoggingLabelsExcludeSet().contains("test3"));
     }
 
     @Test
     public void testLabelsExcludeDefaultsToEmptySet() {
-        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(new HashMap<>(), PARENT_ROOT + LABELS);
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(new HashMap<>(), PARENT_ROOT);
         assertTrue("Excluded set should be empty by default", config.getExcludeSet().isEmpty());
     }
+
+    @Test
+    public void canEnableLabelsViaSystemProperty() {
+        Properties props = new Properties();
+        props.put(PARENT_ROOT + "forwarding.labels.enabled", "true");
+
+        SystemPropertyFactory.setSystemPropertyProvider(
+                new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(props), //only test the system property
+                        new SaveSystemPropertyProviderRule.TestEnvironmentFacade()));
+
+        ApplicationLoggingForwardingConfig forwardingConfig = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
+        assertTrue(forwardingConfig.isLogLabelsEnabled());
+    }
+
+    @Test
+    public void canDisableLabelsViaSystemProperty() {
+        Properties props = new Properties();
+        props.put(PARENT_ROOT + "forwarding.labels.enabled", "false");
+
+        SystemPropertyFactory.setSystemPropertyProvider(
+                new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(props), //only test the system property
+                        new SaveSystemPropertyProviderRule.TestEnvironmentFacade()));
+
+        ApplicationLoggingForwardingConfig forwardingConfig = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
+        assertFalse(forwardingConfig.isLogLabelsEnabled());
+    }
+
+    @Test
+    public void canEnableViaEnvironmentVariables() {
+        Map<String, String> envVars = Collections.singletonMap(ENV_VAR_ENABLE, "true");
+
+        //default labels is false
+        SystemPropertyFactory.setSystemPropertyProvider(
+                new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(), //only test the system property
+                        new SaveSystemPropertyProviderRule.TestEnvironmentFacade(envVars)));
+
+        ApplicationLoggingForwardingConfig forwardingConfig = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
+        assertTrue(forwardingConfig.isLogLabelsEnabled());
+    }
+
+    @Test
+    public void canDisableViaEnvironmentVariables() {
+        Map<String, String> envVars = Collections.singletonMap(ENV_VAR_ENABLE, "false");
+
+        //default labels is false
+        SystemPropertyFactory.setSystemPropertyProvider(
+                new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(), //only test the system property
+                        new SaveSystemPropertyProviderRule.TestEnvironmentFacade(envVars)));
+
+        ApplicationLoggingForwardingConfig forwardingConfig = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
+        assertFalse(forwardingConfig.isLogLabelsEnabled());
+    }
+
+    @Test
+    public void canEnableLabelsViaEnvVarsOverSysProps() {
+        Map<String, String> envVars = Collections.singletonMap(ENV_VAR_ENABLE, "true");
+        Properties props = new Properties();
+        props.put(PARENT_ROOT + "forwarding.labels.enabled", "false");
+
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(props),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(envVars)));
+
+        ApplicationLoggingForwardingConfig forwardingConfig = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
+        assertTrue(forwardingConfig.isLogLabelsEnabled());
+    }
+
+    @Test
+    public void canDisableLabelsViaEnvVarsOverSysProps() {
+        Map<String, String> envVars = Collections.singletonMap(ENV_VAR_ENABLE, "false");
+        Properties props = new Properties();
+        props.put(PARENT_ROOT + "forwarding.labels.enabled", "true");
+
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(new SaveSystemPropertyProviderRule.TestSystemProps(props),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(envVars)));
+
+        ApplicationLoggingForwardingConfig forwardingConfig = new ApplicationLoggingForwardingConfig(Collections.emptyMap(), PARENT_ROOT, false);
+        assertFalse(forwardingConfig.isLogLabelsEnabled());
+    }
+
+    @Test
+    public void testInitExcludesFromList() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("exclude", Arrays.asList("exclude1", "exclude2", "exclude3"));
+
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT);
+        Set<String> excludeSet = config.getExcludeSet();
+
+        assertEquals(3, excludeSet.size());
+        assertTrue(excludeSet.contains("exclude1"));
+        assertTrue(excludeSet.contains("exclude2"));
+        assertTrue(excludeSet.contains("exclude3"));
+    }
+
+    @Test
+    public void testInitExcludesFromCommaSeparatedString() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("exclude", "exclude1, exclude2, exclude3");
+
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT);
+        Set<String> excludeSet = config.getExcludeSet();
+
+        assertEquals(3, excludeSet.size());
+        assertTrue(excludeSet.contains("exclude1"));
+        assertTrue(excludeSet.contains("exclude2"));
+        assertTrue(excludeSet.contains("exclude3"));
+    }
+
+    @Test
+    public void testInitExcludesHandlesNullsGracefully() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("exclude", null);
+
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT);
+        Set<String> excludeSet = config.getExcludeSet();
+
+        assertTrue(excludeSet.isEmpty());
+    }
+
+    @Test
+    public void testInitExcludesHandlesEmptyList() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("exclude", Collections.emptyList());
+
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT);
+        Set<String> excludeSet = config.getExcludeSet();
+
+        assertTrue(excludeSet.isEmpty());
+    }
+
+    @Test
+    public void testRemoveExcludeLabelsRemoveCorrectly() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("exclude", Arrays.asList("exclude1", "exclude2", "exclude3"));
+
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT);
+        Map<String, String> labels = new HashMap<>();
+        labels.put("exclude1", "value1");
+        labels.put("exclude2", "value2");
+        labels.put("exclude3", "value3");
+        labels.put("include1", "value1");
+        labels.put("include2", "value2");
+        labels.put("include3", "value3");
+
+        Map<String, String> filteredLabels = config.removeExcludedLabels(labels);
+
+        assertEquals(3, filteredLabels.size());
+        assertTrue(filteredLabels.containsKey("include1"));
+        assertTrue(filteredLabels.containsKey("include2"));
+        assertTrue(filteredLabels.containsKey("include3"));
+    }
+
+    @Test
+    public void testRemoveExcludedLabelsWhenNoExcludes() {
+        Map<String, Object> props = new HashMap<>();
+        ApplicationLoggingLabelsConfig config = new ApplicationLoggingLabelsConfig(props, PARENT_ROOT);
+        Map<String, String> labels = new HashMap<>();
+        labels.put("exclude1", "value1");
+        labels.put("exclude2", "value2");
+        labels.put("exclude3", "value3");
+        labels.put("include1", "value1");
+        labels.put("include2", "value2");
+        labels.put("include3", "value3");
+
+        Map<String, String> filteredLabels = config.removeExcludedLabels(labels);
+
+        assertEquals(6, filteredLabels.size());
+        assertTrue(filteredLabels.containsKey("exclude1"));
+        assertTrue(filteredLabels.containsKey("exclude2"));
+        assertTrue(filteredLabels.containsKey("exclude3"));
+        assertTrue(filteredLabels.containsKey("include1"));
+        assertTrue(filteredLabels.containsKey("include2"));
+        assertTrue(filteredLabels.containsKey("include3"));
+    }
+
 }


### PR DESCRIPTION
## Overview
Allows the user to add custom tags (labels) to agent-forwarded logs. 



### Related Issue
Resolves Issue #2037 
