### PR TITLE
Manually evict ThreadTracker instances that wrap quick executing threads

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadStateSampler.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/threads/ThreadStateSampler.java
@@ -40,15 +40,13 @@ public class ThreadStateSampler implements Runnable {
     private final ThreadMXBean threadMXBean;
     private final ThreadNameNormalizer threadNameNormalizer;
     private final MetricAggregator metricAggregator;
-    private int cycleCount = 0;
-    private static final int CLEANUP_INTERVAL = 5; // Clean up dead threads every 5 cycles
 
     public ThreadStateSampler(ThreadMXBean threadMXBean, ThreadNameNormalizer nameNormalizer) {
         this.threadMXBean = threadMXBean;
         this.metricAggregator = new ThreadStatsMetricAggregator(ServiceFactory.getStatsService());
         this.threadNameNormalizer = nameNormalizer;
 
-        this.threadsMap = AgentBridge.collectionFactory.createConcurrentAccessTimeBasedEvictionMap(180, 16);
+        this.threadsMap = AgentBridge.collectionFactory.createCacheWithInitialCapacity(16);
         this.threadTrackerCreateFunction = threadId -> threadsMap.computeIfAbsent(threadId, k -> new ThreadTracker());
     }
 
@@ -65,15 +63,8 @@ public class ThreadStateSampler implements Runnable {
             }
         }
 
-        // Periodically, manually clean up dead threads from the cache to prevent a memory leak.
-        // Very short-lived threads terminate quickly and are never accessed again, so the
-        // default lazy eviction doesn't remove them from the cache.
-        // Run this logic every 5 cycles.
-        cycleCount++;
-        if (cycleCount >= CLEANUP_INTERVAL) {
-            cycleCount = 0;
-            cleanupDeadThreads();
-        }
+        // Manually cleanup
+        cleanupDeadThreads();
     }
 
     /**
@@ -112,14 +103,11 @@ public class ThreadStateSampler implements Runnable {
         private long lastBlockedCount = -1;
         private long lastWaitedCount = -1;
 
-        private String duf = "";
-
         public ThreadTracker() {
         }
 
         public void update(ThreadInfo thread) {
             String name = threadNameNormalizer.getNormalizedThreadName(new BasicThreadInfo(thread));
-            duf = name;
 
             metricAggregator.recordMetric("Threads/State/" + name + "/" + thread.getThreadState().toString() + "/Count", 1);
             metricAggregator.recordMetric("Threads/SummaryState/" + thread.getThreadState().toString() + "/Count", 1);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/threads/ThreadStateSamplerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/threads/ThreadStateSamplerTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -39,96 +40,44 @@ public class ThreadStateSamplerTest {
         serviceManager.setStatsService(new StatsServiceImpl());
     }
 
+    /**
+     * Run to get some performance numbers related to cache cleanup
+     */
     @Test
