### PR TITLE
Remove version override on jax rs module

### DIFF
--- a/instrumentation/jax-rs-3.0/build.gradle
+++ b/instrumentation/jax-rs-3.0/build.gradle
@@ -27,5 +27,4 @@ compileJava {
 site {
     title 'JAX-RS'
     type 'Framework'
-    versionOverride '[3.0,4.0)'
 }


### PR DESCRIPTION
There was a version override on the jax 3.0 module because it didn't match the 4.0 milestone release. However, the instrumentation did end up applying to the 4.0 release, so this version override is no longer necessary.