### PR TITLE
Add response attributes for http4s server modules

### DIFF
--- a/instrumentation/http4s-blaze-server-2.12_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
@@ -20,7 +20,7 @@ object TransactionMiddleware {
                txn <- construct(AgentBridge.getAgent.getTransaction)
                token <-  setupTxn(txn, request)
                res <- attachErrorEvent(httpApp(request), tracer, token)
-               _ <- completeTxn(tracer, token)
+               _ <- completeTxn(tracer, token, txn, res)
              } yield res
            )
 
@@ -33,7 +33,8 @@ object TransactionMiddleware {
     token
   }
 
-  private def completeTxn[F[_]:Sync](tracer: ExitTracer, token: Token): F[Unit] = construct {
+  private def completeTxn[F[_]:Sync](tracer: ExitTracer, token: Token, txn: Transaction, res: Response[F]): F[Unit] = construct {
+    txn.setWebResponse(ResponseWrapper(res))
     expireTokenIfNecessary(token)
     tracer.finish(176, null)
   }.handleErrorWith(_ => Sync[F].unit)

--- a/instrumentation/http4s-blaze-server-2.12_0.21/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
+++ b/instrumentation/http4s-blaze-server-2.12_0.21/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
@@ -1,18 +1,18 @@
 package com.nr.http4s
 
 import cats.effect.{IO, Resource}
-import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionTrace}
+import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionEvent, TransactionTrace}
 import org.http4s.Method.GET
 import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.http4s.HttpRoutes
 import org.junit.runner.RunWith
+
 import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.Executors
-
 import collection.JavaConverters._
 import org.junit.{After, Assert, Before, Test}
 
@@ -58,6 +58,8 @@ class BlazeServerBuilderTest {
     Assert.assertEquals("Trace present", 1, traces.size)
     Assert.assertEquals("Transaction name correct", Some("WebTransaction/HTTP4s/BlazeServerHandler"), webTxnName)
 
+    val txns = introspector.getTransactionEvents("WebTransaction/HTTP4s/BlazeServerHandler")
+    txns.forEach(assertWebAttributes)
   }
 
   @Test
@@ -79,4 +81,13 @@ class BlazeServerBuilderTest {
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
     introspector.getTransactionNames.asScala.flatMap(transactionName => introspector.getTransactionTracesForTransaction(transactionName).asScala)
 
+  private def assertWebAttributes(t: TransactionEvent): Unit = {
+    //original implementations of the server instrumentation did not include response attributes
+    val actualAttrs: scala.collection.mutable.Map[String, AnyRef] = t.getAttributes.asScala
+
+    val expectedReqAttrs = List("request.uri", "request.method")
+    val expectedResAttrs = List("httpResponseCode", "http.statusCode") //don't care whether we send standard or legacy, but one of these should be there
+    Assert.assertTrue("Transaction should include web request attributes", expectedReqAttrs.forall(actualAttrs.contains))
+    Assert.assertTrue("Transaction should include web response attributes", expectedResAttrs.exists(actualAttrs.contains))
+  }
 }

--- a/instrumentation/http4s-blaze-server-2.12_0.22/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
+++ b/instrumentation/http4s-blaze-server-2.12_0.22/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
@@ -1,18 +1,18 @@
 package com.nr.http4s
 
 import cats.effect.{IO, Resource}
-import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionTrace}
+import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionEvent, TransactionTrace}
 import org.http4s.Method.GET
 import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.http4s.HttpRoutes
 import org.junit.runner.RunWith
+
 import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.Executors
-
 import collection.JavaConverters._
 import org.junit.{After, Assert, Before, Test}
 
@@ -58,6 +58,8 @@ class BlazeServerBuilderTest {
     Assert.assertEquals("Trace present", 1, traces.size)
     Assert.assertEquals("Transaction name correct", Some("WebTransaction/HTTP4s/BlazeServerHandler"), webTxnName)
 
+    val txns = introspector.getTransactionEvents("WebTransaction/HTTP4s/BlazeServerHandler")
+    txns.forEach(assertWebAttributes)
   }
 
   @Test
