### PR TITLE
Bump commons-lang version to 3.18.0

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 
     shadowIntoJar 'org.apache.httpcomponents:httpclient:4.5.13'
     // We use StringUtils. Since we still support Java 7, we can't go much higher than this.
-    shadowIntoJar("org.apache.commons:commons-lang3:3.8.1")
+    shadowIntoJar("org.apache.commons:commons-lang3:3.18.0")
 
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'


### PR DESCRIPTION
This version bump mitigates (per dependabot):

```
Uncontrolled Recursion vulnerability in Apache Commons Lang.

This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, 
and, from org.apache.commons:commons-lang3 3.0 before 3.18.0.

The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. 
Because an Error is usually not handled by applications and libraries, a 
StackOverflowError could cause an application to stop.

Users are recommended to upgrade to version 3.18.0, which fixes the issue.
```