### PR TITLE
Postgres any explain

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutor.java
@@ -14,22 +14,17 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.newrelic.agent.bridge.datastore.DatabaseVendor;
 import com.newrelic.agent.bridge.datastore.RecordSql;
 import com.newrelic.agent.tracers.SqlTracerExplainInfo;
 
 public class PreparedStatementExplainPlanExecutor extends DefaultExplainPlanExecutor {
 
     private final Object[] sqlParameters;
-    private final DatabaseVendor vendor;
-    private final boolean isOracle;
 
     public PreparedStatementExplainPlanExecutor(SqlTracerExplainInfo tracer, String originalSqlStatement,
-            Object[] sqlParameters, RecordSql recordSql, DatabaseVendor vendor) {
+            Object[] sqlParameters, RecordSql recordSql) {
         super(tracer, originalSqlStatement, recordSql);
         this.sqlParameters = sqlParameters;
-        this.vendor = vendor;
-        this.isOracle = vendor != null && "Oracle".equalsIgnoreCase(vendor.getName());
     }
 
     @Override
@@ -105,7 +100,8 @@ public class PreparedStatementExplainPlanExecutor extends DefaultExplainPlanExec
      * - H2: Supports arrays with these type names
      * - MySQL: Does NOT support SQL array types
      * - SQL Server: Does NOT support SQL array types
-     * - Oracle: Array support (VARRAY) with Oracle-specific type names (handled below)
+     * - Oracle: Array support (VARRAY) with Oracle-specific type names -- NOT
+     *           CURRENTLY SUPPORTED BY THE AGENT
      *
      * The code handles incompatibility gracefully by returning null for unsupported types,
      * which causes the caller to fall back to using setObject() instead of setArray().
@@ -121,23 +117,23 @@ public class PreparedStatementExplainPlanExecutor extends DefaultExplainPlanExec
         }
 
         if (componentType == Integer.class || componentType == int.class) {
-            return isOracle ? "NUMBER" : "integer";
+            return "integer";
         } else if (componentType == Long.class || componentType == long.class) {
-            return isOracle ? "NUMBER" : "bigint";
+            return "bigint";
         } else if (componentType == String.class) {
-            return isOracle ? "VARCHAR2" : "varchar";
+            return "varchar";
         } else if (componentType == Double.class || componentType == double.class) {
-            return isOracle ? "BINARY_DOUBLE" : "double precision";
+            return "double precision";
         } else if (componentType == Float.class || componentType == float.class) {
-            return isOracle ? "BINARY_FLOAT" : "real";
+            return "real";
         } else if (componentType == Boolean.class || componentType == boolean.class) {
-            return isOracle ? null : "boolean"; // Oracle doesn't support boolean arrays
+            return "boolean"; // Oracle doesn't support boolean arrays
         } else if (componentType == Short.class || componentType == short.class) {
-            return isOracle ? "NUMBER" : "smallint";
+            return "smallint";
         } else if (componentType == Byte.class || componentType == byte.class) {
-            return isOracle ? "NUMBER" : "smallint";
+            return "smallint";
         } else if (componentType == Character.class || componentType == char.class) {
-            return isOracle ? "CHAR" : "char";
+            return "char";
         }
         // For other types, return null and fall back to setObject
         return null;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultSqlTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultSqlTracer.java
@@ -340,7 +340,7 @@ public class DefaultSqlTracer extends DefaultTracer implements SqlTracer, Compar
 
     protected ExplainPlanExecutor createExplainPlanExecutor(String sql) {
         if (params != null && params.length > 0) {
-            return new PreparedStatementExplainPlanExecutor(this, getRawSql(), getParams(), getRecordSql(), getDatabaseVendor());
+            return new PreparedStatementExplainPlanExecutor(this, getRawSql(), getParams(), getRecordSql());
         }
         return new DefaultExplainPlanExecutor(this, sql, getRecordSql());
     }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutorTest.java
