### PR TITLE
Serverless POC: Disable the jar collector when serverless mode is enabled

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -188,7 +188,8 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
         jmxService = new JmxService(jmxConfig);
 
         Logger jarCollectorLogger = Agent.LOG.getChildLogger("com.newrelic.jar_collector");
-        boolean jarCollectorEnabled = configService.getDefaultAgentConfig().getJarCollectorConfig().isEnabled();
+        boolean jarCollectorEnabled = !config.getServerlessConfig().isEnabled()
+                && configService.getDefaultAgentConfig().getJarCollectorConfig().isEnabled();
         AtomicBoolean shouldSendAllJars = new AtomicBoolean(true);
         TrackedAddSet<JarData> analyzedJars = new TrackedAddSet<>();
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/ServiceManagerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/ServiceManagerTest.java
@@ -8,13 +8,21 @@
 package com.newrelic.agent.service;
 
 import com.newrelic.agent.AgentHelper;
+import com.newrelic.agent.InstrumentationProxy;
 import com.newrelic.agent.MockCoreService;
+import com.newrelic.agent.config.AgentConfigImpl;
 import com.newrelic.agent.config.ConfigService;
 import com.newrelic.agent.config.ConfigServiceFactory;
 import com.newrelic.agent.core.CoreService;
+import com.newrelic.agent.service.module.JarCollectorService;
 import com.newrelic.api.agent.Logger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
@@ -30,6 +38,93 @@ public class ServiceManagerTest {
         serviceManager.addService(testService);
         Assert.assertEquals(testService, serviceManager.getService(testService.getName()));
         Assert.assertFalse(testService.isStarted());
+    }
+
+    @Test
+    public void jarCollectorDisabledWhenServerlessModeEnabled() throws Exception {
+        AgentHelper.initializeConfig();
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(AgentConfigImpl.APP_NAME, "Test App");
+        configMap.put("serverless_mode", Collections.singletonMap("enabled", true));
+        configMap.put("jar_collector", Collections.singletonMap("enabled", true));
+
+        MockCoreService mockCoreService = new MockCoreService();
+        mockCoreService.setInstrumentation(Mockito.mock(InstrumentationProxy.class));
+        Mockito.when(mockCoreService.getInstrumentation().getAllLoadedClasses()).thenReturn(new Class[] {});
+
+        ConfigService configService = ConfigServiceFactory.createConfigService(
+                AgentConfigImpl.createAgentConfig(configMap), configMap);
+
+        ServiceManager serviceManager = new ServiceManagerImpl(mockCoreService, configService);
+        ServiceFactory.setServiceManager(serviceManager);
+        serviceManager.start();
+
+        JarCollectorService jarCollectorService = serviceManager.getJarCollectorService();
+
+        Assert.assertFalse("Jar collector should be disabled when serverless mode is enabled",
+                jarCollectorService.isEnabled());
+
+        serviceManager.stop();
+        ServiceFactory.setServiceManager(null);
+    }
+
+    @Test
+    public void jarCollectorEnabledWhenServerlessModeDisabled() throws Exception {
+        AgentHelper.initializeConfig();
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(AgentConfigImpl.APP_NAME, "Test App");
+        configMap.put("serverless_mode", Collections.singletonMap("enabled", false));
+        configMap.put("jar_collector", Collections.singletonMap("enabled", true));
+
+        MockCoreService mockCoreService = new MockCoreService();
+        mockCoreService.setInstrumentation(Mockito.mock(InstrumentationProxy.class));
+        Mockito.when(mockCoreService.getInstrumentation().getAllLoadedClasses()).thenReturn(new Class[] {});
+
+        ConfigService configService = ConfigServiceFactory.createConfigService(
+                AgentConfigImpl.createAgentConfig(configMap), configMap);
+
+        ServiceManager serviceManager = new ServiceManagerImpl(mockCoreService, configService);
+        ServiceFactory.setServiceManager(serviceManager);
+        serviceManager.start();
+
+        JarCollectorService jarCollectorService = serviceManager.getJarCollectorService();
+
+        Assert.assertTrue("Jar collector should be enabled when serverless mode is disabled and jar_collector config is enabled",
+                jarCollectorService.isEnabled());
+
+        serviceManager.stop();
+        ServiceFactory.setServiceManager(null);
+    }
+
+    @Test
+    public void jarCollectorDisabledWhenExplicitlyDisabledRegardlessOfServerlessMode() throws Exception {
+        AgentHelper.initializeConfig();
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(AgentConfigImpl.APP_NAME, "Test App");
+        configMap.put("serverless_mode", Collections.singletonMap("enabled", false));
+        configMap.put("jar_collector", Collections.singletonMap("enabled", false));
+
+        MockCoreService mockCoreService = new MockCoreService();
+        mockCoreService.setInstrumentation(Mockito.mock(InstrumentationProxy.class));
+        Mockito.when(mockCoreService.getInstrumentation().getAllLoadedClasses()).thenReturn(new Class[] {});
+
+        ConfigService configService = ConfigServiceFactory.createConfigService(
+                AgentConfigImpl.createAgentConfig(configMap), configMap);
+
+        ServiceManager serviceManager = new ServiceManagerImpl(mockCoreService, configService);
+        ServiceFactory.setServiceManager(serviceManager);
+        serviceManager.start();
+
+        JarCollectorService jarCollectorService = serviceManager.getJarCollectorService();
+
+        Assert.assertFalse("Jar collector should be disabled when explicitly disabled in config",
+                jarCollectorService.isEnabled());
+
+        serviceManager.stop();
+        ServiceFactory.setServiceManager(null);
     }
 
     private static class TestService extends AbstractService {


### PR DESCRIPTION
### Overview
 This PR implements functionality to automatically disable the jar collector service when serverless mode is enabled.

### Related Github Issue
Resolves #2634 

### Testing
Added three unit tests to `ServiceManagerTest` to validate config permutations 

