### PR TITLE
Use xargs to handle empty docker images

### DIFF
--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -215,7 +215,7 @@ jobs:
       # other cleanups were suggested on runner-images repo
       - name: Clean up disk
         run: |
-          docker rmi $(docker images -q)
+          docker images -q | xargs -r docker rmi
           sudo apt clean
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc


### PR DESCRIPTION
Fixes unhandled condition where `docker images -q` is empty by piping through `xargs -r` in the AITs workflow. 
