### PR TITLE
Update alias logging and messaging for ClassTransformerConfigImpl

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
@@ -378,7 +378,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
         if (aliasName != null) {
             Config aliasConfig = getInstrumentationConfig(aliasName);
             if (aliasConfig.getProperty("enabled") != null) {
-                Agent.LOG.log(Level.INFO, "Using deprecated configuration setting {0} for instrumentation {1}", aliasName, moduleName);
+                Agent.LOG.log(Level.FINE, "An alias was used configuring instrumentation: {1} using alias {0}", aliasName, moduleName);
                 aliasEnabled = aliasConfig.getProperty("enabled");
             }
         }


### PR DESCRIPTION
### Overview
Updated the log message to be more neutral and demoted the log level for when configuration aliases are used in the class transformer.

### Related Github Issue
Resolves #2500 

### Testing
Existing tests in `ClassTransformerConfigImplTest.java` cover the alias configuration functionality

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
