### PR TITLE
Cap solr-7.0.0 range at 10.0.0.

### DIFF
--- a/instrumentation/solr-7.0.0/build.gradle
+++ b/instrumentation/solr-7.0.0/build.gradle
@@ -22,7 +22,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.apache.solr:solr-core:[7.0.0,)'
+    passesOnly 'org.apache.solr:solr-core:[7.0.0,10.0.0)'
 
     excludeRegex 'org.apache.solr:solr-core:.*(ALPHA|BETA)+$'
 }


### PR DESCRIPTION
Cap solr-7.0.0 range at 10.0.0.

Relates to https://github.com/newrelic/newrelic-java-agent/issues/2787