### PR TITLE
Wrap setup messages for CT samplers behind isEnabled

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/coretracing/BaseSamplerCoreTracingConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/coretracing/BaseSamplerCoreTracingConfig.java
@@ -54,13 +54,15 @@ public class BaseSamplerCoreTracingConfig extends CoreTracingConfig {
     @Override
     public SamplerConfig createSamplerConfig(String samplerCase){
         SamplerConfig sampler = super.createSamplerConfig(samplerCase);
-        NewRelic.getAgent()
-                .getLogger()
-                .log(Level.INFO,
-                        "The full granularity " + samplerCase + " sampler was configured to use the " +
-                                sampler.getSamplerType() + " sampler type" +
-                                (sampler.getSamplerRatio() != null ? " with a ratio of " + sampler.getSamplerRatio() : "") +
-                                (sampler.getSamplingTarget() != null ? " with a target of " + sampler.getSamplingTarget() : "") + ".");
+        if (isEnabled()) {
+            NewRelic.getAgent()
+                    .getLogger()
+                    .log(Level.INFO,
+                            "The full granularity " + samplerCase + " sampler was configured to use the " +
+                                    sampler.getSamplerType() + " sampler type" +
+                                    (sampler.getSamplerRatio() != null ? " with a ratio of " + sampler.getSamplerRatio() : "") +
+                                    (sampler.getSamplingTarget() != null ? " with a target of " + sampler.getSamplingTarget() : "") + ".");
+        }
         return sampler;
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/coretracing/PartialGranularityConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/coretracing/PartialGranularityConfig.java
@@ -50,13 +50,15 @@ public class PartialGranularityConfig extends CoreTracingConfig {
                                     "Added to full granularity ratio={2} and set effective ratio={3}",
                             samplerCase, originalRatio, fullSampler.getSamplerRatio(), sampler.getSamplerRatio());
         }
-        NewRelic.getAgent()
-                .getLogger()
-                .log(Level.INFO,
-                        "The partial granularity " + samplerCase + " sampler was configured to use the " +
-                                sampler.getSamplerType() + " sampler type" +
-                                (sampler.getSamplerRatio() != null ? " with a ratio of " + sampler.getSamplerRatio() : "") +
-                                (sampler.getSamplingTarget() != null ? " with a target of " + sampler.getSamplingTarget() : "") + ".");
+        if (isEnabled()){
+            NewRelic.getAgent()
+                    .getLogger()
+                    .log(Level.INFO,
+                            "The partial granularity " + samplerCase + " sampler was configured to use the " +
+                                    sampler.getSamplerType() + " sampler type" +
+                                    (sampler.getSamplerRatio() != null ? " with a ratio of " + sampler.getSamplerRatio() : "") +
+                                    (sampler.getSamplingTarget() != null ? " with a target of " + sampler.getSamplingTarget() : "") + ".");
+        }
         return sampler;
     }
 


### PR DESCRIPTION
Small change to wrap the setup messages for samplers depending on whether the sampler is enabled. There is a similar check before we send accompanying metrics. 