### PR TITLE
Add skip class to prevent double instrumentation

### DIFF
--- a/instrumentation/couchbase-client-3.0.0/build.gradle
+++ b/instrumentation/couchbase-client-3.0.0/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 verifyInstrumentation {
-  	passes 'com.couchbase.client:java-client:[3.0.0,3.4.3)'
+  	passesOnly 'com.couchbase.client:java-client:[3.0.0,3.4.3)'
   	excludeRegex '.*SNAPSHOT'
 }
 

--- a/instrumentation/couchbase-client-3.0.0/src/main/java/com/nr/instrumentation/couchbase/SamplingScan$Built_Skip.java
+++ b/instrumentation/couchbase-client-3.0.0/src/main/java/com/nr/instrumentation/couchbase/SamplingScan$Built_Skip.java
@@ -1,0 +1,13 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.nr.instrumentation.couchbase;
+
+import com.newrelic.api.agent.weaver.SkipIfPresent;
+
+@SkipIfPresent(originalName = "com.couchbase.client.java.kv.SamplingScan$Built")
+public class SamplingScan$Built_Skip {
+}

--- a/instrumentation/couchbase-client-3.4.3/build.gradle
+++ b/instrumentation/couchbase-client-3.4.3/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 verifyInstrumentation {
-  	passes 'com.couchbase.client:java-client:[3.4.3,)'
+  	passesOnly 'com.couchbase.client:java-client:[3.4.3,)'
   	excludeRegex '.*SNAPSHOT'
 }
 


### PR DESCRIPTION
### Overview
Add the `SamplingScan$Built_Skip.java` skip class to prevent double instrumentation with module version 3.0.0 and version 3.4.3.

Updated gradle file to utilize `passesOnly` rather than `passes` to properly verify the instrumentation ranges.