@@ -29,7 +29,7 @@ public class PreparedStatementExplainPlanExecutorTest {
         Object [] params = {new Object(), new Object()};
 
         when(mockConn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
-        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(mockExplain, "SELECT * FROM DUAL", params, RecordSql.raw, null);
+        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(mockExplain, "SELECT * FROM DUAL", params, RecordSql.raw);
         Statement statement = executor.createStatement(mockConn, "sql");
         assertNotNull(statement);
     }
@@ -43,14 +43,14 @@ public class PreparedStatementExplainPlanExecutorTest {
 
         when(mockStatement.getConnection()).thenReturn(mockConnection);
         when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
-        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(mockExplain, "SELECT * FROM DUAL", params, RecordSql.raw, null);
+        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(mockExplain, "SELECT * FROM DUAL", params, RecordSql.raw);
         ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
 
         verify(mockStatement, times(2)).setObject(anyInt(), any());
         assertNotNull(resultSet);
 
         //Cover branch where params is null
-        executor = new PreparedStatementExplainPlanExecutor(mockExplain, "SELECT * FROM DUAL", null, RecordSql.raw, null);
+        executor = new PreparedStatementExplainPlanExecutor(mockExplain, "SELECT * FROM DUAL", null, RecordSql.raw);
         executor.executeStatement(mockStatement, "sql_not_used");
     }
 
@@ -69,7 +69,7 @@ public class PreparedStatementExplainPlanExecutorTest {
         when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
 
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw, null);
+                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw);
         ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
 
         verify(mockConnection).createArrayOf(eq("integer"), any(Object[].class));
@@ -92,7 +92,7 @@ public class PreparedStatementExplainPlanExecutorTest {
         when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
 
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw, null);
+                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw);
         ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
 
         verify(mockConnection).createArrayOf(eq("integer"), any(Object[].class));
@@ -115,7 +115,7 @@ public class PreparedStatementExplainPlanExecutorTest {
         when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
 
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT * FROM table WHERE name = ANY(?)", params, RecordSql.raw, null);
+                mockExplain, "SELECT * FROM table WHERE name = ANY(?)", params, RecordSql.raw);
         ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
 
         verify(mockConnection).createArrayOf(eq("varchar"), any(Object[].class));
@@ -139,7 +139,7 @@ public class PreparedStatementExplainPlanExecutorTest {
         when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
 
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT * FROM table WHERE name = ? AND id = ANY(?)", params, RecordSql.raw, null);
+                mockExplain, "SELECT * FROM table WHERE name = ? AND id = ANY(?)", params, RecordSql.raw);
         ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
 
         verify(mockStatement).setObject(eq(1), eq(regularParam));
@@ -163,11 +163,108 @@ public class PreparedStatementExplainPlanExecutorTest {
         when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
 
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw, null);
+                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw);
         ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
 
         verify(mockConnection).createArrayOf(eq("bigint"), any(Object[].class));
         verify(mockStatement).setArray(eq(1), eq(mockSqlArray));