@@ -79,4 +81,13 @@ class BlazeServerBuilderTest {
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
     introspector.getTransactionNames.asScala.flatMap(transactionName => introspector.getTransactionTracesForTransaction(transactionName).asScala)
 
+  private def assertWebAttributes(t: TransactionEvent): Unit = {
+    //original implementations of the server instrumentation did not include response attributes
+    val actualAttrs: scala.collection.mutable.Map[String, AnyRef] = t.getAttributes.asScala
+
+    val expectedReqAttrs = List("request.uri", "request.method")
+    val expectedResAttrs = List("httpResponseCode", "http.statusCode") //don't care whether we send standard or legacy, but one of these should be there
+    Assert.assertTrue("Transaction should include web request attributes", expectedReqAttrs.forall(actualAttrs.contains))
+    Assert.assertTrue("Transaction should include web response attributes", expectedResAttrs.exists(actualAttrs.contains))
+  }
 }

--- a/instrumentation/http4s-blaze-server-2.12_0.23/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
+++ b/instrumentation/http4s-blaze-server-2.12_0.23/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
@@ -1,16 +1,15 @@
 package com.nr.http4s
 
 import cats.effect.IO
-import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionTrace}
+import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionEvent, TransactionTrace}
 import org.http4s.Method.GET
 import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.http4s.HttpRoutes
 import org.junit.runner.RunWith
-
 import org.junit.{After, Assert, Before, Test}
-import collection.JavaConverters._
 
+import collection.JavaConverters._
 import java.net.URL
 import scala.io.Source
 import scala.util.Try
@@ -60,6 +59,8 @@ class BlazeServerBuilderTest {
     Assert.assertEquals("Trace present", 1, traces.size)
     Assert.assertEquals("Transaction name correct", Some("WebTransaction/HTTP4s/BlazeServerHandler"), webTxnName)
 
+    val txns = introspector.getTransactionEvents("WebTransaction/HTTP4s/BlazeServerHandler")
+    txns.forEach(assertWebAttributes)
   }
 
   @Test
@@ -81,4 +82,13 @@ class BlazeServerBuilderTest {
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
     introspector.getTransactionNames.asScala.flatMap(transactionName => introspector.getTransactionTracesForTransaction(transactionName).asScala)
 
+  private def assertWebAttributes(t: TransactionEvent): Unit = {
+    //original implementations of the server instrumentation did not include response attributes
+    val actualAttrs: scala.collection.mutable.Map[String, AnyRef] = t.getAttributes.asScala
+
+    val expectedReqAttrs = List("request.uri", "request.method")
+    val expectedResAttrs = List("httpResponseCode", "http.statusCode") //don't care whether we send standard or legacy, but one of these should be there
+    Assert.assertTrue("Transaction should include web request attributes", expectedReqAttrs.forall(actualAttrs.contains))
+    Assert.assertTrue("Transaction should include web response attributes", expectedResAttrs.exists(actualAttrs.contains))
+  }
 }

--- a/instrumentation/http4s-blaze-server-2.13_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/src/main/scala/com/nr/instrumentation/http4s/TransactionMiddleware.scala
@@ -20,7 +20,7 @@ object TransactionMiddleware {
                txn <- construct(AgentBridge.getAgent.getTransaction)
                token <-  setupTxn(txn, request)
                res <- attachErrorEvent(httpApp(request), tracer, token)
-               _ <- completeTxn(tracer, token)
+               _ <- completeTxn(tracer, token, txn, res)
              } yield res
            )
 
@@ -33,7 +33,8 @@ object TransactionMiddleware {
     token
   }
 
-  private def completeTxn[F[_]:Sync](tracer: ExitTracer, token: Token): F[Unit] = construct {
+  private def completeTxn[F[_]:Sync](tracer: ExitTracer, token: Token, txn: Transaction, res: Response[F]): F[Unit] = construct {
+    txn.setWebResponse(ResponseWrapper(res))
     expireTokenIfNecessary(token)
     tracer.finish(176, null)
   }.handleErrorWith(_ => Sync[F].unit)

--- a/instrumentation/http4s-blaze-server-2.13_0.21/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
+++ b/instrumentation/http4s-blaze-server-2.13_0.21/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
@@ -1,7 +1,7 @@
 package com.nr.http4s
 
 import cats.effect.IO
-import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionTrace}
+import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionEvent, TransactionTrace}
 import org.http4s.Method.GET
 import org.http4s.dsl.io._
 import org.http4s.implicits._
@@ -59,6 +59,8 @@ class BlazeServerBuilderTest {
     Assert.assertEquals("Trace present", 1, traces.size)
     Assert.assertEquals("Transaction name correct", Some("WebTransaction/HTTP4s/BlazeServerHandler"), webTxnName)
 
+    val txns = introspector.getTransactionEvents("WebTransaction/HTTP4s/BlazeServerHandler")
+    txns.forEach(assertWebAttributes)
   }
 
   @Test
