### PR TITLE
Fix AutoConfiguredOpenTelemetrySdk config

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdk.java
@@ -10,9 +10,17 @@ import java.util.logging.Level;
 @Weave(type = MatchType.ExactClass)
 public class AutoConfiguredOpenTelemetrySdk {
 
+    /**
+     * Creates a new {@link AutoConfiguredOpenTelemetrySdkBuilder} with the default configuration.
+     * If the agent configuration yaml, system property `-Dnewrelic.config.opentelemetry.sdk.autoconfigure.enabled`,
+     * or environment variable NEW_RELIC_OPENTELEMETRY_SDK_AUTOCONFIGURE_ENABLED is set to true,
+     * it will append customizers for properties and resources.
+     *
+     * @return a new {@link AutoConfiguredOpenTelemetrySdkBuilder}
+     */
     public static AutoConfiguredOpenTelemetrySdkBuilder builder() {
         final AutoConfiguredOpenTelemetrySdkBuilder builder = Weaver.callOriginal();
-        Boolean autoConfigure = NewRelic.getAgent().getConfig().getValue("opentelemetry.sdk.autoconfigure.enabled");
+        Boolean autoConfigure = NewRelic.getAgent().getConfig().getValue("opentelemetry.sdk.autoconfigure.enabled", false);
         if (autoConfigure == null || autoConfigure) {
             NewRelic.getAgent().getLogger().log(Level.INFO, "Appending OpenTelemetry SDK customizers");
             builder.addPropertiesCustomizer(new PropertiesCustomizer());


### PR DESCRIPTION
Add a default value that forces the `opentelemetry.sdk.autoconfigure.enabled` config to be treated as a `Boolean`. Otherwise it was being treated as a `String` and causing a `ClassCastException`.

```
2025-08-08T14:20:27,682-0700 [70724 1] com.newrelic.agent.instrumentation.ClassTransformerServiceImpl FINEST: An error was thrown from instrumentation library com.newrelic.instrumentation.opentelemetry-sdk-extension-autoconfigure-1.28.0
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean (java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')
```
