### PR TITLE
count bound and enable stats

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/metricname/MetricNameFormats.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/metricname/MetricNameFormats.java
@@ -19,8 +19,10 @@ import com.newrelic.agent.util.Strings;
 public class MetricNameFormats {
 
     private static final Cache<MNFKey, MetricNameFormat> cmsToMnf = Caffeine.newBuilder()
-                                                                                .executor(Runnable::run)
-                                                                                .build();
+            .maximumSize(10_000)
+            .executor(Runnable::run)
+            .recordStats()
+            .build();
 
     private MetricNameFormats() {
     }


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
[newrelic-java-agent/newrelic-agent/src/main/java/com/newrelic/agent/tracers/metricname/MetricNameFormats.java](https://github.com/newrelic/newrelic-java-agent/blob/4b53e4f75d16ebd3c5d41e3c777ea4da15480e6b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/metricname/MetricNameFormats.java#L21-L23)

Lines 21 to 23 in [4b53e4f](https://github.com/newrelic/newrelic-java-agent/commit/4b53e4f75d16ebd3c5d41e3c777ea4da15480e6b)

 private static final Cache<MNFKey, MetricNameFormat> cmsToMnf = Caffeine.newBuilder() 
                                                                             .executor(Runnable::run) 
                                                                             .build(); 
If a customer were to create enough segments with extremely dynamic names, this cache could grow to an unreasonable size and appear to be a memory leak.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/1825


### Considerations
This could optionally be bound by some weighting. However, seems like a simple count bound would probably work for this cache. Somewhat arbitrarily around 10K? Or do you have metrics showing distribution of common counts? This is essentially just every tracer right?

Would you want this configurable?

Any interest in recording stats for this cache? If not, will just remove `recordStats()`
and/or logging spikes?
if (cmsToMnf.stats().evictionCount() > threshold) {
logger.warn("High MetricNameFormat cache eviction rate detected!");
}


### Testing
Dependent on complete changes

### Checks

- [ √] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ √] Your code does not contain any breaking changes. Otherwise please describe. 
- [√ ] Your code does not introduce any new dependencies. Otherwise please describe.