@@ -80,4 +82,13 @@ class BlazeServerBuilderTest {
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
     introspector.getTransactionNames.asScala.flatMap(transactionName => introspector.getTransactionTracesForTransaction(transactionName).asScala)
 
+  private def assertWebAttributes(t: TransactionEvent): Unit = {
+    //original implementations of the server instrumentation did not include response attributes
+    val actualAttrs: scala.collection.mutable.Map[String, AnyRef] = t.getAttributes.asScala
+
+    val expectedReqAttrs = List("request.uri", "request.method")
+    val expectedResAttrs = List("httpResponseCode", "http.statusCode") //don't care whether we send standard or legacy, but one of these should be there
+    Assert.assertTrue("Transaction should include web request attributes", expectedReqAttrs.forall(actualAttrs.contains))
+    Assert.assertTrue("Transaction should include web response attributes", expectedResAttrs.exists(actualAttrs.contains))
+  }
 }

--- a/instrumentation/http4s-blaze-server-2.13_0.22/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
+++ b/instrumentation/http4s-blaze-server-2.13_0.22/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
@@ -1,7 +1,7 @@
 package com.nr.http4s
 
 import cats.effect.IO
-import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionTrace}
+import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionEvent, TransactionTrace}
 import org.http4s.Method.GET
 import org.http4s.dsl.io._
 import org.http4s.implicits._
@@ -59,6 +59,8 @@ class BlazeServerBuilderTest {
     Assert.assertEquals("Trace present", 1, traces.size)
     Assert.assertEquals("Transaction name correct", Some("WebTransaction/HTTP4s/BlazeServerHandler"), webTxnName)
 
+    val txns = introspector.getTransactionEvents("WebTransaction/HTTP4s/BlazeServerHandler")
+    txns.forEach(assertWebAttributes)
   }
 
   @Test
@@ -80,4 +82,13 @@ class BlazeServerBuilderTest {
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
     introspector.getTransactionNames.asScala.flatMap(transactionName => introspector.getTransactionTracesForTransaction(transactionName).asScala)
 
+  private def assertWebAttributes(t: TransactionEvent): Unit = {
+    //original implementations of the server instrumentation did not include response attributes
+    val actualAttrs: scala.collection.mutable.Map[String, AnyRef] = t.getAttributes.asScala
+
+    val expectedReqAttrs = List("request.uri", "request.method")
+    val expectedResAttrs = List("httpResponseCode", "http.statusCode") //don't care whether we send standard or legacy, but one of these should be there
+    Assert.assertTrue("Transaction should include web request attributes", expectedReqAttrs.forall(actualAttrs.contains))
+    Assert.assertTrue("Transaction should include web response attributes", expectedResAttrs.exists(actualAttrs.contains))
+  }
 }

--- a/instrumentation/http4s-blaze-server-2.13_0.23/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
+++ b/instrumentation/http4s-blaze-server-2.13_0.23/src/test/scala/com/nr/http4s/BlazeServerBuilderTest.scala
@@ -12,7 +12,6 @@ import scala.jdk.CollectionConverters._
 import org.junit.{After, Assert, Before, Test}
 
 import java.net.URL
-import java.util.Arrays
 import scala.io.Source
 import scala.util.{Try, Using}
 import scala.concurrent.Future
@@ -23,7 +22,7 @@ import java.util.concurrent.Executors
 
 @RunWith(classOf[InstrumentationTestRunner])
 @InstrumentationTestConfig(includePrefixes = Array("org.http4s", "cats.effect"))
