### PR TITLE
Add restrictions on when to add distributed trace headers for SQS messages. 

### DIFF
--- a/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
@@ -29,7 +29,8 @@ public class SqsV2Util {
     public static final String[] DT_HEADERS = new String[] {"newrelic","NEWRELIC","NewRelic","tracestate","TraceState","TRACESTATE"};
 
     /*
-    5000 bytes is larger than the actual size of new relic headers but this just makes it so exceptionally large messages will not have distributed tracing
+    5000 bytes is larger than the actual size of new relic headers but setting it to that value
+    makes it so exceptionally large messages will not have distributed tracing
     */
     public static int NR_HEADERS_BYTES_SIZE = 5000;
 

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
@@ -94,15 +94,15 @@ public class SqsV2Util {
         }
         int attributesBytesSize = attributesBytesSize(message.messageAttributes().entrySet());
         int messageBytesSize = bodyBytesSize + attributesBytesSize;
-        boolean messageTooBig = messageBytesSize < DT_MAX_MESSAGE_BYTES_SIZE;
-        if(messageTooBig) {
+        boolean messageWithinSizeLimits = messageBytesSize < DT_MAX_MESSAGE_BYTES_SIZE;
+        if(!messageWithinSizeLimits) {
             AgentBridge.getAgent().getLogger().log(Level.FINEST,
                     "SQS message is too large for distributed tracing. The message body has {0} bytes. " +
                             "The total number of bytes added to attributes is {1} bytes. Total of both is {2}",
                     bodyBytesSize, attributesBytesSize, messageBytesSize);
 
         }
-        return messageTooBig;
+        return messageWithinSizeLimits;
     }
 
     public static int attributesBytesSize(Set<Map.Entry<String, MessageAttributeValue>> attributes) {

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
@@ -98,7 +98,7 @@ public class SqsV2Util {
         if(!messageWithinSizeLimits) {
             AgentBridge.getAgent().getLogger().log(Level.FINEST,
                     "SQS message is too large for distributed tracing. The message body has {0} bytes. " +
-                            "The total number of bytes added to attributes is {1} bytes. Total of both is {2} bytes.",
+                            "The total number of bytes within attributes is {1} bytes. Total of both is {2} bytes.",
                     bodyBytesSize, attributesBytesSize, messageBytesSize);
 
         }

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
@@ -98,7 +98,7 @@ public class SqsV2Util {
         if(!messageWithinSizeLimits) {
             AgentBridge.getAgent().getLogger().log(Level.FINEST,
                     "SQS message is too large for distributed tracing. The message body has {0} bytes. " +
-                            "The total number of bytes added to attributes is {1} bytes. Total of both is {2}",
+                            "The total number of bytes added to attributes is {1} bytes. Total of both is {2} bytes.",
                     bodyBytesSize, attributesBytesSize, messageBytesSize);
 
         }

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
@@ -13,12 +13,23 @@ import com.newrelic.api.agent.MessageConsumeParameters;
 import com.newrelic.api.agent.MessageProduceParameters;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.weaver.Weaver;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class SqsV2Util {
 
     public static final String LIBRARY = "SQS";
     public static final String OTEL_LIBRARY = "aws_sqs";
     public static final String[] DT_HEADERS = new String[] {"newrelic","NEWRELIC","NewRelic","tracestate","TraceState","TRACESTATE"};
+    public static int NR_HEADERS_SIZE = 5000; // 5 KB
+    public static int SDK_MAX_MESSAGE_SIZE = 262144; // 262144 bytes
+    public static int PRE_DT_HEADERS_MAX_MESSAGE_SIZE = SDK_MAX_MESSAGE_SIZE - NR_HEADERS_SIZE;
 
     public static MessageProduceParameters generateExternalProduceMetrics(String queueUrl) {
         DestinationData destinationData = DestinationData.parse(queueUrl);
@@ -54,6 +65,52 @@ public class SqsV2Util {
         } catch (Throwable t) {
             AgentBridge.instrumentation.noticeInstrumentationError(t, Weaver.getImplementationTitle());
         }
+    }
+
+    public static boolean canAddDtHeaders(SendMessageRequest message) {
+        int bodySize = message.messageBody() != null ? message.messageBody().getBytes().length : 0;
+        if (message.messageAttributes().size() > 8) {
+            return false;
+        }
+        int attributesBytesSize = attributesBytesSize(message.messageAttributes().entrySet());
+        int messageBytesSize = bodySize + attributesBytesSize;
+        return messageBytesSize < PRE_DT_HEADERS_MAX_MESSAGE_SIZE;
+    }
+
+    public static boolean canAddDtHeaders(SendMessageBatchRequestEntry message) {
+        int bodyBytesSize = message.messageBody() != null ? message.messageBody().getBytes().length : 0;
+        if (message.messageAttributes().size() > 8) {
+            return false;
+        }
+        int attributesBytesSize = attributesBytesSize(message.messageAttributes().entrySet());
+        int messageBytesSize = bodyBytesSize + attributesBytesSize;
+        return messageBytesSize < PRE_DT_HEADERS_MAX_MESSAGE_SIZE;
+    }
+
+    public static int attributesBytesSize(Set<Map.Entry<String, MessageAttributeValue>> attributes) {
+        int totalAttributeSize = 0;
+        for (Map.Entry<String, MessageAttributeValue> attr : attributes) {
+            totalAttributeSize += attr.getKey().getBytes().length;
+            String stringValue = attr.getValue().stringValue();
+            if (stringValue != null) {
+                totalAttributeSize += stringValue.getBytes().length;
+                continue;
+            }
+            SdkBytes sdkBytes = attr.getValue().binaryValue();
+            if (sdkBytes != null) {
+                totalAttributeSize += sdkBytes.asByteArray().length;
+                continue;
+            }
+            List<SdkBytes> sdkBytesList = attr.getValue().binaryListValues();
+            if (sdkBytesList != null) {
+                for (SdkBytes bytesEntry : sdkBytesList) {
+                    if (bytesEntry != null) {
+                        totalAttributeSize += bytesEntry.asByteArray().length;
+                    }
+                }
+            }
+        }
+        return totalAttributeSize;
     }
 
 }

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/src/main/java/com/newrelic/utils/SqsV2Util.java
@@ -98,7 +98,7 @@ public class SqsV2Util {
         if(!messageWithinSizeLimits) {
             AgentBridge.getAgent().getLogger().log(Level.FINEST,
                     "SQS message is too large for distributed tracing. The message body has {0} bytes. " +
-                            "The total number of bytes within attributes is {1} bytes. Total of both is {2} bytes.",
+                            "Message attributes have a total of {1} bytes. Total of both is {2} bytes.",
                     bodyBytesSize, attributesBytesSize, messageBytesSize);
 
         }

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/src/test/java/com/newrelic/utils/SqsV2UtilTest.java
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/src/test/java/com/newrelic/utils/SqsV2UtilTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.newrelic.utils.SqsV2Util.PRE_DT_HEADERS_MAX_MESSAGE_SIZE;
+import static com.newrelic.utils.SqsV2Util.DT_MAX_MESSAGE_BYTES_SIZE;
 
 public class SqsV2UtilTest {
 
@@ -150,7 +150,7 @@ public class SqsV2UtilTest {
         for (int i = 0; i < 9; i++) {
             attributeValues.put(String.valueOf(i), MessageAttributeValue.builder().stringValue(String.valueOf(i)).build());
         }
-        int MESSAGE_BODY_SIZE = PRE_DT_HEADERS_MAX_MESSAGE_SIZE - 17;
+        int MESSAGE_BODY_SIZE = DT_MAX_MESSAGE_BYTES_SIZE - 17;
 
         char[] charArray = new char[MESSAGE_BODY_SIZE];
         Arrays.fill(charArray, 'a');
@@ -203,7 +203,7 @@ public class SqsV2UtilTest {
         for (int i = 0; i < 9; i++) {
             attributeValues.put(String.valueOf(i), MessageAttributeValue.builder().stringValue(String.valueOf(i)).build());
         }
-        int MESSAGE_BODY_SIZE = PRE_DT_HEADERS_MAX_MESSAGE_SIZE - 17;
+        int MESSAGE_BODY_SIZE = DT_MAX_MESSAGE_BYTES_SIZE - 17;
 
         char[] charArray = new char[MESSAGE_BODY_SIZE];
         Arrays.fill(charArray, 'a');


### PR DESCRIPTION
### Overview
Adds a restriction on when to add distributed trace headers for SQS messages. This is based on how large the contents of a message is in bytes and the and the size of attributes. Messages with size greater than 251 KB and/or with 9 or more attributes are excluded from getting distributed trace headers added.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2292
