### PR TITLE
Correct Trace ratio and Probability sampler logic

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSampler.java
@@ -8,6 +8,7 @@ package com.newrelic.agent.tracing.samplers;
 
 import com.newrelic.agent.Transaction;
 import com.newrelic.agent.config.SamplerConfig;
+import com.newrelic.agent.tracing.DistributedTraceServiceImpl;
 import com.newrelic.api.agent.NewRelic;
 
 import java.util.logging.Level;
@@ -25,8 +26,8 @@ import java.util.logging.Level;
  * deterministic random value (R) is derived by extracting the last 7 bytes
  * (14 characters) of the id and converting into a long value.
  * <br>
- * If this value is greater than or equal to T, we return a priority of 2.0 which
- * will mark this trace for sampling.
+ * If this value is greater than or equal to T, we return a priority of
+ * (Random Float Value of 0.0 - 1) + 1.0 which will mark this trace for sampling.
  */
 public class ProbabilityBasedSampler implements Sampler {
     private final long rejectionThreshold;
@@ -53,9 +54,10 @@ public class ProbabilityBasedSampler implements Sampler {
     public float calculatePriority(Transaction tx) {
         String traceId = Sampler.traceIdFromTransaction(tx);
         if (traceId != null && traceId.length() == 32) {
+            float initialPriority = DistributedTraceServiceImpl.nextTruncatedFloat();
             try {
                 String last14Chars = traceId.substring(18);
-                return Long.parseUnsignedLong(last14Chars, 16) >= rejectionThreshold ? 2.0f : 0.0f;
+                return initialPriority + (Long.parseUnsignedLong(last14Chars, 16) >= rejectionThreshold ? 1.0f : 0.0f);
             } catch (NumberFormatException ignored) {
             }
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSampler.java
@@ -8,6 +8,7 @@ package com.newrelic.agent.tracing.samplers;
 
 import com.newrelic.agent.Transaction;
 import com.newrelic.agent.config.SamplerConfig;
+import com.newrelic.agent.tracing.DistributedTraceServiceImpl;
 import com.newrelic.api.agent.NewRelic;
 
 import java.util.logging.Level;
@@ -25,8 +26,8 @@ import java.util.logging.Level;
  * deterministic random value (R) is derived by extracting the last 8 bytes
  * (16 characters) of the id and converting into a long value.
  * <br>
- * If this value is less than or equal to T, we return a priority of 2.0 which
- * will mark this trace for sampling.
+ * If this value is less than or equal to T, we return a priority of
+ * (Random Float Value of 0.0 - 1) + 1.0 which will mark this trace for sampling.
  */
 public class TraceRatioBasedSampler implements Sampler {
     private final long threshold;
@@ -54,9 +55,10 @@ public class TraceRatioBasedSampler implements Sampler {
         String traceId = Sampler.traceIdFromTransaction(tx);
 
         if (traceId != null && traceId.length() == 32) {
+            float initialPriority = DistributedTraceServiceImpl.nextTruncatedFloat();
             try {
                 String last16Chars = traceId.substring(16);
-                return (Math.abs(Long.parseUnsignedLong(last16Chars, 16)) <= threshold) ? 2.0f : 0.0f;
+                return initialPriority + ((Math.abs(Long.parseUnsignedLong(last16Chars, 16)) <= threshold) ? 1.0f : 0.0f);
             } catch (NumberFormatException ignored) {
             }
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSamplerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSamplerTest.java
@@ -97,7 +97,7 @@ public class ProbabilityBasedSamplerTest {
 
         while (++iterations <= iterationCount) {
             when(tx.getOrCreateTraceId()).thenReturn(TransactionGuidFactory.generate16CharGuid() + TransactionGuidFactory.generate16CharGuid());
-            if (sampler.calculatePriority(tx) == 2.0f) {
+            if (sampler.calculatePriority(tx) >= 1.0f) {
                 sampledCount++;
             }
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSamplerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSamplerTest.java
@@ -104,7 +104,7 @@ public class TraceRatioBasedSamplerTest {
 
         while (++iterations <= iterationCount) {
             when(tx.getOrCreateTraceId()).thenReturn(TransactionGuidFactory.generate16CharGuid() + TransactionGuidFactory.generate16CharGuid());
-            if (sampler.calculatePriority(tx) == 2.0f) {
+            if (sampler.calculatePriority(tx) >= 1.0f) {
                 sampledCount++;
             }
         }


### PR DESCRIPTION
Corrects the logic in the TraceRatio and Probability sampler classes so that probability values are now in the range of 0.0 - 2.0. Previously the sampler would return a constant value of `0.0` for not sampled and a constant value of `2.0` when sampled.
