### PR TITLE
Llm Token Counting Update

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/aimonitoring/LlmTokenCountResolver.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/aimonitoring/LlmTokenCountResolver.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.bridge.aimonitoring;
+
+import com.newrelic.api.agent.LlmTokenCountCallback;
+
+
+/**
+ * Resolves token counts for LLM events.
+ * <p>
+ * <b>Token Count Resolution Order:</b>
+ * <ol>
+ *   <li>Response usage metadata - when all three fields are present and valid</li>
+ *   <li>Customer callback ({@link com.newrelic.api.agent.LlmTokenCountCallback})</li>
+ *   <li>Backend tokenization - when token_count is omitted (null)</li>
+ * </ol>
+ * <p>
+ * This utility class uses static methods and cannot be instantiated.
+ *
+ * @see com.newrelic.api.agent.LlmTokenCountCallback
+ * @see LlmTokenCountCallbackHolder
+ */
+
+public class LlmTokenCountResolver {
+
+    private LlmTokenCountResolver() {}
+
+    /**
+     * Check if all required usage fields are present and valid.
+     * All three fields must be non-null and >= 0 to use response usage data.
+     *
+     * @param promptTokens number of tokens in the prompt/request
+     * @param completionTokens number of tokens in the completion/response
+     * @param totalTokens total tokens (sum of prompt and completion)
+     * @return true if all three fields are present and valid, false otherwise
+     */
+    public static boolean hasCompleteUsageData(Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+        return promptTokens != null && promptTokens >= 0
+                && completionTokens != null && completionTokens >= 0
+                && totalTokens != null && totalTokens >= 0;
+    }
+
+    /**
+     * Get token count for LlmChatCompletionMessage events.
+     * <p>
+     * Returns 0 if the summary has complete usage data (signals backend not to tokenize).
+     * Otherwise, attempts to use the customer callback if available.
+     * Returns null if no callback is registered (backend will tokenize).
+     *
+     * @param completeSummaryUsage true if the summary event has complete usage data from all three fields
+     * @param model the LLM model name
+     * @param content the message content or prompt text
+     * @return 0 if completeSummaryUsage is true, callback result if available, or null for backend tokenization
+     */
+    public static Integer getMessageTokenCount(boolean completeSummaryUsage, String model, String content) {
+        LlmTokenCountCallback llmTokenCountCallback = LlmTokenCountCallbackHolder.getLlmTokenCountCallback();
+
+        if (completeSummaryUsage) {
+            return 0;
+        } else if (llmTokenCountCallback != null && content != null && !content.isEmpty()) {
+            return llmTokenCountCallback.calculateLlmTokenCount(model, content);
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/agent-bridge/src/test/java/com/newrelic/agent/bridge/aimonitoring/LlmTokenCountResolverTest.java
+++ b/agent-bridge/src/test/java/com/newrelic/agent/bridge/aimonitoring/LlmTokenCountResolverTest.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.bridge.aimonitoring;
+
+import com.newrelic.api.agent.LlmTokenCountCallback;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class LlmTokenCountResolverTest {
+
+    @After
+    public void tearDown() {
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(null);
+    }
+
+    @Test
+    public void hasCompleteUsageData_allFieldsValid_returnsTrue() {
+        assertCompleteUsageReturnsTrue(10, 20, 30);
+        assertCompleteUsageReturnsTrue(0, 0, 0);
+    }
+
+    @Test
+    public void hasCompleteUsageData_anyFieldNull_returnsFalse() {
+        assertCompleteUsageReturnsFalse(null, 20, 30);
+        assertCompleteUsageReturnsFalse(10, null, 30);
+        assertCompleteUsageReturnsFalse(10, 20, null);
+    }
+
+    @Test
+    public void hasCompleteUsageData_anyFieldNegative_returnsFalse() {
+        assertCompleteUsageReturnsFalse(-1, 20, 30);
+        assertCompleteUsageReturnsFalse(10, -1, 30);
+        assertCompleteUsageReturnsFalse(10, 20, -1);
+    }
+
+    @Test
+    public void hasCompleteUsageData_allFieldsNull_returnsFalse() {
+        boolean result = LlmTokenCountResolver.hasCompleteUsageData(null, null, null);
+        assertFalse(result);
+    }
+
+    @Test
+    public void getMessageTokenCount_completeSummaryUsage_returnsZero() {
+        assertMessageTokenCountEquals(0, true, "gpt-4", "content", null);
+        assertMessageTokenCountEquals(0, true, "gpt-4", "content", new MockCallback(100));
+    }
+
+    @Test
+    public void getMessageTokenCount_incompleteSummaryUsageWithCallback_returnsCallbackResult() {
+        assertMessageTokenCountEquals(42, false, "gpt-4", "content", new MockCallback(42));
+    }
+
+    @Test
+    public void getMessageTokenCount_incompleteSummaryUsageNoCallback_returnsNull() {
+        Integer result = LlmTokenCountResolver.getMessageTokenCount(false, "gpt-4", "content");
+        assertNull(result);
+    }
+
+    @Test
+    public void getMessageTokenCount_invalidContent_returnsNull() {
+        assertMessageTokenCountReturnsNull(false, "gpt-4", null, new MockCallback(100));
+        assertMessageTokenCountReturnsNull(false, "gpt-4", "", new MockCallback(100));
+    }
+
+    @Test
+    public void getMessageTokenCount_whitespaceContent_returnsCallbackResult() {
+        assertMessageTokenCountEquals(5, false, "gpt-4", "   ", new MockCallback(5));
+    }
+
+    private void assertCompleteUsageReturnsTrue(Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+        boolean result = LlmTokenCountResolver.hasCompleteUsageData(promptTokens, completionTokens, totalTokens);
+        assertTrue(result);
+    }
+
+    private void assertCompleteUsageReturnsFalse(Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+        boolean result = LlmTokenCountResolver.hasCompleteUsageData(promptTokens, completionTokens, totalTokens);
+        assertFalse(result);
+    }
+
+    private void assertMessageTokenCountEquals(Integer expected, boolean completeSummaryUsage, String model, String content, LlmTokenCountCallback callback) {
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(callback);
+        Integer result = LlmTokenCountResolver.getMessageTokenCount(completeSummaryUsage, model, content);
+        assertEquals(expected, result);
+    }
+
+    private void assertMessageTokenCountReturnsNull(boolean completeSummaryUsage, String model, String content, LlmTokenCountCallback callback) {
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(callback);
+        Integer result = LlmTokenCountResolver.getMessageTokenCount(completeSummaryUsage, model, content);
+        assertNull(result);
+    }
+
+    /**
+     * Mock callback that returns a fixed token count
+     */
+    private static class MockCallback implements LlmTokenCountCallback {
+        private final int tokenCount;
+
+        public MockCallback(int tokenCount) {
+            this.tokenCount = tokenCount;
+        }
+
+        @Override
+        public int calculateLlmTokenCount(String model, String content) {
+            return tokenCount;
+        }
+    }
+}


### PR DESCRIPTION
### Description
Adds a centralized token counting strategy for capturing token counts from LLM Responses.
Resolves Issue [#2460](https://github.com/newrelic/newrelic-java-agent/issues/2460)