### PR TITLE
Update the excludes to exclude all milestones for Glassfish.

### DIFF
--- a/instrumentation/glassfish-6/build.gradle
+++ b/instrumentation/glassfish-6/build.gradle
@@ -11,13 +11,10 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.glassfish.main.web:web-core:[6.0.0-RC1,8.0.0-M2)'
-    exclude 'org.glassfish.main.web:web-core:7.0.0-M3'
-    exclude 'org.glassfish.main.web:web-core:7.0.0-M4'
-    exclude 'org.glassfish.main.web:web-core:7.0.0-M10'
-    exclude 'org.glassfish.main.web:web-core:8.0.0-M[0-9]*$'
+    passesOnly 'org.glassfish.main.web:web-core:[6.0.0-RC1,)'
     exclude 'org.glassfish.main.web:web-core:8.0.0-DONTPUBLISH'
     excludeRegex 'org.glassfish.main.web:web-core:8.0.0-JDK17-M[0-9]*$'
+    excludeRegex 'org.glassfish.main.web:web-core:[0-9]*.0.0-M[0-9]*$'
 }
 
 site {


### PR DESCRIPTION
Normally we would want milestone releases to fail, to give a heads up that the full release will likely fail.  But this hasn't turned out to be true for Glassfish specifically, so let's just ignore milestones to avoid the overhead.