### PR TITLE
Refactor AWS docker id fetch

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/AwsFargateMetadataFetcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/AwsFargateMetadataFetcher.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 
 /**
  * Thin wrapper class over the JRE URL class to assist in testing
@@ -22,6 +23,10 @@ public class AwsFargateMetadataFetcher {
     }
 
     public InputStream openStream() throws IOException {
-        return (url == null ? null : url.openStream());
+        URLConnection connection = url.openConnection();
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+
+        return connection.getInputStream();
     }
 }


### PR DESCRIPTION
### Overview
Refactor the code used to fetch the AWS Fargate docker ID to use `URLConnection`, which allows a sane timeout value to be assigned for the connect sequence.

Resolves #2247