-class BlazeServerBuilderSchmest {
+class BlazeServerBuilderTest {
 
   val blazeServer = new Http4sTestServer(HttpRoutes.of[IO] {
     case GET -> Root / "hello" / name =>

--- a/instrumentation/http4s-ember-server-2.12_0.23/src/test/scala/com/nr/http4s/EmberServerBuilderTest.scala
+++ b/instrumentation/http4s-ember-server-2.12_0.23/src/test/scala/com/nr/http4s/EmberServerBuilderTest.scala
@@ -3,7 +3,7 @@ package com.nr.http4s
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.effect.unsafe.implicits.global
-import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionTrace}
+import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionEvent, TransactionTrace}
 import org.http4s.Method.GET
 import org.http4s.dsl.io._
 import org.http4s.implicits._
@@ -61,6 +61,8 @@ class EmberServerBuilderTest {
     Assert.assertEquals("Trace present", 1, traces.size)
     Assert.assertEquals("Transaction name correct", Some("WebTransaction/HTTP4s/EmberServerHandler"), webTxnName)
 
+    val txns = introspector.getTransactionEvents("WebTransaction/HTTP4s/EmberServerHandler")
+    txns.forEach(assertWebAttributes)
   }
 
   @Test
@@ -82,4 +84,13 @@ class EmberServerBuilderTest {
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
     introspector.getTransactionNames.asScala.flatMap(transactionName => introspector.getTransactionTracesForTransaction(transactionName).asScala)
 
+  private def assertWebAttributes(t: TransactionEvent): Unit = {
+    //original implementations of the server instrumentation did not include response attributes
+    val actualAttrs: scala.collection.mutable.Map[String, AnyRef] = t.getAttributes.asScala
+
+    val expectedReqAttrs = List("request.uri", "request.method")
+    val expectedResAttrs = List("httpResponseCode", "http.statusCode") //don't care whether we send standard or legacy, but one of these should be there
+    Assert.assertTrue("Transaction should include web request attributes", expectedReqAttrs.forall(actualAttrs.contains))
+    Assert.assertTrue("Transaction should include web response attributes", expectedResAttrs.exists(actualAttrs.contains))
+  }
 }

--- a/instrumentation/http4s-ember-server-2.13_0.23/src/main/java/org/http4s/ember/server/EmberServerBuilder_Instrumentation.java
+++ b/instrumentation/http4s-ember-server-2.13_0.23/src/main/java/org/http4s/ember/server/EmberServerBuilder_Instrumentation.java
@@ -7,7 +7,6 @@ import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.instrumentation.http4s.TransactionMiddleware$;
 import org.http4s.Request;
 import org.http4s.Response;
-import org.http4s.ember.server.EmberServerBuilder;
 
 @Weave(originalName = "org.http4s.ember.server.EmberServerBuilder")
 public class EmberServerBuilder_Instrumentation<F> {

--- a/instrumentation/http4s-ember-server-2.13_0.23/src/test/scala/com/nr/http4s/EmberServerBuilderTest.scala
+++ b/instrumentation/http4s-ember-server-2.13_0.23/src/test/scala/com/nr/http4s/EmberServerBuilderTest.scala
@@ -1,7 +1,7 @@
 package com.nr.http4s
 
 import cats.effect.IO
-import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionTrace}
+import com.newrelic.agent.introspec.{InstrumentationTestConfig, InstrumentationTestRunner, Introspector, TransactionEvent, TransactionTrace}
 import org.http4s.Method.GET
 import org.http4s.dsl.io._
 import org.http4s.implicits._
@@ -61,6 +61,8 @@ class EmberServerBuilderTest {
     Assert.assertEquals("Trace present", 1, traces.size)
     Assert.assertEquals("Transaction name correct", Some("WebTransaction/HTTP4s/EmberServerHandler"), webTxnName)
 
+    val txns = introspector.getTransactionEvents("WebTransaction/HTTP4s/EmberServerHandler")
+    txns.forEach(assertWebAttributes)
   }
 
   @Test
@@ -83,4 +85,13 @@ class EmberServerBuilderTest {
   private def getTraces(introspector: Introspector): Iterable[TransactionTrace] =
     introspector.getTransactionNames.asScala.flatMap(transactionName => introspector.getTransactionTracesForTransaction(transactionName).asScala)
 
+  private def assertWebAttributes(t: TransactionEvent): Unit = {
+    //original implementations of the server instrumentation did not include response attributes
+    val actualAttrs: scala.collection.mutable.Map[String, AnyRef] = t.getAttributes.asScala
+
+    val expectedReqAttrs = List("request.uri", "request.method")
+    val expectedResAttrs = List("httpResponseCode", "http.statusCode") //don't care whether we send standard or legacy, but one of these should be there
+    Assert.assertTrue("Transaction should include web request attributes", expectedReqAttrs.forall(actualAttrs.contains))
+    Assert.assertTrue("Transaction should include web response attributes", expectedResAttrs.exists(actualAttrs.contains))
+  }
 }


### PR DESCRIPTION
Resolves #2150

Our http4s modules for blaze and ember server were not setting a web response in transactions (they were only setting the request attributes). 

This PR adds a small bit of code to each of the server modules to add the response attributes. It also adds a test for these attributes to all the tests. 