### PR TITLE
Allow the org.crac JAR to actually be shadowed as requested.

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -173,6 +173,7 @@ task relocatedShadowJar(type: ShadowJar) {
             "com.google", "org.yaml", "org.slf4j", "org.objectweb", "org.json",
             "org.apache.commons", "org.apache.http", "org.apache.logging", "jregex",
             "io.grpc", "com.squareup", "okio", "io.perfmark", "android", "com.github.benmanes",
+            "org.crac",
 
             // The following rules are to prevent these transitive dependencies from breaking anything
             "org.apache.log4j", "org.apache.log", "org.apache.avalon",


### PR DESCRIPTION
The package has to be added to an allow-list for the shadowIntoJar to actually work properly.