### PR TITLE
Remove redundant line in release notes for kafka consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enhances visibility into Reactor `Mono.flatMap` calls in https://github.com/newrelic/newrelic-java-agent/pull/2308
 - Adds new instrumentation for Spring-Kafka and distributed tracing when using the core Kafka client library in https://github.com/newrelic/newrelic-java-agent/pull/2312
-- Adds a new Kafka instrumentation module named `kafka-clients-spans-consumer-0.11.0.0` that accepts distributed trace headers for consumers in https://github.com/newrelic/newrelic-java-agent/pull/2283
 - Adds `KafkaConsumerConfig` event support for Kafka 3.7+ in https://github.com/newrelic/newrelic-java-agent/pull/2358
 
 ## Fixes


### PR DESCRIPTION
\### Overview
Remove redundant line in release notes for kafka consumers. It was confusing for users because we support adding auto-adding distributed traces for Kafka Clients in kafka-clients 2.0 and up.

### Related Github Issue
https://github.com/newrelic/docs-website/pull/21014
