### PR TITLE
Cleanup temp jars during agent startup

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/bootstrap/EmbeddedJarFilesImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/bootstrap/EmbeddedJarFilesImplTest.java
@@ -4,10 +4,16 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Comparator;
 
 public class EmbeddedJarFilesImplTest {
+
+    private static final long TWO_SEC = 2000L;
 
     @Test
     public void noArgConstructor_initsWithInternalJarFileNames() {
@@ -39,5 +45,147 @@ public class EmbeddedJarFilesImplTest {
     public void getJarFileInAgent_withInvalidFilename_throwsException() throws IOException {
         EmbeddedJarFiles embeddedJarFiles = new EmbeddedJarFilesImpl();
         Assert.assertNotNull(embeddedJarFiles.getJarFileInAgent("foo"));
+    }
+
+    @Test
+    public void cleanupCalledOnStartup_deletesOldFiles() throws Exception {
+        Path tempDir = Files.createTempDirectory("nr-agent-test-temp");
+        try {
+            // Configure agent to use our temp dir and make cleanup aggressive for test
+            System.setProperty("newrelic.tempdir", tempDir.toString());
+            System.clearProperty("newrelic.tempdir.cleanup.disable");
+            System.setProperty("newrelic.tempdir.cleanup.age.ms", "100"); // 100ms
+
+            // Create fake old agent jar files that match the INTERNAL_JAR_FILE_NAMES pattern
+            File file1 = tempDir.resolve(BootstrapLoader.AGENT_BRIDGE_JAR_NAME + "-old.jar").toFile();
+            File file2 = tempDir.resolve(BootstrapLoader.API_JAR_NAME + "-old.jar").toFile();
+
+            Assert.assertTrue("Failed to create test file1", file1.createNewFile());
+            Assert.assertTrue("Failed to create test file2", file2.createNewFile());
+
+            // Set last modified to be older than the cutoff (now - 1000ms)
+            long oldTime = System.currentTimeMillis() - 1000L;
+            Assert.assertTrue(file1.setLastModified(oldTime));
+            Assert.assertTrue(file2.setLastModified(oldTime));
+
+            // Sanity check files exist before cleanup
+            Assert.assertTrue(file1.exists());
+            Assert.assertTrue(file2.exists());
+
+            // Ensure cleanup is enabled and CRaC simulation is disabled for this test run
+            System.setProperty("newrelic.tempdir.cleanup.disable", "false");
+            System.clearProperty("newrelic.tempdir.cleanup.crac.present");
+            // Force cleanup in tests to avoid accidental CRaC detection interfering
+            System.setProperty("newrelic.tempdir.cleanup.force", "true");
+
+            File configuredTemp = BootstrapLoader.getTempDir();
+            Assert.assertNotNull("BootstrapLoader.getTempDir() should return our test temp dir", configuredTemp);
+            Assert.assertEquals("Temp dir mismatch", tempDir.toFile().getAbsolutePath(), configuredTemp.getAbsolutePath());
+            Assert.assertEquals("cleanup.disable must be false", "false", System.getProperty("newrelic.tempdir.cleanup.disable"));
+            Assert.assertNull("crac.present should be unset for this test", System.getProperty("newrelic.tempdir.cleanup.crac.present"));
+
+             // Invoke cleanup directly to avoid timing/classloading issues with constructor-run cleanup
+             EmbeddedJarFilesImpl ej = new EmbeddedJarFilesImpl();
+            try {
+                java.lang.reflect.Method m = EmbeddedJarFilesImpl.class.getDeclaredMethod("cleanupOldAgentTempFiles");
+                m.setAccessible(true);
+                m.invoke(ej);
+            } catch (ReflectiveOperationException roe) {
+                throw new RuntimeException(roe);
+            }
+
+            // The cleanup runs synchronously, but file deletion may be slightly delayed on some platforms.
+            // Wait up to 2 seconds for the files to be removed to avoid flaky failures.
+            long waitUntil = System.currentTimeMillis() + TWO_SEC;
+            while (System.currentTimeMillis() < waitUntil && (file1.exists() || file2.exists())) {
+                Thread.sleep(50);
+            }
+
+            Assert.assertFalse("Old file1 should have been deleted by cleanup", file1.exists());
+            Assert.assertFalse("Old file2 should have been deleted by cleanup", file2.exists());
+        } finally {
+            // Clear system properties and remove temp dir
+            System.clearProperty("newrelic.tempdir");
+            System.clearProperty("newrelic.tempdir.cleanup.age.ms");
+            System.clearProperty("newrelic.tempdir.cleanup.disable");
+            System.clearProperty("newrelic.tempdir.cleanup.force");
+
+            try {
+                try (java.util.stream.Stream<Path> s = Files.walk(tempDir)) {
+                    s.sorted(Comparator.reverseOrder())
+                            .map(Path::toFile)
+                            .forEach(f -> {
+                                try {
+                                    if (!f.delete()) {
+                                        System.err.println("Failed to delete test file: " + f.getAbsolutePath());
+                                    }
+                                } catch (Throwable ignored) {
+                                }
+                            });
+                }
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void cleanupSkippedWhenCRacPresent_doesNotDeleteOldFiles() throws Exception {
+        Path tempDir = Files.createTempDirectory("nr-agent-test-temp-crac");
+        try {
+            // Configure agent to use our temp dir and make cleanup aggressive for test
+            System.setProperty("newrelic.tempdir", tempDir.toString());
+            System.clearProperty("newrelic.tempdir.cleanup.disable");
+            System.setProperty("newrelic.tempdir.cleanup.age.ms", "100"); // 100ms
+
+            // Create fake old agent jar files that match the INTERNAL_JAR_FILE_NAMES pattern
+            File file1 = tempDir.resolve(BootstrapLoader.AGENT_BRIDGE_JAR_NAME + "-old.jar").toFile();
+            File file2 = tempDir.resolve(BootstrapLoader.API_JAR_NAME + "-old.jar").toFile();
+
+            Assert.assertTrue("Failed to create test file1", file1.createNewFile());
+            Assert.assertTrue("Failed to create test file2", file2.createNewFile());
+
+            // Set last modified to be older than the cutoff (now - 1000ms)
+            long oldTime = System.currentTimeMillis() - 1000L;
+            Assert.assertTrue(file1.setLastModified(oldTime));
+            Assert.assertTrue(file2.setLastModified(oldTime));
+
+            // Sanity check files exist before cleanup
+            Assert.assertTrue(file1.exists());
+            Assert.assertTrue(file2.exists());
+
+            // The presence of the test-only jdk.crac.Checkpoint class on the test classpath
+            // should cause EmbeddedJarFilesImpl to detect CRaC and skip cleanup.
+            System.setProperty("newrelic.tempdir.cleanup.crac.present", "true");
+            try {
+                new EmbeddedJarFilesImpl();
+            } finally {
+                System.clearProperty("newrelic.tempdir.cleanup.crac.present");
+            }
+
+            // Because CRaC marker class is present, cleanup should have been skipped and files remain
+            Assert.assertTrue("Old file1 should NOT have been deleted when CRaC API present", file1.exists());
+            Assert.assertTrue("Old file2 should NOT have been deleted when CRaC API present", file2.exists());
+        } finally {
+            // Clear system properties and remove temp dir
+            System.clearProperty("newrelic.tempdir");
+            System.clearProperty("newrelic.tempdir.cleanup.age.ms");
+            System.clearProperty("newrelic.tempdir.cleanup.disable");
+
+            try {
+                try (java.util.stream.Stream<Path> s = Files.walk(tempDir)) {
+                    s.sorted(Comparator.reverseOrder())
+                            .map(Path::toFile)
+                            .forEach(f -> {
+                                try {
+                                    if (!f.delete()) {
+                                        System.err.println("Failed to delete test file: " + f.getAbsolutePath());
+                                    }
+                                } catch (Throwable ignored) {
+                                }
+                            });
+                }
+            } catch (IOException ignored) {
+            }
+        }
     }
 }

--- a/newrelic-agent/src/test/java/jdk/crac/Core.java
+++ b/newrelic-agent/src/test/java/jdk/crac/Core.java
@@ -1,0 +1,7 @@
+package jdk.crac;
+
+/**
+ * Test-only marker (moved) to avoid being detected as jdk.crac.Core by production code.
+ */
+public class Core {
+}


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
The temp agent jars left over during the JVM abnormal exits are automatically cleaned during startup.

- Check for the presence of  property `newrelic.tempdir.cleanup.disable` and return early if set true
- Check for CRaC present  `newrelic.tempdir.cleanup.crac.present` if yes then skip cleanup
- Determines the age threshold default 24 hours can be overidden by `newrelic.tempdir.cleanup.age.ms`

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2345

### Testing
- Added cleanupSkippedWhenCRacPresent_doesNotDeleteOldFiles and cleanupCalledOnStartup_deletesOldFiles unit tests
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [X] Your contributions are backwards compatible with relevant frameworks and APIs.
- [X] Your code does not contain any breaking changes. Otherwise please describe. 
- [X] Your code does not introduce any new dependencies. Otherwise please describe.
