### PR TITLE
Skip the 6.0 instrumentation if the RedisJsonCommandBuilder exists

### DIFF
--- a/instrumentation/lettuce-6.0/src/main/java/io/lettuce/core/Skip_RedisJsonCommandBuilder.java
+++ b/instrumentation/lettuce-6.0/src/main/java/io/lettuce/core/Skip_RedisJsonCommandBuilder.java
@@ -1,0 +1,23 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.lettuce.core;
+
+import com.newrelic.api.agent.weaver.SkipIfPresent;
+
+/***
+ * This is a convenience version-matching-control class.
+ * We do not want this instrumentation module to apply to lettuce versions >= 6.5.
+ * RedisJSONCommandBuilder was introduced in lettuce 6.5 and will force earlier versions not to match.
+ *
+ * This weave class provides no instrumentation and can be safely removed if another matching control mechanism is identified.
+ */
+
+@SkipIfPresent(originalName = "io.lettuce.core.RedisJsonCommandBuilder")
+class Skip_RedisJsonCommandBuilder {
+    //Here for matching purposes only.
+}


### PR DESCRIPTION
... just like it's required for the 6.5 instrumentation.
