### PR TITLE
removed labs from implementation title

### DIFF
--- a/instrumentation/couchbase-client-2.4.0/build.gradle
+++ b/instrumentation/couchbase-client-2.4.0/build.gradle
@@ -1,5 +1,5 @@
 jar {
-  manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.labs.Couchbase_Client-2.4.0'}
+  manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.Couchbase_Client-2.4.0'}
 }
 
 dependencies {

--- a/instrumentation/couchbase-client-3.0.0/build.gradle
+++ b/instrumentation/couchbase-client-3.0.0/build.gradle
@@ -1,5 +1,5 @@
 jar {
-  manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.labs.Couchbase_Client-3.0.0'}
+  manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.Couchbase_Client-3.0.0'}
 }
 
 dependencies {

--- a/instrumentation/couchbase-client-3.4.3/build.gradle
+++ b/instrumentation/couchbase-client-3.4.3/build.gradle
@@ -1,5 +1,5 @@
 jar {
-  manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.labs.Couchbase_Client-3.4.3'}
+  manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.Couchbase_Client-3.4.3'}
 }
 
 dependencies {


### PR DESCRIPTION
When the Couchbase Client instrumentation from Labs was merged into the Java Agent, we failed to remove labs from the Implementation-Title in the manifest.  
This pull request removes them so that they now match what other instrumentation in the Java Agent uses
