### PR TITLE
Drop in replacement for snakeyaml

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -32,7 +32,7 @@ can be found at https://github.com/newrelic/.
 * [Okio](#okio)
 * [Protobuf](#protobuf)
 * [SLF4J](#slf4j)
-* [SnakeYAML](#snakeyaml)
+* [SafeYAML](#safeyaml)
 
 ## ASM
 This product includes [ASM](https://asm.ow2.io), which is released under the following license(s):
@@ -858,9 +858,9 @@ This product includes [SLF4J](https://www.slf4j.org/), which is released under t
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-## SnakeYAML
-This product includes [SnakeYAML](https://bitbucket.org/asomov/snakeyaml), which is released under the following license(s):
-    Apache License 2.0 <https://bitbucket.org/asomov/snakeyaml/src/default/LICENSE.txt>
+## SafeYAML
+This product includes [SafeYAML](https://github.com/Konloch/SafeYAML), which is released under the following license(s):
+    Apache License 2.0 <https://github.com/Konloch/SafeYAML/blob/main/LICENSE>
 
 ```
                                  Apache License

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -99,7 +99,8 @@ dependencies {
 
     shadowIntoJar('com.github.ben-manes.caffeine:caffeine:2.9.3')
 
-    shadowIntoJar("org.yaml:snakeyaml:1.33")
+    //shadowIntoJar("org.yaml:snakeyaml:1.33")
+    shadowIntoJar('com.konloch:safeyaml:1.34.1')
 
     shadowIntoJar("org.crac:crac:1.5.0")
 


### PR DESCRIPTION
### Overview
Resolves #2328 

Upgrading to snakeyaml 2.4 causes startup failures for Glassfish and Wildfly, related to configuration of their respective loggers.

A drop in replacement for snakeyaml exists - [SafeYaml](https://github.com/Konloch/SafeYAML). This is a fork of snakeyaml v1.33 with the security fixes from snakeyaml 2.0 back ported. 