### PR TITLE
enhancements to coroutine ignores

### DIFF
--- a/instrumentation/kotlin-coroutines-1.4/src/main/java/com/newrelic/instrumentation/kotlin/coroutines_14/Utils.java
+++ b/instrumentation/kotlin-coroutines-1.4/src/main/java/com/newrelic/instrumentation/kotlin/coroutines_14/Utils.java
@@ -217,8 +217,8 @@ public class Utils implements CoroutineConfigListener {
 		if(ignoresRegExs != null) {
 			for(String ignore : ignoresRegExs) {
 				ignoredContinuationPatterns.add(Pattern.compile(ignore));
-				NewRelic.getAgent().getLogger().log(Level.FINER,"Will ignore these continuations regexs: {0}", ignoredContinuations);
 			}
+			NewRelic.getAgent().getLogger().log(Level.FINER,"Will ignore these continuations regexs: {0}", ignoredContinuationPatterns);
 		}
 	}
 

--- a/instrumentation/kotlin-coroutines-1.7/src/main/java/com/newrelic/instrumentation/kotlin/coroutines_17/Utils.java
+++ b/instrumentation/kotlin-coroutines-1.7/src/main/java/com/newrelic/instrumentation/kotlin/coroutines_17/Utils.java
@@ -221,8 +221,8 @@ public class Utils implements CoroutineConfigListener {
 		if(ignoresRegExs != null) {
 			for(String ignore : ignoresRegExs) {
 				ignoredContinuationPatterns.add(Pattern.compile(ignore));
-				NewRelic.getAgent().getLogger().log(Level.FINER,"Will ignore these continuations matching regex: {0}", ignore);
 			}
+			NewRelic.getAgent().getLogger().log(Level.FINER,"Will ignore these continuations regexs: {0}", ignoredContinuationPatterns);
 		}
 	}
 

--- a/instrumentation/kotlin-coroutines-1.9/src/main/java/com/newrelic/instrumentation/kotlin/coroutines_19/Utils.java
+++ b/instrumentation/kotlin-coroutines-1.9/src/main/java/com/newrelic/instrumentation/kotlin/coroutines_19/Utils.java
@@ -217,8 +217,8 @@ public class Utils implements CoroutineConfigListener {
 		if(ignoresRegExs != null) {
 			for(String ignore : ignoresRegExs) {
 				ignoredContinuationPatterns.add(Pattern.compile(ignore));
-				NewRelic.getAgent().getLogger().log(Level.FINER,"Will ignore these continuations regexs: {0}", ignoredContinuations);
 			}
+			NewRelic.getAgent().getLogger().log(Level.FINER,"Will ignore these continuations regexs: {0}", ignoredContinuationPatterns);
 		}
 	}
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/KotlinCoroutinesConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/KotlinCoroutinesConfigImpl.java
@@ -1,9 +1,6 @@
 package com.newrelic.agent.config;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class KotlinCoroutinesConfigImpl extends BaseConfig implements KotlinCoroutinesConfig {
 
@@ -15,6 +12,7 @@ public class KotlinCoroutinesConfigImpl extends BaseConfig implements KotlinCoro
     public static final String IGNORE_REGEX = "ignoreRegex";
     public static final String DELAYED_ROOT = "delayed";
     public static final String ENABLED = "enabled";
+    public static final String SUSPENDS_ROOT = "suspends";
     private static final boolean DELAY_DEFAULT = true;
     private String[] ignoredContinuations = null;
     private String[] ignoredScopes = null;
@@ -75,6 +73,17 @@ public class KotlinCoroutinesConfigImpl extends BaseConfig implements KotlinCoro
         } else {
             delayedEnabled = DELAY_DEFAULT;
         }
+
+        Map<String, String> suspended_root = getProperty(SUSPENDS_ROOT);
+        if (suspended_root != null) {
+            String suspendsToIgnore = suspended_root.get(IGNORE);
+            ignoredSuspends = splitString(suspendsToIgnore);
+            String suspendsToIgnoreRegex = suspended_root.get(IGNORE_REGEX);
+            ignoredRegexSuspends = splitString(suspendsToIgnoreRegex);
+        } else {
+            ignoredSuspends = new String[0];
+            ignoredRegexSuspends = new String[0];
+        }
     }
 
     static KotlinCoroutinesConfigImpl create(Map<String, Object> settings) {
@@ -125,15 +134,20 @@ public class KotlinCoroutinesConfigImpl extends BaseConfig implements KotlinCoro
         return delayedEnabled;
     }
 