+        assertNotNull(resultSet);
+    }
+
+    @Test
+    public void executeStatement_handlesDoubleArrayParameters() throws SQLException {
+        SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        Connection mockConnection = mock(Connection.class);
+        Array mockSqlArray = mock(Array.class);
+
+        Double[] doubleArray = {1.1, 2.2, 3.3};
+        Object[] params = {doubleArray};
+
+        when(mockStatement.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.createArrayOf(eq("double precision"), any(Object[].class))).thenReturn(mockSqlArray);
+        when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
+
+        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
+                mockExplain, "SELECT * FROM table WHERE value = ANY(?)", params, RecordSql.raw);
+        ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
+
+        verify(mockConnection).createArrayOf(eq("double precision"), any(Object[].class));
+        verify(mockStatement).setArray(eq(1), eq(mockSqlArray));
+        assertNotNull(resultSet);
+    }
+
+    @Test
+    public void executeStatement_handlesBooleanArrayParameters() throws SQLException {
+        SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        Connection mockConnection = mock(Connection.class);
+        Array mockSqlArray = mock(Array.class);
+
+        Boolean[] booleanArray = {true, false, true};
+        Object[] params = {booleanArray};
+
+        when(mockStatement.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.createArrayOf(eq("boolean"), any(Object[].class))).thenReturn(mockSqlArray);
+        when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
+
+        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
+                mockExplain, "SELECT * FROM table WHERE flag = ANY(?)", params, RecordSql.raw);
+        ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
+
+        verify(mockConnection).createArrayOf(eq("boolean"), any(Object[].class));
+        verify(mockStatement).setArray(eq(1), eq(mockSqlArray));
+        assertNotNull(resultSet);
+    }
+
+    @Test
+    public void executeStatement_handlesArrayWithNullElements() throws SQLException {
+        SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        Connection mockConnection = mock(Connection.class);
+        Array mockSqlArray = mock(Array.class);
+
+        Integer[] arrayWithNulls = {1, null, 3};
+        Object[] params = {arrayWithNulls};
+
+        when(mockStatement.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.createArrayOf(eq("integer"), any(Object[].class))).thenReturn(mockSqlArray);
+        when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
+
+        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
+                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw);
+        ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
+
+        verify(mockConnection).createArrayOf(eq("integer"), any(Object[].class));
+        verify(mockStatement).setArray(eq(1), eq(mockSqlArray));
+        assertNotNull(resultSet);
+    }
+
+    @Test
+    public void executeStatement_handlesMultipleArrayParameters() throws SQLException {
+        SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        Connection mockConnection = mock(Connection.class);
+        Array mockIntArray = mock(Array.class);
+        Array mockStringArray = mock(Array.class);
+
+        Integer[] integerArray = {1, 2, 3};
+        String[] stringArray = {"a", "b", "c"};
+        Object[] params = {integerArray, stringArray};
+
+        when(mockStatement.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.createArrayOf(eq("integer"), any(Object[].class))).thenReturn(mockIntArray);
+        when(mockConnection.createArrayOf(eq("varchar"), any(Object[].class))).thenReturn(mockStringArray);
+        when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
+
+        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
+                mockExplain, "SELECT * FROM table WHERE id = ANY(?) AND name = ANY(?)", params, RecordSql.raw);
+        ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
+
+        verify(mockConnection).createArrayOf(eq("integer"), any(Object[].class));
+        verify(mockStatement).setArray(eq(1), eq(mockIntArray));
+        verify(mockConnection).createArrayOf(eq("varchar"), any(Object[].class));
+        verify(mockStatement).setArray(eq(2), eq(mockStringArray));
         assertNotNull(resultSet);
     }
 
@@ -186,7 +283,7 @@ public class PreparedStatementExplainPlanExecutorTest {
         when(mockStatement.executeQuery()).thenReturn(mock(ResultSet.class));
 
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw, null);
+                mockExplain, "SELECT * FROM table WHERE id = ANY(?)", params, RecordSql.raw);
         ResultSet resultSet = executor.executeStatement(mockStatement, "sql_not_used");
 
         // Should fall back to setObject when createArrayOf fails
@@ -199,7 +296,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesIntArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         int[] primitiveArray = {1, 2, 3, 4, 5};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -213,7 +310,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesLongArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         long[] primitiveArray = {100L, 200L, 300L};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -227,7 +324,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesDoubleArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         double[] primitiveArray = {1.1, 2.2, 3.3};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -241,7 +338,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesFloatArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         float[] primitiveArray = {1.5f, 2.5f, 3.5f};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -255,7 +352,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesBooleanArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         boolean[] primitiveArray = {true, false, true};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -269,7 +366,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesShortArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         short[] primitiveArray = {10, 20, 30};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -283,7 +380,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesByteArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         byte[] primitiveArray = {1, 2, 3};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -297,7 +394,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesCharArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         char[] primitiveArray = {'a', 'b', 'c'};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -311,7 +408,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesEmptyArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         int[] primitiveArray = {};
         Object[] result = executor.convertToObjectArray(primitiveArray);
@@ -324,7 +421,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_passesThoughObjectArray() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         Integer[] objectArray = {1, 2, 3};
         Object[] result = executor.convertToObjectArray(objectArray);
@@ -338,7 +435,7 @@ public class PreparedStatementExplainPlanExecutorTest {
     public void convertToObjectArray_handlesMinMaxIntValues() {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
-                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw, null);
+                mockExplain, "SELECT 1", new Object[]{}, RecordSql.raw);
 
         int[] primitiveArray = {Integer.MIN_VALUE, 0, Integer.MAX_VALUE};
         Object[] result = executor.convertToObjectArray(primitiveArray);


### PR DESCRIPTION
Resolves #2270 

Adds support for explain plans that utilize SQL arrays. Note that this is only supported for Postgres and H2.
