### PR TITLE
Optimize verify ranges for various AWS SDK modules

### DIFF
--- a/instrumentation/aws-java-sdk-firehose-2.1.0/build.gradle
+++ b/instrumentation/aws-java-sdk-firehose-2.1.0/build.gradle
@@ -8,7 +8,70 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'software.amazon.awssdk:firehose:[2.1.0,)'
+    /*
+        This is the original verifier range prior to this update.
+        Previously it was simply "passes"; this changes it to
+        the standard "passOnly" method.
+     */
+    passesOnly 'software.amazon.awssdk:firehose:[2.1.0,)'
+
+    /*
+        Now, exclude the ranges we know have passed verification
+        previously. We set the range such that the last revision
+        of each minor version will still get verified.
+
+
+        For the last known minor version, we leave the verify
+        range open ended to catch any new versions released
+        (including any new major/minor versions). The verify
+        ranges will probably need to be manually inspected
+        every so often to keep the task runtime in check.
+
+        This dramatically reduces the runtime of the verification
+        task. For this module, there were over 1500 artifacts that
+        were being downloaded for each verification - AWS seems to
+        enjoy releasing new revisions of SDK artifacts every few days.
+
+        This pattern can be applied to any module that suffers from
+        large numbers of artifacts (looking at anything AWS related).
+     */
     exclude 'software.amazon.awssdk:firehose:2.17.200' // this version failed the test, but the next one works again.
     excludeRegex '.*-preview-[0-9a-f]+'
+
+    exclude 'software.amazon.awssdk:firehose:[2.1.0,2.1.3]'
+    // Note: There is only a single 2.2.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:firehose:[2.3.0,2.3.8]'
+    exclude 'software.amazon.awssdk:firehose:[2.4.0,2.4.16]'
+    exclude 'software.amazon.awssdk:firehose:[2.5.0,2.5.68]'
+    exclude 'software.amazon.awssdk:firehose:[2.6.0,2.6.4]'
+    exclude 'software.amazon.awssdk:firehose:[2.7.0,2.7.35]'
+    exclude 'software.amazon.awssdk:firehose:[2.8.0,2.8.6]'
+    exclude 'software.amazon.awssdk:firehose:[2.9.0,2.9.25]'
+    exclude 'software.amazon.awssdk:firehose:[2.10.0,2.10.90]'
+    exclude 'software.amazon.awssdk:firehose:[2.11.0,2.11.13]'
+    // Note: There is only a single 2.12.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:firehose:[2.13.0,2.13.75]'
+    exclude 'software.amazon.awssdk:firehose:[2.14.0,2.14.27]'
+    exclude 'software.amazon.awssdk:firehose:[2.15.0,2.15.81]'
+    exclude 'software.amazon.awssdk:firehose:[2.16.0,2.16.103]'
+    exclude 'software.amazon.awssdk:firehose:[2.17.0,2.17.294]'
+    exclude 'software.amazon.awssdk:firehose:[2.18.0,2.18.40]'
+    exclude 'software.amazon.awssdk:firehose:[2.19.0,2.19.32]'
+    exclude 'software.amazon.awssdk:firehose:[2.20.0,2.20.161]'
+    exclude 'software.amazon.awssdk:firehose:[2.21.0,2.21.45]'
+    exclude 'software.amazon.awssdk:firehose:[2.22.0,2.22.12]'
+    exclude 'software.amazon.awssdk:firehose:[2.23.0,2.23.20]'
+    exclude 'software.amazon.awssdk:firehose:[2.24.0,2.24.12]'
+    exclude 'software.amazon.awssdk:firehose:[2.25.0,2.25.69]'
+    exclude 'software.amazon.awssdk:firehose:[2.26.0,2.26.30]'
+    exclude 'software.amazon.awssdk:firehose:[2.27.0,2.27.23]'
+    exclude 'software.amazon.awssdk:firehose:[2.28.0,2.28.28]'
+    exclude 'software.amazon.awssdk:firehose:[2.29.0,2.29.51]'
+    exclude 'software.amazon.awssdk:firehose:[2.30.0,2.30.37]'
+    exclude 'software.amazon.awssdk:firehose:[2.31.0,2.31.77]'
+    exclude 'software.amazon.awssdk:firehose:[2.32.0,2.32.32]'
+    exclude 'software.amazon.awssdk:firehose:[2.33.0,2.33.12]'
+
+    // The next excludes will be 2.34.x -- Leaving this out so the verifier actually
+    // has something to run against.
 }

