### PR TITLE
Replace hardcoded mock thread id with current thread id

### DIFF
--- a/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/TransactionProfileTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/profile/v2/TransactionProfileTest.java
@@ -42,7 +42,7 @@ public class TransactionProfileTest {
         TransactionActivity ta = Mockito.mock(TransactionActivity.class);
         Mockito.when(ta.getTracers()).thenReturn(Arrays.asList(tracer));
         Mockito.when(ta.getTotalCpuTime()).thenReturn(123L);
-        Mockito.when(ta.getThreadId()).thenReturn(1L);
+        Mockito.when(ta.getThreadId()).thenReturn(Thread.currentThread().getId());
         Mockito.when(ta.getRootTracer()).thenReturn(tracer);
         TransactionData td = Mockito.mock(TransactionData.class);
         Mockito.when(td.getTransactionActivities()).thenReturn(new HashSet<>(Arrays.asList(ta)));


### PR DESCRIPTION
Small correction to replace a hardcoded thread id of 1 with the actual id of the current thread. 

Something in J25 changed that stopped guaranteeing that a thread with id 1 would always be present. 
