### PR TITLE
Update to support v24 of graphql

### DIFF
--- a/instrumentation/graphql-java-22.0/build.gradle
+++ b/instrumentation/graphql-java-22.0/build.gradle
@@ -22,7 +22,8 @@ java {
 }
 
 verifyInstrumentation {
-    passesOnly 'com.graphql-java:graphql-java:[22.0,23.0)'
+    passesOnly 'com.graphql-java:graphql-java:[22.0,)'
+    excludeRegex 'com.graphql-java:graphql-java:(23.*)'
     excludeRegex 'com.graphql-java:graphql-java:(0.0.0|201|202).*'
     excludeRegex 'com.graphql-java:graphql-java:.*(vTEST|-beta|-alpha1|-nf-execution|-rc|-TEST).*'
 }

--- a/instrumentation/graphql-java-22.0/src/main/java/com/nr/instrumentation/graphql/GraphQLErrorHandler.java
+++ b/instrumentation/graphql-java-22.0/src/main/java/com/nr/instrumentation/graphql/GraphQLErrorHandler.java
@@ -20,7 +20,7 @@ import java.util.logging.Level;
 
 public class GraphQLErrorHandler {
     public static void reportNonNullableExceptionToNR(FieldValueInfo result) {
-        CompletableFuture<ExecutionResult> exceptionResult = result.getFieldValue();
+        CompletableFuture<Object> exceptionResult = result.getFieldValueFuture();
         if (resultHasException(exceptionResult)) {
             reportExceptionFromCompletedExceptionally(exceptionResult);
         }
@@ -34,11 +34,11 @@ public class GraphQLErrorHandler {
         NewRelic.noticeError(throwableFromGraphQLError(error));
     }
 
-    private static boolean resultHasException(CompletableFuture<ExecutionResult> exceptionResult) {
+    private static boolean resultHasException(CompletableFuture<Object> exceptionResult) {
         return exceptionResult != null && exceptionResult.isCompletedExceptionally();
     }
 
-    private static void reportExceptionFromCompletedExceptionally(CompletableFuture<ExecutionResult> exceptionResult) {
+    private static void reportExceptionFromCompletedExceptionally(CompletableFuture<Object> exceptionResult) {
         try {
             exceptionResult.get();
         } catch (InterruptedException e) {


### PR DESCRIPTION
### Overview
Resolves #2301 

It seems that the only change to support v24+ of graphql is to update the method call on the [FieldValueInfo](https://github.com/graphql-java/graphql-java/blob/76f32f6c206a6f775f0ef0a95ab6f6a7ed539ffb/src/main/java/graphql/execution/FieldValueInfo.java#L71) instance. The `getFieldValue` method was marked for deprecation in v22 and removed in v24. The replacement call is `getFieldValueFuture` which still returns a `CompletableFuture`, although the generic typing changed.

Note that the verification explicitly skips v23.x since this was marked as "Do not use" by the maintainers.
https://github.com/graphql-java/graphql-java/releases/tag/v23.0
