### PR TITLE
Serverless POC: Disable JFR when serverless mode is enabled

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -97,12 +97,15 @@ public class JfrService extends AbstractService implements AgentConfigListener {
     public final boolean isEnabled() {
         final boolean enabled = jfrConfig.isEnabled();
         boolean isHighSecurity = defaultAgentConfig.isHighSecurity();
+        boolean isServerless = defaultAgentConfig.getServerlessConfig().isEnabled();
         if (!enabled) {
             Agent.LOG.log(Level.INFO, "New Relic JFR Monitor is disabled: JFR config has not been enabled in the Java agent.");
         } else if (isHighSecurity) {
             Agent.LOG.log(Level.INFO, "New Relic JFR Monitor is enabled but High Security mode is also enabled; JFR will not be activated.");
+        } else if (isServerless) {
+            Agent.LOG.log(Level.INFO, "New Relic JFR Monitor is enabled but Serverless mode is also enabled; JFR will not be activated.");
         }
-        return enabled && !isHighSecurity;
+        return enabled && !isHighSecurity && !isServerless;
     }
 
     @Override


### PR DESCRIPTION
### Overview
This PR disables Java Flight Recorder (JFR) reporting when serverless mode is enabled to avoid potential conflicts with sending data via a Lambda extension (i.e., data being sent to 2 entities instead of 1).

### Related Github Issue
Resolves #2601 

### Testing
Added a unit test (verifies JFR is disabled when serverless mode is enabled).