-    private String[] splitString(String input) {
+
+    private static String[] splitString(String input) {
         if (input == null) {
             return new String[0];
         }
         String[] firstSplit = input.split("\"");
         List<String> result = new ArrayList<>();
         for (String s : firstSplit) {
-            if(!s.trim().equals(",")) {
-                result.add(s.trim());
+            String[] secondSplit = s.split(",");
+            for(String split : secondSplit) {
+
+                if(!split.trim().equals(",")) {
+                    result.add(split.trim());
+                }
             }
         }
         String[] returnValue = new String[result.size()];

--- a/newrelic-agent/src/main/java/com/newrelic/agent/kotlincoroutines/KotlinIgnoresCache.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/kotlincoroutines/KotlinIgnoresCache.java
@@ -1,0 +1,89 @@
+package com.newrelic.agent.kotlincoroutines;
+
+import com.newrelic.agent.service.ServiceFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Class that stores ignored Coroutine components that are added programmatically rather than
+ * via the configuration.  Used primarily by instrumentation modules built on top of Kotlin
+ * Coroutines (e.g. Ktor)
+ * This allows the instrumentation developer to add ignores without having the user enter them
+ * in newrelic.yml
+ */
+class KotlinIgnoresCache {
+
+    private static final Set<String> ignoredSuspends = new HashSet<String>();
+    private static final Set<String> ignoredRegexSuspends = new HashSet<>();
+    private static final Set<String> ignoredContinuations = new HashSet<>();
+    private static final Set<String> ignoredRegexContinuations = new HashSet<>();
+    private static final Set<String> ignoredScopes = new HashSet<>();
+    private static final Set<String> ignoredRegexScopes = new HashSet<>();
+    private static final Set<String> ignoredDispatched = new HashSet<>();
+    private static final Set<String> ignoredRegExDispatched = new HashSet<>();
+
+    protected static Set<String> getIgnoredSuspends() {
+        return ignoredSuspends;
+    }
+
+    protected static void addIgnoredSuspend(String suspend) {
+        ignoredSuspends.add(suspend);
+    }
+
+    protected static Set<String> getIgnoredRegexSuspends() {
+        return ignoredRegexSuspends;
+    }
+
+    protected static void addIgnoredRegexSuspend(String suspendRegex) {
+        ignoredRegexSuspends.add(suspendRegex);
+    }
+
+    protected static Set<String> getIgnoredContinuations() {
+        return ignoredContinuations;
+    }
+
+    protected static void addIgnoredContinuation(String continuation) {
+        ignoredContinuations.add(continuation);
+    }
+
+    protected static Set<String> getIgnoredRegexContinuations() {
+        return ignoredRegexContinuations;
+    }
+
+    protected static void addIgnoredRegexContinuation(String continuationRegex) {
+        ignoredRegexContinuations.add(continuationRegex);
+    }
+
+    protected static Set<String> getIgnoredScopes() {
+        return ignoredScopes;
+    }
+
+    protected static void addIgnoredScope(String scope) {
+        ignoredScopes.add(scope);
+    }
+
+    protected static Set<String> getIgnoredRegexScopes() {
+        return ignoredRegexScopes;
+    }
+
+    protected static void addIgnoredRegexScope(String scopeRegex) {
+        ignoredRegexScopes.add(scopeRegex);
+    }
+
+    protected static Set<String> getIgnoredDispatched() {
+        return ignoredDispatched;
+    }
+
+    protected static void addIgnoredDispatched(String dispatched) {
+        ignoredDispatched.add(dispatched);
+    }
+
+    protected static Set<String> getIgnoredRegexDispatched() {
+        return ignoredRegExDispatched;
+    }
+
+    protected static void addIgnoredRegexDispatched(String dispatchedRegex) {
+        ignoredRegExDispatched.add(dispatchedRegex);
+    }
+}


### PR DESCRIPTION
Corrections to address problems related to the ignores in Kotlin Coroutines
Added the ability to add ignore configurations programmatically rather than by including them in newrelic.yml.  This is meant for instrumentation modules that are written for frameworks built using Kotlin Coroutines.  Initially this will be used by the Ktor instrumentation written by New Relic Labs but can be used by future frameworks as well. 
