### PR TITLE
OTel attribute mapper impl

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
@@ -1,6 +1,13 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     id("java")
 }
+
+configurations {
+    shadowIntoJar
+}
+configurations.implementation.extendsFrom(configurations.shadowIntoJar)
 
 dependencies {
     implementation(project(":agent-bridge"))
@@ -8,13 +15,50 @@ dependencies {
     implementation(project(":newrelic-weaver-api"))
     implementation(project(":newrelic-agent"))
     implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0")
+
+    shadowIntoJar('com.googlecode.json-simple:json-simple:1.1.1') {
+        transitive = false
+    }
+
     testImplementation("junit:junit:4.12")
     testImplementation("io.opentelemetry:opentelemetry-exporter-otlp:1.28.0")
     testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.28.0")
     testImplementation("com.google.guava:guava:30.1.1-jre")
 }
 
+/**
+ * We have to shadow dependencies into instrumentation modules
+ * so they're accessible. We try not to rely on the agent dependencies
+ * otherwise.
+ */
+tasks.create("shadowJar", ShadowJar) {
+    archiveClassifier.set("shadowed")
+    setConfigurations([project.configurations.shadowIntoJar])
+    from(sourceSets.main.output.classesDirs)
+    relocate("org.json.simple", "com.nr.agent.deps.org.json.simple")
+}
+
+artifacts {
+    instrumentationWithDependencies shadowJar
+}
+
+project.tasks.getByName("writeCachedWeaveAttributes").dependsOn(shadowJar)
+
+/**
+ * shadowJar takes care of dependencies, but the jar task is what
+ * the agent build wants, so we copy the shadowJar contents.
+ */
 jar {
+    dependsOn("shadowJar")
+    from(zipTree(project.tasks["shadowJar"].archiveFile.get().asFile.path))
+
+    // The default jar task re-includes the original classes files, which we don't want.
+    exclude {
+        sourceSets.main.output.classesDirs.any {dir ->
+            it.getFile().getPath().startsWith(dir.getPath())
+        }
+    }
+
     manifest {
         attributes "Implementation-Title" : "com.newrelic.instrumentation.opentelemetry-sdk-extension-autoconfigure-1.28.0"
     }

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/span/AttributeKey.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/span/AttributeKey.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.nr.agent.instrumentation.utils.span;
+
+public class AttributeKey {
+    private final String key;
+    private final String semanticConvention;
+    private final String version;
+
+    AttributeKey(String key, String semanticConventionString) {
+        this.key = key;
+        String [] conventionNameAndVersion = semanticConventionString.split(":");
+        this.semanticConvention = conventionNameAndVersion[0];
+        this.version = conventionNameAndVersion[1];
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getSemanticConvention() {
+        return semanticConvention;
+    }
+}

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/span/AttributeMapper.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/span/AttributeMapper.java
@@ -1,0 +1,123 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.nr.agent.instrumentation.utils.span;
+
+import com.newrelic.api.agent.NewRelic;
+import io.opentelemetry.api.trace.SpanKind;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+
+public class AttributeMapper {
+    private static final String MAPPING_RESOURCE = "attribute-mappings.json";
+
+    private static volatile AttributeMapper instance;
+    private final Map<SpanKind, Map<AttributeType, List<AttributeKey>>> mappings = new HashMap<>();
+
+    private AttributeMapper() {
+        for(SpanKind spanKind : SpanKind.values()) {
+            Map<AttributeType, List<AttributeKey>> typeToKeysMap = new HashMap<>();
+            for (AttributeType attributeType : AttributeType.values()) {
+                typeToKeysMap.put(attributeType, new ArrayList<>());
+            }
+            this.mappings.put(spanKind, typeToKeysMap);
+        }
+    }
+
+    public static AttributeMapper getInstance() {
+        // Double-Checked Locking init
+        if (instance == null) {
+            synchronized (AttributeMapper.class) {
+                if (instance == null) {
+                    try (InputStream inputStream = AttributeMapper.class.getClassLoader().getResourceAsStream(MAPPING_RESOURCE);
+                         InputStreamReader reader = new InputStreamReader(inputStream)) {
+
+                        instance = new AttributeMapper();
+
+                        JSONParser parser = new JSONParser();
+                        JSONArray rootArray = (JSONArray) parser.parse(reader);
+
+                        for (Object spanKindObj : rootArray) {
+                            // Span kind and a list of attribute types
+                            JSONObject spanKindObject = (JSONObject) spanKindObj;
+                            SpanKind spanKind = SpanKind.valueOf((String) spanKindObject.get("spanKind"));
+                            JSONArray jsonAttributeTypes = (JSONArray) spanKindObject.get("attributeTypes");
+
+                            for (Object typeObj : jsonAttributeTypes) {
+                                JSONObject categoryObject = (JSONObject) typeObj;
+
+                                // Grab the attribute type (Port, Host, etc) and then iterate over the actual attribute keys
+                                AttributeType attributeType = AttributeType.valueOf((String) categoryObject.get("attributeType"));
+                                JSONArray jsonAttributes = (JSONArray) categoryObject.get("attributes");
+                                for (Object jsonAttribute : jsonAttributes) {
+                                    JSONObject attribute = (JSONObject) jsonAttribute;
+                                    instance.addAttributeMapping(spanKind, attributeType, new AttributeKey((String) attribute.get("name"), (String) attribute.get("version")));
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        // Should never happen...
+                        NewRelic.getAgent().getLogger().log(Level.SEVERE, "Unable to read OTel attribute mappings", e);
+                    }
+                }
+            }
+        }
+
+        return instance;
+    }
+
+    /**
+     * Based on the SpanKind and type of attribute, search through the available OTel keys and find the correct key
+     * since we don't know ahead of time what semantic convention version is in use and some keys vary based on
+     * that version.
+     *
+     * @param spanKind the span kind (SERVER, CLIENT, PRODUCER, CONSUMER, INTERNAL)
+     * @param type the "type" of key we're looking for: host, port, etc
+     * @param otelKeys the available OTel keys to search through
+     *
+     * @return the available key String
+     */
+    public String findProperOtelKey(SpanKind spanKind, AttributeType type, Set<String> otelKeys) {
+        List<AttributeKey> keys = mappings.get(spanKind).get(type);
+        for (AttributeKey key : keys) {
+            if (otelKeys.contains(key.getKey())) {
+                return key.getKey();
+            }
+        }
+
+        return "";
+    }
+
+    /**
+     * Visible for testing
+     *
+     * @return the configured mappings: SpanKind --> Map<AttributeType, List<AttributeKey>>
+     */
+    Map<SpanKind, Map<AttributeType, List<AttributeKey>>> getMappings() {
+        return mappings;
+    }
+
+    /**
+     * Adds a new mapping to this mapper
+     *
+     * @param spanKind the SpanKind this mapping belongs to
+     * @param attributeType the type (Port, Host...)
+     * @param attributeKey the AttributeKey instance for this mapping
+     */
+    private void addAttributeMapping(SpanKind spanKind, AttributeType attributeType, AttributeKey attributeKey) {
+        this.mappings.get(spanKind).get(attributeType).add(attributeKey);
+    }
+}

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/span/AttributeType.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/span/AttributeType.java
@@ -1,0 +1,11 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.nr.agent.instrumentation.utils.span;
+
+public enum AttributeType {
+    Port, Host
+}

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/resources/attribute-mappings.json
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/resources/attribute-mappings.json
@@ -1,0 +1,35 @@
+[
+  {
+    "spanKind": "SERVER",
+    "attributeTypes": [
+      {
+        "Port": [
+          {
+            "server.port": {
+              "semanticConvention": "HTTP-Server:1.23"
+            }
+          },
+          {
+            "net.host.port": {
+              "semanticConvention": "HTTP-Server:1.20"
+            }
+          }
+        ]
+      },
+      {
+        "Host": [
+          {
+            "server.address": {
+              "semanticConvention": "HTTP-Server:1.23"
+            }
+          },
+          {
+            "net.host.name": {
+              "semanticConvention": "HTTP-Server:1.20"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/com/nr/agent/instrumentation/utils/span/AttributeMapperTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/com/nr/agent/instrumentation/utils/span/AttributeMapperTest.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.nr.agent.instrumentation.utils.span;
+
+import io.opentelemetry.api.trace.SpanKind;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttributeMapperTest {
+    @Test
+    public void getInstance_withValidJson_createsValidMapper() {
+        AttributeMapper attributeMapper = AttributeMapper.getInstance();
+
+        // 5 SpanKind types
+        Map<SpanKind, Map<AttributeType, List<AttributeKey>>> mappings = attributeMapper.getMappings();
+        assertEquals(5, mappings.size());
+
+        for (SpanKind spanKind : SpanKind.values()) {
+            Map<AttributeType, List<AttributeKey>> attributeTypesBySpan = mappings.get(spanKind);
+            assertEquals(2, attributeTypesBySpan.size());
+
+            // The actual attribute key mappings...
+            for (AttributeType attributeType : AttributeType.values()) {
+                assertEquals(2, attributeTypesBySpan.get(attributeType).size());
+            }
+        }
+    }
+
+    @Test
+    public void findProperOtelKey_returnsProperKey() {
+        AttributeMapper attributeMapper = AttributeMapper.getInstance();
+        Set<String> otelKeys = new HashSet<>();
+        otelKeys.add("key1");
+        otelKeys.add("key2");
+        otelKeys.add("key3");
+        otelKeys.add("server.port");    //Should find this in the mapper
+
+        assertEquals("server.port", attributeMapper.findProperOtelKey(SpanKind.SERVER, AttributeType.Port, otelKeys));
+    }
+
+    @Test
+    public void findProperOtelKey_returnsEmptyString_whenRequestedKeyNotFound() {
+        AttributeMapper attributeMapper = AttributeMapper.getInstance();
+        Set<String> otelKeys = new HashSet<>();
+        otelKeys.add("key1");
+        otelKeys.add("key2");
+        otelKeys.add("key3");
+
+        assertEquals("", attributeMapper.findProperOtelKey(SpanKind.SERVER, AttributeType.Port, otelKeys));
+    }
+}

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/resources/attribute-mappings.json
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/resources/attribute-mappings.json
@@ -1,0 +1,157 @@
+[
+  {
+    "spanKind": "SERVER",
+    "attributeTypes": [
+      {
+        "attributeType": "Port",
+        "attributes": [
+          {
+            "name": "server.port",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.port",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      },
+      {
+        "attributeType": "Host",
+        "attributes": [
+          {
+            "name": "server.address",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.name",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "spanKind": "INTERNAL",
+    "attributeTypes": [
+      {
+        "attributeType": "Port",
+        "attributes": [
+          {
+            "name": "server.port",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.port",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      },
+      {
+        "attributeType": "Host",
+        "attributes": [
+          {
+            "name": "server.address",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.name",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "spanKind": "CONSUMER",
+    "attributeTypes": [
+      {
+        "attributeType": "Port",
+        "attributes": [
+          {
+            "name": "server.port",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.port",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      },
+      {
+        "attributeType": "Host",
+        "attributes": [
+          {
+            "name": "server.address",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.name",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "spanKind": "PRODUCER",
+    "attributeTypes": [
+      {
+        "attributeType": "Port",
+        "attributes": [
+          {
+            "name": "server.port",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.port",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      },
+      {
+        "attributeType": "Host",
+        "attributes": [
+          {
+            "name": "server.address",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.name",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "spanKind": "CLIENT",
+    "attributeTypes": [
+      {
+        "attributeType": "Port",
+        "attributes": [
+          {
+            "name": "server.port",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.port",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      },
+      {
+        "attributeType": "Host",
+        "attributes": [
+          {
+            "name": "server.address",
+            "version": "HTTP-Server:1.23"
+          },
+          {
+            "name": "net.host.name",
+            "version": "HTTP-Server:1.20"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
### Overview
Resolves #2436 

This change allows OTel attributes to be mapped across the various OTel semantic conventions.

#### Approach
Categorize the various attributes via:
- SpanKind
    - Attribute Type (For example "Port", "Host", etc)
        - Actual attribute keys with it's correseponding semantic convention version

For example:
```
SERVER
  Port
    server.port - HTTP Server v1.23
    net.host.port - HTTP Server v1.20
  Host
    server.address - HTTP Server v1.23
    net.host.name - HTTP Server v1.20
```

These mappings will be stored in a JSON file, which will be read and parsed one time, when the `AttributeMapper` singleton is accessed. Note that the JSON files are incomplete at this point until we make sure this is a valid approach.

A method on the mapper, `findProperOtelKey` is used to locate the key being used by the OTel SDK so that the correct value can be retrieved.

`public String findProperOtelKey(SpanKind spanKind, AttributeType type, Set<String> otelKeys)`

Which can be used as follows:
```
Object host = attributes.get(AttributeMapper.getInstance()
    .findProperOtelKey(SpanKind.SERVER, AttributeType.Host, otelAttributes));
// Will look for "server.port" and "new.host.name" and return the one that's present
```

Note that the semantic version value isn't currently used. It was added in case it's needed in the future.

