### PR TITLE
Fix SkipIfPresent annotation

### DIFF
--- a/instrumentation/java.completable-future-jdk8u40/src/main/java/skip/Skip_SecurityPolicy.java
+++ b/instrumentation/java.completable-future-jdk8u40/src/main/java/skip/Skip_SecurityPolicy.java
@@ -1,13 +1,19 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package skip;
 
-import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.SkipIfPresent;
 
 /**
  *  * This Weave class instructs JREs 11 and up to skip this instrumentation module,
  *  * and use java.completable-future-jdk11 instead.
  *  * javax.security.auth.Policy was chosen because it was removed in Java 11.
  */
-@Weave(originalName = "javax.security.auth.Policy")
+@SkipIfPresent(originalName = "javax.security.auth.Policy")
 public class Skip_SecurityPolicy {
     //This does nothing
 }


### PR DESCRIPTION
The `completable-future-jdk8u40` module wasn't properly skipped in the presence of the `javax.security.auth.Policy` class.

