### PR TITLE
All lambda core modules use same alias

### DIFF
--- a/instrumentation/aws-lambda-java-core-events-1.1.0/build.gradle
+++ b/instrumentation/aws-lambda-java-core-events-1.1.0/build.gradle
@@ -1,6 +1,6 @@
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.aws-lambda-java-core-events-1.2.0',
-            'Implementation-Title-Alias': 'aws-lambda-java-core-events' }
+            'Implementation-Title-Alias': 'aws-lambda-java-core' }
 }
 
 dependencies {


### PR DESCRIPTION
### Overview

Small tweak to make the lambda core modules have the same alias.
