### PR TITLE
Suppress segments in HttpUrlConnection

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpTracedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpTracedMethod.java
@@ -100,6 +100,9 @@ public final class NoOpTracedMethod implements TracedMethod {
     }
 
     @Override
+    public void excludeLeaf(){}
+
+    @Override
     public void addOutboundRequestHeaders(OutboundHeaders outboundHeaders) {
     }
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
@@ -82,6 +82,8 @@ public interface TracedMethod extends com.newrelic.api.agent.TracedMethod {
 
     public boolean isTrackCallbackRunnable();
 
+    void excludeLeaf();
+
     /**
      * Do not use. Use
      * {@link com.newrelic.api.agent.TracedMethod#addOutboundRequestHeaders(OutboundHeaders)} instead.
@@ -121,5 +123,4 @@ public interface TracedMethod extends com.newrelic.api.agent.TracedMethod {
      */
     @Deprecated
     void reportAsExternal(com.newrelic.agent.bridge.external.ExternalParameters externalParameters);
-
 }

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/TracedMethod.java
@@ -82,6 +82,9 @@ public interface TracedMethod extends com.newrelic.api.agent.TracedMethod {
 
     public boolean isTrackCallbackRunnable();
 
+    /**
+     * Mark a leaf tracer as excluded, similar to how excludeFromTransactionTrace works.
+     */
     void excludeLeaf();
 
     /**

--- a/functional_test/src/test/java/com/newrelic/agent/bridge/MockTracer.java
+++ b/functional_test/src/test/java/com/newrelic/agent/bridge/MockTracer.java
@@ -129,4 +129,8 @@ public class MockTracer implements ExitTracer {
     @Override
     public void reportAsExternal(com.newrelic.agent.bridge.external.ExternalParameters externalParameters) {
     }
+
+    @Override
+    public void excludeLeaf(){
+    }
 }

--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/HttpURLConnectionConfig.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/HttpURLConnectionConfig.java
@@ -13,14 +13,19 @@ import com.newrelic.api.agent.NewRelic;
 import java.util.logging.Level;
 
 /**
- * Provides some config options for tuning the instrumentation's use of a SegmentCleanupTask runnable.
- * Specifically, thread_pool_size configures the number of threads used by the executor to execute
- * the runnables and delay_ms configures the delay before a scheduled runnable task is executed.
- * <p>
- * See README for config examples.
+ * Provides sconfig options for tuning the HttpUrlConnection instrumentation.
+ * By default, the instrumentation is verbose and captures every response handler method as a segment,
+ * with only the first segment reporting the associated external call.
+ *
+ * To turn off verbose reporting and suppress HTTPUrlConnection segments that don't make external calls, set
+ * -Dnewrelic.config.class_transformer.com.newrelic.instrumentation.htturlconnection.verbose=false
  */
 public class HttpURLConnectionConfig {
     private static final boolean DEFAULT_DISTRIBUTED_TRACING_ENABLED = true;
+
+    private static final String VERBOSE_PREFIX = "class_transformer.com.newrelic.instrumentation.httpurlconnection.verbose";
+
+    private static final boolean DEFAULT_VERBOSE_SETTING = true;
 
     private HttpURLConnectionConfig() {
     }
@@ -33,5 +38,9 @@ public class HttpURLConnectionConfig {
             AgentBridge.getAgent().getLogger().log(Level.FINEST, "HttpURLConnection - using default distributed tracing enabled: " + dtEnabled);
         }
         return dtEnabled;
+    }
+
+    public static boolean getVerbose() {
+        return NewRelic.getAgent().getConfig().getValue(VERBOSE_PREFIX, DEFAULT_VERBOSE_SETTING);
     }
 }

--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
@@ -14,7 +14,6 @@ import com.newrelic.agent.bridge.external.URISupport;
 import com.newrelic.api.agent.GenericParameters;
 import com.newrelic.api.agent.HeaderType;
 import com.newrelic.api.agent.HttpParameters;
-import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.OutboundHeaders;
 
 import java.lang.ref.WeakReference;

