### PR TITLE
Increase spotbugs workflow timeout

### DIFF
--- a/.github/workflows/GHA-Spotbugs.yml
+++ b/.github/workflows/GHA-Spotbugs.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   spotbugs:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4


### PR DESCRIPTION
The spotbugs workflow seems to be timing out suddenly. This increases the timeout to 30 minutes