### PR TITLE
New DataSender impl that writes data to /tmp/newrelic-telemetry or st…

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMServiceManagerImpl.java
@@ -72,9 +72,14 @@ public class RPMServiceManagerImpl extends AbstractService implements RPMService
         };
 
         AgentConfig config = ServiceFactory.getConfigService().getDefaultAgentConfig();
-        String host = config.getHost();
-        String port = Integer.toString(config.getPort());
-        getLogger().config(MessageFormat.format("Configured to connect to New Relic at {0}:{1}", host, port));
+
+        if (config.getServerlessConfig().isEnabled()) {
+            getLogger().config("Configured to connect to New Relic via serverless layer");
+        } else {
+            String host = config.getHost();
+            String port = Integer.toString(config.getPort());
+            getLogger().config(MessageFormat.format("Configured to connect to New Relic at {0}:{1}", host, port));
+        }
         defaultRPMService = createRPMService(config.getApplicationNames(), connectionConfigListener, connectionListener);
         List<IRPMService> list = new ArrayList<>(1);
         list.add(defaultRPMService);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
@@ -9,10 +9,15 @@ package com.newrelic.agent.transport;
 
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.config.DataSenderConfig;
+import com.newrelic.agent.logging.IAgentLogger;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.transport.apache.ApacheHttpClientWrapper;
 import com.newrelic.agent.transport.apache.ApacheProxyManager;
 import com.newrelic.agent.transport.apache.ApacheSSLManager;
+import com.newrelic.agent.transport.serverless.DataSenderServerless;
+import com.newrelic.agent.transport.serverless.DataSenderServerlessConfig;
+import com.newrelic.agent.transport.serverless.ServerLessWriterImpl;
+import com.newrelic.agent.transport.serverless.ServerlessWriter;
 import com.newrelic.api.agent.Logger;
 
 import javax.net.ssl.SSLContext;
@@ -36,6 +41,11 @@ public class DataSenderFactory {
      */
     public static IDataSenderFactory getDataSenderFactory() {
         return DATA_SENDER_FACTORY;
+    }
+
+    public static DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger) {
+        ServerlessWriter serverlessWriter = new ServerLessWriterImpl(logger);
+        return new DataSenderServerless(config, logger, serverlessWriter);
     }
 
     public static DataSender create(DataSenderConfig config) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerless.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerless.java
@@ -1,0 +1,139 @@
+package com.newrelic.agent.transport.serverless;
+
+import com.newrelic.agent.MetricData;
+import com.newrelic.agent.errors.TracedError;
+import com.newrelic.agent.logging.IAgentLogger;
+import com.newrelic.agent.model.AnalyticsEvent;
+import com.newrelic.agent.model.CustomInsightsEvent;
+import com.newrelic.agent.model.ErrorEvent;
+import com.newrelic.agent.model.LogEvent;
+import com.newrelic.agent.model.SpanEvent;
+import com.newrelic.agent.profile.ProfileData;
+import com.newrelic.agent.sql.SqlTrace;
+import com.newrelic.agent.trace.TransactionTrace;
+import com.newrelic.agent.transport.DataSender;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONStreamAware;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+// Todo: reformat all data into a serverless spec
+// Todo: Unit tests once the data is properly formatted
+
+public class DataSenderServerless implements DataSender {
+
+    private final ServerlessWriter serverlessWriter;
+    private final IAgentLogger logger;
+    private final DataSenderServerlessConfig dataSenderServerlessConfig;
+
+    public DataSenderServerless(DataSenderServerlessConfig dataSenderServerlessConfig, IAgentLogger logger, ServerlessWriter serverlessWriter) {
+        this.dataSenderServerlessConfig = dataSenderServerlessConfig;
+        this.logger = logger;
+        this.serverlessWriter = serverlessWriter;
+    }
+
+    @Override
+    public Map<String, Object> connect(Map<String, Object> startupOptions) throws Exception {
+        // The serverless data sender is not making any external connections
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<List<?>> getAgentCommands() throws Exception {
+        // The serverless data sender is not involved in agent commands
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void sendCommandResults(Map<Long, Object> commandResults) throws Exception {
+        // The serverless data sender is not involved in agent commands
+    }
+
+    @Override
+    public void sendErrorData(List<TracedError> errors) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("errors", errors);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void sendErrorEvents(int reservoirSize, int eventsSeen, Collection<ErrorEvent> errorEvents) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("errorEvents", errorEvents);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public <T extends AnalyticsEvent & JSONStreamAware> void sendAnalyticsEvents(int reservoirSize, int eventsSeen, Collection<T> events) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("events", events);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void sendCustomAnalyticsEvents(int reservoirSize, int eventsSeen, Collection<? extends CustomInsightsEvent> events) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("events", events);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void sendLogEvents(Collection<? extends LogEvent> events) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("events", events);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void sendSpanEvents(int reservoirSize, int eventsSeen, Collection<SpanEvent> events) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("events", events);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("metricData", metricData);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public List<Long> sendProfileData(List<ProfileData> profiles) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("profiles", profiles);
+        serverlessWriter.write(metadata);
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void sendSqlTraceData(List<SqlTrace> sqlTraces) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("sqlTraces", sqlTraces);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void sendTransactionTraceData(List<TransactionTrace> traces) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("traces", traces);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void sendModules(List<? extends JSONStreamAware> jarDataToSend) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("jarDataToSend", jarDataToSend);
+        serverlessWriter.write(metadata);
+    }
+
+    @Override
+    public void shutdown(long timeMillis) throws Exception {
+        JSONObject metadata = new JSONObject();
+        metadata.put("timeMillis", timeMillis);
+        serverlessWriter.write(metadata);
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerlessConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerlessConfig.java
@@ -1,0 +1,13 @@
+package com.newrelic.agent.transport.serverless;
+
+public class DataSenderServerlessConfig {
+    private final String agentVersion;
+
+    public DataSenderServerlessConfig(String agentVersion) {
+        this.agentVersion = agentVersion;
+    }
+
+    public String getAgentVersion() {
+        return agentVersion;
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerLessWriterImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerLessWriterImpl.java
@@ -1,0 +1,34 @@
+package com.newrelic.agent.transport.serverless;
+
+import com.newrelic.agent.logging.IAgentLogger;
+import org.json.simple.JSONObject;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.logging.Level;
+
+public class ServerLessWriterImpl implements ServerlessWriter {
+    private static final String FILE_PATH = "/tmp/newrelic-telemetry";
+    private final IAgentLogger logger;
+    private final File pathFile;
+
+    public ServerLessWriterImpl(IAgentLogger logger) {
+        this.logger = logger;
+        pathFile = new File(FILE_PATH);
+    }
+
+    @Override
+    public void write(JSONObject payload) {
+        String payloadString = payload.toJSONString();
+        if (pathFile.exists()) {
+            try (BufferedWriter pipe = new BufferedWriter(new FileWriter(pathFile, false))) {
+                pipe.write(payloadString);
+            } catch (IOException ignored) {
+                logger.log(Level.FINEST, "Failed to write payload", ignored);
+            }
+        }
+        System.out.println(payloadString);
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerlessWriter.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerlessWriter.java
@@ -1,0 +1,7 @@
+package com.newrelic.agent.transport.serverless;
+
+import org.json.simple.JSONObject;
+
+public interface ServerlessWriter {
+    void write(JSONObject message);
+}


### PR DESCRIPTION
### Overview
Replaces the implementation of DataSender with a serverless variant. 
The new implementation writes data to /tmp/newrelic-telemetry or stdout.

Unit tests will be covered in a future ticket when the data gets reformatted.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2598
