### PR TITLE
Fix Illegal Access Error

### DIFF
--- a/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/ClassWeave.java
@@ -77,7 +77,7 @@ public class ClassWeave {
             }
         });
 
-        WeaveUtils.updateClassVersion(composite);
+        WeaveUtils.updateClassVersion(composite, target);
 
         // copy class annotations
         composite.visibleAnnotations = merge(match.getWeaveClassAnnotations().visibleAnnotations,

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/utils/WeaveUtils.java
@@ -763,6 +763,23 @@ public final class WeaveUtils {
         }
     }
 
+    /**
+     * This resolves IllegalAccessErrors that occur when the agent is run on a Scala 2.12 + Java 11 application.
+     *
+     * Scala 2.12 always emits Java 8-level bytecode (i.e., Scala 2.12 apps secretly compile to Java 8 even if they are built and run with higher versions of Java).
+     * This bytecode is exempt from a restriction imposed by the JVM for Java 9 and higher, which prohibits the assignment of final fields outside of constructors. Scala 2.12 deliberately exploits this loophole,
+     * and generates Java 8 classes that assign final fields in trait setters.
+     *
+     * Because these Scala 2.12 classes are compiled to Java 8 and are exempt from the restriction, nothing bad happens.
+     *
+     * However, if a user runs Scala 2.12 + Java 11 + New Relic Java Agent:
+     *   - Scala secretly compiles classes to Java 8
+     *   - The agent updates classfiles to the runtime version (Java 11)
+     *   - The Java 11 class files are subject to the JVM's final field assignment restriction, and an IllegalAccessError is thrown.
+     *
+     *  To fix this, we need to keep the original class version for Scala 2.12 classes.
+     */
+
     private static boolean shouldKeepOriginalClassVersion() {
         return isScala212();
     }


### PR DESCRIPTION
Resolves #2290 

This PR resolves the Illegal Access Error that has plagued environments using the agent with Scala 2.12 and JDK 11. 

The fix is to avoid bumping class file versions to the runtime version, as the agent does normally, for apps that have Scala 2.12 in the environment. Since Scala 2.12 is not always detectable by the agent (we check the system classloader for this - notably, sbt will load Scala classes into custom Scala loaders), there is also a feature flag to manually enable the fix via system property `-Dnewrelic.config.class_transformer.illegal_access_fix=true`. 

I added an AIT for the IllegalAccessError. The branch for that is [here](https://github.com/newrelic/java-agent-integration-tests/compare/illegal-access-ait?expand=1) with AITs run results [here](https://github.com/newrelic/newrelic-java-agent/actions/runs/14651711371). 