### PR TITLE
Update versionOverride range for WebLogic

### DIFF
--- a/instrumentation/weblogic-12.2/build.gradle
+++ b/instrumentation/weblogic-12.2/build.gradle
@@ -23,5 +23,5 @@ jar {
 site {
     title 'WebLogic'
     type 'Appserver'
-    versionOverride '[12.2,14.1.1]'
+    versionOverride '[12.2,14.1.x]'
 }


### PR DESCRIPTION
Java agent instrumentation should apply to versions beyond 14.1.1.

Related change on public docs: https://github.com/newrelic/docs-website/pull/23158