### PR TITLE
#2494: Fix parsing of error class names to handle whitespace and newlines

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ErrorCollectorConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ErrorCollectorConfigImpl.java
@@ -112,6 +112,7 @@ public final class ErrorCollectorConfigImpl extends BaseConfig implements ErrorC
 
                     // Error class cannot be null, but the ignored error message is optional and can be null
                     if (className != null) {
+                        className = className.trim();
                         if (message != null && !message.isEmpty()) {
                             MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_IGNORE_ERROR_CONFIG_CLASS_MESSAGE);
                         } else {
@@ -123,7 +124,7 @@ public final class ErrorCollectorConfigImpl extends BaseConfig implements ErrorC
                                 " encountered. class_name must not be null. This configuration will be ignored");
                     }
                 } else if (ignoreError instanceof String) {
-                    String className = (String) ignoreError;
+                    String className = ((String) ignoreError).trim();
                     ignoreErrorsConfig.add(new IgnoreErrorConfigImpl(className.replace('/', '.'), null));
                     MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_IGNORE_ERROR_CONFIG_CLASS);
                 }
@@ -135,7 +136,7 @@ public final class ErrorCollectorConfigImpl extends BaseConfig implements ErrorC
         if (ignoreMessages instanceof Map) {
             Map<String, List<String>> ignoreMessagesMap = (Map) ignoreMessages;
             for (Map.Entry<String, List<String>> ignoreError : ignoreMessagesMap.entrySet()) {
-                String className = ignoreError.getKey();
+                String className = ignoreError.getKey().trim();
                 for (String message : ignoreError.getValue()) {
                     ignoreErrorsConfig.add(new IgnoreErrorConfigImpl(className.replace('/', '.'), message));
                     MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_IGNORE_ERROR_CONFIG_CLASS_MESSAGE);
@@ -181,6 +182,7 @@ public final class ErrorCollectorConfigImpl extends BaseConfig implements ErrorC
 
                     // Error class cannot be null, but the expected error message is optional and can be null
                     if (errorClass != null && !errorClass.isEmpty()) {
+                        errorClass = errorClass.trim();
                         if (errorMessage != null && !errorMessage.isEmpty()) {
                             MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_EXPECTED_ERROR_CONFIG_CLASS_MESSAGE);
                         } else {
@@ -192,7 +194,7 @@ public final class ErrorCollectorConfigImpl extends BaseConfig implements ErrorC
                                 " encountered. class_name must not be null. This configuration will be ignored");
                     }
                 } else if (expectedError instanceof String) {
-                    String className = (String) expectedError;
+                    String className = ((String) expectedError).trim();
                     expectedErrorConfigs.add(new ExpectedErrorConfigImpl(className.replace('/', '.'), null));
                     MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_EXPECTED_ERROR_CONFIG_CLASS);
                 }
