### PR TITLE
Move wrapper class out of S3AsyncClient_Instrumentation

### DIFF
--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/ResultWrapper.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/ResultWrapper.java
@@ -1,0 +1,24 @@
+package com.agent.instrumentation.awsjavasdk2.services.s3;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.Segment;
+import com.newrelic.api.agent.weaver.Weaver;
+
+import java.util.function.BiConsumer;
+
+public class ResultWrapper<T, U> implements BiConsumer<T, U> {
+    private Segment segment;
+
+    public ResultWrapper(Segment segment) {
+        this.segment = segment;
+    }
+
+    @Override
+    public void accept(T t, U u) {
+        try {
+            segment.end();
+        } catch (Throwable t1) {
+            AgentBridge.instrumentation.noticeInstrumentationError(t1, Weaver.getImplementationTitle());
+        }
+    }
+}

--- a/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3ResponseResultWrapper.java
+++ b/instrumentation/aws-java-sdk-s3-2.0/src/main/java/com/agent/instrumentation/awsjavasdk2/services/s3/S3ResponseResultWrapper.java
@@ -1,0 +1,30 @@
+package com.agent.instrumentation.awsjavasdk2.services.s3;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.Segment;
+import com.newrelic.api.agent.weaver.Weaver;
+import software.amazon.awssdk.services.s3.model.S3Response;
+
+import java.util.function.BiConsumer;
+
+public class S3ResponseResultWrapper<T extends S3Response, U> implements BiConsumer<T, U> {
+    private Segment segment;
+    private String uri;
+    private String operationName;
+
+    public S3ResponseResultWrapper(Segment segment, String uri, String operationName) {
+        this.segment = segment;
+        this.uri = uri;
+        this.operationName = operationName;
+    }
+
+    @Override
+    public void accept(T s3Response, U u) {
+        try {
+            S3MetricUtil.reportExternalMetrics(segment, uri, s3Response, operationName);
+            segment.end();
+        } catch (Throwable t1) {
+            AgentBridge.instrumentation.noticeInstrumentationError(t1, Weaver.getImplementationTitle());
+        }
+    }
+}


### PR DESCRIPTION
### Overview
Refactor the response wrapper inner classes into their own top level classes. This is in response to an issue a customer raised where there was an `IllegalAccessError` when the weaved `MultipartS3AsyncClient` attempted to access the wrapper.

GTSE: https://new-relic.atlassian.net/jira/software/c/projects/NR/boards/289?selectedIssue=NR-468253

