### PR TITLE
[Serverless] Auto-enable serverless mode in Lambda environment

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Agent.java
@@ -312,7 +312,7 @@ public final class Agent {
             ServiceFactory.setServiceManager(serviceManager);
 
             AgentConfig agentConfig = serviceManager.getConfigService().getDefaultAgentConfig();
-            if (isLicenseKeyEmpty(agentConfig.getLicenseKey())) {
+            if (isLicenseKeyEmpty(agentConfig.getLicenseKey()) && !agentConfig.getServerlessConfig().isEnabled()) {
                 AgentControlIntegrationUtils.reportUnhealthyStatusPriorToServiceStart(agentConfig, AgentHealth.Status.MISSING_LICENSE);
                 LOG.error("license_key is empty in the config. Not starting New Relic Agent.");
                 return false;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ServerlessConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ServerlessConfigImpl.java
@@ -23,14 +23,21 @@ public class ServerlessConfigImpl extends BaseConfig implements ServerlessConfig
     public static final String DEFAULT_FILE_PATH = "/tmp/newrelic-telemetry";
     public static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
 
+    static final String AWS_LAMBDA_FUNCTION_NAME_ENV_VAR = "AWS_LAMBDA_FUNCTION_NAME";
+
     private final boolean isEnabled;
     private final String filePath;
     private final String arn;
     private final String functionVersion;
 
     public ServerlessConfigImpl(Map<String, Object> props) {
+        this(props, System.getenv(AWS_LAMBDA_FUNCTION_NAME_ENV_VAR) != null);
+    }
+
+    ServerlessConfigImpl(Map<String, Object> props, boolean isLambdaEnvironment) {
         super(props, SYSTEM_PROPERTY_ROOT);
-        isEnabled = getProperty(ENABLED, DEFAULT_ENABLED);
+        Boolean explicitEnabled = getProperty(ENABLED);
+        isEnabled = explicitEnabled != null ? explicitEnabled : isLambdaEnvironment;
         filePath = getProperty(FILE_PATH, DEFAULT_FILE_PATH);
         arn = getProperty(ARN);
         functionVersion = getProperty(FUNCTION_VERSION);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ServerlessConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ServerlessConfigImplTest.java
@@ -12,6 +12,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -72,6 +73,58 @@ public class ServerlessConfigImplTest {
         ServerlessConfig config = ServerlessConfigImpl.createServerlessConfig(localMap);
 
         Assert.assertEquals("/tmp/some-file", config.filePath());
+    }
+
+    @Test
+    public void newRelicServerlessModeEnabledTrueWinsRegardlessOfLambdaEnvVar() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("newrelic.config.serverless_mode.enabled", "true");
+        Mocks.createSystemPropertyProvider(new HashMap<>(), envVars);
+        ServerlessConfigImpl config = new ServerlessConfigImpl(Collections.emptyMap(), false);
+
+        Assert.assertTrue(config.isEnabled());
+    }
+
+    @Test
+    public void newRelicServerlessModeEnabledFalseWinsRegardlessOfLambdaEnvVar() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("newrelic.config.serverless_mode.enabled", "false");
+        Mocks.createSystemPropertyProvider(new HashMap<>(), envVars);
+        ServerlessConfigImpl config = new ServerlessConfigImpl(Collections.emptyMap(), true);
+
+        Assert.assertFalse(config.isEnabled());
+    }
+
+    @Test
+    public void awsLambdaFunctionNameEnablesServerlessMode() {
+        ServerlessConfigImpl config = new ServerlessConfigImpl(Collections.emptyMap(), true);
+
+        Assert.assertTrue(config.isEnabled());
+    }
+
+    @Test
+    public void explicitFalseOverridesAwsLambdaFunctionName() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ServerlessConfigImpl.ENABLED, false);
+        ServerlessConfigImpl config = new ServerlessConfigImpl(props, true);
+
+        Assert.assertFalse(config.isEnabled());
+    }
+
+    @Test
+    public void explicitTrueWithNoLambdaEnvVar() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ServerlessConfigImpl.ENABLED, true);
+        ServerlessConfigImpl config = new ServerlessConfigImpl(props, false);
+
+        Assert.assertTrue(config.isEnabled());
+    }
+
+    @Test
+    public void noConfigAndNoLambdaEnvVarDefaultsToDisabled() {
+        ServerlessConfigImpl config = new ServerlessConfigImpl(Collections.emptyMap(), false);
+
+        Assert.assertFalse(config.isEnabled());
     }
 
     @Test


### PR DESCRIPTION
### Overview
This PR implements two requirements from the Lambda spec's agent config [section](https://source.datanerd.us/agents/agent-specs/blob/main/Lambda.md#agent-configuration):
- When `NEW_RELIC_SERVERLESS_MODE_ENABLED` is not set, serverless mode now enables automatically if `AWS_LAMBDA_FUNCTION_NAME` is present (an environment variable AWS sets with Lambda execution context). Explicit configuration (`NEW_RELIC_SERVERLESS_MODE_ENABLED=false`) still overrides it.
- The agent no longer aborts startup when the license key is missing and serverless mode is enabled.

### Related Github Issue
Resolves #2777

### Testing
`ServerlessConfigImplTest` has been modified to add tests for all four rows of the spec's `NEW_RELIC_SERVERLESS_MODE_ENABLED`/`AWS_LAMBDA_FUNCTION_NAME` precedence table.
