### PR TITLE
Added sampling options when an inbound traceparent exists

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/HeadersUtil.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/HeadersUtil.java
@@ -261,7 +261,7 @@ public class HeadersUtil {
             W3CTracePayload w3CTracePayload = W3CTracePayload.parseHeaders(tx, traceParent, traceState);
             if (w3CTracePayload != null) {
                 if (w3CTracePayload.getPayload() != null) {
-                    tx.acceptDistributedTracePayload(w3CTracePayload.getPayload());
+                    tx.acceptDistributedTracePayload(w3CTracePayload.getPayload(), w3CTracePayload.getTraceParent());
                 }
                 if (w3CTracePayload.getTraceParent() != null) {
                     tx.getSpanProxy().setInitiatingW3CTraceParent(w3CTracePayload.getTraceParent());

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TransactionApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TransactionApiImpl.java
@@ -509,7 +509,7 @@ public class TransactionApiImpl implements com.newrelic.agent.bridge.Transaction
     public void acceptDistributedTracePayload(DistributedTracePayload payload) {
         Transaction tx = getTransactionIfExists();
         if (tx != null) {
-            tx.acceptDistributedTracePayload(payload);
+            tx.acceptDistributedTracePayload(payload, null);
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/DistributedTracingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/DistributedTracingConfig.java
@@ -21,12 +21,20 @@ public class DistributedTracingConfig extends BaseConfig {
     public static final String DISTRIBUTED_TRACING_ENABLED = SYSTEM_PROPERTY_ROOT + ENABLED;
     public static final String ENABLED_ENV_KEY = "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED";
     public static final String EXCLUDE_NEWRELIC_HEADER = "exclude_newrelic_header";
+    public static final String SAMPLER = "sampler";
+    public static final String REMOTE_PARENT_SAMPLED = "remote_parent_sampled";
+    public static final String REMOTE_PARENT_NOT_SAMPLED = "remote_parent_not_sampled";
+    public static final String SAMPLE_ALWAYS_ON = "always_on";
+    public static final String SAMPLE_ALWAYS_OFF = "always_off";
+    public static final String SAMPLE_DEFAULT = "default";
 
     private final boolean enabled;
     private final String trustedAccountKey;
     private final String accountId;
     private final String primaryApplicationId;
     private final boolean includeNewRelicHeader;
+    private final String remoteParentSampled;
+    private final String remoteParentNotSampled;
 
     DistributedTracingConfig(Map<String, Object> props) {
         super(props, SYSTEM_PROPERTY_ROOT);
@@ -35,6 +43,10 @@ public class DistributedTracingConfig extends BaseConfig {
         this.accountId = getProperty(ACCOUNT_ID);
         this.primaryApplicationId = getProperty(PRIMARY_APPLICATION_ID);
         this.includeNewRelicHeader = !getProperty(EXCLUDE_NEWRELIC_HEADER, false);
+
+        BaseConfig samplerConfig = new BaseConfig(nestedProps(SAMPLER), SYSTEM_PROPERTY_ROOT+"."+SAMPLER);
+        this.remoteParentSampled = samplerConfig.getProperty(REMOTE_PARENT_SAMPLED, SAMPLE_DEFAULT);
+        this.remoteParentNotSampled = samplerConfig.getProperty(REMOTE_PARENT_NOT_SAMPLED, SAMPLE_DEFAULT);
     }
 
     public String getTrustedAccountKey() {
@@ -55,5 +67,13 @@ public class DistributedTracingConfig extends BaseConfig {
 
     public boolean isIncludeNewRelicHeader() {
         return includeNewRelicHeader;
+    }
+
+    public String getRemoteParentSampled() {
+        return remoteParentSampled;
+    }
+
+    public String getRemoteParentNotSampled() {
+        return remoteParentNotSampled;
     }
 }

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -311,6 +311,21 @@ common: &default_settings
     # Default is false.
     exclude_newrelic_header: false
 
+    # Agent version 8.20.0+ utilize these settings for controlling how to sample when we have a remote parent
+    # involved. That is, if there is a valid traceparent with a value in the sampled flag on the inbound headers.
+    # If the inbound traceparent is marked as sampled then the remote_parent_sampled setting will be used.
+    # If the inbound traceparent is marked as NOT sampled then the remote_parent_not_sampled setting will be used.
+    # Otherwise New Relic's standard sampling will be used.
+    # Note: Reservoir limits are still in effect on top of these settings, so spans may be dropped even if they
+    # are marked for sampling, if the reservoir reaches its limit (max_samples_stored).
+    # Possible values:
+    #   default: New Relic's standard sampling rules will be used.
+    #   always_on: Always sample spans in this case.
+    #   always_off: Always skip sampling in this case.
+    sampler:
+      remote_parent_sampled: default
+      remote_parent_not_sampled: default
+
   # New Relic's distributed tracing UI uses Span events to display traces across different services.
   # Span events capture attributes that describe execution context and provide linking metadata.
   # Span events require distributed tracing to be enabled.

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerClmTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerClmTest.java
@@ -888,7 +888,7 @@ public class DefaultTracerClmTest {
         DefaultTracer span5Tracer = new OtherRootTracer(txB, new ClassMethodSignature("class",
                 "span5", "()V"), null, DefaultTracer.NULL_METRIC_NAME_FORMATTER);
         txB.getTransactionActivity().tracerStarted(span5Tracer);
-        span5Tracer.getTransaction().acceptDistributedTracePayload(payload);
+        span5Tracer.getTransaction().acceptDistributedTracePayload(payload, null);
 
         txB.setTransactionName(com.newrelic.api.agent.TransactionNamePriority.CUSTOM_HIGH, true, "Transaction B");
         txB.setThrowable(new Throwable(), TransactionErrorPriority.API, false);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultTracerTest.java
@@ -924,7 +924,7 @@ public class DefaultTracerTest {
         DefaultTracer span5Tracer = new OtherRootTracer(txB, new ClassMethodSignature("class",
                 "span5", "()V"), null, DefaultTracer.NULL_METRIC_NAME_FORMATTER);
         txB.getTransactionActivity().tracerStarted(span5Tracer);
-        span5Tracer.getTransaction().acceptDistributedTracePayload(payload);
+        span5Tracer.getTransaction().acceptDistributedTracePayload(payload, null);
 
         txB.setTransactionName(com.newrelic.api.agent.TransactionNamePriority.CUSTOM_HIGH, true, "Transaction B");
         txB.setThrowable(new Throwable(), TransactionErrorPriority.API, false);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracing/W3CTraceStateSupportTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracing/W3CTraceStateSupportTest.java
@@ -120,7 +120,7 @@ public class W3CTraceStateSupportTest extends BaseDistributedTraceTest {
                 Collections.singletonList("02-12341234123412341234123412341234-4321432143214321-01"),
                 Arrays.asList("190@nr=0-0-709288-8599547-f85f42fd82a4cf1d-164d3b4b0d09cb05164d3b4b0d09cb05---1563574856827")).getPayload();
         assertNotNull(inboundPayload);
-        transaction.acceptDistributedTracePayload(inboundPayload);
+        transaction.acceptDistributedTracePayload(inboundPayload, null);
 
         transaction.createDistributedTracePayload("meatball!");
         String[] outboundPayload = new W3CTraceStateHeader(true, true).create(transaction.getSpanProxy()).split("-");
@@ -159,7 +159,7 @@ public class W3CTraceStateSupportTest extends BaseDistributedTraceTest {
                 Arrays.asList("190@nr=0-0-709288-8599547-f85f42fd82a4cf1d-164d3b4b0d09cb05164d3b4b0d09cb05-1-0.789-1563574856827", "congo@=0-qzx932-abc123",
                         "congo@=0-very-qzx932-abc123")).getPayload();
         assertNotNull(inboundPayload);
-        transaction.acceptDistributedTracePayload(inboundPayload);
+        transaction.acceptDistributedTracePayload(inboundPayload, null);
 
         String newSpanId = TransactionGuidFactory.generate16CharGuid();
         transaction.createDistributedTracePayload(newSpanId);


### PR DESCRIPTION
New config options for how to sample when we have sampling data from an upstream entity.

Possible values:
  default: New Relic's standard sampling rules will be used.
  always_on: Always sample spans in this case.
  always_off: Always skip sampling in this case.

YML config
```
distributed_tracing:
    sampler:
      remote_parent_sampled: default
      remote_parent_not_sampled: default
```

So, setting `remote_parent_sampled` to `always_on` would tell the agent to try and always sample anything that an upstream entity told us was sampled, until the sampling reservoir is full.

Or, setting `remote_parent_not_sampled` to `always_off` would tell the agent to not bother sampling anything if the upstream entity told us that it was not sampled.