### PR TITLE
Add support for server-side application logging configs

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
@@ -57,8 +57,14 @@ public class AgentConfigFactory {
     public static final String COLLECT_CUSTOM_INSIGHTS_EVENTS = CUSTOM_INSIGHT_EVENTS_PREFIX + InsightsConfigImpl.COLLECT_CUSTOM_EVENTS;
     public static final String RECORD_SQL = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.RECORD_SQL;
     public static final String APPLICATION_LOGGING_ENABLED =  AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR + ApplicationLoggingConfigImpl.ENABLED;
-    public static final String APPLICATION_LOGGING_MAX_SAMPLES_STORED = AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR +
+    public static final String APPLICATION_LOGGING_FORWARDING_ENABLED = AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR +
+            ApplicationLoggingConfigImpl.FORWARDING + DOT_SEPARATOR + ApplicationLoggingForwardingConfig.ENABLED;
+    public static final String APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED = AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR +
             ApplicationLoggingConfigImpl.FORWARDING + DOT_SEPARATOR + ApplicationLoggingForwardingConfig.MAX_SAMPLES_STORED;
+    public static final String APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED = AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR +
+            ApplicationLoggingConfigImpl.LOCAL_DECORATING + DOT_SEPARATOR + ApplicationLoggingForwardingConfig.ENABLED;
+    public static final String APPLICATION_LOGGING_METRICS_ENABLED = AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR +
+            ApplicationLoggingConfigImpl.METRICS + DOT_SEPARATOR + ApplicationLoggingForwardingConfig.ENABLED;
     @Deprecated
     public static final String SLOW_QUERY_WHITELIST = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.SLOW_QUERY_WHITELIST;
     public static final String COLLECT_SLOW_QUERIES_FROM = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM;
@@ -212,8 +218,13 @@ public class AgentConfigFactory {
         addServerProp(DistributedTracingConfig.ACCOUNT_ID, serverData.get(DistributedTracingConfig.ACCOUNT_ID), settings);
         addServerProp("agent_home", ConfigFileHelper.getNewRelicDirectory().getAbsolutePath(), settings);
 
-        addServerProp(APPLICATION_LOGGING_MAX_SAMPLES_STORED, agentData.get(APPLICATION_LOGGING_MAX_SAMPLES_STORED), settings);
+        // Application logging
         addServerProp(APPLICATION_LOGGING_ENABLED, agentData.get(APPLICATION_LOGGING_ENABLED), settings);
+        addServerProp(APPLICATION_LOGGING_FORWARDING_ENABLED, agentData.get(APPLICATION_LOGGING_FORWARDING_ENABLED), settings);
+        addServerProp(APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED, agentData.get(APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED), settings);
+        addServerProp(APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED, agentData.get(APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED), settings);
+        addServerProp(APPLICATION_LOGGING_METRICS_ENABLED, agentData.get(APPLICATION_LOGGING_METRICS_ENABLED), settings);
+
         if (AgentJarHelper.getAgentJarDirectory() != null) {
             addServerProp("agent_jar_location", AgentJarHelper.getAgentJarDirectory().getAbsolutePath(), settings);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
@@ -56,6 +56,9 @@ public class AgentConfigFactory {
     public static final String COLLECT_SPAN_EVENTS = SPAN_EVENTS_PREFIX + SpanEventsConfig.COLLECT_SPAN_EVENTS;
     public static final String COLLECT_CUSTOM_INSIGHTS_EVENTS = CUSTOM_INSIGHT_EVENTS_PREFIX + InsightsConfigImpl.COLLECT_CUSTOM_EVENTS;
     public static final String RECORD_SQL = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.RECORD_SQL;
+    public static final String APPLICATION_LOGGING_ENABLED =  AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR + ApplicationLoggingConfigImpl.ENABLED;
+    public static final String APPLICATION_LOGGING_MAX_SAMPLES_STORED = AgentConfigImpl.APPLICATION_LOGGING + DOT_SEPARATOR +
+            ApplicationLoggingConfigImpl.FORWARDING + DOT_SEPARATOR + ApplicationLoggingForwardingConfig.MAX_SAMPLES_STORED;
     @Deprecated
     public static final String SLOW_QUERY_WHITELIST = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.SLOW_QUERY_WHITELIST;
     public static final String COLLECT_SLOW_QUERIES_FROM = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.COLLECT_SLOW_QUERIES_FROM;
@@ -208,6 +211,9 @@ public class AgentConfigFactory {
         addServerProp(ConnectionResponse.AGENT_RUN_ID_KEY, serverData.get(ConnectionResponse.AGENT_RUN_ID_KEY), settings);
         addServerProp(DistributedTracingConfig.ACCOUNT_ID, serverData.get(DistributedTracingConfig.ACCOUNT_ID), settings);
         addServerProp("agent_home", ConfigFileHelper.getNewRelicDirectory().getAbsolutePath(), settings);
+
+        addServerProp(APPLICATION_LOGGING_MAX_SAMPLES_STORED, agentData.get(APPLICATION_LOGGING_MAX_SAMPLES_STORED), settings);
+        addServerProp(APPLICATION_LOGGING_ENABLED, agentData.get(APPLICATION_LOGGING_ENABLED), settings);
         if (AgentJarHelper.getAgentJarDirectory() != null) {
             addServerProp("agent_jar_location", AgentJarHelper.getAgentJarDirectory().getAbsolutePath(), settings);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ApplicationLoggingConfigImpl.java
@@ -7,6 +7,8 @@
 
 package com.newrelic.agent.config;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +90,11 @@ public class ApplicationLoggingConfigImpl extends BaseConfig implements Applicat
     @Override
     public boolean isLocalDecoratingEnabled() {
         return applicationLoggingEnabled && applicationLoggingLocalDecoratingConfig.getEnabled();
+    }
+
+    @VisibleForTesting
+    public ApplicationLoggingLocalDecoratingConfig getLocalDecoratingConfig() {
+        return applicationLoggingLocalDecoratingConfig;
     }
 
     @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/MergeServerDataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/MergeServerDataTest.java
@@ -54,8 +54,11 @@ public class MergeServerDataTest {
                 "    \"beacon\": \"staging-bam.nr-data.net\",\n" +
                 "    \"collect_analytics_events\": true,\n" +
                 "    \"agent_config\": {\n" +
-                "      \"application_logging.forwarding.max_samples_stored\": 10001, \n" +
                 "      \"application_logging.enabled\": false, \n" +
+                "      \"application_logging.forwarding.enabled\": false, \n" +
+                "      \"application_logging.forwarding.max_samples_stored\": 10001, \n" +
+                "      \"application_logging.local_decorating.enabled\": true, \n" +
+                "      \"application_logging.metrics.enabled\": false, \n" +
                 "      \"transaction_tracer.explain_enabled\": true,\n" +
                 "      \"transaction_tracer.transaction_threshold\": 0.005,\n" +
                 "      \"transaction_tracer.enabled\": true,\n" +
@@ -110,7 +113,10 @@ public class MergeServerDataTest {
         assertEquals(false, config.isCustomInstrumentationEditorAllowed());
         assertTrue(config.getAttributesConfig().attributesRootInclude().isEmpty());
         assertEquals(true, config.getApplicationLoggingConfig().isEnabled());
+        assertEquals(true, config.getApplicationLoggingConfig().isForwardingEnabled());
         assertEquals(10000, config.getApplicationLoggingConfig().getMaxSamplesStored());
+        assertEquals(false, ((ApplicationLoggingConfigImpl)config.getApplicationLoggingConfig()).getLocalDecoratingConfig().getEnabled());
+        assertEquals(true, config.getApplicationLoggingConfig().isMetricsEnabled());
     }
 
     @Test
@@ -144,7 +150,10 @@ public class MergeServerDataTest {
         assertEquals(true, config.isCustomInstrumentationEditorAllowed());
         assertTrue(config.getAttributesConfig().attributesRootInclude().isEmpty());
         assertEquals(false, config.getApplicationLoggingConfig().isEnabled());
+        assertEquals(false, config.getApplicationLoggingConfig().isForwardingEnabled());
         assertEquals(10001, config.getApplicationLoggingConfig().getMaxSamplesStored());
+        assertEquals(true, ((ApplicationLoggingConfigImpl)config.getApplicationLoggingConfig()).getLocalDecoratingConfig().getEnabled());
+        assertEquals(false, config.getApplicationLoggingConfig().isMetricsEnabled());
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/MergeServerDataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/MergeServerDataTest.java
@@ -54,6 +54,8 @@ public class MergeServerDataTest {
                 "    \"beacon\": \"staging-bam.nr-data.net\",\n" +
                 "    \"collect_analytics_events\": true,\n" +
                 "    \"agent_config\": {\n" +
+                "      \"application_logging.forwarding.max_samples_stored\": 10001, \n" +
+                "      \"application_logging.enabled\": false, \n" +
                 "      \"transaction_tracer.explain_enabled\": true,\n" +
                 "      \"transaction_tracer.transaction_threshold\": 0.005,\n" +
                 "      \"transaction_tracer.enabled\": true,\n" +
@@ -107,6 +109,8 @@ public class MergeServerDataTest {
         assertEquals(true, config.getAttributesConfig().isEnabledRoot());
         assertEquals(false, config.isCustomInstrumentationEditorAllowed());
         assertTrue(config.getAttributesConfig().attributesRootInclude().isEmpty());
+        assertEquals(true, config.getApplicationLoggingConfig().isEnabled());
+        assertEquals(10000, config.getApplicationLoggingConfig().getMaxSamplesStored());
     }
 
     @Test
@@ -139,6 +143,8 @@ public class MergeServerDataTest {
         assertEquals(true, config.getAttributesConfig().isEnabledRoot());
         assertEquals(true, config.isCustomInstrumentationEditorAllowed());
         assertTrue(config.getAttributesConfig().attributesRootInclude().isEmpty());
+        assertEquals(false, config.getApplicationLoggingConfig().isEnabled());
+        assertEquals(10001, config.getApplicationLoggingConfig().getMaxSamplesStored());
     }
 
     @Test


### PR DESCRIPTION
### Overview
Add support for server-side configs for `application_logging.enabled` and additional logging server-side configs provided by the collector

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2174
