### PR TITLE
Refactor ServerlessApi to add ServerlessService

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorServiceManager.java
@@ -34,6 +34,8 @@ import com.newrelic.agent.reinstrument.RemoteInstrumentationService;
 import com.newrelic.agent.reinstrument.RemoteInstrumentationServiceImpl;
 import com.newrelic.agent.rpm.RPMConnectionService;
 import com.newrelic.agent.samplers.SamplerService;
+import com.newrelic.agent.serverless.ServerlessService;
+import com.newrelic.agent.serverless.ServerlessServiceImpl;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.Service;
 import com.newrelic.agent.service.ServiceFactory;
@@ -86,6 +88,7 @@ class IntrospectorServiceManager extends AbstractService implements ServiceManag
     private volatile DistributedTraceServiceImpl distributedTraceService;
     private volatile SpanEventsService spanEventsService;
     private volatile SourceLanguageService sourceLanguageService;
+    private volatile ServerlessService serverlessService;
     private ExpirationService expirationService;
     private volatile KotlinCoroutinesService kotlinCoroutinesService;
 
@@ -184,6 +187,8 @@ class IntrospectorServiceManager extends AbstractService implements ServiceManag
         configService.addIAgentConfigListener((IntrospectorSpanEventService)spanEventsService);
         transactionService.addTransactionListener((IntrospectorSpanEventService)spanEventsService);
 
