### PR TITLE
Support server side sampling_target config

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
@@ -53,6 +53,7 @@ public class AgentConfigFactory {
     public static final String MAX_ERROR_EVENT_SAMPLES_STORED = ERROR_COLLECTOR_PREFIX + ErrorCollectorConfigImpl.MAX_EVENT_SAMPLES_STORED;
     public static final String COLLECT_TRACES = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.COLLECT_TRACES;
     public static final String COLLECT_TRANSACTION_EVENTS = TRANSACTION_EVENTS_PREFIX + "collect_analytics_events";
+    public static final String TRANSACTION_TARGET_SAMPLES_STORED = TRANSACTION_EVENTS_PREFIX + "target_samples_stored";
     public static final String COLLECT_SPAN_EVENTS = SPAN_EVENTS_PREFIX + SpanEventsConfig.COLLECT_SPAN_EVENTS;
     public static final String COLLECT_CUSTOM_INSIGHTS_EVENTS = CUSTOM_INSIGHT_EVENTS_PREFIX + InsightsConfigImpl.COLLECT_CUSTOM_EVENTS;
     public static final String RECORD_SQL = TRANSACTION_TRACER_PREFIX + TransactionTracerConfigImpl.RECORD_SQL;
@@ -212,6 +213,7 @@ public class AgentConfigFactory {
         // Expected errors server properties
         addServerProp(EXPECTED_CLASSES, serverData.get(ErrorCollectorConfigImpl.EXPECTED_CLASSES), settings);
         addServerProp(EXPECTED_STATUS_CODES, serverData.get(ErrorCollectorConfigImpl.EXPECTED_STATUS_CODES), settings);
+        addServerProp(TRANSACTION_TARGET_SAMPLES_STORED, serverData.get("sampling_target"), settings);
 
         // Adding agent_run_id & account_id to config as required by Security agent
         addServerProp(ConnectionResponse.AGENT_RUN_ID_KEY, serverData.get(ConnectionResponse.AGENT_RUN_ID_KEY), settings);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/AgentConfigFactory.java
@@ -213,6 +213,8 @@ public class AgentConfigFactory {
         // Expected errors server properties
         addServerProp(EXPECTED_CLASSES, serverData.get(ErrorCollectorConfigImpl.EXPECTED_CLASSES), settings);
         addServerProp(EXPECTED_STATUS_CODES, serverData.get(ErrorCollectorConfigImpl.EXPECTED_STATUS_CODES), settings);
+
+        // Transaction event properties
         addServerProp(TRANSACTION_TARGET_SAMPLES_STORED, serverData.get("sampling_target"), settings);
 
         // Adding agent_run_id & account_id to config as required by Security agent

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigFactoryTest.java
@@ -244,6 +244,20 @@ public class AgentConfigFactoryTest {
         Assert.assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
     }
 
+    @Test
+    public void mergeServerData_withServerSideSampledTotals_overridesAgentDefault() {
+        Map<String, Object> localSettings = createMap();
+        Map<String, Object> txnEventsSettings = createMap();
+        Map<String, Object> serverSettings = createMap();
+
+        txnEventsSettings.put("target_samples_stored", 50);
+        localSettings.put(AgentConfigImpl.TRANSACTION_EVENTS, txnEventsSettings);
+        serverSettings.put("sampling_target", 10);
+
+        AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
+        Assert.assertEquals(10, config.getTransactionEventsConfig().getTargetSamplesStored());
+    }
+
     private Map<String, Object> logForwardingSettingsEnabled(boolean enabled) {
         Map<String, Object> localSettings = createMap();
         Map<String, Object> loggingSettings = createMap();


### PR DESCRIPTION
When the agent connects to NR, there will be a connect response with server side configuration data from NR. The agent takes this config data and merges it with the local config. One of the server side configuration settings is `sampling_target`.

This change adds support for the `sampling_target` server side config.

Resolves #447 