### PR TITLE
Add lettuce dbName to datastore params where available

### DIFF
--- a/instrumentation/lettuce-4.3/src/main/java/com/nr/lettuce43/instrumentation/RedisDatastoreParameters.java
+++ b/instrumentation/lettuce-4.3/src/main/java/com/nr/lettuce43/instrumentation/RedisDatastoreParameters.java
@@ -9,7 +9,7 @@ public class RedisDatastoreParameters {
         if (uri != null) {
 
             params = DatastoreParameters.product("Redis").collection(null).operation(operation)
-                    .instance(uri.getHost(), uri.getPort()).noDatabaseName().build();
+                    .instance(uri.getHost(), uri.getPort()).databaseName(String.valueOf(uri.getDatabase())).build();
         } else {
             params = DatastoreParameters.product("Redis").collection(null).operation(operation).noInstance()
                     .noDatabaseName().noSlowQuery().build();

--- a/instrumentation/lettuce-4.3/src/test/java/com/nr/lettuce43/instrumentation/RedisDatastoreParametersTest.java
+++ b/instrumentation/lettuce-4.3/src/test/java/com/nr/lettuce43/instrumentation/RedisDatastoreParametersTest.java
@@ -24,6 +24,27 @@ public class RedisDatastoreParametersTest extends TestCase {
         // And database info is populated correctly
         assertEquals("Redis", dbParams.getProduct());
         assertEquals(operation, dbParams.getOperation());
+        assertEquals("0", dbParams.getDatabaseName());
+    }
+
+    @Test
+    public void testDatastoreParametersForUriWithDB() {
+        // Given
+        Integer expectedPort = 12345;
+        RedisURI uri = RedisURI.create("redis://localhost:" + expectedPort + "/3");
+        String operation = "GET";
+
+        // When
+        DatastoreParameters dbParams = RedisDatastoreParameters.from(uri, operation);
+
+        // Then url values are correct
+        assertEquals(expectedPort, dbParams.getPort());
+        assertEquals("localhost", dbParams.getHost());
+
+        // And database info is populated correctly
+        assertEquals("Redis", dbParams.getProduct());
+        assertEquals(operation, dbParams.getOperation());
+        assertEquals("3", dbParams.getDatabaseName());
     }
 
     @Test
@@ -37,6 +58,7 @@ public class RedisDatastoreParametersTest extends TestCase {
         // Then there are no url values
         assertNull(dbParams.getPort());
         assertNull(dbParams.getHost());
+        assertNull(dbParams.getDatabaseName());
 
         // And database info is STILL populated correctly
         assertEquals("Redis", dbParams.getProduct());

--- a/instrumentation/lettuce-5.0/src/main/java/com/nr/lettuce5/instrumentation/RedisDatastoreParameters.java
+++ b/instrumentation/lettuce-5.0/src/main/java/com/nr/lettuce5/instrumentation/RedisDatastoreParameters.java
@@ -9,7 +9,7 @@ public class RedisDatastoreParameters {
         if (uri != null) {
 
             params = DatastoreParameters.product("Redis").collection(null).operation(operation)
-                    .instance(uri.getHost(), uri.getPort()).noDatabaseName().build();
+                    .instance(uri.getHost(), uri.getPort()).databaseName(String.valueOf(uri.getDatabase())).build();
         } else {
             params = DatastoreParameters.product("Redis").collection(null).operation(operation).noInstance()
                     .noDatabaseName().noSlowQuery().build();

--- a/instrumentation/lettuce-5.0/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands_Instrumentation.java
+++ b/instrumentation/lettuce-5.0/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands_Instrumentation.java
@@ -80,8 +80,8 @@ public abstract class AbstractRedisReactiveCommands_Instrumentation<K, V> {
                 params = DatastoreParameters.product("Redis")
                         .collection(collName)
                         .operation(operation)
-                        .instance(uri.getHost(), Integer.valueOf(uri.getPort()))
-                        .noDatabaseName()
+                        .instance(uri.getHost(), uri.getPort())
+                        .databaseName(String.valueOf(uri.getDatabase()))
                         .build();
             } else {
                 params = DatastoreParameters.product("Redis").collection(collName).operation("").noInstance().noDatabaseName().noSlowQuery().build();

--- a/instrumentation/lettuce-5.0/src/test/java/com/nr/lettuce5/instrumentation/RedisDatastoreParametersTest.java
+++ b/instrumentation/lettuce-5.0/src/test/java/com/nr/lettuce5/instrumentation/RedisDatastoreParametersTest.java
@@ -24,6 +24,27 @@ public class RedisDatastoreParametersTest extends TestCase {
         // And database info is populated correctly
         assertEquals("Redis", dbParams.getProduct());
         assertEquals(operation, dbParams.getOperation());
+        assertEquals("0", dbParams.getDatabaseName());
+    }
+
+    @Test
+    public void testDatastoreParametersForUriWithDB() {
+        // Given
+        Integer expectedPort = 12345;
+        RedisURI uri = RedisURI.create("redis://localhost:" + expectedPort + "/2");
+        String operation = "GET";
+
+        // When
+        DatastoreParameters dbParams = RedisDatastoreParameters.from(uri, operation);
+
+        // Then url values are correct
+        assertEquals(expectedPort, dbParams.getPort());
+        assertEquals("localhost", dbParams.getHost());
+
+        // And database info is populated correctly
+        assertEquals("Redis", dbParams.getProduct());
+        assertEquals(operation, dbParams.getOperation());
+        assertEquals("2", dbParams.getDatabaseName());
     }
 
     @Test
@@ -37,6 +58,7 @@ public class RedisDatastoreParametersTest extends TestCase {
         // Then there are no url values
         assertNull(dbParams.getPort());
         assertNull(dbParams.getHost());
+        assertNull(dbParams.getDatabaseName());
 
         // And database info is STILL populated correctly
         assertEquals("Redis", dbParams.getProduct());

--- a/instrumentation/lettuce-6.0/src/main/java/com/nr/lettuce6/instrumentation/RedisDatastoreParameters.java
+++ b/instrumentation/lettuce-6.0/src/main/java/com/nr/lettuce6/instrumentation/RedisDatastoreParameters.java
@@ -9,7 +9,7 @@ public class RedisDatastoreParameters {
         if (uri != null) {
 
             params = DatastoreParameters.product("Redis").collection(null).operation(operation)
-                    .instance(uri.getHost(), uri.getPort()).noDatabaseName().build();
+                    .instance(uri.getHost(), uri.getPort()).databaseName(String.valueOf(uri.getDatabase())).build();
         } else {
             params = DatastoreParameters.product("Redis").collection(null).operation(operation).noInstance()
                     .noDatabaseName().noSlowQuery().build();

--- a/instrumentation/lettuce-6.0/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands_Instrumentation.java
+++ b/instrumentation/lettuce-6.0/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands_Instrumentation.java
@@ -80,8 +80,8 @@ public abstract class AbstractRedisReactiveCommands_Instrumentation<K, V> {
                 params = DatastoreParameters.product("Redis")
                         .collection(collName)
                         .operation(operation)
-                        .instance(uri.getHost(), Integer.valueOf(uri.getPort()))
-                        .noDatabaseName()
+                        .instance(uri.getHost(), uri.getPort())
+                        .databaseName(String.valueOf(uri.getDatabase()))
                         .build();
             } else {
                 params = DatastoreParameters.product("Redis").collection(collName).operation("").noInstance().noDatabaseName().noSlowQuery().build();

--- a/instrumentation/lettuce-6.0/src/test/java/com/nr/lettuce6/instrumentation/RedisDatastoreParametersTest.java
+++ b/instrumentation/lettuce-6.0/src/test/java/com/nr/lettuce6/instrumentation/RedisDatastoreParametersTest.java
@@ -24,6 +24,30 @@ public class RedisDatastoreParametersTest extends TestCase {
         // And database info is populated correctly
         assertEquals("Redis", dbParams.getProduct());
         assertEquals(operation, dbParams.getOperation());
+        //If no db is specified in the connection string, it should default to 0 in the datastore parameters
+        assertEquals("0", dbParams.getDatabaseName());
+    }
+
+    @Test
+    public void testDatastoreParametersWithDB() {
+        // Given
+        Integer expectedPort = 12345;
+        RedisURI uri = RedisURI.create("redis://localhost:" + expectedPort + "/1");
+        String operation = "GET";
+
+        // When
+        DatastoreParameters dbParams = RedisDatastoreParameters.from(uri, operation);
+
+        // Then url values are correct
+        assertEquals(expectedPort, dbParams.getPort());
+        assertEquals("localhost", dbParams.getHost());
+
+        // And database info is populated correctly
+        assertEquals("Redis", dbParams.getProduct());
+        assertEquals(operation, dbParams.getOperation());
+
+        // And we picked up the db instance number from the URI
+        assertEquals("1", dbParams.getDatabaseName());
     }
 
     @Test
@@ -37,6 +61,7 @@ public class RedisDatastoreParametersTest extends TestCase {
         // Then there are no url values
         assertNull(dbParams.getPort());
         assertNull(dbParams.getHost());
+        assertNull(dbParams.getDatabaseName());
 
         // And database info is STILL populated correctly
         assertEquals("Redis", dbParams.getProduct());


### PR DESCRIPTION
Resolves #2256

Small enhancement to add the redis db index (which is always an integer) to the datastore params when a URI is available. This is exposed OOTB by the RedisURI API. I ported it back to all versions of the lettuce instrumentation.

I did not pursue trying to modify the way we grab the URI.

(This instrumentation hasn't been touched in some time - also threw out an unnecessary boxing operation since I was already fiddling with things.)
