### PR TITLE
Updates to support restoring in a different environment

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
@@ -431,6 +431,9 @@ class IntrospectorServiceManager extends AbstractService implements ServiceManag
         return expirationService;
     }
 
+    @Override
+    public void refreshDataForCRaCRestore() {}
+
     private AgentConfig createAgentConfig(Map<String, Object> settings, Map<String, Object> serverData) {
         settings = new HashMap<>(settings);
         serverData = new HashMap<>(serverData);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentImpl.java
@@ -39,7 +39,6 @@ public class AgentImpl implements com.newrelic.agent.bridge.Agent, Resource {
 
     public AgentImpl(Logger logger) {
         this.logger = logger;
-        Agent.LOG.info("JGB registering with CRaC");
         Core.getGlobalContext().register(this);
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManager.java
@@ -125,4 +125,6 @@ public interface ServiceManager extends Service {
     SourceLanguageService getSourceLanguageService();
 
     ExpirationService getExpirationService();
+
+    void refreshDataForCRaCRestore();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -94,6 +94,7 @@ import com.newrelic.api.agent.NewRelic;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URL;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -684,6 +685,28 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
     @Override
     public ExpirationService getExpirationService() {
         return expirationService;
+    }
+
+    @Override
+    public synchronized void refreshDataForCRaCRestore() {
+        environmentService = new EnvironmentServiceImpl();
+
+        boolean realAgent = coreService.getInstrumentation() != null;
+        if (realAgent) {
+            try {
+                utilizationService.stop();
+            } catch (Exception e) {
+                Agent.LOG.warning(MessageFormat.format("Error stopping UtilizationService during CRaC Restore: ",e.getMessage()));
+            }
+        }
+        utilizationService = new UtilizationService();
+        if (realAgent) {
+            try {
+                utilizationService.start();
+            } catch (Exception e) {
+                Agent.LOG.warning(MessageFormat.format("Error starting UtilizationService during CRaC Restore: ",e.getMessage()));
+            }
+        }
     }
 
     private class InitialStatsService extends AbstractService implements StatsService {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheHttpClientWrapper.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/apache/ApacheHttpClientWrapper.java
@@ -274,7 +274,6 @@ public class ApacheHttpClientWrapper implements HttpClientWrapper, Resource {
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
         Agent.LOG.info("Stopping collector connection for CRaC checkpoint");
-        NewRelic.getAgent().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_AGENT_CRAC_CHECKPOINT);
         connectionManager.close();
         httpClient.close();
     }
@@ -282,7 +281,6 @@ public class ApacheHttpClientWrapper implements HttpClientWrapper, Resource {
     @Override
     public void afterRestore(Context<? extends Resource> context) throws Exception {
         Agent.LOG.info("Restarting collector connection for CRaC restore");
-        NewRelic.getAgent().getMetricAggregator().incrementCounter(MetricNames.SUPPORTABILITY_AGENT_CRAC_RESTORE);
         connectionManager = createHttpClientConnectionManager(sslContext);
         httpClient = createHttpClient(defaultTimeoutInMillis);
     }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
@@ -673,6 +673,9 @@ public class MockServiceManager extends AbstractService implements ServiceManage
         return expirationService;
     }
 
+    @Override
+    public void refreshDataForCRaCRestore() {}
+
     public void setSourceLanguageService(SourceLanguageService sourceLanguageService) {
         this.sourceLanguageService = sourceLanguageService;
     }


### PR DESCRIPTION
These updates force the RPMService to update data about the Environment and Utilization Services when a restore is performed, so that we will send up data about the (possibly) new environment, instead of the old one.

Please note: When using CRaC with the New Relic Java agent, if you move your checkpoint to a different environment, you will also need to move the New Relic JAR files that are created under the temp directory as well.

Resolves: https://github.com/newrelic/newrelic-java-agent/issues/2277