### PR TITLE
Relocate IntelliJ annotations

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -180,7 +180,7 @@ task relocatedShadowJar(type: ShadowJar) {
             "org.apache.log4j", "org.apache.log", "org.apache.avalon",
             "org.checkerframework", "org.dom4j", "org.zeromq", "org.apache.kafka",
             "com.lmax", "com.conversantmedia", "org.jctools",
-            "com.fasterxml", "org.osgi", "org.codehaus", "org.fusesource", "kotlin", "org.jetbrains",
+            "com.fasterxml", "org.osgi", "org.codehaus", "org.fusesource", "kotlin", "org.jetbrains", "org.intellij",
             "okhttp3", "org.bouncycastle", "org.conscrypt", "org.openjsse"
     ].each {
         relocate(it, "com.newrelic.agent.deps.$it")


### PR DESCRIPTION
### Overview
Some dependency is bringing `org.jetbrains:annotations` and its contents are not being relocated. This could cause incompatibilities if an applications uses a different version of the artifact.

### Related Github Issue
None

### Testing
No new testing was created.

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
