### PR TITLE
Cap vertx-postgres-sqlclient-4.4.2 to 5.0

### DIFF
--- a/instrumentation/vertx-postgres-sqlclient-4.4.2/build.gradle
+++ b/instrumentation/vertx-postgres-sqlclient-4.4.2/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passes 'io.vertx:vertx-pg-client:[4.4.2,)'
+    passes 'io.vertx:vertx-pg-client:[4.4.2,5.0.0)'
     excludeRegex '.*SNAPSHOT'
     excludeRegex '.*milestone.*'
     excludeRegex '.*alpha.*'


### PR DESCRIPTION
### Overview
Cap the verify range for vertx-postgres-sqlclient-4.4.2 to v5.0.0

