### PR TITLE
Initial commit reconfiguring publishing steps per new migration

### DIFF
--- a/.github/workflows/migrate_publish_release.yml
+++ b/.github/workflows/migrate_publish_release.yml
@@ -1,0 +1,54 @@
+name: Publish release version explicitly
+
+on:
+  workflow-dispatch:
+    inputs:
+      agent-ref:
+        description: "Specify agent branch/tag/sha (main is default)"
+        required: false
+        default: 'main'
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Agent
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
+        with:
+          ref: ${{ inputs.agent-ref || 'main' }}
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Publish release
+        env:
+          SONATYPE_USERNAME: ${{ secrets.MIGRATION_TEST_SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.MIGRATION_TEST_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew $GRADLE_OPTIONS publish -x :newrelic-scala3-api:publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish -x :newrelic-scala-zio2-api:publish -x :agent-bridge:publish -x :agent-bridge-datastore:publish -x :newrelic-weaver:publish -x :newrelic-weaver-api:publish -x :newrelic-weaver-scala:publish -x :newrelic-weaver-scala-api:publish -x :newrelic-opentelemetry-agent-extension:publish -Prelease=true
+      - name: Publish release scala apis
+        env:
+          SONATYPE_USERNAME: ${{ secrets.MIGRATION_TEST_SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.MIGRATION_TEST_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-scala3-api:publish :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish :newrelic-scala-zio2-api:publish -Prelease=true
+      - name: Publish apis for Security agent
+        env:
+          SONATYPE_USERNAME: ${{ secrets.MIGRATION_TEST_SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.MIGRATION_TEST_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew $GRADLE_OPTIONS :agent-bridge:publish :agent-bridge-datastore:publish :newrelic-weaver:publish :newrelic-weaver-api:publish :newrelic-weaver-scala:publish :newrelic-weaver-scala-api:publish -Prelease=true
+      - name: Publish New Relic OpenTelemetry API Extension
+        env:
+          SONATYPE_USERNAME: ${{ secrets.MIGRATION_TEST_SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.MIGRATION_TEST_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         }
     }
 
-    group = 'com.newrelic.agent.java'
+    group = 'io.github.kanderson250.agent.java'
     version = agentVersion + (project.findProperty("release") == "true" ? "" : "-SNAPSHOT")
     version = version + (project.findProperty("release-suffix") != null ? project.findProperty("release-suffix") : "")
 

--- a/buildSrc/src/main/java/com/nr/builder/publish/PublishConfig.java
+++ b/buildSrc/src/main/java/com/nr/builder/publish/PublishConfig.java
@@ -59,8 +59,8 @@ public class PublishConfig {
     }
 
     private static void configureRepo(MavenArtifactRepository repo, String projectVersion) {
-        URI releasesRepoUri = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/");
-        URI snapshotsRepoUrl = URI.create("https://oss.sonatype.org/content/repositories/snapshots/");
+        URI releasesRepoUri = URI.create("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/");
+        URI snapshotsRepoUrl = URI.create("https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/");
         repo.setUrl(
                 projectVersion.endsWith("SNAPSHOT")
                         ? snapshotsRepoUrl

--- a/newrelic-java/build.gradle
+++ b/newrelic-java/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 evaluationDependsOn(":newrelic-agent")
 
-group = "com.newrelic.agent.java"
+group = "io.github.kanderson250.agent.java"
 
 task dist(type: Zip, dependsOn: [
     project(":newrelic-agent").newrelicVersionedAgentJar,


### PR DESCRIPTION
This branch includes a slightly modified publishing action and configuration to test out the new OSSRH staging API. 

Note that my personal namespace is used. The official agent namespace should be used once the migration is complete. 
