### PR TITLE
Add sys prop recognition for full_granularity.enabled setting

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/coretracing/BaseSamplerCoreTracingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/coretracing/BaseSamplerCoreTracingConfig.java
@@ -17,6 +17,7 @@ public class BaseSamplerCoreTracingConfig extends CoreTracingConfig {
     private static final String SAMPLER_SYSTEM_PROPERTY_ROOT = "sampler.";
     public static final String SHARED_ADAPTIVE_SAMPLING_TARGET = "adaptive_sampling_target";
     public static final int SHARED_ADAPTIVE_SAMPLING_TARGET_DEFAULT = 120;
+    public static final String FULL_GRANULARITY_SYSTEM_PROPERTY_ROOT = "full_granularity.";
 
     public static final boolean BASE_SAMPLER_ENABLED_DEFAULT = true;
     public static final boolean FULL_GRANULARITY_ENABLED_DEFAULT = true;
@@ -28,7 +29,7 @@ public class BaseSamplerCoreTracingConfig extends CoreTracingConfig {
     public BaseSamplerCoreTracingConfig(Map<String, Object> props, String dtSystemPropertyRoot) {
         super(props, dtSystemPropertyRoot + SAMPLER_SYSTEM_PROPERTY_ROOT, BASE_SAMPLER_ENABLED_DEFAULT);
         //there is no sampler.enabled property that we honor. The full granularity enabled property is at sampler.full_granularity.enabled.
-        this.isFullGranularityEnabled = (new BaseConfig(nestedProps(FULL_GRANULARITY))).getProperty(ENABLED, FULL_GRANULARITY_ENABLED_DEFAULT);
+        this.isFullGranularityEnabled = (new BaseConfig(nestedProps(FULL_GRANULARITY), dtSystemPropertyRoot + SAMPLER_SYSTEM_PROPERTY_ROOT + FULL_GRANULARITY_SYSTEM_PROPERTY_ROOT)).getProperty(ENABLED, FULL_GRANULARITY_ENABLED_DEFAULT);
         this.sharedAdaptiveSamplingTarget = getProperty(SHARED_ADAPTIVE_SAMPLING_TARGET, SHARED_ADAPTIVE_SAMPLING_TARGET_DEFAULT);
         this.partialGranularityConfig = new PartialGranularityConfig(nestedProps(PARTIAL_GRANULARITY), this.systemPropertyPrefix, this);
     }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/CoreTracingConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/CoreTracingConfigTest.java
@@ -370,6 +370,36 @@ public class CoreTracingConfigTest {
     }
 
     @Test
+    public void testSysPropsFullGranularityDisabled() {
+        Properties props = new Properties();
+        props.setProperty("newrelic.config.distributed_tracing.sampler.full_granularity.enabled", String.valueOf(false));
+
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new SaveSystemPropertyProviderRule.TestSystemProps(props),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade()
+        ));
+
+        distributedTracingConfig = new DistributedTracingConfig(new HashMap<>());
+
+        assertFalse(distributedTracingConfig.getFullGranularityConfig().isEnabled());
+    }
+
+    @Test
+    public void testEnvVariableFullGranularityDisabled() {
+        Map<String, String> environmentVars = ImmutableMap.<String, String>builder()
+                .put("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_FULL_GRANULARITY_ENABLED", "false")
+                .build();
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new SaveSystemPropertyProviderRule.TestSystemProps(),
+                new SaveSystemPropertyProviderRule.TestEnvironmentFacade(environmentVars)
+        ));
+
+        distributedTracingConfig = new DistributedTracingConfig(new HashMap<>());
+
+        assertFalse(distributedTracingConfig.getFullGranularityConfig().isEnabled());
+    }
+
+    @Test
     public void testEnvironmentVariables() {
         // Given: Environment variables with conflicting base sampler and full_granularity settings
         /*


### PR DESCRIPTION
The inline config for the lone `full_granularity.enabled` setting was missing a system property argument, which means the setting was respected in yml but not in env/sys props. 

Adds the sys property prefix and tests. 
