### PR TITLE
Update JFR service to run as a daemon

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -16,6 +16,7 @@ import com.newrelic.agent.config.AgentConfigListener;
 import com.newrelic.agent.config.JfrConfig;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.agent.util.DefaultThreadFactory;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.jfr.ThreadNameNormalizer;
 import com.newrelic.jfr.daemon.*;
@@ -37,6 +38,8 @@ public class JfrService extends AbstractService implements AgentConfigListener {
     private final JfrConfig jfrConfig;
     private final AgentConfig defaultAgentConfig;
     private JfrController jfrController;
+
+    private final String JFR_SERVICE_THREAD_NAME = "New Relic JFR Service";
 
     public JfrService(JfrConfig jfrConfig, AgentConfig defaultAgentConfig) {
         super(JfrService.class.getSimpleName());
@@ -67,16 +70,16 @@ public class JfrService extends AbstractService implements AgentConfigListener {
                 uploader.readyToSend(new EventConverter(commonAttrs, pattern));
                 jfrController = SetupUtils.buildJfrController(daemonConfig, uploader);
 
-                ExecutorService jfrMonitorService = Executors.newSingleThreadExecutor();
+                ExecutorService jfrMonitorService = Executors.newSingleThreadExecutor(new DefaultThreadFactory(JFR_SERVICE_THREAD_NAME, true));
                 jfrMonitorService.submit(
-                    () -> {
-                        try {
-                            startJfrLoop();
-                        } catch (JfrRecorderException e) {
-                            Agent.LOG.log(Level.INFO, "Error in JFR Monitor, shutting down", e);
-                            jfrController.shutdown();
-                        }
-                    });
+                        () -> {
+                            try {
+                                startJfrLoop();
+                            } catch (JfrRecorderException e) {
+                                Agent.LOG.log(Level.INFO, "Error in JFR Monitor, shutting down", e);
+                                jfrController.shutdown();
+                            }
+                        });
             } catch (Throwable t) {
                 Agent.LOG.log(Level.INFO, "Unable to attach JFR Monitor", t);
             }


### PR DESCRIPTION
Resolves #2205 

We heard from a customer that their Tomcat process wasn't terminating when they ran the agent with JFR turned on. 

Turns out that although the external JFR *Controller* (responsible for sending JFR data) [runs on daemon threads](https://github.com/newrelic/newrelic-jfr-core/blob/6225c7ed6babfcccf72f67ac513ee7253814ee08/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JfrController.java#L33), the JFR *Service* inside the agent (responsible for turning the controller on and off) does not. So the JFR Service kept the JVM alive.

This PR makes the JFR Service use a daemon thread for its lifecycle like the rest of our services.