### PR TITLE
Update Generate-Compatibility-Doc.yml

### DIFF
--- a/.github/workflows/Generate-Compatibility-Doc.yml
+++ b/.github/workflows/Generate-Compatibility-Doc.yml
@@ -131,9 +131,9 @@ jobs:
           branch: update-java-agent-compatibility-${{ inputs.release_tag }}
           delete-branch: true
           base: develop
-          title: '[DO-NOT-MERGE] Update Java Agent Compatibility Requirements'
+          title: 'Update Java Agent Compatibility Requirements'
           body: |
-            This is a WIP.
+            This PR was manually triggered in the Java Agent Repository.
             This PR updates the Java agent compatibility documentation.
 
       - name: Summary


### PR DESCRIPTION
Remove guarding language around docs PR written by the bot. This was too friction-heavy to be sustainable. And we feel good about this action now that we've run it a few times. 
