### PR TITLE
Broaden suspends fix

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/InstrumentationClassTransformer.java
@@ -149,6 +149,8 @@ public class InstrumentationClassTransformer implements ClassFileTransformer {
                                 System.nanoTime() - transformStartTimeInNs), MetricNames.SUPPORTABILITY_CLASSLOADER_TRANSFORM_TIME);
                 return transformation;
             }
+        } catch (ArrayIndexOutOfBoundsException e){
+            Agent.LOG.log(Level.FINE, e, "Unexpected ArrayIndexOutOfBoundsException thrown during class transformation. Try restarting the Java Agent with flag -Dnewrelic.config.class_transformer.clear_return_stacks=true");
         } catch (Throwable t) {
             Agent.LOG.log(Level.FINE, t, "Unexpected exception thrown in class transformer: {0}--{1}", loader, className);
         }

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -253,15 +253,6 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
         return enabled.equalsIgnoreCase("true");
     }
 
-//    /**
-//     * Feature flag to disable return stack processing.
-//     * To use this feature flag, set -Dnewrelic.config.class_transformer.clear_return_stacks=false at JVM startup.
-//     */
-//    private boolean clearReturnStacksDisabled() {
-//        String enabled = System.getProperty("newrelic.config.class_transformer.clear_return_stacks", "true");
-//        return enabled.equalsIgnoreCase("false");
-//    }
-
     /**
      * This adapter checks a method's return instructions, adding additional POPs prior to return instructions
      * if the return is made with extra (>1) operands on the stack.

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -133,7 +133,10 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
             } else {
                 // Copy the MethodNode before modifying the instructions list (which is not thread safe)
                 MethodNode methodNodeCopy = WeaveUtils.copy(method.method);
-                if (shouldClearReturnStacks(name, desc)) {
+                //Feature flag for method nodes that require additional return insn processing.
+                //Introduced because some Kotlin code throws ArrayIndexOutOfBoundsException when weaved.
+                //To enable this feature, set -Dnewrelic.config.class_transformer.clear_return_stacks=true
+                if (Boolean.getBoolean("newrelic.config.class_transformer.clear_return_stacks")) {
                     MethodNode result = WeaveUtils.newMethodNode(methodNodeCopy);
                     methodNodeCopy.accept(new ClearReturnAdapter(owner, methodNodeCopy, result));
                     methodNodeCopy = result;
@@ -237,20 +240,6 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
             // do about the same thing but a little more. anyway, the tests pass..
             return caller.newLocal(type);
         }
-    }
-
-    /**
-     * Flags method nodes requiring additional return insn processing.
-     *
-     * It returns false by default.
-     *
-     * To enable this feature, set -Dnewrelic.config.class_transformer.clear_return_stacks=true
-     * For future reference, if other code surfaces a bytecode verification failure (such as an ArrayIndexOutOfBoundsException),
-     * modify this guard to process additional methods.
-     */
-    private boolean shouldClearReturnStacks(String name, String desc) {
-        String enabled = System.getProperty("newrelic.config.class_transformer.clear_return_stacks", "false");
-        return enabled.equalsIgnoreCase("true");
     }
 
     /**

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/MethodCallInlinerAdapter.java
@@ -240,27 +240,27 @@ public abstract class MethodCallInlinerAdapter extends LocalVariablesSorter {
     }
 
     /**
-     * Flags method nodes requiring additional return insn processing, which for now is only invokeSuspend.
+     * Flags method nodes requiring additional return insn processing.
+     *
+     * It returns false by default.
+     *
+     * To enable this feature, set -Dnewrelic.config.class_transformer.clear_return_stacks=true
      * For future reference, if other code surfaces a bytecode verification failure (such as an ArrayIndexOutOfBoundsException),
-     * modify this guard to process additional methods beyond invokeSuspend.
+     * modify this guard to process additional methods.
      */
     private boolean shouldClearReturnStacks(String name, String desc) {
-        if (clearReturnStacksDisabled()) {
-            return false;
-        }
-        final String invokeSuspendName = "invokeSuspend";
-        final String invokeSuspendDesc = "(Ljava/lang/Object;)Ljava/lang/Object;";
-        return invokeSuspendName.equals(name) && invokeSuspendDesc.equals(desc);
+        String enabled = System.getProperty("newrelic.config.class_transformer.clear_return_stacks", "false");
+        return enabled.equalsIgnoreCase("true");
     }
 
-    /**
-     * Feature flag to disable return stack processing.
-     * To use this feature flag, set -Dnewrelic.config.class_transformer.clear_return_stacks=false at JVM startup.
-     */
-    private boolean clearReturnStacksDisabled() {
-        String enabled = System.getProperty("newrelic.config.class_transformer.clear_return_stacks", "true");
-        return enabled.equalsIgnoreCase("false");
-    }
+//    /**
+//     * Feature flag to disable return stack processing.
+//     * To use this feature flag, set -Dnewrelic.config.class_transformer.clear_return_stacks=false at JVM startup.
+//     */
+//    private boolean clearReturnStacksDisabled() {
+//        String enabled = System.getProperty("newrelic.config.class_transformer.clear_return_stacks", "true");
+//        return enabled.equalsIgnoreCase("false");
+//    }
 
     /**
      * This adapter checks a method's return instructions, adding additional POPs prior to return instructions


### PR DESCRIPTION
Resolves #2285 

This PR refactors our check for applying additional return insn processing to depend completely on the feature flag `-Dnewrelic.config.class_transformer.clear_return_stacks`. When this flag is set to `true`, the kotlin weaver fix will apply to **all methods**. When the flag is set to `false` (default/when the flag is unset), the kotlin weave fix will apply to **no methods**. A new warning message will appear in the agent logs instructing users to turn the flag on if the class transformer encounters the AIOOBE. 

This refactor was made because there isn't a consistent method signature that the Weaver can recognize as having the Kotlin problem; this is only known at the bytecode insn level, once the frames have been analyzed. 