### PR TITLE
update otel autoconfigure site stanza

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/build.gradle
@@ -73,6 +73,6 @@ verifyInstrumentation {
 }
 
 site {
-    title = "OpenTelemetry"
-    type = "Framework"
+    title "OpenTelemetry"
+    type "Framework"
 }


### PR DESCRIPTION
Updates the Otel Autoconfigure site stanza. Previously this was excluded from our compatibility docs due to a typo with = signs. 
