### PR TITLE
Refactor AWS staging and prod workflows to comply with Central Sonatype

### DIFF
--- a/.github/workflows/Release-CopyToS3-prod.yml
+++ b/.github/workflows/Release-CopyToS3-prod.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run script
         env:
           RUNNING_ON_GHA: 'true'
-        run: ./automation/release/copy-to-s3.sh staging ${{ inputs.version_number }} default
+        run: ./automation/release/copy-to-s3-prod.sh ${{ inputs.version_number }} default

--- a/.github/workflows/Release-CopyToS3-staging.yml
+++ b/.github/workflows/Release-CopyToS3-staging.yml
@@ -3,10 +3,10 @@ name: Release - Copy to S3 (Staging)
 on:
   workflow_dispatch:
     inputs:
-      repo_name:
+      deployment_id:
         required: true
         type: string
-        description: 'The sonatype repo name. Eg. comnewrelic-1234'
+        description: 'The sonatype deployment id. Eg. x9a06328-cc91-24a5-fg13-7xa1d3669d842k'
       version_number:
         required: true
         type: string
@@ -31,4 +31,4 @@ jobs:
       - name: Run script
         env:
           RUNNING_ON_GHA: 'true'
-        run: ./automation/release/copy-to-s3.sh ${{ inputs.repo_name }} ${{ inputs.version_number }} staging
+        run: ./automation/release/copy-to-s3.sh ${{ inputs.deployment_id }} ${{ inputs.version_number }} staging ${{ secrets.SONATYPE_USERNAME }} ${{ secrets.SONATYPE_PASSWORD }}

--- a/automation/release/copy-to-s3-prod.sh
+++ b/automation/release/copy-to-s3-prod.sh
@@ -1,0 +1,73 @@
+#! /bin/bash
+
+if test $# -ne 2
+	then
+		echo "Usage: $0 version-num s3-profile-name"
+		exit 1
+	fi
+
+VERSION=$1
+S3_PROFILE=$2
+
+#Prod downloads bucket
+BASE_S3_URL=nr-downloads-main/newrelic/java-agent
+
+
+SERVERAGENTDIR=${BASE_S3_URL}/newrelic-agent/${VERSION}
+SERVERAPIDIR=${BASE_S3_URL}/newrelic-api/${VERSION}
+
+ZIPNAME=newrelic-java-${VERSION}.zip
+AGENT_POM_NAME=newrelic-agent-${VERSION}.pom
+AGENT_API_NAME=newrelic-api-${VERSION}.pom
+MYPATH=$0
+INSTALLDIR="`dirname ${MYPATH}`"
+
+MYDIR=/tmp/$$
+
+MVNDIR=${MYDIR}/sonatype
+POMPATH=${MVNDIR}/pom.xml
+ZIP=${MVNDIR}/${ZIPNAME}
+AGENT_POM=${MVNDIR}/${AGENT_POM_NAME}
+API_POM=${MVNDIR}/${AGENT_API_NAME}
+mkdir -p ${MVNDIR}
+
+BASE_PUBLIC_DOWNLOAD_URL=https://repo1.maven.org/maven2/com/newrelic/agent/java
+AGENT_ZIP_URL=${BASE_PUBLIC_DOWNLOAD_URL}/newrelic-java/${VERSION}/newrelic-java-${VERSION}.zip
+AGENT_POM_URL=${BASE_PUBLIC_DOWNLOAD_URL}/newrelic-agent/${VERSION}/newrelic-agent-${VERSION}.pom
+API_POM_URL=${BASE_PUBLIC_DOWNLOAD_URL}/newrelic-api/${VERSION}/newrelic-api-${VERSION}.pom
+
+echo "Attempting to fetch artifacts from Public Facing Site"
+
+#Download the newrelic zip directory
+wget -O ${ZIP} ${AGENT_ZIP_URL}
+if test $? -ne 0
+  then
+    echo "Error fetching ${ZIPNAME} from Public Site, aborting"
+    exit 10
+  fi
+
+#Download the agent pom file
+wget -O ${AGENT_POM} ${AGENT_POM_URL}
+if test $? -ne 0
+  then
+    echo "Error fetching ${AGENT_POM_NAME} from Public Site, aborting"
+    exit 10
+  fi
+
+#Download the api pom file
+wget -O ${API_POM} ${API_POM_URL}
+if test $? -ne 0
+  then
+    echo "Error fetching ${API_POM_NAME} from Public Site, aborting"
+    exit 10
+  fi
+
+ echo "Successfully downloaded artifacts from Public Facing Site"
+
+ /bin/sh "${INSTALLDIR}/send-zip-to-s3.sh" ${VERSION} ${ZIP} ${AGENT_POM} ${API_POM} ${SERVERAGENTDIR} ${SERVERAPIDIR} ${BASE_S3_URL} ${S3_PROFILE}
+
+EXITSTATUS=$?
+
+/bin/rm -rf ${MYDIR}
+
+exit ${EXITSTATUS}


### PR DESCRIPTION
Our release process migration requires updates to the way we publish our artifacts to AWS S3 buckets (first to staging, then to prod). 

Note that these changes only affect the way we obtain our zip and pom artifacts- we used to be able to get them directly from OSSRH, and now we can't. The actual script which publishes our artifacts to S3, copy-to-s3.sh, remains unchanged. 

## Changes to the Staging workflow
- Refactors the `copy-to-s3.sh` script to download the artifacts directly from Central Sonatype. This requires the use of a `deployment-id` to identify the staged artifacts, and a sonatype authorization token to download the staged artifacts. 
  - In the past we did this using a dynamically generated maven project (the long pom.xml file shown in the file comparison below), and had mvn manage the downloads. We couldn't think of a good reason to keep doing this - especially since continuing to do so would require the addition of a settings.xml file in which to pass the authorization token. 

## Changes to the Prod workflow
- Uses a new `copy-to-s3-prod.sh` script to download the artifacts from the public-facing maven site, https://repo1.maven.org/maven2/com/newrelic/agent/java/ 
  - In the past, we did this with a maven project (same as staging above). That was only possible because OSSRH Nexus would send our released repos to a dedicated endpoint, `https://oss.sonatype.org/content/repositories/releases`. This endpoint doesn't exist anymore. Instead we will take them directly from the downloads site. 
- Updates the `Release-CopyToS3-prod` action to use this new script. 


