### PR TITLE
Minor tweaks to samplers

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSampler.java
@@ -31,6 +31,7 @@ import java.util.logging.Level;
  */
 public class ProbabilityBasedSampler implements Sampler {
     private final long rejectionThreshold;
+    private final String description;
 
     /**
      * Construct a new ProbabilityBasedSampler with the desired probability
@@ -48,6 +49,8 @@ public class ProbabilityBasedSampler implements Sampler {
             NewRelic.getAgent().getLogger().log(Level.WARNING, "ProbabilityBasedSampler: Invalid sampling probability supplied; setting " +
                             "rejection threshold to {0}", rejectionThreshold);
         }
+
+        this.description = String.format("Probability Based Sampler, samplingProbability=%.4f; rejectionThreshold=%d", samplingProbability, rejectionThreshold);
     }
 
     @Override
@@ -72,7 +75,7 @@ public class ProbabilityBasedSampler implements Sampler {
 
     @Override
     public String getDescription() {
-        return "Probability Based Sampler, rejection threshold=" + rejectionThreshold;
+        return description;
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSampler.java
@@ -31,7 +31,6 @@ import java.util.logging.Level;
  */
 public class TraceRatioBasedSampler implements Sampler {
     private final long threshold;
-    private final float ratio;
     private final String description;
 
     /**
@@ -50,8 +49,7 @@ public class TraceRatioBasedSampler implements Sampler {
             NewRelic.getAgent().getLogger().log(Level.WARNING, "TraceRatioBasedSampler: Invalid sampling ratio supplied; setting " +
                     "threshold to {0}", threshold);
         }
-        this.ratio = traceRatio;
-        this.description = String.format("Trace Id Ratio Based Sampler, ratio=%.4f", traceRatio);
+        this.description = String.format("Trace Id Ratio Based Sampler, ratio=%.4f; threshold=%d", traceRatio, threshold);
     }
 
     @Override
@@ -87,9 +85,5 @@ public class TraceRatioBasedSampler implements Sampler {
      */
     public long getThreshold() {
         return threshold;
-    }
-
-    public float getRatio() {
-        return ratio;
     }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracing/DistributedTraceServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracing/DistributedTraceServiceImplTest.java
@@ -446,7 +446,6 @@ public class DistributedTraceServiceImplTest {
         serviceManager.setDistributedTraceService(distributedTraceService);
 
         assertEquals(SamplerFactory.TRACE_RATIO_ID_BASED, distributedTraceService.getFullGranularitySamplers().get(ROOT).getType());
-        assertEquals(0.6, ((TraceRatioBasedSampler) distributedTraceService.getFullGranularitySamplers().get(ROOT)).getRatio(), 0.00001f);
         assertEquals(SamplerFactory.ALWAYS_ON, distributedTraceService.getFullGranularitySamplers().get(REMOTE_PARENT_SAMPLED).getType());
         assertEquals(SamplerFactory.ALWAYS_OFF, distributedTraceService.getFullGranularitySamplers().get(REMOTE_PARENT_NOT_SAMPLED).getType());
 
@@ -454,7 +453,6 @@ public class DistributedTraceServiceImplTest {
         assertEquals(15, ((AdaptiveSampler) distributedTraceService.getPartialGranularitySamplers().get(ROOT)).getTarget());
         assertEquals(SamplerFactory.ADAPTIVE, distributedTraceService.getPartialGranularitySamplers().get(REMOTE_PARENT_SAMPLED).getType());
         assertEquals(SamplerFactory.TRACE_RATIO_ID_BASED, distributedTraceService.getPartialGranularitySamplers().get(REMOTE_PARENT_NOT_SAMPLED).getType());
-        assertEquals(0.1, ((TraceRatioBasedSampler) distributedTraceService.getPartialGranularitySamplers().get(REMOTE_PARENT_NOT_SAMPLED)).getRatio(), 0.00001f);
 
         assertEquals(Transaction.PartialSampleType.REDUCED, distributedTraceService.getPartialSampleType());
     }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSamplerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/ProbabilityBasedSamplerTest.java
@@ -84,6 +84,12 @@ public class ProbabilityBasedSamplerTest {
         assertEquals(0.0f, sampler.calculatePriority(null), 0.0f);
     }
 
+    @Test
+    public void sampler_returnsCorrectDesc() {
+        when(mockSamplerConfig.getSamplerRatio()).thenReturn(0.5f);
+        ProbabilityBasedSampler sampler = new ProbabilityBasedSampler(mockSamplerConfig);
+        assertEquals("Probability Based Sampler, samplingProbability=0.5000; rejectionThreshold=36028797018963968", sampler.getDescription());
+    }
 
     private int runSamplerWith(int iterationCount, float samplingProbability) {
         int iterations = 0;

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSamplerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracing/samplers/TraceRatioBasedSamplerTest.java
@@ -93,6 +93,13 @@ public class TraceRatioBasedSamplerTest {
         assertNull(Sampler.traceIdFromTransaction(null));
     }
 
+    @Test
+    public void sampler_returnsCorrectDesc() {
+        when(mockSamplerConfig.getSamplerRatio()).thenReturn(0.5f);
+        TraceRatioBasedSampler sampler = new TraceRatioBasedSampler(mockSamplerConfig);
+        assertEquals("Trace Id Ratio Based Sampler, ratio=0.5000; threshold=4611686018427387904", sampler.getDescription());
+    }
+
     private int runSamplerWith(int iterationCount, float samplingRatio) {
         int iterations = 0;
         int sampledCount = 0;


### PR DESCRIPTION
### Overview
Some minor tweaks for the Probability sampler and Trace ratio sampler.
- Cleanup the `getDescription()` method
- Remove `traceRatio` variable 