### PR TITLE
Align AzureAppService with other cloud vendor utilities

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/AzureAppService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/AzureAppService.java
@@ -30,6 +30,10 @@ public class AzureAppService implements CloudVendor {
         String siteName = System.getenv("WEBSITE_SITE_NAME");
         String ownerName = System.getenv("WEBSITE_OWNER_NAME");
 
+        if (resourceGroup == null && siteName == null && ownerName == null) {
+            return AzureAppServiceData.EMPTY_DATA;
+        }
+
         return parseEnvVars(resourceGroup, siteName, ownerName);
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/utilization/AzureAppServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/utilization/AzureAppServiceTest.java
@@ -45,4 +45,11 @@ public class AzureAppServiceTest {
         assertTrue(azureAppServiceData.getValueMap().containsKey("cloud.resource_id"));
     }
 
+    @Test
+    public void testGetDataReturnsEmptyWhenNotInAzureAppService() {
+        AzureAppService azureAppService = new AzureAppService(new CloudUtility());
+
+        AzureAppServiceData azureAppServiceData = azureAppService.getData();
+        assertTrue(azureAppServiceData.isEmpty());
+    }
 }


### PR DESCRIPTION
### Overview
Improved `AzureAppService` cloud detection to align with other cloud vendor implementations. While the configuration (`utilization.detect_azure`) was working correctly, `AzureAppService` had a design inconsistency compared to other cloud vendors utility classes (e.g. AWS, GCP, Azure). 

Early detection logic in `AzureAppService.getData()` now returns `EMPTY_DATA` immediately when all Azure App Service environment variables (```WEBSITE_RESOURCE_GROUP, WEBSITE_SITE_NAME, WEBSITE_OWNER_NAME```) are `null`. This mirrors the detection pattern used by other cloud vendor utility classes.

### Related Github Issue
Resolves #2489 

### Testing
Added `testGetDataReturnsEmptyWhenNotInAzureAppService()` to verify early detection when when all env vars are null/we are not in/using Azure


### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
