### PR TITLE
Backporting changes made in PR #1927 to older versions of the vertx-core implementation

### DIFF
--- a/instrumentation/vertx-core-4.0.0/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
+++ b/instrumentation/vertx-core-4.0.0/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
@@ -28,8 +28,9 @@ public class AsyncHandlerWrapper<T> implements Handler<AsyncResult<T>> {
             token.linkAndExpire();
             token = null;
         }
-
-        this.original.handle(event);
-        this.original = null;
+        if (this.original != null) {
+            this.original.handle(event);
+            this.original = null;
+        }
     }
 }

--- a/instrumentation/vertx-core-4.0.0/src/main/java/io/vertx/core/impl/AbstractContext_Instrumentation.java
+++ b/instrumentation/vertx-core-4.0.0/src/main/java/io/vertx/core/impl/AbstractContext_Instrumentation.java
@@ -19,9 +19,11 @@ import io.vertx.core.Handler;
 @Weave(originalName = "io.vertx.core.impl.AbstractContext")
 abstract class AbstractContext_Instrumentation {
     private static <T> void setResultHandler(ContextInternal ctx, Future<T> fut, Handler<AsyncResult<T>> resultHandler) {
-        Transaction txn = AgentBridge.getAgent().getTransaction(false);
-        if (txn != null) {
-            resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+        if (resultHandler != null){
+            Transaction txn = AgentBridge.getAgent().getTransaction(false);
+            if (txn != null) {
+                resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+            }
         }
         Weaver.callOriginal();
     }

--- a/instrumentation/vertx-core-4.1.0/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
+++ b/instrumentation/vertx-core-4.1.0/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
@@ -28,8 +28,9 @@ public class AsyncHandlerWrapper<T> implements Handler<AsyncResult<T>> {
             token.linkAndExpire();
             token = null;
         }
-
-        this.original.handle(event);
-        this.original = null;
+        if (this.original != null) {
+            this.original.handle(event);
+            this.original = null;
+        }
     }
 }

--- a/instrumentation/vertx-core-4.1.0/src/main/java/io/vertx/core/impl/AbstractContext_Instrumentation.java
+++ b/instrumentation/vertx-core-4.1.0/src/main/java/io/vertx/core/impl/AbstractContext_Instrumentation.java
@@ -19,9 +19,11 @@ import io.vertx.core.Handler;
 @Weave(originalName = "io.vertx.core.impl.AbstractContext")
 abstract class AbstractContext_Instrumentation {
     private static <T> void setResultHandler(ContextInternal ctx, Future<T> fut, Handler<AsyncResult<T>> resultHandler) {
-        Transaction txn = AgentBridge.getAgent().getTransaction(false);
-        if (txn != null) {
-            resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+        if (resultHandler != null){
+            Transaction txn = AgentBridge.getAgent().getTransaction(false);
+            if (txn != null) {
+                resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+            }
         }
         Weaver.callOriginal();
     }

--- a/instrumentation/vertx-core-4.3.2/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
+++ b/instrumentation/vertx-core-4.3.2/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
@@ -28,8 +28,9 @@ public class AsyncHandlerWrapper<T> implements Handler<AsyncResult<T>> {
             token.linkAndExpire();
             token = null;
         }
-
-        this.original.handle(event);
-        this.original = null;
+        if (this.original != null) {
+            this.original.handle(event);
+            this.original = null;
+        }
     }
 }

--- a/instrumentation/vertx-core-4.3.2/src/main/java/io/vertx/core/impl/ContextBase_Instrumentation.java
+++ b/instrumentation/vertx-core-4.3.2/src/main/java/io/vertx/core/impl/ContextBase_Instrumentation.java
@@ -30,9 +30,11 @@ public abstract class ContextBase_Instrumentation {
     }
 
     static <T> void setResultHandler(ContextInternal ctx, Future<T> fut, Handler<AsyncResult<T>> resultHandler) {
-        Transaction txn = AgentBridge.getAgent().getTransaction(false);
-        if (txn != null) {
-            resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+        if (resultHandler != null){
+            Transaction txn = AgentBridge.getAgent().getTransaction(false);
+            if (txn != null) {
+                resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+            }
         }
         Weaver.callOriginal();
     }

--- a/instrumentation/vertx-core-4.5.0/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
+++ b/instrumentation/vertx-core-4.5.0/src/main/java/com/nr/vertx/instrumentation/AsyncHandlerWrapper.java
@@ -28,8 +28,9 @@ public class AsyncHandlerWrapper<T> implements Handler<AsyncResult<T>> {
             token.linkAndExpire();
             token = null;
         }
-
-        this.original.handle(event);
-        this.original = null;
+        if (this.original != null) {
+            this.original.handle(event);
+            this.original = null;
+        }
     }
 }

--- a/instrumentation/vertx-core-4.5.0/src/main/java/io/vertx/core/impl/ContextImpl_Instrumentation.java
+++ b/instrumentation/vertx-core-4.5.0/src/main/java/io/vertx/core/impl/ContextImpl_Instrumentation.java
@@ -30,9 +30,11 @@ public abstract class ContextImpl_Instrumentation {
     }
 
     static <T> void setResultHandler(ContextInternal ctx, Future<T> fut, Handler<AsyncResult<T>> resultHandler) {
-        Transaction txn = AgentBridge.getAgent().getTransaction(false);
-        if (txn != null) {
-            resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+        if (resultHandler != null){
+            Transaction txn = AgentBridge.getAgent().getTransaction(false);
+            if (txn != null) {
+                resultHandler = new AsyncHandlerWrapper<>(resultHandler, NewRelic.getAgent().getTransaction().getToken());
+            }
         }
         Weaver.callOriginal();
     }

--- a/instrumentation/vertx-core-4.5.1/src/test/java/com/nr/vertx/instrumentation/VertxBlockingTest.java
+++ b/instrumentation/vertx-core-4.5.1/src/test/java/com/nr/vertx/instrumentation/VertxBlockingTest.java
@@ -43,6 +43,7 @@ public class VertxBlockingTest {
             vertx.close();
         }
     }
+
     @Test
     public void executeBlocking_nullResultHandler() throws InterruptedException {
         //Vertx allows resultHandler to be null.
@@ -81,6 +82,4 @@ public class VertxBlockingTest {
         //give the call to executeBlocking time to complete
         Thread.sleep(500);
     }
-
-
 }


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
This PR contains a backport of the changes made in #1927 to older versions of the vertx-core implementation, to prevent the NPE to also happen when using an older version than 4.5.1.

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
