### PR TITLE
Cap OTel SDK Extension module at 1.59

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
@@ -69,7 +69,7 @@ java {
 }
 
 verifyInstrumentation {
-    passesOnly ("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:[1.26.0-alpha,)")
+    passesOnly ("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:[1.26.0-alpha,1.59.0)")
 }
 
 site {


### PR DESCRIPTION
     ReferenceViolation{type=MISSING_ORIGINAL_BYTECODE, weaveClass=io/opentelemetry/sdk/trace/ExitTracerSpan, originalClass=io/opentelemetry/sdk/internal/AttributeUtil, violationMessage=Could not find resource}

