### PR TITLE
Mark deployments command as deprecated - UPDATE DOCS PAGE LINKED BELOW ON RELEASE

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/AgentCommandLineParser.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/AgentCommandLineParser.java
@@ -44,7 +44,8 @@ class AgentCommandLineParser {
         commandOptionsMap.put(VERIFY_INSTRUMENTATION, getVerifyInstrumentationOptions());
 
         commandDescriptions = new HashMap<>();
-        commandDescriptions.put(DEPLOYMENT_COMMAND, "[OPTIONS] [description]  Records a deployment");
+        commandDescriptions.put(DEPLOYMENT_COMMAND, "[OPTIONS] [description]  Records a deployment. Note: This command is deprecated and will be removed " +
+                "in the next major release.");
         commandDescriptions.put(INSTRUMENT_COMMAND, "[OPTIONS]                Validates a custom instrumentation xml configuration file.");
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Deployments.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Deployments.java
@@ -37,7 +37,9 @@ public class Deployments {
         return recordDeployment(cmd, config);
     }
 
+    @Deprecated
     static int recordDeployment(CommandLine cmd, AgentConfig config) throws Exception {
+        System.out.println("Note: This command is deprecated and will be removed in the next major release.");
         String appName = config.getApplicationName();
         if (cmd.hasOption(APP_NAME_OPTION)) {
             appName = cmd.getOptionValue(APP_NAME_OPTION);


### PR DESCRIPTION
### Overview
Resolves #2484 

Mark the `deployment` command as deprecated.  Mark the method with `@Deprecated`. Update the help text and deployment execute text with deprecation message.

Doc update: https://docs.newrelic.com/docs/apm/agents/java-agent/instrumentation/monitor-deployments-java-agent/