-    public void liveThreadsShouldNotBeRemovedDuringCleanup() throws Exception {
+    public void testCleanupPerformanceWithDifferentCacheSizes() {
         ThreadStateSampler threadStateSampler = new ThreadStateSampler(
                 ManagementFactory.getThreadMXBean(),
                 ThreadNameNormalizerTest.getThreadNameNormalizer());
 
-        int initialCacheSize = threadStateSampler.getTrackedThreadCount();
+        System.out.println("\n=== Cleanup Performance Test ===");
 
-        // Create long-lived threads that will stay alive throughout the test
-        Thread[] longLivedThreads = new Thread[5];
-        for (int i = 0; i < longLivedThreads.length; i++) {
-            final int threadNum = i;
-            longLivedThreads[i] = new Thread(() -> {
-                try {
-                    Thread.sleep(30000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }, "LongLivedThread-" + threadNum);
-            longLivedThreads[i].start();
-        }
-
-        // Sample to add threads to the cache
         threadStateSampler.run();
-        int cacheAfterFirstSample = threadStateSampler.getTrackedThreadCount();
-        assertTrue("Cache should contain more threads after sampling",
-                cacheAfterFirstSample > initialCacheSize);
 
-        // Trigger cleanup
-        for (int i = 0; i < 4; i++) {
-            threadStateSampler.run();
+        int cacheSize = threadStateSampler.getTrackedThreadCount();
+        System.out.println("Initial cache size: " + cacheSize);
+
+        // Test cleanup performance - measure getThreadInfo() calls
+        long startTime = System.nanoTime();
+
+        // This simulates what cleanupDeadThreads() does
+        int deadThreadCount = 0;
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+        // Simulate checking many thread IDs (including dead ones)
+        for (long threadId = 1; threadId < cacheSize * 10000; threadId++) {
+            if (threadMXBean.getThreadInfo(threadId) == null) {
+                deadThreadCount++;
+            }
         }
 
-        // Verify live threads aare still around
-        int cacheAfterCleanup = threadStateSampler.getTrackedThreadCount();
-        assertTrue("Live threads should still be in cache after cleanup",
-                cacheAfterCleanup >= cacheAfterFirstSample);
+        long endTime = System.nanoTime();
+        double totalTimeMs = (endTime - startTime) / 1_000_000.0;
+        int checksPerformed = cacheSize * 10000;
 
-        // Nuke long-running threads manually
-        for (Thread thread : longLivedThreads) {
-            thread.interrupt();
-        }
-        for (Thread thread : longLivedThreads) {
-            thread.join(1000);
-        }
-    }
-
-    @Test
-    public void shortLivedThreadsShouldBeEvictedFromCache() throws Exception {
-        ThreadStateSampler threadStateSampler = new ThreadStateSampler(
-                ManagementFactory.getThreadMXBean(),
-                ThreadNameNormalizerTest.getThreadNameNormalizer());
-
-        int initialCacheSize = threadStateSampler.getTrackedThreadCount();
-
-        // Create and start 10 short-lived threads that will terminate quickly
-        Thread[] shortLivedThreads = new Thread[10];
-        for (int i = 0; i < shortLivedThreads.length; i++) {
-            final int threadNum = i;
-            shortLivedThreads[i] = new Thread(() -> {
-                try {
-                    // Just sleep for a short time and exit
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }, "ShortLivedThread-" + threadNum);
-            shortLivedThreads[i].start();
-        }
-
-        // Sample to add threads to the cache
-        threadStateSampler.run();
-        int cacheAfterFirstSample = threadStateSampler.getTrackedThreadCount();
-        assertTrue("Cache should contain more threads after sampling",
-                cacheAfterFirstSample > initialCacheSize);
-
-        // Wait for all short-lived threads to terminate and verify they're dead
-        for (Thread thread : shortLivedThreads) {
-            thread.join(5000); // Wait up to 5 seconds for each thread
-            assertFalse("Thread should be terminated: " + thread.getName(), thread.isAlive());
-        }
-
-        // Trigger cleanup
-        for (int i = 0; i < 4; i++) {
-            threadStateSampler.run();
-        }
-
-        int cacheAfterCleanup = threadStateSampler.getTrackedThreadCount();
-        assertEquals("Dead threads should be removed from cache after cleanup cycle",
-                initialCacheSize, cacheAfterCleanup, cacheAfterFirstSample - initialCacheSize);
+        System.out.println(String.format(
+            "Checked %d thread IDs in %.2f ms (%.3f µs per check). Simulated an eviction of %d threads from cache.",
+            checksPerformed, totalTimeMs, (totalTimeMs * 1000.0) / checksPerformed, deadThreadCount
+        ));
     }
 
     @Test


### PR DESCRIPTION
### Overview
Resolves #2556  

Manually evict any dead threads from the TheadTracker cache to prevent a memory leak.

Every time the ThreadStateSampler is executed, call a method that will check the state of every thread in the cache. If the thread is dead, remove it from the cache.
```
threadsMap.keySet().removeIf(threadId -> threadMXBean.getThreadInfo(threadId) == null);
```

