### PR TITLE
Delete stale agent temp jars on startup

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -163,6 +163,8 @@ public final class Agent {
             LOG.warning(msg);
         }
 
+        EmbeddedJarFilesImpl.cleanupStaleTempJarFiles();
+
         if (!tryToInitializeServiceManager(inst)) {
             return;
         }

--- a/newrelic-agent/src/test/java/com/newrelic/bootstrap/EmbeddedJarFilesImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/bootstrap/EmbeddedJarFilesImplTest.java
@@ -188,6 +188,6 @@ public class EmbeddedJarFilesImplTest {
                 String.valueOf(thresholdHours));
 
         // Constructor triggers cleanup
-        new EmbeddedJarFilesImpl();
+        EmbeddedJarFilesImpl.cleanupStaleTempJarFiles();
     }
 }


### PR DESCRIPTION
Resolves #2345 

In some customer environments, agent temp jars aren't properly cleaned up, even though these jars are marked as [deleteOnExit](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#deleteOnExit--). This is likely due to abnormal termination of the JVM.

To activate this feature, one of the following config options must be set:
Environment variable: `NEW_RELIC_TEMP_JARFILE_AGE_THRESHOLD_HOURS`
System property: `newrelic.config.temp_jarfile_age_threshold_hours`

The value is the number of hours old a temp jar needs to be in order to be deleted (whole numbers only).
Note that there is no yml config option since the deletion operation occurs prior to the agent's ConfigService being initialized.

A file is eligible to be deleted if: 
- it starts with one of the internal agent jar prefixes: `agent-bridge`, `newrelic-api`, `newrelic-weaver-api`, `newrelic-security-agent`, `instrumentation`, `newrelic-bootstrap`, `newrelic-security-api`, `agent-bridge-datastore`
- has the ".jar" extension 
- is older than the specified cutoff value in hours.

Includes contributions by @badri-mel

