### PR TITLE
Force API version for test containers

### DIFF
--- a/.github/workflows/Java-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-Instrumentation-Tests.yml
@@ -51,7 +51,9 @@ jobs:
         run: ./gradlew $GRADLE_OPTIONS clean jar
 
       - name: Remove parallel from GRADLE_OPTIONS
-        run: echo "GRADLE_OPTIONS=$GRADLE_OPTIONS" | sed "s/--parallel//" >> $GITHUB_ENV
+        run: |
+          echo "GRADLE_OPTIONS=$GRADLE_OPTIONS" | sed "s/--parallel//" >> $GITHUB_ENV
+          echo "api.version=1.44" > $HOME/.docker-java.properties
 
       # GHA run instrumentation tests
 

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -337,6 +337,7 @@ jobs:
         if: ${{ failure() || success() }}
         run: |
           cd agent-integration-tests
+          echo "api.version=1.44" > $HOME/.docker-java.properties
           echo "conf/testenv complains of the path below - creating symlink for now"
           ln -s ${GITHUB_WORKSPACE}/apps /home/runner/apps
           ln -s ${GITHUB_WORKSPACE}/newrelic-agent/build/newrelicJar/newrelic.jar ${GITHUB_WORKSPACE}/newrelic.jar


### PR DESCRIPTION
### Overview
Test containers started failing on AITs and instrumentation tests. Per this [issue](https://github.com/testcontainers/testcontainers-java/issues/10788#issuecomment-3921564794), the fix is to add this to a run command:
`echo "api.version=1.44" > $HOME/.docker-java.properties`

