### PR TITLE
Rename and reenable aws sqs modules

### DIFF
--- a/instrumentation/aws-java-sdk-sqs-1.10.44/build.gradle
+++ b/instrumentation/aws-java-sdk-sqs-1.10.44/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-java-sdk-sqs-spans-1.10.44', 'Enabled': 'false',
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-java-sdk-sqs-1.10.44',
             'Implementation-Title-Alias': 'aws-java-sdk-sqs'  }
 }
 

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-java-sdk-sqs-spans-2.1.0', 'Enabled': 'false',
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-java-sdk-sqs-2.1.0',
             'Implementation-Title-Alias': 'aws-java-sdk-sqs'  }
 }
 


### PR DESCRIPTION
Remove "Enabled": false from the sqs modules. 

This was accidentally introduced in v8.18. 