+        serverlessService = new ServerlessServiceImpl();
+
         try {
             transactionTraceService.start();
             transactionEventsService.start();
@@ -226,6 +231,11 @@ class IntrospectorServiceManager extends AbstractService implements ServiceManag
     @Override
     public RPMServiceManager getRPMServiceManager() {
         return rpmServiceManager;
+    }
+
+    @Override
+    public ServerlessService getServerlessService() {
+        return serverlessService;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/PrivateApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/PrivateApiImpl.java
@@ -13,6 +13,7 @@ import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.PrivateApi;
 import com.newrelic.agent.environment.Environment;
 import com.newrelic.agent.jmx.JmxApiImpl;
+import com.newrelic.agent.serverless.ServerlessApiImpl;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.util.AgentCollectionFactory;
 import com.newrelic.api.agent.Logger;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -112,7 +112,9 @@ public class RPMService extends AbstractService implements IRPMService, Environm
         AgentConfig config = ServiceFactory.getConfigService().getAgentConfig(appName);
         this.serverlessMode = config.getServerlessConfig().isEnabled();
         if (serverlessMode) {
-            dataSender = DataSenderFactory.createServerless(new DataSenderServerlessConfig(Agent.getVersion(), config.getServerlessConfig()), Agent.LOG, config.getServerlessConfig());
+            dataSender = DataSenderFactory.createServerless(new DataSenderServerlessConfig(Agent.getVersion(), config.getServerlessConfig()), Agent.LOG,
+                    ServiceFactory.getServiceManager().getServerlessService(),
+                    config.getServerlessConfig());
         } else {
             dataSender = DataSenderFactory.create(config, dataSenderListener);
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessApiImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessApiImpl.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Copyright 2025 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.serverless;
+
+import com.newrelic.agent.bridge.ServerlessApi;
+import com.newrelic.agent.service.ServiceFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Implementation of ServerlessApi that stores serverless metadata for serverless mode.
+ * This class acts as a bridge between serverless instrumentation and the core agent,
+ * storing metadata that will be included in the serverless payload envelope.
+ */
+public class ServerlessApiImpl implements ServerlessApi {
+
+    @Override
+    public void setArn(String arnValue) {
+        ServiceFactory.getServiceManager().getServerlessService().setArn(arnValue);
+    }
+
+    @Override
+    public void setFunctionVersion(String version) {
+        ServiceFactory.getServiceManager().getServerlessService().setFunctionVersion(version);
+    }
+
+    @Override
+    public String getArn() {
+        return ServiceFactory.getServiceManager().getServerlessService().getArn();
+    }
+
+    @Override
+    public String getFunctionVersion() {
+        return ServiceFactory.getServiceManager().getServerlessService().getFunctionVersion();
+    }
+
+    @Override
+    public boolean isApmLambdaModeEnabled() {
+        return ServiceFactory.getServiceManager().getServerlessService().isApmLambdaModeEnabled();
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessService.java
@@ -1,3 +1,10 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.agent.serverless;
 
 public interface ServerlessService {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessService.java
@@ -1,0 +1,41 @@
+package com.newrelic.agent.serverless;
+
+public interface ServerlessService {
+
+    /**
+     * Store the function ARN/identifier for the current invocation.
+     * This value will be included in the serverless payload metadata.
+     *
+     * @param arn The function ARN (AWS Lambda)
+     */
+    void setArn(String arn);
+
+    /**
+     * Store the function version for the current invocation.
+     * This value will be included in the serverless payload metadata.
+     *
+     * @param functionVersion The function version
+     */
+    void setFunctionVersion(String functionVersion);
+
+    /**
+     * Retrieve the stored function ARN/identifier.
+     * Used by DataSenderServerlessImpl to construct the serverless payload envelope.
+     *
+     * @return The stored ARN, or null if not set
+     */
+    String getArn();
+
+    /**
+     * Retrieve the stored function version.
+     * Used by DataSenderServerlessImpl to construct the serverless payload envelope.
+     *
+     * @return The stored function version, or null if not set
+     */
+    String getFunctionVersion();
+
+    /**
+     * @return True if APM mode is enabled for this lambda using the NEW_RELIC_APM_LAMBDA_MODE environment variable, otherwise false
+     */
+    boolean isApmLambdaModeEnabled();
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessServiceImpl.java
@@ -1,26 +1,17 @@
-/*
- *
- *  * Copyright 2025 New Relic Corporation. All rights reserved.
- *  * SPDX-License-Identifier: Apache-2.0
- *
- */
+package com.newrelic.agent.serverless;
 
-package com.newrelic.agent;
-
-import com.newrelic.agent.bridge.ServerlessApi;
+import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-/**
- * Implementation of ServerlessApi that stores serverless metadata for serverless mode.
- * This class acts as a bridge between serverless instrumentation and the core agent,
- * storing metadata that will be included in the serverless payload envelope.
- */
-public class ServerlessApiImpl implements ServerlessApi {
-
+public class ServerlessServiceImpl extends AbstractService implements ServerlessService {
     private final AtomicReference<String> arn = new AtomicReference<>();
     private final AtomicReference<String> functionVersion = new AtomicReference<>();
+
+    public ServerlessServiceImpl() {
+        super(ServerlessService.class.getSimpleName());
+    }
 
     @Override
     public void setArn(String arnValue) {
@@ -49,5 +40,20 @@ public class ServerlessApiImpl implements ServerlessApi {
     @Override
     public boolean isApmLambdaModeEnabled() {
         return ServiceFactory.getConfigService().getDefaultAgentConfig().isApmLambdaModeEnabled();
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return ServiceFactory.getConfigService().getDefaultAgentConfig().getServerlessConfig().isEnabled();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/serverless/ServerlessServiceImpl.java
@@ -1,3 +1,10 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.agent.serverless;
 
 import com.newrelic.agent.service.AbstractService;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManager.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManager.java
@@ -10,6 +10,7 @@ package com.newrelic.agent.service;
 import com.newrelic.agent.ExpirationService;
 import com.newrelic.agent.HarvestService;
 import com.newrelic.agent.RPMServiceManager;
+import com.newrelic.agent.serverless.ServerlessService;
 import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.TracerService;
 import com.newrelic.agent.TransactionService;
@@ -88,6 +89,8 @@ public interface ServiceManager extends Service {
     CommandParser getCommandParser();
 
     RPMServiceManager getRPMServiceManager();
+
+    ServerlessService getServerlessService();
 
     SamplerService getSamplerService();
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/ServiceManagerImpl.java
@@ -19,6 +19,8 @@ import com.newrelic.agent.ServerlessHarvestService;
 import com.newrelic.agent.IRPMService;
 import com.newrelic.agent.RPMServiceManager;
 import com.newrelic.agent.RPMServiceManagerImpl;
+import com.newrelic.agent.serverless.ServerlessService;
+import com.newrelic.agent.serverless.ServerlessServiceImpl;
 import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.TracerService;
 import com.newrelic.agent.TransactionService;
@@ -120,6 +122,7 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
     private final ConcurrentMap<String, Service> services = new ConcurrentHashMap<>();
     private final CoreService coreService;
     private final ConfigService configService;
+    private final ServerlessService serverlessService = new ServerlessServiceImpl();
     private final BlockingQueue<StatsWork> statsWork = new LinkedBlockingQueue<>();
     private volatile ExtensionService extensionService;
     private volatile ProfilerService profilerService;
@@ -572,6 +575,11 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
     @Override
     public RPMServiceManager getRPMServiceManager() {
         return rpmServiceManager;
+    }
+
+    @Override
+    public ServerlessService getServerlessService() {
+        return serverlessService;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderFactory.java
@@ -8,6 +8,7 @@
 package com.newrelic.agent.transport;
 
 import com.newrelic.agent.Agent;
+import com.newrelic.agent.serverless.ServerlessService;
 import com.newrelic.agent.config.DataSenderConfig;
 import com.newrelic.agent.config.ServerlessConfig;
 import com.newrelic.agent.logging.IAgentLogger;
@@ -44,8 +45,8 @@ public class DataSenderFactory {
         return DATA_SENDER_FACTORY;
     }
 
-    public static DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessConfig serverlessConfig) {
-        return DATA_SENDER_FACTORY.createServerless(config, logger, serverlessConfig);
+    public static DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessService serverlessService, ServerlessConfig serverlessConfig) {
+        return DATA_SENDER_FACTORY.createServerless(config, logger, serverlessService, serverlessConfig);
     }
 
     public static DataSender create(DataSenderConfig config) {
@@ -59,9 +60,9 @@ public class DataSenderFactory {
     private static class DefaultDataSenderFactory implements IDataSenderFactory {
 
         @Override
-        public DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessConfig serverlessConfig) {
+        public DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessService serverlessService, ServerlessConfig serverlessConfig) {
             ServerlessWriter serverlessWriter = new ServerlessWriterImpl(logger, serverlessConfig.filePath());
-            return new DataSenderServerlessImpl(config, logger, serverlessWriter);
+            return new DataSenderServerlessImpl(config, logger, serverlessService, serverlessWriter);
         }
 
         @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/IDataSenderFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/IDataSenderFactory.java
@@ -7,6 +7,7 @@
 
 package com.newrelic.agent.transport;
 
+import com.newrelic.agent.serverless.ServerlessService;
 import com.newrelic.agent.config.DataSenderConfig;
 import com.newrelic.agent.config.ServerlessConfig;
 import com.newrelic.agent.logging.IAgentLogger;
@@ -14,7 +15,7 @@ import com.newrelic.agent.transport.serverless.DataSenderServerlessConfig;
 
 public interface IDataSenderFactory {
 
-    DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessConfig serverlessConfig);
+    DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessService serverlessService, ServerlessConfig serverlessConfig);
 
     DataSender create(DataSenderConfig config);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImpl.java
@@ -8,7 +8,7 @@
 package com.newrelic.agent.transport.serverless;
 
 import com.newrelic.agent.MetricData;
-import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.serverless.ServerlessService;
 import com.newrelic.agent.errors.TracedError;
 import com.newrelic.agent.logging.IAgentLogger;
 import com.newrelic.agent.model.AnalyticsEvent;
@@ -46,13 +46,15 @@ public class DataSenderServerlessImpl implements DataSender {
     private final DataSenderServerlessConfig config;
     private final String awsExecutionEnv;
     private final TelemetryBuffer buffer;
+    private final ServerlessService serverlessService;
 
-    public DataSenderServerlessImpl(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessWriter serverlessWriter) {
+    public DataSenderServerlessImpl(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessService serverlessService, ServerlessWriter serverlessWriter) {
         this.config = config;
         this.logger = logger;
         this.serverlessWriter = serverlessWriter;
         this.awsExecutionEnv = System.getenv("AWS_EXECUTION_ENV");
         this.buffer = new TelemetryBuffer();
+        this.serverlessService = serverlessService;
     }
 
     @Override
@@ -195,7 +197,7 @@ public class DataSenderServerlessImpl implements DataSender {
      */
     private String getArn() {
         // Try to get from instrumentation via AgentBridge
-        String arn = AgentBridge.serverlessApi.getArn();
+        String arn = serverlessService.getArn();
         if (arn != null && !arn.isEmpty()) {
             return arn;
         }
@@ -220,7 +222,7 @@ public class DataSenderServerlessImpl implements DataSender {
      */
     private String getFunctionVersion() {
         // Try to get from instrumentation via AgentBridge
-        String version = AgentBridge.serverlessApi.getFunctionVersion();
+        String version = serverlessService.getFunctionVersion();
         if (version != null && !version.isEmpty()) {
             return version;
         }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockDataSenderFactory.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockDataSenderFactory.java
@@ -10,6 +10,7 @@ package com.newrelic.agent;
 import com.newrelic.agent.config.DataSenderConfig;
 import com.newrelic.agent.config.ServerlessConfig;
 import com.newrelic.agent.logging.IAgentLogger;
+import com.newrelic.agent.serverless.ServerlessService;
 import com.newrelic.agent.transport.DataSender;
 import com.newrelic.agent.transport.DataSenderListener;
 import com.newrelic.agent.transport.IDataSenderFactory;
@@ -23,9 +24,9 @@ public class MockDataSenderFactory implements IDataSenderFactory {
     private MockDataSender lastDataSender;
 
     @Override
-    public DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessConfig serverlessConfig) {
+    public DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessService serverlessService, ServerlessConfig serverlessConfig) {
         ServerlessWriter serverlessWriter = new ServerlessWriterImpl(logger, serverlessConfig.filePath());
-        return new DataSenderServerlessImpl(config, logger, serverlessWriter);
+        return new DataSenderServerlessImpl(config, logger, serverlessService, serverlessWriter);
     }
 
     @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockServiceManager.java
@@ -23,7 +23,6 @@ import com.newrelic.agent.environment.EnvironmentServiceImpl;
 import com.newrelic.agent.extension.ExtensionService;
 import com.newrelic.agent.extension.ExtensionsLoadedListener;
 import com.newrelic.agent.instrumentation.ClassTransformerService;
-import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.jfr.JfrService;
 import com.newrelic.agent.jmx.JmxService;
 import com.newrelic.agent.kotlincoroutines.KotlinCoroutinesService;
@@ -34,6 +33,8 @@ import com.newrelic.agent.profile.ProfilerService;
 import com.newrelic.agent.reinstrument.RemoteInstrumentationService;
 import com.newrelic.agent.rpm.RPMConnectionService;
 import com.newrelic.agent.samplers.SamplerService;
+import com.newrelic.agent.serverless.ServerlessService;
+import com.newrelic.agent.serverless.ServerlessServiceImpl;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.Service;
 import com.newrelic.agent.service.ServiceFactory;
@@ -62,6 +63,7 @@ import java.util.Map;
 public class MockServiceManager extends AbstractService implements ServiceManager {
 
     private volatile RPMServiceManager rpmServiceManager = Mockito.mock(RPMServiceManager.class);
+    private final ServerlessService serverlessService = new ServerlessServiceImpl();
     private volatile CoreService coreService;
     private volatile ConfigService configService;
     private volatile ThreadService threadService;
@@ -209,6 +211,11 @@ public class MockServiceManager extends AbstractService implements ServiceManage
     @Override
     public RPMServiceManager getRPMServiceManager() {
         return rpmServiceManager;
+    }
+
+    @Override
+    public ServerlessService getServerlessService() {
+        return serverlessService;
     }
 
     public void setHarvestService(HarvestService harvestService) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
@@ -38,6 +38,7 @@ import com.newrelic.agent.profile.ProfilerParameters;
 import com.newrelic.agent.profile.ProfilerService;
 import com.newrelic.agent.rpm.RPMConnectionService;
 import com.newrelic.agent.rpm.RPMConnectionServiceImpl;
+import com.newrelic.agent.serverless.ServerlessService;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.service.analytics.SpanEventsServiceImpl;
 import com.newrelic.agent.service.analytics.TransactionDataToDistributedTraceIntrinsics;
@@ -423,9 +424,9 @@ public class RPMServiceTest {
 
         IDataSenderFactory dataSenderFactory = new IDataSenderFactory() {
             @Override
-            public DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessConfig serverlessConfig) {
+            public DataSender createServerless(DataSenderServerlessConfig config, IAgentLogger logger, ServerlessService serverlessService, ServerlessConfig serverlessConfig) {
                 ServerlessWriter serverlessWriter = new ServerlessWriterImpl(logger, serverlessConfig.filePath());
-                return new DataSenderServerlessImpl(config, logger, serverlessWriter);
+                return new DataSenderServerlessImpl(config, logger, serverlessService, serverlessWriter);
             }
 
             @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/serverless/ServerlessApiImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/serverless/ServerlessApiImplTest.java
@@ -5,9 +5,10 @@
  *
  */
 
-package com.newrelic.agent;
+package com.newrelic.agent.serverless;
 
-import com.newrelic.agent.bridge.ServerlessApi;
+import com.newrelic.agent.MockServiceManager;
+import com.newrelic.agent.service.ServiceFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,10 +17,11 @@ import static org.junit.Assert.assertNull;
 
 public class ServerlessApiImplTest {
 
-    private ServerlessApi serverlessApi;
+    private ServerlessApiImpl serverlessApi;
 
     @Before
     public void setup() {
+        ServiceFactory.setServiceManager(new MockServiceManager());
         serverlessApi = new ServerlessApiImpl();
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/serverless/ServerlessServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/serverless/ServerlessServiceImplTest.java
@@ -1,3 +1,10 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package com.newrelic.agent.serverless;
 
 import org.junit.Before;

--- a/newrelic-agent/src/test/java/com/newrelic/agent/serverless/ServerlessServiceImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/serverless/ServerlessServiceImplTest.java
@@ -1,0 +1,83 @@
+package com.newrelic.agent.serverless;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ServerlessServiceImplTest {
+
+    private ServerlessService serverlessService;
+
+    @Before
+    public void setup() {
+        serverlessService = new ServerlessServiceImpl();
+    }
+
+    @Test
+    public void setAndGetArn() {
+        String arn = "arn:aws:lambda:us-east-1:123456789012:function:my-function";
+        serverlessService.setArn(arn);
+        assertEquals(arn, serverlessService.getArn());
+    }
+
+    @Test
+    public void setAndGetFunctionVersion() {
+        String version = "$LATEST";
+        serverlessService.setFunctionVersion(version);
+        assertEquals(version, serverlessService.getFunctionVersion());
+    }
+
+    @Test
+    public void getArn_whenNotSet_returnsNull() {
+        assertNull(serverlessService.getArn());
+    }
+
+    @Test
+    public void getFunctionVersion_whenNotSet_returnsNull() {
+        assertNull(serverlessService.getFunctionVersion());
+    }
+
+    @Test
+    public void setArn_withNull_doesNotStore() {
+        serverlessService.setArn("initial-arn");
+        serverlessService.setArn(null);
+        assertEquals("initial-arn", serverlessService.getArn());
+    }
+
+    @Test
+    public void setArn_withEmptyString_doesNotStore() {
+        serverlessService.setArn("initial-arn");
+        serverlessService.setArn("");
+        assertEquals("initial-arn", serverlessService.getArn());
+    }
+
+    @Test
+    public void setFunctionVersion_withNull_doesNotStore() {
+        serverlessService.setFunctionVersion("initial-version");
+        serverlessService.setFunctionVersion(null);
+        assertEquals("initial-version", serverlessService.getFunctionVersion());
+    }
+
+    @Test
+    public void setFunctionVersion_withEmptyString_doesNotStore() {
+        serverlessService.setFunctionVersion("initial-version");
+        serverlessService.setFunctionVersion("");
+        assertEquals("initial-version", serverlessService.getFunctionVersion());
+    }
+
+    @Test
+    public void setArn_canOverwritePreviousValue() {
+        serverlessService.setArn("first-arn");
+        serverlessService.setArn("second-arn");
+        assertEquals("second-arn", serverlessService.getArn());
+    }
+
+    @Test
+    public void setFunctionVersion_canOverwritePreviousValue() {
+        serverlessService.setFunctionVersion("v1");
+        serverlessService.setFunctionVersion("v2");
+        assertEquals("v2", serverlessService.getFunctionVersion());
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImplTest.java
@@ -12,6 +12,7 @@ import com.newrelic.agent.MetricData;
 import com.newrelic.agent.MockDispatcher;
 import com.newrelic.agent.MockRPMServiceManager;
 import com.newrelic.agent.MockServiceManager;
+import com.newrelic.agent.serverless.ServerlessService;
 import com.newrelic.agent.Transaction;
 import com.newrelic.agent.TransactionData;
 import com.newrelic.agent.TransactionDataTestBuilder;
@@ -106,7 +107,12 @@ public class DataSenderServerlessImplTest {
         Mockito.when(serverlessConfig.getFunctionVersion()).thenReturn("15");
 
         DataSenderServerlessConfig config = new DataSenderServerlessConfig("9.0.0", serverlessConfig);
-        this.dataSender = new DataSenderServerlessImpl(config, logger, serverlessWriter);
+
+        ServerlessService serverlessService = Mockito.mock(ServerlessService.class);
+        Mockito.when(serverlessService.getArn()).thenReturn("TMP_ARN");
+        Mockito.when(serverlessService.getFunctionVersion()).thenReturn("15");
+
+        this.dataSender = new DataSenderServerlessImpl(config, logger, serverlessService, serverlessWriter);
     }
 
     @Test


### PR DESCRIPTION
### Overview
Create a ServerlessService, transfer all Agent Bridge ServerlessAPI 's logic into that service, and the ServerlessAPI should proxy to ServerlessService.

This decouples the agent module from the agent bridge API.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2783