### PR TITLE
Add Implementation-Title-Alias to aws-lambda-java-core* instr modules

### DIFF
--- a/instrumentation/aws-lambda-java-core-1.1.0/build.gradle
+++ b/instrumentation/aws-lambda-java-core-1.1.0/build.gradle
@@ -1,5 +1,6 @@
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-lambda-java-core-1.2.0' }
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-lambda-java-core-1.2.0',
+            'Implementation-Title-Alias': 'aws-lambda-java-core' }
 }
 
 dependencies {

--- a/instrumentation/aws-lambda-java-core-events-1.1.0/build.gradle
+++ b/instrumentation/aws-lambda-java-core-events-1.1.0/build.gradle
@@ -1,5 +1,6 @@
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-lambda-java-core-events-1.2.0' }
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-lambda-java-core-events-1.2.0',
+            'Implementation-Title-Alias': 'aws-lambda-java-core-events' }
 }
 
 dependencies {

--- a/instrumentation/graphql-java-16.2/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
+++ b/instrumentation/graphql-java-16.2/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
@@ -48,6 +48,11 @@ public class PrivateApiStub implements PrivateApi {
     }
 
     @Override
+    public void addCustomAttribute(String key, boolean value) {
+
+    }
+
+    @Override
     public void addTracerParameter(String key, Number value) {
 
     }

--- a/instrumentation/graphql-java-17.0/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
+++ b/instrumentation/graphql-java-17.0/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
@@ -48,6 +48,11 @@ public class PrivateApiStub implements PrivateApi {
     }
 
     @Override
+    public void addCustomAttribute(String key, boolean value) {
+
+    }
+
+    @Override
     public void addTracerParameter(String key, Number value) {
 
     }

--- a/instrumentation/graphql-java-21.0/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
+++ b/instrumentation/graphql-java-21.0/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
@@ -51,6 +51,11 @@ public class PrivateApiStub implements PrivateApi {
     }
 
     @Override
+    public void addCustomAttribute(String key, boolean value) {
+
+    }
+
+    @Override
     public void addTracerParameter(String key, Number value) {
 
     }

--- a/instrumentation/graphql-java-22.0/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
+++ b/instrumentation/graphql-java-22.0/src/test/java/com/nr/instrumentation/graphql/helper/PrivateApiStub.java
@@ -51,6 +51,11 @@ public class PrivateApiStub implements PrivateApi {
     }
 
     @Override
+    public void addCustomAttribute(String key, boolean value) {
+
+    }
+
+    @Override
     public void addTracerParameter(String key, Number value) {
 
     }


### PR DESCRIPTION
### Overview
Adds Implementation-Title-Alias to aws lambda core modules.

There is also an update in the graphql tests to adjust to the private API changes we previously made for our AWS lambda instrumentation