### PR TITLE
Fixes configuration logic for netty-4.1.16 module

### DIFF
--- a/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/NettyUtil.java
+++ b/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/NettyUtil.java
@@ -24,7 +24,6 @@ public class NettyUtil {
     // Only use it if it provides the coverage you need for your application's use case.
     public static final Boolean START_HTTP2_FRAME_READ_LISTENER_TXN =
             NewRelic.getAgent().getConfig().getValue("netty.http2.frame_read_listener.start_transaction", false);
-    public static final Boolean START_HTTP2_FRAME_CODEC_TXN = !START_HTTP2_FRAME_READ_LISTENER_TXN;
 
     public static String getNettyVersion() {
         return "4.1.16";

--- a/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/FrameReadListener_Instrumentation.java
+++ b/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/FrameReadListener_Instrumentation.java
@@ -20,7 +20,7 @@ class FrameReadListener_Instrumentation {
     // Process HTTP/2 request headers and start txn
     public void onHeadersRead(ChannelHandlerContext_Instrumentation ctx, int streamId, Http2Headers headers, int streamDependency, short weight,
             boolean exclusive, int padding, boolean endOfStream) {
-        if (NettyUtil.START_HTTP2_FRAME_CODEC_TXN && ctx.pipeline().token == null) {
+        if (NettyUtil.START_HTTP2_FRAME_READ_LISTENER_TXN && ctx.pipeline().token == null) {
             // NettyDispatcher class is usually initialized in AbstractBootstrap; however,
             // that code is not always invoked when using recent Netty versions (4.1.54)
             // so we check here and initialize if we haven't yet.


### PR DESCRIPTION
### Overview
Fixes a bug in the internal netty config where setting the below config to `false` (i.e. the default value) causes 'Unknown' transactions to show up again. 
```
  netty:
    http2:
      frame_read_listener:
        start_transaction: false
```
Setting the above config to `true` disables HTTP2 support.

The fix sets up the config such that HTTP2 support is enabled when the config is `true`, setting it to `false` removes the `unknown` transaction issue but setting it to `true` increases granularity for catching HTTP2 requests while still risking the `unknown` transaction issue showing up. 