--- a/instrumentation/aws-java-sdk-kinesis-2.1.0/build.gradle
+++ b/instrumentation/aws-java-sdk-kinesis-2.1.0/build.gradle
@@ -8,7 +8,65 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'software.amazon.awssdk:kinesis:[2.1.0,)'
-    exclude 'software.amazon.awssdk:kinesis:2.17.200' // this version failed the test, but the next one works again.
-    excludeRegex '.*-preview-[0-9a-f]+'
+/*
+        This is the original verifier range prior to this update.
+        Previously it was simply "passes"; this changes it to
+        the standard "passOnly" method.
+     */
+    passesOnly 'software.amazon.awssdk:kinesis:[2.1.0,)'
+    excludeRegex ".*preview.*"
+
+    /*
+        Now, exclude the ranges we know have passed verification
+        previously. We set the range such that the last revision
+        of each minor version will still get verified.
+
+
+        For the last known minor version, we leave the verify
+        range open ended to catch any new versions released
+        (including any new major/minor versions). The verify
+        ranges will probably need to be manually inspected
+        every so often to keep the task runtime in check.
+
+        This dramatically reduces the runtime of the verification
+        task. For this module, there were over 1500 artifacts that
+        were being downloaded for each verification - AWS seems to
+        enjoy releasing new revisions of SDK artifacts every few days.
+
+        This pattern can be applied to any module that suffers from
+        large numbers of artifacts (looking at anything AWS related).
+     */
+    exclude 'software.amazon.awssdk:kinesis:[2.1.0,2.1.3]'
+    // Note: There is only a single 2.2.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:kinesis:[2.3.0,2.3.8]'
+    exclude 'software.amazon.awssdk:kinesis:[2.4.0,2.4.16]'
+    exclude 'software.amazon.awssdk:kinesis:[2.5.0,2.5.70]'
+    exclude 'software.amazon.awssdk:kinesis:[2.6.0,2.6.4]'
+    exclude 'software.amazon.awssdk:kinesis:[2.7.0,2.7.35]'
+    exclude 'software.amazon.awssdk:kinesis:[2.8.0,2.8.6]'
+    exclude 'software.amazon.awssdk:kinesis:[2.9.0,2.9.25]'
+    exclude 'software.amazon.awssdk:kinesis:[2.10.0,2.10.90]'
+    exclude 'software.amazon.awssdk:kinesis:[2.11.0,2.11.13]'
+    // Note: There is only a single 2.12.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:kinesis:[2.13.0,2.13.75]'
+    exclude 'software.amazon.awssdk:kinesis:[2.14.0,2.14.27]'
+    exclude 'software.amazon.awssdk:kinesis:[2.15.0,2.15.81]'
+    exclude 'software.amazon.awssdk:kinesis:[2.16.0,2.16.103]'
+    exclude 'software.amazon.awssdk:kinesis:[2.17.0,2.17.294]'
+    exclude 'software.amazon.awssdk:kinesis:[2.18.0,2.18.40]'
+    exclude 'software.amazon.awssdk:kinesis:[2.19.0,2.19.32]'
+    exclude 'software.amazon.awssdk:kinesis:[2.20.0,2.20.161]'
+    exclude 'software.amazon.awssdk:kinesis:[2.21.0,2.21.45]'
+    exclude 'software.amazon.awssdk:kinesis:[2.22.0,2.22.12]'
+    exclude 'software.amazon.awssdk:kinesis:[2.23.0,2.23.20]'
+    exclude 'software.amazon.awssdk:kinesis:[2.24.0,2.24.12]'
+    exclude 'software.amazon.awssdk:kinesis:[2.25.0,2.25.69]'
+    exclude 'software.amazon.awssdk:kinesis:[2.26.0,2.26.30]'
+    exclude 'software.amazon.awssdk:kinesis:[2.27.0,2.27.23]'
+    exclude 'software.amazon.awssdk:kinesis:[2.28.0,2.28.28]'
+    exclude 'software.amazon.awssdk:kinesis:[2.29.0,2.29.51]'
+    exclude 'software.amazon.awssdk:kinesis:[2.30.0,2.30.37]'
+    exclude 'software.amazon.awssdk:kinesis:[2.31.0,2.31.77]'
+    exclude 'software.amazon.awssdk:kinesis:[2.32.0,2.32.32]'
+    exclude 'software.amazon.awssdk:kinesis:[2.33.0,2.33.12]'
 }

