### PR TITLE
Cap kafka-clients-metrics-3.9.0 up to 4.0.0

### DIFF
--- a/instrumentation/kafka-clients-metrics-3.9.0/build.gradle
+++ b/instrumentation/kafka-clients-metrics-3.9.0/build.gradle
@@ -12,7 +12,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.apache.kafka:kafka-clients:[3.9.0,)'
+    passesOnly 'org.apache.kafka:kafka-clients:[3.9.0,4.0.0)'
 }
 
 site {


### PR DESCRIPTION
### Overview
Cap kafka-clients-metrics-3.9.0 module to 4.0.0

