### PR TITLE
Migrate release process

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -53,3 +53,28 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew $GRADLE_OPTIONS :newrelic-opentelemetry-agent-extension:publish -Prelease=true
+
+      - name: Upload staged artifacts to Central Sonatype
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        run: |
+          # token is a b64-encoded string of username:password, used in auth header of API call
+          SONATYPE_TOKEN=$(printf "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" | base64)
+          PUBLISH_NAMESPACE="io.github.kanderson250"
+          # makes a curl request to ossrh-staging-api to upload everything to Central Sonatype
+          echo "Uploading artifacts from OSSRH-Staging to Central Sonatype..."
+          # captures response code and body of curl request
+          RESPONSE=$(curl -s -w "%{http_code}" -o response_body.txt -X POST \
+            -H "Authorization: Bearer $SONATYPE_TOKEN" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/$PUBLISH_NAMESPACE?publishing_type=user_managed")
+          # job fails if we got anything back but a 200
+          if [ "$RESPONSE" -ne 200 ]; then
+            echo "Failed to upload artifacts to Central Sonatype. Response code: $RESPONSE. Response body: "
+            cat response_body.txt
+            echo "Visit https://central.sonatype.com/publishing/deployments for more information."
+            exit 1
+          else
+            echo "Artifacts were uploaded successfully to Central Sonatype."
+            echo "Visit https://central.sonatype.com/publishing/deployments to view your artifacts."
+          fi

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           # token is a b64-encoded string of username:password, used in auth header of API call
           SONATYPE_TOKEN=$(printf "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" | base64)
-          PUBLISH_NAMESPACE="io.github.kanderson250"
+          PUBLISH_NAMESPACE="com.newrelic"
           # makes a curl request to ossrh-staging-api to upload everything to Central Sonatype
           echo "Uploading artifacts from OSSRH-Staging to Central Sonatype..."
           # captures response code and body of curl request

--- a/buildSrc/src/main/java/com/nr/builder/publish/PublishConfig.java
+++ b/buildSrc/src/main/java/com/nr/builder/publish/PublishConfig.java
@@ -59,8 +59,8 @@ public class PublishConfig {
     }
 
     private static void configureRepo(MavenArtifactRepository repo, String projectVersion) {
-        URI releasesRepoUri = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/");
-        URI snapshotsRepoUrl = URI.create("https://oss.sonatype.org/content/repositories/snapshots/");
+        URI releasesRepoUri = URI.create("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/");
+        URI snapshotsRepoUrl = URI.create("https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/");
         repo.setUrl(
                 projectVersion.endsWith("SNAPSHOT")
                         ? snapshotsRepoUrl


### PR DESCRIPTION
This PR fulfills our requirement to publish to the new Sonatype platform. It:

- updates our publish config to point to the OSSRH-Staging-API service
- updates our publish workflow to run a curl request that will deploy our repos from the OSSRH-Staging-API service to the Central Portal, where they can be reviewed, deleted, or released. 