--- a/instrumentation/aws-java-sdk-lambda-2.1/build.gradle
+++ b/instrumentation/aws-java-sdk-lambda-2.1/build.gradle
@@ -12,9 +12,67 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passes 'software.amazon.awssdk:lambda:[2.1.0,)'
+    /*
+        This is the original verifier range prior to this update.
+        Previously it was simply "passes"; this changes it to
+        the standard "passOnly" method.
+     */
+    passesOnly 'software.amazon.awssdk:lambda:[2.1.0,)'
     excludeRegex ".*preview.*"
-    exclude "software.amazon.awssdk:lambda:2.17.200"
+
+    /*
+        Now, exclude the ranges we know have passed verification
+        previously. We set the range such that the last revision
+        of each minor version will still get verified.
+
+
+        For the last known minor version, we leave the verify
+        range open ended to catch any new versions released
+        (including any new major/minor versions). The verify
+        ranges will probably need to be manually inspected
+        every so often to keep the task runtime in check.
+
+        This dramatically reduces the runtime of the verification
+        task. For this module, there were over 1500 artifacts that
+        were being downloaded for each verification - AWS seems to
+        enjoy releasing new revisions of SDK artifacts every few days.
+
+        This pattern can be applied to any module that suffers from
+        large numbers of artifacts (looking at anything AWS related).
+     */
+    exclude 'software.amazon.awssdk:lambda:[2.1.0,2.1.3]'
+    // Note: There is only a single 2.2.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:lambda:[2.3.0,2.3.8]'
+    exclude 'software.amazon.awssdk:lambda:[2.4.0,2.4.16]'
+    exclude 'software.amazon.awssdk:lambda:[2.5.0,2.5.68]'
+    exclude 'software.amazon.awssdk:lambda:[2.6.0,2.6.4]'
+    exclude 'software.amazon.awssdk:lambda:[2.7.0,2.7.35]'
+    exclude 'software.amazon.awssdk:lambda:[2.8.0,2.8.6]'
+    exclude 'software.amazon.awssdk:lambda:[2.9.0,2.9.25]'
+    exclude 'software.amazon.awssdk:lambda:[2.10.0,2.10.90]'
+    exclude 'software.amazon.awssdk:lambda:[2.11.0,2.11.13]'
+    // Note: There is only a single 2.12.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:lambda:[2.13.0,2.13.75]'
+    exclude 'software.amazon.awssdk:lambda:[2.14.0,2.14.27]'
+    exclude 'software.amazon.awssdk:lambda:[2.15.0,2.15.81]'
+    exclude 'software.amazon.awssdk:lambda:[2.16.0,2.16.103]'
+    exclude 'software.amazon.awssdk:lambda:[2.17.0,2.17.294]'
+    exclude 'software.amazon.awssdk:lambda:[2.18.0,2.18.40]'
+    exclude 'software.amazon.awssdk:lambda:[2.19.0,2.19.32]'
+    exclude 'software.amazon.awssdk:lambda:[2.20.0,2.20.161]'
+    exclude 'software.amazon.awssdk:lambda:[2.21.0,2.21.45]'
+    exclude 'software.amazon.awssdk:lambda:[2.22.0,2.22.12]'
+    exclude 'software.amazon.awssdk:lambda:[2.23.0,2.23.20]'
+    exclude 'software.amazon.awssdk:lambda:[2.24.0,2.24.12]'
+    exclude 'software.amazon.awssdk:lambda:[2.25.0,2.25.69]'
+    exclude 'software.amazon.awssdk:lambda:[2.26.0,2.26.30]'
+    exclude 'software.amazon.awssdk:lambda:[2.27.0,2.27.23]'
+    exclude 'software.amazon.awssdk:lambda:[2.28.0,2.28.28]'
+    exclude 'software.amazon.awssdk:lambda:[2.29.0,2.29.51]'
+    exclude 'software.amazon.awssdk:lambda:[2.30.0,2.30.37]'
+    exclude 'software.amazon.awssdk:lambda:[2.31.0,2.31.77]'
+    exclude 'software.amazon.awssdk:lambda:[2.32.0,2.32.32]'
+    exclude 'software.amazon.awssdk:lambda:[2.33.0,2.33.12]'
 }
 
 site {

--- a/instrumentation/aws-java-sdk-sns-2.0/build.gradle
+++ b/instrumentation/aws-java-sdk-sns-2.0/build.gradle
@@ -12,8 +12,67 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'software.amazon.awssdk:sns:[2.1.0,)'
-    excludeRegex '.*preview.*'
+/*
+        This is the original verifier range prior to this update.
+        Previously it was simply "passes"; this changes it to
+        the standard "passOnly" method.
+     */
+    passesOnly 'software.amazon.awssdk:sns:[2.1.0,)'
+    excludeRegex ".*preview.*"
+
+    /*
+        Now, exclude the ranges we know have passed verification
+        previously. We set the range such that the last revision
+        of each minor version will still get verified.
+
+
+        For the last known minor version, we leave the verify
+        range open ended to catch any new versions released
+        (including any new major/minor versions). The verify
+        ranges will probably need to be manually inspected
+        every so often to keep the task runtime in check.
+
+        This dramatically reduces the runtime of the verification
+        task. For this module, there were over 1500 artifacts that
+        were being downloaded for each verification - AWS seems to
+        enjoy releasing new revisions of SDK artifacts every few days.
+
+        This pattern can be applied to any module that suffers from
+        large numbers of artifacts (looking at anything AWS related).
+     */
+    exclude 'software.amazon.awssdk:sns:[2.1.0,2.1.3]'
+    // Note: There is only a single 2.2.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:sns:[2.3.0,2.3.8]'
+    exclude 'software.amazon.awssdk:sns:[2.4.0,2.4.16]'
+    exclude 'software.amazon.awssdk:sns:[2.5.0,2.5.68]'
+    exclude 'software.amazon.awssdk:sns:[2.6.0,2.6.4]'
+    exclude 'software.amazon.awssdk:sns:[2.7.0,2.7.35]'
+    exclude 'software.amazon.awssdk:sns:[2.8.0,2.8.6]'
+    exclude 'software.amazon.awssdk:sns:[2.9.0,2.9.25]'
+    exclude 'software.amazon.awssdk:sns:[2.10.0,2.10.90]'
+    exclude 'software.amazon.awssdk:sns:[2.11.0,2.11.13]'
+    // Note: There is only a single 2.12.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:sns:[2.13.0,2.13.75]'
+    exclude 'software.amazon.awssdk:sns:[2.14.0,2.14.27]'
+    exclude 'software.amazon.awssdk:sns:[2.15.0,2.15.81]'
+    exclude 'software.amazon.awssdk:sns:[2.16.0,2.16.103]'
+    exclude 'software.amazon.awssdk:sns:[2.17.0,2.17.294]'
+    exclude 'software.amazon.awssdk:sns:[2.18.0,2.18.40]'
+    exclude 'software.amazon.awssdk:sns:[2.19.0,2.19.32]'
+    exclude 'software.amazon.awssdk:sns:[2.20.0,2.20.161]'
+    exclude 'software.amazon.awssdk:sns:[2.21.0,2.21.45]'
+    exclude 'software.amazon.awssdk:sns:[2.22.0,2.22.12]'
+    exclude 'software.amazon.awssdk:sns:[2.23.0,2.23.20]'
+    exclude 'software.amazon.awssdk:sns:[2.24.0,2.24.12]'
+    exclude 'software.amazon.awssdk:sns:[2.25.0,2.25.69]'
+    exclude 'software.amazon.awssdk:sns:[2.26.0,2.26.30]'
+    exclude 'software.amazon.awssdk:sns:[2.27.0,2.27.23]'
+    exclude 'software.amazon.awssdk:sns:[2.28.0,2.28.28]'
+    exclude 'software.amazon.awssdk:sns:[2.29.0,2.29.51]'
+    exclude 'software.amazon.awssdk:sns:[2.30.0,2.30.37]'
+    exclude 'software.amazon.awssdk:sns:[2.31.0,2.31.77]'
+    exclude 'software.amazon.awssdk:sns:[2.32.0,2.32.32]'
+    exclude 'software.amazon.awssdk:sns:[2.33.0,2.33.12]'
 }
 
 site {

--- a/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
+++ b/instrumentation/aws-java-sdk-sqs-2.1.0/build.gradle
@@ -13,7 +13,67 @@ jar {
 }
 
 verifyInstrumentation {
-    passes 'software.amazon.awssdk:sqs:[2.1.0,)'
+    /*
+        This is the original verifier range prior to this update.
+        Previously it was simply "passes"; this changes it to
+        the standard "passOnly" method.
+     */
+    passesOnly 'software.amazon.awssdk:sqs:[2.1.0,)'
+    excludeRegex ".*preview.*"
+
+    /*
+        Now, exclude the ranges we know have passed verification
+        previously. We set the range such that the last revision
+        of each minor version will still get verified.
+
+
+        For the last known minor version, we leave the verify
+        range open ended to catch any new versions released
+        (including any new major/minor versions). The verify
+        ranges will probably need to be manually inspected
+        every so often to keep the task runtime in check.
+
+        This dramatically reduces the runtime of the verification
+        task. For this module, there were over 1500 artifacts that
+        were being downloaded for each verification - AWS seems to
+        enjoy releasing new revisions of SDK artifacts every few days.
+
+        This pattern can be applied to any module that suffers from
+        large numbers of artifacts (looking at anything AWS related).
+     */
+    exclude 'software.amazon.awssdk:sqs:[2.1.0,2.1.3]'
+    // Note: There is only a single 2.2.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:sqs:[2.3.0,2.3.8]'
+    exclude 'software.amazon.awssdk:sqs:[2.4.0,2.4.16]'
+    exclude 'software.amazon.awssdk:sqs:[2.5.0,2.5.70]'
+    exclude 'software.amazon.awssdk:sqs:[2.6.0,2.6.4]'
+    exclude 'software.amazon.awssdk:sqs:[2.7.0,2.7.35]'
+    exclude 'software.amazon.awssdk:sqs:[2.8.0,2.8.6]'
+    exclude 'software.amazon.awssdk:sqs:[2.9.0,2.9.25]'
+    exclude 'software.amazon.awssdk:sqs:[2.10.0,2.10.90]'
+    exclude 'software.amazon.awssdk:sqs:[2.11.0,2.11.13]'
+    // Note: There is only a single 2.12.0 version which is why that range is missing
+    exclude 'software.amazon.awssdk:sqs:[2.13.0,2.13.75]'
+    exclude 'software.amazon.awssdk:sqs:[2.14.0,2.14.27]'
+    exclude 'software.amazon.awssdk:sqs:[2.15.0,2.15.81]'
+    exclude 'software.amazon.awssdk:sqs:[2.16.0,2.16.103]'
+    exclude 'software.amazon.awssdk:sqs:[2.17.0,2.17.294]'
+    exclude 'software.amazon.awssdk:sqs:[2.18.0,2.18.40]'
+    exclude 'software.amazon.awssdk:sqs:[2.19.0,2.19.32]'
+    exclude 'software.amazon.awssdk:sqs:[2.20.0,2.20.161]'
+    exclude 'software.amazon.awssdk:sqs:[2.21.0,2.21.45]'
+    exclude 'software.amazon.awssdk:sqs:[2.22.0,2.22.12]'
+    exclude 'software.amazon.awssdk:sqs:[2.23.0,2.23.20]'
+    exclude 'software.amazon.awssdk:sqs:[2.24.0,2.24.12]'
+    exclude 'software.amazon.awssdk:sqs:[2.25.0,2.25.69]'
+    exclude 'software.amazon.awssdk:sqs:[2.26.0,2.26.30]'
+    exclude 'software.amazon.awssdk:sqs:[2.27.0,2.27.23]'
+    exclude 'software.amazon.awssdk:sqs:[2.28.0,2.28.28]'
+    exclude 'software.amazon.awssdk:sqs:[2.29.0,2.29.51]'
+    exclude 'software.amazon.awssdk:sqs:[2.30.0,2.30.37]'
+    exclude 'software.amazon.awssdk:sqs:[2.31.0,2.31.77]'
+    exclude 'software.amazon.awssdk:sqs:[2.32.0,2.32.32]'
+    exclude 'software.amazon.awssdk:sqs:[2.33.0,2.33.12]'
 }
 
 site {


### PR DESCRIPTION
### Overview
Resolves #2504 

Optimize the verify ranges for:
- aws-java-sdk-sns-2.0
- aws-java-sdk-sqs-2.1.0
- aws-java-sdk-firehose-2.1.0
- aws-java-sdk-lambda-2.1
- aws-java-sdk-kinesis-2.1.0

This reduces the verification of these modules from > 1 hour to around 2 minutes.
