### PR TITLE
Fix log context_data config

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/logging/AppLoggingUtils.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/logging/AppLoggingUtils.java
@@ -43,7 +43,7 @@ public class AppLoggingUtils {
     private static final boolean APP_LOGGING_METRICS_DEFAULT_ENABLED = true;
     private static final boolean APP_LOGGING_FORWARDING_DEFAULT_ENABLED = true;
     private static final boolean APP_LOGGING_LOCAL_DECORATING_DEFAULT_ENABLED = false;
-    private static final boolean APP_LOGGING_FORWARDING_INCLUDE_CONTEXT_DATA_DEFAULT_ENABLED = false;
+    private static final boolean APP_LOGGING_FORWARDING_CONTEXT_DATA_DEFAULT_ENABLED = false;
 
     /**
      * Gets a String representing the agent linking metadata in blob format:
@@ -150,12 +150,12 @@ public class AppLoggingUtils {
     }
 
     /**
-     * Check if the application_logging forwarding include_context_data feature is enabled.
+     * Check if the application_logging forwarding context_data feature is enabled.
      *
      * @return true if enabled, else false
      */
     public static boolean isAppLoggingContextDataEnabled() {
         return NewRelic.getAgent().getConfig().getValue("application_logging.forwarding.context_data.enabled",
-                APP_LOGGING_FORWARDING_INCLUDE_CONTEXT_DATA_DEFAULT_ENABLED);
+                APP_LOGGING_FORWARDING_CONTEXT_DATA_DEFAULT_ENABLED);
     }
 }

--- a/newrelic-agent/src/test/resources/com/newrelic/agent/config/newrelic.yml
+++ b/newrelic-agent/src/test/resources/com/newrelic/agent/config/newrelic.yml
@@ -22,7 +22,7 @@ common: &default_settings
     enabled: true
     forwarding:
       enabled: true
-      include_context_data:
+      context_data:
         enabled: false
       max_samples_stored: 10000
     metrics:


### PR DESCRIPTION
Remove references to the `include_context_data` config that was changed to `context_data`.