### PR TITLE
Add supportability metrics for auto named apps

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/MetricNames.java
@@ -205,6 +205,8 @@ public class MetricNames {
 
     public static final String TIMEOUT_ASYNC = "Java/Timeout/asyncActivityNotStarted";
 
+    public static final String SUPPORTABILITY_AUTO_APP_NAMING_REPORTING_TO = "Supportability/AutoAppNaming/ReportingTo/{0}";
+
     public static final String SUPPORTABILITY_AZURE_SITE_EXT_INSTALL_TYPE = "Supportability/Java/InstallType";
 
     public static final String SUPPORTABILITY_JAVA_AGENTVERSION = "Supportability/Java/AgentVersion/{0}";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMServiceManagerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMServiceManagerImpl.java
@@ -11,6 +11,7 @@ import com.newrelic.agent.application.PriorityApplicationName;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.api.agent.NewRelic;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -157,6 +158,8 @@ public class RPMServiceManagerImpl extends AbstractService implements RPMService
             list.addAll(appNameToRPMService.values());
             list.add(defaultRPMService);
             rpmServices = Collections.unmodifiableList(list);
+            //Report app name to the default app so we can find all auto-named apps in the UI.
+            NewRelic.incrementCounter(MessageFormat.format(MetricNames.SUPPORTABILITY_AUTO_APP_NAMING_REPORTING_TO, appName));
             if (isStarted()) {
                 try {
                     rpmService.start();


### PR DESCRIPTION
Resolves #2793 

Simple PR to send up a metric every time an RPMService is registered for a new appName. These metrics will report to the default app to help us identify auto-named apps in the UI. 

Eg: auto-named `webapp-123` will generate the metric `Supportability/AutoAppNaming/ReportingTo/webapp-123` in the default app. 

The default app does not record a metric for its own name. Example below is a screenshot from my test webapp with three servlets. 

<img width="540" height="223" alt="Screenshot 2026-03-20 at 2 36 27 PM" src="https://github.com/user-attachments/assets/daa714cb-127d-4962-b4c6-f67bb8af2154" />
