### PR TITLE
Log4j Core Upgrade

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -170,9 +170,6 @@ dependencies {
     shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.25.3'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
-    shadowIntoJar 'org.jspecify:jspecify:1.0.0'
-    shadowIntoJar 'biz.aQute.bnd:biz.aQute.bnd.annotation:6.4.0'
-
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'
 
     shadowIntoJar('com.google.guava:guava:30.1.1-jre')

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -167,8 +167,11 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.17.1'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.25.3'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
+
+    shadowIntoJar 'org.jspecify:jspecify:1.0.0'
+    shadowIntoJar 'biz.aQute.bnd:biz.aQute.bnd.annotation:6.4.0'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'
 
@@ -297,7 +300,7 @@ task relocatedShadowJar(type: ShadowJar) {
 
             // The following rules are to prevent these transitive dependencies from breaking anything
             "org.apache.log4j", "org.apache.log", "org.apache.avalon",
-            "org.checkerframework", "org.dom4j", "org.zeromq", "org.apache.kafka",
+            "org.checkerframework", "org.jspecify", "aQute", "org.dom4j", "org.zeromq", "org.apache.kafka",
             "com.lmax", "com.conversantmedia", "org.jctools",
             "com.fasterxml", "org.osgi", "org.codehaus", "org.fusesource", "kotlin", "org.jetbrains", "org.intellij",
             "okhttp3", "org.bouncycastle", "org.conscrypt", "org.openjsse"

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -320,7 +320,6 @@ task relocatedShadowJar(type: ShadowJar) {
             "LICENSE",
             // log4j2
             "META-INF/versions/9/module-info.class",
-            "META-INF/services/org.apache.logging*",
             // asm
             "module-info.class",
             // httpclient

--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.25.3'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.25.4'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'


### PR DESCRIPTION
### Description
Upgrade log4j-core from 2.17.1 to 2.25.4 

### Changes
- Added dependency exclusions for new transitive dependencies:
  - org.jspecify
  - aQute
- Removed service file exclusion (META-INF/services/org.apache.logging.*)
  - Required for log4j 2.25.3+ compatibility (build fails without them)
  - ShadowJar automatically relocates path and class references 
  
### Testing
- builds successfully
- all logging tests pass
- ran with spring-petclinic (modified to use log4j), no reported exceptions or classpath conflicts

Resolves #2691 and Dependabot Alerts [#751](https://github.com/newrelic/newrelic-java-agent/security/dependabot/751),  [#752](https://github.com/newrelic/newrelic-java-agent/security/dependabot/752),  [#753](https://github.com/newrelic/newrelic-java-agent/security/dependabot/753)
Supersedes PR [#2692](https://github.com/newrelic/newrelic-java-agent/pull/2692)