### PR TITLE
Exclude milestone releases for Apache Pekko HTTP Core

### DIFF
--- a/instrumentation/apache-pekko-http-core-2.13_1/build.gradle
+++ b/instrumentation/apache-pekko-http-core-2.13_1/build.gradle
@@ -19,6 +19,8 @@ verifyInstrumentation {
     passesOnly('org.apache.pekko:pekko-http-core_3:[1.0.0,)') {
         implementation("org.apache.pekko:pekko-stream_3:1.0.0")
     }
+
+    excludeRegex 'org.apache.pekko:pekko-http-core_.*:.*-M[0-9]*'
 }
 
 site {


### PR DESCRIPTION
Verify instrumentation began failing for the 2.0.0-M1 release, a ticket was opened to research support.