### PR TITLE
Simple correction to sampler supportability metric names

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -445,8 +445,8 @@ public class MetricNames {
     public static final String SUPPORTABILITY_CREATE_PAYLOAD_EXCEPTION = "Supportability/DistributedTrace/CreatePayload/Exception";
     public static final String SUPPORTABILITY_PARTIAL_GRANULARITY_TYPE = "Supportability/Java/PartialGranularity/{0}";
 
-    //Sampler stats - to be used as Supportability/Java/Sampler/{granularity}/{case}/{type}
-    public static final String SUPPORTABILITY_SAMPLER = "Supportability/Java/Sampler/{0}/{1}/{2}";
+    //Sampler stats - to be used as Supportability/Java/{granularity}/{case}/{type}
+    public static final String SUPPORTABILITY_SAMPLER = "Supportability/Java/{0}/{1}/{2}";
     public static final String SUPPORTABILITY_TRACE_SAMPLING_TARGET_SERVER_VALUE = "Supportability/Trace/SamplingTarget/Server/Value";
     public static final String SUPPORTABILITY_TRACE_SAMPLING_TARGET_APPLIED_VALUE = "Supportability/Trace/SamplingTarget/Applied/Value";
 


### PR DESCRIPTION
Resolves #2755 

I had an extra word in the sampler supportability metrics.

They should be named `Supportability/Java/FullGranularity/...`, not `Supportability/Java/Sampler/FullGranularity...` per the spec: https://source.datanerd.us/agents/agent-specs/blob/main/distributed_tracing/New-Relic-Payload.md#supportability-metrics 