@@ -206,7 +208,7 @@ public final class ErrorCollectorConfigImpl extends BaseConfig implements ErrorC
         if (expectedMessages instanceof Map) {
             Map<String, List<String>> expectedMessagesMap = (Map) expectedMessages;
             for (Map.Entry<String, List<String>> expectedError : expectedMessagesMap.entrySet()) {
-                String className = expectedError.getKey();
+                String className = expectedError.getKey().trim();
                 for (String message : expectedError.getValue()) {
                     expectedErrorConfigs.add(new ExpectedErrorConfigImpl(className.replace('/', '.'), message));
                     MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_EXPECTED_ERROR_CONFIG_CLASS_MESSAGE);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ErrorCollectorConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ErrorCollectorConfigImplTest.java
@@ -1258,6 +1258,114 @@ public class ErrorCollectorConfigImplTest {
         }
     }
 
+    @Test
+    public void ignoreErrorsClassWithLeadingSpaces() {
+        LogMocker mocker = new LogMocker();
+        try {
+            String ignoreErrorClass = "com.newrelic.IgnoreErrorClass";
+
+            Map<String, Object> localSettings = createMap();
+            List<String> ignoreClassesList = new ArrayList<>();
+            ignoreClassesList.add("  " + ignoreErrorClass);
+
+            localSettings.put(ErrorCollectorConfigImpl.IGNORE_CLASSES, ignoreClassesList);
+            ErrorCollectorConfig config = ErrorCollectorConfigImpl.createErrorCollectorConfig(localSettings);
+
+            Set<IgnoreErrorConfig> ignoreErrors = config.getIgnoreErrors();
+            assertFalse(ignoreErrors.isEmpty());
+            assertEquals(1, ignoreErrors.size());
+
+            IgnoreErrorConfig ignoreError = ignoreErrors.iterator().next();
+            assertEquals(ignoreErrorClass, ignoreError.getErrorClass());
+            assertNull(ignoreError.getErrorMessage());
+
+            mocker.verifyNoMessage();
+        } finally {
+            mocker.close();
+        }
+    }
+
+    @Test
+    public void ignoreErrorsClassWithTrailingSpaces() {
+        LogMocker mocker = new LogMocker();
+        try {
+            String ignoreErrorClass = "com.newrelic.IgnoreErrorClass";
+
+            Map<String, Object> localSettings = createMap();
+            List<String> ignoreClassesList = new ArrayList<>();
+            ignoreClassesList.add(ignoreErrorClass + "  ");
+
+            localSettings.put(ErrorCollectorConfigImpl.IGNORE_CLASSES, ignoreClassesList);
+            ErrorCollectorConfig config = ErrorCollectorConfigImpl.createErrorCollectorConfig(localSettings);
+
+            Set<IgnoreErrorConfig> ignoreErrors = config.getIgnoreErrors();
+            assertFalse(ignoreErrors.isEmpty());
+            assertEquals(1, ignoreErrors.size());
+
+            IgnoreErrorConfig ignoreError = ignoreErrors.iterator().next();
+            assertEquals(ignoreErrorClass, ignoreError.getErrorClass());
+            assertNull(ignoreError.getErrorMessage());
+
+            mocker.verifyNoMessage();
+        } finally {
+            mocker.close();
+        }
+    }
+
+    @Test
+    public void ignoreErrorsClassWithLeadingAndTrailingSpaces() {
+        LogMocker mocker = new LogMocker();
+        try {
+            String ignoreErrorClass = "com.newrelic.IgnoreErrorClass";
+
+            Map<String, Object> localSettings = createMap();
+            List<String> ignoreClassesList = new ArrayList<>();
+            ignoreClassesList.add(" " + ignoreErrorClass + " ");
+
+            localSettings.put(ErrorCollectorConfigImpl.IGNORE_CLASSES, ignoreClassesList);
+            ErrorCollectorConfig config = ErrorCollectorConfigImpl.createErrorCollectorConfig(localSettings);
+
+            Set<IgnoreErrorConfig> ignoreErrors = config.getIgnoreErrors();
+            assertFalse(ignoreErrors.isEmpty());
+            assertEquals(1, ignoreErrors.size());
+
+            IgnoreErrorConfig ignoreError = ignoreErrors.iterator().next();
+            assertEquals(ignoreErrorClass, ignoreError.getErrorClass());
+            assertNull(ignoreError.getErrorMessage());
+
+            mocker.verifyNoMessage();
+        } finally {
+            mocker.close();
+        }
+    }
+
+    @Test
+    public void ignoreErrorsClassWithNewlinePrefix() {
+        LogMocker mocker = new LogMocker();
+        try {
+            String ignoreErrorClass = "com.newrelic.IgnoreErrorClass";
+
+            Map<String, Object> localSettings = createMap();
+            List<String> ignoreClassesList = new ArrayList<>();
+            ignoreClassesList.add("\n" + ignoreErrorClass);
+
+            localSettings.put(ErrorCollectorConfigImpl.IGNORE_CLASSES, ignoreClassesList);
+            ErrorCollectorConfig config = ErrorCollectorConfigImpl.createErrorCollectorConfig(localSettings);
+
+            Set<IgnoreErrorConfig> ignoreErrors = config.getIgnoreErrors();
+            assertFalse(ignoreErrors.isEmpty());
+            assertEquals(1, ignoreErrors.size());
+
+            IgnoreErrorConfig ignoreError = ignoreErrors.iterator().next();
+            assertEquals(ignoreErrorClass, ignoreError.getErrorClass());
+            assertNull(ignoreError.getErrorMessage());
+
+            mocker.verifyNoMessage();
+        } finally {
+            mocker.close();
+        }
+    }
+
     // Mock out the Logger so we can verify warnings were (or were not) logged at a given level.
     // Note: do not "over verify" by checking the log message itself - too brittle.
     private class LogMocker {


### PR DESCRIPTION
### Overview
Updated `ErrorCollectorConfigImpl.java` to trim whitespace from error class names during configuration parsing  

### Related Github Issue
Resolves #2494 

### Testing
Added 4 new test cases in `ErrorCollectorConfigImplTest.java` to verify proper handling of:
- Leading spaces in class names
- Trailing spaces in class names  
- Both leading and trailing spaces
- Newline prefixes in class names

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.


[NR-465573]: https://new-relic.atlassian.net/browse/NR-465573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