### PR TITLE
feat: add agent metadata action - step 2

### DIFF
--- a/.github/workflows/Agent-Metadata.yml
+++ b/.github/workflows/Agent-Metadata.yml
@@ -19,33 +19,29 @@ on:
       use-cache:
         description: 'Use cache'
         required: false
-        default: false
+        default: true
         type: boolean
-      fetch-depth:
-        description: 'Number of commits to fetch (> 1 may be required for docs flow)'
-        required: false
-        default: '1'
-        type: string
-      oci-registry:
-        description: 'OCI registry URL for binary uploads (e.g., ghcr.io/newrelic/agents). Leave empty to skip binary upload.'
-        required: false
-        default: ''
-        type: string
-      oci-username:
-        description: 'OCI registry username (required if oci-registry is set)'
-        required: false
-        default: ''
-        type: string
-      oci-password:
-        description: 'OCI registry password or token (required if oci-registry is set)'
-        required: false
-        default: ''
-        type: string
-      binaries:
-        description: 'JSON array with artifact definitions'
-        required: false
-        default: ''
-        type: string
+# commented items below pertain to future work
+#      oci-registry:
+#        description: 'OCI registry URL for binary uploads (e.g., ghcr.io/newrelic/agents). Leave empty to skip binary upload.'
+#        required: false
+#        default: ''
+#        type: string
+#      oci-username:
+#        description: 'OCI registry username (required if oci-registry is set)'
+#        required: false
+#        default: ''
+#        type: string
+#      oci-password:
+#        description: 'OCI registry password or token (required if oci-registry is set)'
+#        required: false
+#        default: ''
+#        type: string
+#      binaries:
+#        description: 'JSON array with artifact definitions'
+#        required: false
+#        default: ''
+#        type: string
 
   # Allows calling from another workflow
   workflow_call:
@@ -62,33 +58,29 @@ on:
       use-cache:
         description: 'Use cache'
         required: false
-        default: false
+        default: true
         type: boolean
-      fetch-depth:
-        description: 'Number of commits to fetch (> 1 may be required for docs flow)'
-        required: false
-        default: '1'
-        type: string
-      oci-registry:
-        description: 'OCI registry URL for binary uploads (e.g., ghcr.io/newrelic/agents). Leave empty to skip binary upload.'
-        required: false
-        default: ''
-        type: string
-      oci-username:
-        description: 'OCI registry username (required if oci-registry is set)'
-        required: false
-        default: ''
-        type: string
-      oci-password:
-        description: 'OCI registry password or token (required if oci-registry is set)'
-        required: false
-        default: ''
-        type: string
-      binaries:
-        description: 'JSON array with artifact definitions'
-        required: false
-        default: ''
-        type: string
+# commented items below pertain to future work
+#      oci-registry:
+#        description: 'OCI registry URL for binary uploads (e.g., ghcr.io/newrelic/agents). Leave empty to skip binary upload.'
+#        required: false
+#        default: ''
+#        type: string
+#      oci-username:
+#        description: 'OCI registry username (required if oci-registry is set)'
+#        required: false
+#        default: ''
+#        type: string
+#      oci-password:
+#        description: 'OCI registry password or token (required if oci-registry is set)'
+#        required: false
+#        default: ''
+#        type: string
+#      binaries:
+#        description: 'JSON array with artifact definitions'
+#        required: false
+#        default: ''
+#        type: string
     secrets:
       FC_SYS_ID_CLIENT_ID:
         required: true
@@ -110,3 +102,4 @@ jobs:
           apm-control-nr-license-key: ${{ secrets.APM_CONTROL_NR_LICENSE_KEY_STAGING }}
           agent-type: TestAgent #${{ inputs.agent-type }}
           version: ${{ inputs.version }}
+          cache: ${{ inputs.use-cache }}

--- a/.github/workflows/Agent-Metadata.yml
+++ b/.github/workflows/Agent-Metadata.yml
@@ -1,14 +1,14 @@
 name: Agent Metadata
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   # Allows manual triggering with parameters
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., v0.0.8)'
+        description: 'Version tag (e.g., v9.0.0)'
         required: true
         type: string
       agent-type:
@@ -95,11 +95,11 @@ jobs:
     continue-on-error: true
     steps:
       - name: Run action
-        uses: newrelic/agent-metadata-action@v1.0.0
+        uses: newrelic/agent-metadata-action@v1.0.1
         with:
           newrelic-client-id: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
           newrelic-private-key: ${{ secrets.FC_SYS_ID_PR_KEY }}
-          apm-control-nr-license-key: ${{ secrets.APM_CONTROL_NR_LICENSE_KEY_STAGING }}
-          agent-type: TestAgent #${{ inputs.agent-type }}
+          apm-control-nr-license-key: ${{ secrets.APM_CONTROL_NR_LICENSE_KEY_STAGING }} # action app is instrumented and supported by APM Control team
+          agent-type: ${{ inputs.agent-type }}
           version: ${{ inputs.version }}
           cache: ${{ inputs.use-cache }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -78,3 +78,12 @@ jobs:
             echo "Artifacts were uploaded successfully to Central Sonatype."
             echo "Visit https://central.sonatype.com/publishing/deployments to view your artifacts."
           fi
+  update-agent-metadata:
+    needs: [publish_release]
+    uses: ./.github/workflows/Agent-Metadata.yml
+    with:
+      version: ${{ github.event.release.tag_name }}
+    secrets:
+      FC_SYS_ID_CLIENT_ID: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
+      FC_SYS_ID_PR_KEY: ${{ secrets.FC_SYS_ID_PR_KEY }}
+      APM_CONTROL_NR_LICENSE_KEY_STAGING: ${{ secrets.APM_CONTROL_NR_LICENSE_KEY_STAGING }}


### PR DESCRIPTION
### Overview
This PR completes the ability for the NR agent team to send agent metadata to New Relic for use in fleets and other features. This will be triggered normally during a release, but if it fails, it will not fail the release. It can also be run on-demand for backfilling older agent versions, to make corrections, or to re-run the job after a failure.

GH action info: https://github.com/newrelic/agent-metadata-action/blob/main/README.md

### Testing
This work has been tested manually in https://github.com/newrelic/newrelic-java-agent/pull/2732 

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe. - new dependency  on GH action but won't affect the agent deliverable