--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
@@ -45,7 +45,7 @@ import java.net.UnknownHostException;
  *
  */
 public class MetricState {
-    private static final boolean VERBOSE = NewRelic.getAgent().getConfig().getValue("http_url_connection.verbose", true);
+    private static final boolean VERBOSE = HttpURLConnectionConfig.getVerbose();
     private static final String LIBRARY = "HttpURLConnection";
     private static final URI UNKNOWN_HOST = URI.create("UnknownHost");
 

--- a/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
+++ b/instrumentation/httpurlconnection/src/main/java/com/nr/agent/instrumentation/httpurlconnection/MetricState.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.bridge.external.URISupport;
 import com.newrelic.api.agent.GenericParameters;
 import com.newrelic.api.agent.HeaderType;
 import com.newrelic.api.agent.HttpParameters;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.OutboundHeaders;
 
 import java.lang.ref.WeakReference;
@@ -44,6 +45,7 @@ import java.net.UnknownHostException;
  *
  */
 public class MetricState {
+    private static final boolean VERBOSE = NewRelic.getAgent().getConfig().getValue("http_url_connection.verbose", true);
     private static final String LIBRARY = "HttpURLConnection";
     private static final URI UNKNOWN_HOST = URI.create("UnknownHost");
 
@@ -82,11 +84,13 @@ public class MetricState {
     public void inboundPreamble(boolean isConnected, HttpURLConnection connection, TracedMethod tracer) {
         if (externalReported || getExternalTracer() != null) {
             // another method already ran the preamble
+            if (!VERBOSE) {
+                tracer.excludeLeaf();
+            }
             return;
         }
         Transaction tx = AgentBridge.getAgent().getTransaction(false);
         setExternalTracer(tracer);
-
         if (!isConnected && tracer.isMetricProducer() && tx != null) {
             addOutboundHeadersIfNotAdded(connection);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/FlyweightTraceMethodVisitor.java
@@ -122,6 +122,7 @@ public class FlyweightTraceMethodVisitor extends AdviceAdapter {
         addUnsupportedMethod(map, new Method("trackChildThreads", "()Z"));
         addUnsupportedMethod(map, new Method("setTrackCallbackRunnable", "(Z)V"));
         addUnsupportedMethod(map, new Method("isTrackCallbackRunnable", "()Z"));
+        addUnsupportedMethod(map, new Method("excludeLeaf", "()V"));
         addUnsupportedMethod(map, new Method("reportAsDatastore",
                 "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"));
         addUnsupportedMethod(map, new Method("addOutboundRequestHeaders",

--- a/newrelic-agent/src/main/java/com/newrelic/agent/trace/TransactionTrace.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/trace/TransactionTrace.java
@@ -177,7 +177,9 @@ public class TransactionTrace implements Comparable<TransactionTrace>, JSONStrea
                 kids = new ArrayList<>(parentTracer == null ? 1 : Math.max(1, parentTracer.getChildCount()));
                 children.put(parentTracer, kids);
             }
-            kids.add(tracer);
+            if (tracer.isTransactionSegment()){
+                kids.add(tracer);
+            }
         }
         return children;
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/trace/TransactionTrace.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/trace/TransactionTrace.java
@@ -177,6 +177,8 @@ public class TransactionTrace implements Comparable<TransactionTrace>, JSONStrea
                 kids = new ArrayList<>(parentTracer == null ? 1 : Math.max(1, parentTracer.getChildCount()));
                 children.put(parentTracer, kids);
             }
+            //This check was added to allow leaves to be marked as excluded after they are constructed and added to the tracer list.
+            //It should have no effect on traces that are marked as excluded the normal way, via annotation.
             if (tracer.isTransactionSegment()){
                 kids.add(tracer);
             }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/AbstractTracer.java
@@ -178,6 +178,9 @@ public abstract class AbstractTracer implements Tracer, AttributeHolder {
     }
 
     @Override
+    public void excludeLeaf(){}
+
+    @Override
     public boolean isAsync() {
         return false;
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -166,10 +166,20 @@ public class DefaultTracer extends AbstractTracer {
         this.tracerFlags = (byte) TracerFlags.clearSegment(this.tracerFlags);
     }
 
+    /**
+     * This API method allows leaves to be excluded outside the constructor.
+     * Their data will still be collected (ie, they'll still be on the Txa tracer stack and produce metrics),
+     * but they will not be added to Transaction Traces or turned into Spans.
+     *
+     * This is useful for instrumentation in which large numbers of tracers are created that can't
+     * be marked as excluded at the time of creation, for example, HttpUrlConnection.
+     *
+     * Excluding root tracers is (for now) prohibited and this method is overridden in roots.
+     */
     @Override
     public void excludeLeaf() {
         if (isLeaf()){
-            this.tracerFlags = (byte) TracerFlags.clearSegment(this.tracerFlags);
+            tracerFlags = (byte) TracerFlags.clearSegment(tracerFlags);
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultTracer.java
@@ -167,6 +167,13 @@ public class DefaultTracer extends AbstractTracer {
     }
 
     @Override
+    public void excludeLeaf() {
+        if (isLeaf()){
+            this.tracerFlags = (byte) TracerFlags.clearSegment(this.tracerFlags);
+        }
+    }
+
+    @Override
     public String getGuid() {
         if (this.guid == null) {
             this.guid = TransactionGuidFactory.generate16CharGuid();

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/NoOpTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/NoOpTracer.java
@@ -257,6 +257,9 @@ public final class NoOpTracer implements Tracer {
     }
 
     @Override
+    public void excludeLeaf(){}
+
+    @Override
     public void addOutboundRequestHeaders(OutboundHeaders outboundHeaders) {
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/OtherRootSqlTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/OtherRootSqlTracer.java
@@ -62,4 +62,15 @@ public class OtherRootSqlTracer extends DefaultSqlTracer implements TransactionA
             transaction.setThrowable(throwable, TransactionErrorPriority.TRACER, false);
         }
     }
+
+    /***
+     * This API method allows leaves to be excluded outside the constructor in DefaultTracer.
+     * For now, we don't want to give this capability to root tracers. The existing agent pattern is to force
+     * root tracers to be included (see TracerFlags.forceMandatoryRootFlags, which ignores excludeFromTransactionTrace).
+     *
+     * This can be reevaluated in the future if we find a use case for excluding root tracers.
+     */
+
+    @Override
+    public void excludeLeaf() {}
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/OtherRootTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/OtherRootTracer.java
@@ -81,4 +81,15 @@ public class OtherRootTracer extends DefaultTracer implements TransactionActivit
         }
     }
 
+    /***
+     * This API method allows leaves to be excluded outside the constructor in DefaultTracer.
+     * For now, we don't want to give this capability to root tracers. The existing agent pattern is to force
+     * root tracers to be included (see TracerFlags.forceMandatoryRootFlags, which ignores excludeFromTransactionTrace).
+     *
+     * This can be reevaluated in the future if we find a use case for excluding root tracers.
+     */
+
+    @Override
+    public void excludeLeaf() {}
+
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/UltraLightTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/UltraLightTracer.java
@@ -157,6 +157,9 @@ public class UltraLightTracer implements Tracer {
     /////////////////////////////////////////////
 
     @Override
+    public void excludeLeaf(){}
+
+    @Override
     public void addCustomAttribute(String key, Number value) {
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
@@ -423,4 +423,8 @@ public class NoOpTrackingSqlTracer implements SqlTracer {
     public int getChildCount() {
         return 0;
     }
+
+    @Override
+    public void excludeLeaf(){
+    }
 }


### PR DESCRIPTION
Resolves #2337 

Our HttpUrlConnection instrumentation creates a tracer for each response handler called by the HttpUrlConnection instance. We do this to ensure we have *some* tracer available to report the external call. This isn't ideal, because only the first tracer gets used to report the external, but it is not known at the time each tracer is created (via `@Trace` annotation) whether it is the first one. The result is that HttpUrlConnection transaction traces/DTs may be cluttered with a great number of response handler segments (such as `getInputStream`) that weren't chosen to become externals. 

This PR introduces a low-verbose mode to give users the option of suppressing these non-external segments in transaction traces and DTs. This can be enabled by setting:

`NEW_RELIC_CLASS_TRANSFORMER_COM_NEWRELIC_INSTRUMENTATION_HTTURLCONNECTION_VERBOSE=false`, sys prop `-Dnewrelic.config.class_transformer.com.newrelic.instrumentation.httpurlconnection.verbose=false`, or equivalent stanza in `newrelic.yml`. Default setting is `true` (ie, non-external `getInputStream` and other response handler methods will be reported as before). 

### Implementation comments

This functionality is implemented via an internal-only API method, `excludeLeaf`, which has the ability to toggle the `excludes` tracer flag on leaf tracers, just like the annotation `@Trace(excludeFromTransactionTrace=true)`. The difference is that the new `excludeLeaf` method can be called *after* the tracer has already been created, whereas the annotation applies only when the tracer is constructed. 

`excludeLeaf` is a no-op everywhere but in `DefaultTracer`. It is also a no-op in root tracer implementations to stay consistent with our existing agent behavior that prohibits root tracers from being excluded. 

We chose to make `excludeLeaf` (rather than a general `excludeTracer`) to ensure we don't unintentionally exclude parent tracers and orphan their children. However, this could be revisited in the future as a potential enhancement. 

### Tests

There are a few new unit tests, plus a small AIT update for the HttpUrlConnection instrumentation. AIT branch is [here](https://github.com/newrelic/java-agent-integration-tests/compare/main...httpurlconnection-verbose) and test run for that against this PR is [here](https://github.com/newrelic/newrelic-java-agent/actions/runs/15123193344). 

