### PR TITLE
Optimize verification ranges for AWS DynamoDB and S3 SDKs

### DIFF
--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
@@ -24,8 +24,67 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'software.amazon.awssdk:dynamodb:[2.1.0,)'
-    exclude 'software.amazon.awssdk:dynamodb:2.17.200' // this version failed the test, but the next one works again.
+    /*
+        This is the original verifier range prior to this update.
+        Previously it was simply "passes"; this changes it to
+        the standard "passOnly" method.
+     */
+    passesOnly 'software.amazon.awssdk:dynamodb:[2.1.0,)'
+
+    /*
+        Now, exclude the ranges we know have passed verification
+        previously. The ranges ensure we will run verification if
+        a new revision of a previous minor version is released.
+
+        For the last known minor version, we leave the verify
+        range open ended to catch any new versions released
+        (including any new major/minor versions). The verify
+        ranges will probably need to be manually inspected
+        every so often to keep the task runtime in check.
+
+        This dramatically reduces the runtime of the verification
+        task. For this module, there were over 1500 artifacts that
+        were being downloaded for each verification - AWS seems to
+        enjoy releasing new revisions of SDK artifacts every few days.
+
+        This pattern can be applied to any module that suffers from
+        large numbers of artifacts (looking at anything AWS related).
+     */
+    excludeRegex ".*preview.*"
+    exclude('software.amazon.awssdk:dynamodb:[2.1.0,2.1.4]')
+    exclude('software.amazon.awssdk:dynamodb:2.2.0')
+    exclude('software.amazon.awssdk:dynamodb:[2.3.0,2.3.9]')
+    exclude('software.amazon.awssdk:dynamodb:[2.4.0,2.4.17]')
+    exclude('software.amazon.awssdk:dynamodb:[2.5.0,2.5.71]')
+    exclude('software.amazon.awssdk:dynamodb:[2.6.0,2.6.5]')
+    exclude('software.amazon.awssdk:dynamodb:[2.7.0,2.7.36]')
+    exclude('software.amazon.awssdk:dynamodb:[2.8.0,2.8.7]')
+    exclude('software.amazon.awssdk:dynamodb:[2.9.0,2.9.26]')
+    exclude('software.amazon.awssdk:dynamodb:[2.10.0,2.10.91]')
+    exclude('software.amazon.awssdk:dynamodb:[2.11.0,2.11.14]')
+    exclude('software.amazon.awssdk:dynamodb:2.12.0')
+    exclude('software.amazon.awssdk:dynamodb:[2.13.0,2.13.76]')
+    exclude('software.amazon.awssdk:dynamodb:[2.14.0,2.14.28]')
+    exclude('software.amazon.awssdk:dynamodb:[2.15.0,2.15.82]')
+    exclude('software.amazon.awssdk:dynamodb:[2.16.0,2.16.104]')
+    exclude('software.amazon.awssdk:dynamodb:[2.17.0,2.17.295]')
+    exclude('software.amazon.awssdk:dynamodb:[2.18.0,2.18.41]')
+    exclude('software.amazon.awssdk:dynamodb:[2.19.0,2.19.33]')
+    exclude('software.amazon.awssdk:dynamodb:[2.20.0,2.20.162]')
+    exclude('software.amazon.awssdk:dynamodb:[2.21.0,2.21.46]')
+    exclude('software.amazon.awssdk:dynamodb:[2.22.0,2.22.13]')
+    exclude('software.amazon.awssdk:dynamodb:[2.23.0,2.23.21]')
+    exclude('software.amazon.awssdk:dynamodb:[2.24.0,2.24.13]')
+    exclude('software.amazon.awssdk:dynamodb:[2.25.0,2.25.70]')
+    exclude('software.amazon.awssdk:dynamodb:[2.26.0,2.26.31]')
+    exclude('software.amazon.awssdk:dynamodb:[2.27.0,2.27.24]')
+    exclude('software.amazon.awssdk:dynamodb:[2.28.0,2.28.29]')
+    exclude('software.amazon.awssdk:dynamodb:[2.29.0,2.29.52]')
+    exclude('software.amazon.awssdk:dynamodb:[2.30.0,2.30.38]')
+    exclude('software.amazon.awssdk:dynamodb:[2.31.0,2.31.78]')
+
+    // The next excludes will be 2.32.x -- Leaving this out so the verifier actually
+    // has something to run against.
 }
 
 task copyNativeDeps(type: Copy) {

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
@@ -33,8 +33,8 @@ verifyInstrumentation {
 
     /*
         Now, exclude the ranges we know have passed verification
-        previously. The ranges ensure we will run verification if
-        a new revision of a previous minor version is released.
+        previously. We set the range such that the last revision
+        of each minor version will still get verified.
 
         For the last known minor version, we leave the verify
         range open ended to catch any new versions released
@@ -51,37 +51,35 @@ verifyInstrumentation {
         large numbers of artifacts (looking at anything AWS related).
      */
     excludeRegex ".*preview.*"
-    exclude 'software.amazon.awssdk:dynamodb:[2.1.0,2.1.4]'
-    exclude 'software.amazon.awssdk:dynamodb:2.2.0'
-    exclude 'software.amazon.awssdk:dynamodb:[2.3.0,2.3.9]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.4.0,2.4.17]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.5.0,2.5.71]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.6.0,2.6.5]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.7.0,2.7.36]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.8.0,2.8.7]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.9.0,2.9.26]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.10.0,2.10.91]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.11.0,2.11.14]'
-    exclude 'software.amazon.awssdk:dynamodb:2.12.0'
-    exclude 'software.amazon.awssdk:dynamodb:[2.13.0,2.13.76]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.14.0,2.14.28]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.15.0,2.15.82]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.16.0,2.16.104]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.17.0,2.17.295]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.18.0,2.18.41]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.19.0,2.19.33]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.20.0,2.20.162]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.21.0,2.21.46]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.22.0,2.22.13]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.23.0,2.23.21]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.24.0,2.24.13]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.25.0,2.25.70]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.26.0,2.26.31]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.27.0,2.27.24]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.28.0,2.28.29]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.29.0,2.29.52]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.30.0,2.30.38]'
-    exclude 'software.amazon.awssdk:dynamodb:[2.31.0,2.31.78]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.1.0,2.1.3]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.3.0,2.3.8]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.4.0,2.4.16]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.5.0,2.5.70]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.6.0,2.6.4]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.7.0,2.7.35]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.8.0,2.8.6]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.9.0,2.9.25]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.10.0,2.10.90]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.11.0,2.11.13]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.13.0,2.13.75]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.14.0,2.14.27]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.15.0,2.15.81]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.16.0,2.16.103]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.17.0,2.17.294]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.18.0,2.18.40]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.19.0,2.19.32]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.20.0,2.20.161]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.21.0,2.21.45]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.22.0,2.22.12]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.23.0,2.23.20]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.24.0,2.24.12]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.25.0,2.25.69]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.26.0,2.26.30]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.27.0,2.27.23]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.28.0,2.28.28]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.29.0,2.29.51]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.30.0,2.30.37]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.31.0,2.31.77]'
 
     // The next excludes will be 2.32.x -- Leaving this out so the verifier actually
     // has something to run against.

--- a/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
+++ b/instrumentation/aws-java-sdk-dynamodb-2.15.34/build.gradle
@@ -51,37 +51,37 @@ verifyInstrumentation {
         large numbers of artifacts (looking at anything AWS related).
      */
     excludeRegex ".*preview.*"
-    exclude('software.amazon.awssdk:dynamodb:[2.1.0,2.1.4]')
-    exclude('software.amazon.awssdk:dynamodb:2.2.0')
-    exclude('software.amazon.awssdk:dynamodb:[2.3.0,2.3.9]')
-    exclude('software.amazon.awssdk:dynamodb:[2.4.0,2.4.17]')
-    exclude('software.amazon.awssdk:dynamodb:[2.5.0,2.5.71]')
-    exclude('software.amazon.awssdk:dynamodb:[2.6.0,2.6.5]')
-    exclude('software.amazon.awssdk:dynamodb:[2.7.0,2.7.36]')
-    exclude('software.amazon.awssdk:dynamodb:[2.8.0,2.8.7]')
-    exclude('software.amazon.awssdk:dynamodb:[2.9.0,2.9.26]')
-    exclude('software.amazon.awssdk:dynamodb:[2.10.0,2.10.91]')
-    exclude('software.amazon.awssdk:dynamodb:[2.11.0,2.11.14]')
-    exclude('software.amazon.awssdk:dynamodb:2.12.0')
-    exclude('software.amazon.awssdk:dynamodb:[2.13.0,2.13.76]')
-    exclude('software.amazon.awssdk:dynamodb:[2.14.0,2.14.28]')
-    exclude('software.amazon.awssdk:dynamodb:[2.15.0,2.15.82]')
-    exclude('software.amazon.awssdk:dynamodb:[2.16.0,2.16.104]')
-    exclude('software.amazon.awssdk:dynamodb:[2.17.0,2.17.295]')
-    exclude('software.amazon.awssdk:dynamodb:[2.18.0,2.18.41]')
-    exclude('software.amazon.awssdk:dynamodb:[2.19.0,2.19.33]')
-    exclude('software.amazon.awssdk:dynamodb:[2.20.0,2.20.162]')
-    exclude('software.amazon.awssdk:dynamodb:[2.21.0,2.21.46]')
-    exclude('software.amazon.awssdk:dynamodb:[2.22.0,2.22.13]')
-    exclude('software.amazon.awssdk:dynamodb:[2.23.0,2.23.21]')
-    exclude('software.amazon.awssdk:dynamodb:[2.24.0,2.24.13]')
-    exclude('software.amazon.awssdk:dynamodb:[2.25.0,2.25.70]')
-    exclude('software.amazon.awssdk:dynamodb:[2.26.0,2.26.31]')
-    exclude('software.amazon.awssdk:dynamodb:[2.27.0,2.27.24]')
-    exclude('software.amazon.awssdk:dynamodb:[2.28.0,2.28.29]')
-    exclude('software.amazon.awssdk:dynamodb:[2.29.0,2.29.52]')
-    exclude('software.amazon.awssdk:dynamodb:[2.30.0,2.30.38]')
-    exclude('software.amazon.awssdk:dynamodb:[2.31.0,2.31.78]')
+    exclude 'software.amazon.awssdk:dynamodb:[2.1.0,2.1.4]'
+    exclude 'software.amazon.awssdk:dynamodb:2.2.0'
+    exclude 'software.amazon.awssdk:dynamodb:[2.3.0,2.3.9]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.4.0,2.4.17]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.5.0,2.5.71]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.6.0,2.6.5]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.7.0,2.7.36]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.8.0,2.8.7]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.9.0,2.9.26]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.10.0,2.10.91]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.11.0,2.11.14]'
+    exclude 'software.amazon.awssdk:dynamodb:2.12.0'
+    exclude 'software.amazon.awssdk:dynamodb:[2.13.0,2.13.76]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.14.0,2.14.28]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.15.0,2.15.82]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.16.0,2.16.104]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.17.0,2.17.295]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.18.0,2.18.41]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.19.0,2.19.33]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.20.0,2.20.162]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.21.0,2.21.46]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.22.0,2.22.13]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.23.0,2.23.21]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.24.0,2.24.13]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.25.0,2.25.70]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.26.0,2.26.31]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.27.0,2.27.24]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.28.0,2.28.29]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.29.0,2.29.52]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.30.0,2.30.38]'
+    exclude 'software.amazon.awssdk:dynamodb:[2.31.0,2.31.78]'
 
     // The next excludes will be 2.32.x -- Leaving this out so the verifier actually
     // has something to run against.

--- a/instrumentation/aws-java-sdk-s3-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-s3-2.0/build.gradle
@@ -28,8 +28,9 @@ verifyInstrumentation {
 
     /*
         Now, exclude the ranges we know have passed verification
-        previously. The ranges ensure we will run verification if
-        a new revision of a previous minor version is released.
+        previously. We set the range such that the last revision
+        of each minor version will still get verified.
+
 
         For the last known minor version, we leave the verify
         range open ended to catch any new versions released
@@ -46,37 +47,35 @@ verifyInstrumentation {
         large numbers of artifacts (looking at anything AWS related).
      */
     excludeRegex ".*preview.*"
-    exclude  'software.amazon.awssdk:s3:[2.1.0,2.1.4]'
-    exclude  'software.amazon.awssdk:s3:2.2.0'
-    exclude  'software.amazon.awssdk:s3:[2.3.0,2.3.9]'
-    exclude  'software.amazon.awssdk:s3:[2.4.0,2.4.17]'
-    exclude  'software.amazon.awssdk:s3:[2.5.0,2.5.71]'
-    exclude  'software.amazon.awssdk:s3:[2.6.0,2.6.5]'
-    exclude  'software.amazon.awssdk:s3:[2.7.0,2.7.36]'
-    exclude  'software.amazon.awssdk:s3:[2.8.0,2.8.6]'
-    exclude  'software.amazon.awssdk:s3:[2.9.0,2.9.26]'
-    exclude  'software.amazon.awssdk:s3:[2.10.0,2.10.91]'
-    exclude  'software.amazon.awssdk:s3:[2.11.0,2.11.14]'
-    exclude  'software.amazon.awssdk:s3:2.12.0'
-    exclude  'software.amazon.awssdk:s3:[2.13.0,2.13.76]'
-    exclude  'software.amazon.awssdk:s3:[2.14.0,2.14.28]'
-    exclude  'software.amazon.awssdk:s3:[2.15.0,2.15.82]'
-    exclude  'software.amazon.awssdk:s3:[2.16.0,2.16.104]'
-    exclude  'software.amazon.awssdk:s3:[2.17.0,2.17.295]'
-    exclude  'software.amazon.awssdk:s3:[2.18.0,2.18.41]'
-    exclude  'software.amazon.awssdk:s3:[2.19.0,2.19.31]'
-    exclude  'software.amazon.awssdk:s3:[2.20.0,2.20.162]'
-    exclude  'software.amazon.awssdk:s3:[2.21.0,2.21.46]'
-    exclude  'software.amazon.awssdk:s3:[2.22.0,2.22.13]'
-    exclude  'software.amazon.awssdk:s3:[2.23.0,2.23.21]'
-    exclude  'software.amazon.awssdk:s3:[2.24.0,2.24.13]'
-    exclude  'software.amazon.awssdk:s3:[2.25.0,2.25.70]'
-    exclude  'software.amazon.awssdk:s3:[2.26.0,2.26.31]'
-    exclude  'software.amazon.awssdk:s3:[2.27.0,2.27.24]'
-    exclude  'software.amazon.awssdk:s3:[2.28.0,2.28.29]'
-    exclude  'software.amazon.awssdk:s3:[2.29.0,2.29.52]'
-    exclude  'software.amazon.awssdk:s3:[2.30.0,2.30.38]'
-    exclude  'software.amazon.awssdk:s3:[2.31.0,2.31.78]'
+    exclude  'software.amazon.awssdk:s3:[2.1.0,2.1.3]'
+    exclude  'software.amazon.awssdk:s3:[2.3.0,2.3.8]'
+    exclude  'software.amazon.awssdk:s3:[2.4.0,2.4.16]'
+    exclude  'software.amazon.awssdk:s3:[2.5.0,2.5.70]'
+    exclude  'software.amazon.awssdk:s3:[2.6.0,2.6.4]'
+    exclude  'software.amazon.awssdk:s3:[2.7.0,2.7.35]'
+    exclude  'software.amazon.awssdk:s3:[2.8.0,2.8.5]'
+    exclude  'software.amazon.awssdk:s3:[2.9.0,2.9.25]'
+    exclude  'software.amazon.awssdk:s3:[2.10.0,2.10.90]'
+    exclude  'software.amazon.awssdk:s3:[2.11.0,2.11.13]'
+    exclude  'software.amazon.awssdk:s3:[2.13.0,2.13.75]'
+    exclude  'software.amazon.awssdk:s3:[2.14.0,2.14.27]'
+    exclude  'software.amazon.awssdk:s3:[2.15.0,2.15.81]'
+    exclude  'software.amazon.awssdk:s3:[2.16.0,2.16.103]'
+    exclude  'software.amazon.awssdk:s3:[2.17.0,2.17.294]'
+    exclude  'software.amazon.awssdk:s3:[2.18.0,2.18.40]'
+    exclude  'software.amazon.awssdk:s3:[2.19.0,2.19.30]'
+    exclude  'software.amazon.awssdk:s3:[2.20.0,2.20.161]'
+    exclude  'software.amazon.awssdk:s3:[2.21.0,2.21.45]'
+    exclude  'software.amazon.awssdk:s3:[2.22.0,2.22.12]'
+    exclude  'software.amazon.awssdk:s3:[2.23.0,2.23.20]'
+    exclude  'software.amazon.awssdk:s3:[2.24.0,2.24.12]'
+    exclude  'software.amazon.awssdk:s3:[2.25.0,2.25.69]'
+    exclude  'software.amazon.awssdk:s3:[2.26.0,2.26.30]'
+    exclude  'software.amazon.awssdk:s3:[2.27.0,2.27.23]'
+    exclude  'software.amazon.awssdk:s3:[2.28.0,2.28.28]'
+    exclude  'software.amazon.awssdk:s3:[2.29.0,2.29.51]'
+    exclude  'software.amazon.awssdk:s3:[2.30.0,2.30.37]'
+    exclude  'software.amazon.awssdk:s3:[2.31.0,2.31.77]'
 
     // The next excludes will be 2.32.x -- Leaving this out so the verifier actually
     // has something to run against.

--- a/instrumentation/aws-java-sdk-s3-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-s3-2.0/build.gradle
@@ -19,38 +19,67 @@ dependencies {
 // The only uncapped verification is the most recent minor version. This may need
 // to be revisited as AWS release more minor versions.
 verifyInstrumentation {
-    passes 'software.amazon.awssdk:s3:2.1.4'
-    passes 'software.amazon.awssdk:s3:2.2.0'
-    passes 'software.amazon.awssdk:s3:2.3.9'
-    passes 'software.amazon.awssdk:s3:2.4.17'
-    passes 'software.amazon.awssdk:s3:2.5.71'
-    passes 'software.amazon.awssdk:s3:2.6.5'
-    passes 'software.amazon.awssdk:s3:2.7.36'
-    passes 'software.amazon.awssdk:s3:2.8.6'
-    passes 'software.amazon.awssdk:s3:2.9.26'
-    passes 'software.amazon.awssdk:s3:2.10.91'
-    passes 'software.amazon.awssdk:s3:2.11.14'
-    passes 'software.amazon.awssdk:s3:2.12.0'
-    passes 'software.amazon.awssdk:s3:2.13.76'
-    passes 'software.amazon.awssdk:s3:2.14.28'
-    passes 'software.amazon.awssdk:s3:2.15.82'
-    passes 'software.amazon.awssdk:s3:2.16.104'
-    passes 'software.amazon.awssdk:s3:2.17.295'
-    passes 'software.amazon.awssdk:s3:2.18.41'
-    passes 'software.amazon.awssdk:s3:2.19.31'
-    passes 'software.amazon.awssdk:s3:2.20.162'
-    passes 'software.amazon.awssdk:s3:2.21.46'
-    passes 'software.amazon.awssdk:s3:2.22.13'
-    passes 'software.amazon.awssdk:s3:2.23.21'
-    passes 'software.amazon.awssdk:s3:2.24.13'
-    passes 'software.amazon.awssdk:s3:2.25.70'
-    passes 'software.amazon.awssdk:s3:2.26.31'
-    passes 'software.amazon.awssdk:s3:2.27.24'
-    passes 'software.amazon.awssdk:s3:2.28.29'
-    passes 'software.amazon.awssdk:s3:2.29.52'
-    passes 'software.amazon.awssdk:s3:2.30.38'
-    passes 'software.amazon.awssdk:s3:[2.31.0,)'
+    /*
+        This is the original verifier range prior to this update.
+        Previously it was simply "passes"; this changes it to
+        the standard "passOnly" method.
+     */
+    passesOnly 'software.amazon.awssdk:s3:[2.1.0,)'
+
+    /*
+        Now, exclude the ranges we know have passed verification
+        previously. The ranges ensure we will run verification if
+        a new revision of a previous minor version is released.
+
+        For the last known minor version, we leave the verify
+        range open ended to catch any new versions released
+        (including any new major/minor versions). The verify
+        ranges will probably need to be manually inspected
+        every so often to keep the task runtime in check.
+
+        This dramatically reduces the runtime of the verification
+        task. For this module, there were over 1500 artifacts that
+        were being downloaded for each verification - AWS seems to
+        enjoy releasing new revisions of SDK artifacts every few days.
+
+        This pattern can be applied to any module that suffers from
+        large numbers of artifacts (looking at anything AWS related).
+     */
     excludeRegex ".*preview.*"
+    exclude  'software.amazon.awssdk:s3:[2.1.0,2.1.4]'
+    exclude  'software.amazon.awssdk:s3:2.2.0'
+    exclude  'software.amazon.awssdk:s3:[2.3.0,2.3.9]'
+    exclude  'software.amazon.awssdk:s3:[2.4.0,2.4.17]'
+    exclude  'software.amazon.awssdk:s3:[2.5.0,2.5.71]'
+    exclude  'software.amazon.awssdk:s3:[2.6.0,2.6.5]'
+    exclude  'software.amazon.awssdk:s3:[2.7.0,2.7.36]'
+    exclude  'software.amazon.awssdk:s3:[2.8.0,2.8.6]'
+    exclude  'software.amazon.awssdk:s3:[2.9.0,2.9.26]'
+    exclude  'software.amazon.awssdk:s3:[2.10.0,2.10.91]'
+    exclude  'software.amazon.awssdk:s3:[2.11.0,2.11.14]'
+    exclude  'software.amazon.awssdk:s3:2.12.0'
+    exclude  'software.amazon.awssdk:s3:[2.13.0,2.13.76]'
+    exclude  'software.amazon.awssdk:s3:[2.14.0,2.14.28]'
+    exclude  'software.amazon.awssdk:s3:[2.15.0,2.15.82]'
+    exclude  'software.amazon.awssdk:s3:[2.16.0,2.16.104]'
+    exclude  'software.amazon.awssdk:s3:[2.17.0,2.17.295]'
+    exclude  'software.amazon.awssdk:s3:[2.18.0,2.18.41]'
+    exclude  'software.amazon.awssdk:s3:[2.19.0,2.19.31]'
+    exclude  'software.amazon.awssdk:s3:[2.20.0,2.20.162]'
+    exclude  'software.amazon.awssdk:s3:[2.21.0,2.21.46]'
+    exclude  'software.amazon.awssdk:s3:[2.22.0,2.22.13]'
+    exclude  'software.amazon.awssdk:s3:[2.23.0,2.23.21]'
+    exclude  'software.amazon.awssdk:s3:[2.24.0,2.24.13]'
+    exclude  'software.amazon.awssdk:s3:[2.25.0,2.25.70]'
+    exclude  'software.amazon.awssdk:s3:[2.26.0,2.26.31]'
+    exclude  'software.amazon.awssdk:s3:[2.27.0,2.27.24]'
+    exclude  'software.amazon.awssdk:s3:[2.28.0,2.28.29]'
+    exclude  'software.amazon.awssdk:s3:[2.29.0,2.29.52]'
+    exclude  'software.amazon.awssdk:s3:[2.30.0,2.30.38]'
+    exclude  'software.amazon.awssdk:s3:[2.31.0,2.31.78]'
+
+    // The next excludes will be 2.32.x -- Leaving this out so the verifier actually
+    // has something to run against.
 }
 
 site {

--- a/instrumentation/aws-java-sdk-s3-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-s3-2.0/build.gradle
@@ -13,11 +13,6 @@ dependencies {
 
 }
 
-// This long list of "passes" versions is designed to only verify the last revision
-// for each minor version. This was required since some minor versions had hundreds
-// of revisions which was causing the verification task to take hours.
-// The only uncapped verification is the most recent minor version. This may need
-// to be revisited as AWS release more minor versions.
 verifyInstrumentation {
     /*
         This is the original verifier range prior to this update.


### PR DESCRIPTION
Update the verification ranges on DynamoDB and S3 SDKs so we only verify the full range of the latest minor version and the latest revision of each minor version.  This dramatically cuts down on the verification task runtime.

Details are in the comments of each build file.
