### PR TITLE
JDBC batchExecute() support

### DIFF
--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/DatastoreMetrics.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/DatastoreMetrics.java
@@ -20,14 +20,30 @@ public class DatastoreMetrics {
      * Notice a SQL statement to detect long running queries and enqueue for future processing.
      *
      * Note: This method has no implementation, instead it is automatically wired up in
-     * {@link com.newrelic.agent.instrumentation.tracing.TraceClassVisitor} by creating a
-     * SqlTracer (instead of a DefaultTracer) for the SQL specific functions.
+     * com.newrelic.agent.instrumentation.tracing.TraceClassVisitor (newrelic-agent project)
+     * by creating a SqlTracer (instead of a DefaultTracer) for the SQL specific functions.
      *
      * @param connection Connection used to run this query
      * @param sql The raw SQL string used in this query
      * @param params The parameters provided with the query (or null if no parameters are required)
      */
     public static void noticeSql(Connection connection, String sql, Object[] params) {
+        // No-op
+    }
+
+    /**
+     * Notice a SQL statement executed as a batch operation.
+     *
+     * Note: This method has no implementation, instead it is automatically wired up in
+     * com.newrelic.agent.instrumentation.tracing.TraceClassVisitor (newrelic-agent project)
+     * by creating a SqlTracer with a batch size attribute.
+     *
+     * @param connection Connection used to run this query
+     * @param sql The raw SQL string used in this query
+     * @param params The parameters provided with the query (or null if no parameters are required)
+     * @param batchSize Number of operations in the batch
+     */
+    public static void noticeBatchSql(Connection connection, String sql, Object[] params, int batchSize) {
         // No-op
     }
 }

--- a/functional_test/src/test/java/com/newrelic/agent/instrumentation/tracing/TraceMethodVisitorTest.java
+++ b/functional_test/src/test/java/com/newrelic/agent/instrumentation/tracing/TraceMethodVisitorTest.java
@@ -82,6 +82,32 @@ public class TraceMethodVisitorTest {
         Assert.assertEquals(noticeSqlClass.noticeSqlInvokeCount, 0);
     }
 
+    @Test
+    public void testNoticeBatchSql() {
+        NoticeBatchSqlClass noticeBatchSqlClass = new NoticeBatchSqlClass();
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlInvokeCount, counter.tracerCount);
+
+        noticeBatchSqlClass.noticeBatchSqlMethod();
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlInvokeCount, counter.tracerCount);
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlConnection, counter.tracer.connection);
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlSql, counter.tracer.rawSql);
+        Assert.assertArrayEquals(noticeBatchSqlClass.noticeBatchSqlParams, counter.tracer.params);
+        Assert.assertEquals(noticeBatchSqlClass.batchSize, counter.tracer.batchSize);  // NEW: Verify batch size
+    }
+
+    @Test
+    public void testNoticeBatchSqlAsDispatcher() {
+        NoticeBatchSqlClass noticeBatchSqlClass = new NoticeBatchSqlClass();
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlDispatcherInvokeCount, counter.tracerCount);
+
+        noticeBatchSqlClass.noticeBatchSqlDispatcherMethod();
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlDispatcherInvokeCount, counter.tracerCount);
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlDispatcherConnection, counter.tracer.connection);
+        Assert.assertEquals(noticeBatchSqlClass.noticeBatchSqlDispatcherSql, counter.tracer.rawSql);
+        Assert.assertArrayEquals(noticeBatchSqlClass.noticeBatchSqlDispatcherParams, counter.tracer.params);
+        Assert.assertEquals(noticeBatchSqlClass.batchSizeDispatcher, counter.tracer.batchSize);  // NEW: Verify batch size
+    }
+
     public static class NoOpCountingInstrumentation extends NoOpInstrumentation {
         public int tracerCount = 0;
         public NoOpTrackingSqlTracer tracer; 
@@ -410,5 +436,31 @@ public class TraceMethodVisitorTest {
             return false;
         }
     }
-    
+
+    public static class NoticeBatchSqlClass {
+        public int noticeBatchSqlInvokeCount = 0;
+        public Connection noticeBatchSqlConnection = new NoOpConnection();
+        public String noticeBatchSqlSql = "INSERT INTO users VALUES (?, ?)";
+        public Object[] noticeBatchSqlParams = null;
+        public int batchSize = 50;
+
+        public int noticeBatchSqlDispatcherInvokeCount = 0;
+        public Connection noticeBatchSqlDispatcherConnection = new NoOpConnection();
+        public String noticeBatchSqlDispatcherSql = "UPDATE orders SET status = ? WHERE id = ?";
+        public Object[] noticeBatchSqlDispatcherParams = null;
+        public int batchSizeDispatcher = 100;
+
+        @Trace
+        public void noticeBatchSqlMethod() {
+            noticeBatchSqlInvokeCount++;
+            DatastoreMetrics.noticeBatchSql(noticeBatchSqlConnection, noticeBatchSqlSql, noticeBatchSqlParams, batchSize);
+        }
+
+        @Trace(dispatcher = true)
+        public void noticeBatchSqlDispatcherMethod() {
+            noticeBatchSqlDispatcherInvokeCount++;
+            DatastoreMetrics.noticeBatchSql(noticeBatchSqlDispatcherConnection, noticeBatchSqlDispatcherSql,
+                    noticeBatchSqlDispatcherParams, batchSizeDispatcher);
+        }
+    }
 }

--- a/functional_test/src/test/java/test/newrelic/test/agent/DatabaseTest.java
+++ b/functional_test/src/test/java/test/newrelic/test/agent/DatabaseTest.java
@@ -156,8 +156,8 @@ public class DatabaseTest {
             }
         };
 
-        // AgentHelper.verifyMetrics(applicationName, "Database/test/select", "Database/test2/delete",
-        // "Database/test3/delete");
+        Set<String> metrics = AgentHelper.getMetrics();
+        AgentHelper.verifyDatastoreMetrics(metrics, DatastoreVendor.Derby, "test", "batch_insert");
     }
 
     @Test

--- a/instrumentation/jdbc-generic/src/main/java/java/sql/PreparedStatement_Weaved.java
+++ b/instrumentation/jdbc-generic/src/main/java/java/sql/PreparedStatement_Weaved.java
@@ -28,6 +28,14 @@ public abstract class PreparedStatement_Weaved {
     @NewField
     String preparedSql;
 
+    public void addBatch() throws SQLException {
+        // If we have SQL in our newfield but not in the shared map, store it
+        if (preparedSql != null && JdbcHelper.getSql((Statement) this) == null) {
+            JdbcHelper.putSql((Statement) this, preparedSql);
+        }
+        Weaver.callOriginal();
+    }
+
     @Trace(leaf = true)
     public ResultSet executeQuery() throws SQLException {
         if (preparedSql == null) {

--- a/instrumentation/jdbc-generic/src/main/java/java/sql/Statement_Weaved.java
+++ b/instrumentation/jdbc-generic/src/main/java/java/sql/Statement_Weaved.java
@@ -7,15 +7,42 @@
 
 package java.sql;
 
+import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.datastore.DatastoreMetrics;
 import com.newrelic.agent.bridge.datastore.JdbcHelper;
 import com.newrelic.api.agent.Trace;
 import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 
 @Weave(originalName = "java.sql.Statement", type = MatchType.Interface)
 public abstract class Statement_Weaved {
+    @NewField
+    String sampleBatchSql = null;
+
+    public void addBatch(String sql) throws SQLException {
+        if (sampleBatchSql == null) {
+            sampleBatchSql = sql;
+        }
+        Weaver.callOriginal();
+    }
+
+    @Trace(leaf = true)
+    public int [] executeBatch() throws SQLException {
+        String sql = sampleBatchSql;
+        if (sql == null) {
+            sql = JdbcHelper.getSql((Statement) this);
+        }
+
+        int [] results = Weaver.callOriginal();
+        String batchSql = sql;
+        if (results != null && sql != null) {
+            DatastoreMetrics.noticeBatchSql(getConnection(), batchSql, null, results.length);
+        }
+
+        return results;
+    }
 
     @Trace(leaf = true)
     public ResultSet executeQuery(String sql) throws SQLException {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/NoticeSqlVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/NoticeSqlVisitor.java
@@ -34,8 +34,20 @@ public class NoticeSqlVisitor extends ClassVisitor {
             "setParams", Type.getType(Object[].class)
             );
 
+    // See comment above - this map is for batch SQL operations which contains a new field to store
+    // the batch size
+    private static final Map<String, Type> batchSetterNamesToTypes = ImmutableMap.of(
+            "provideConnection", Type.getType(Connection.class),
+            "setRawSql", Type.getType(String.class),
+            "setParams", Type.getType(Object[].class),
+            "setBatchSize", Type.INT_TYPE
+    );
+
     private static final Method noticeSqlMethod = new Method("noticeSql", Type.VOID_TYPE,
             setterNamesToTypes.values().toArray(new Type[setterNamesToTypes.size()]));
+
+    private static final Method noticeBatchSqlMethod = new Method("noticeBatchSql", Type.VOID_TYPE,
+            batchSetterNamesToTypes.values().toArray(new Type[batchSetterNamesToTypes.size()]));
 
     private final Set<Method> noticeSqlMethods;
 
@@ -53,6 +65,11 @@ public class NoticeSqlVisitor extends ClassVisitor {
                 if (isNoticeSqlMethod(owner, name, desc)) {
                     noticeSqlMethods.add(new Method(methodName, methodDesc));
                 }
+
+                if (isNoticeBatchSqlMethod(owner, name, desc)) {
+                    noticeSqlMethods.add(new Method(methodName, methodDesc));
+                }
+                
                 super.visitMethodInsn(opcode, owner, name, desc, itf);
             }
         };
@@ -68,6 +85,12 @@ public class NoticeSqlVisitor extends ClassVisitor {
                 && desc.equals(noticeSqlMethod.getDescriptor());
     }
 
+    public static boolean isNoticeBatchSqlMethod(String owner, String name, String desc) {
+        return owner.equals(BridgeUtils.DATASTORE_METRICS_TYPE.getInternalName())
+                && name.equals(noticeBatchSqlMethod.getName())
+                && desc.equals(noticeBatchSqlMethod.getDescriptor());
+    }
+
     public static int getSqlTracerSettersCount() {
         return setterNamesToTypes.size();
     }
@@ -76,6 +99,16 @@ public class NoticeSqlVisitor extends ClassVisitor {
         LinkedList<Map.Entry<String, Type>> entries = new LinkedList<>(
                 setterNamesToTypes.entrySet());
 
+        return entries.descendingIterator();
+    }
+
+    public static int getBatchSqlTracerSettersCount() {
+        return batchSetterNamesToTypes.size();
+    }
+
+    public static Iterator<Map.Entry<String, Type>> getBatchSqlTracerSettersInReverseOrder() {
+        LinkedList<Map.Entry<String, Type>> entries = new LinkedList<>(
+                batchSetterNamesToTypes.entrySet());
         return entries.descendingIterator();
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/TraceMethodVisitor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/tracing/TraceMethodVisitor.java
@@ -256,6 +256,9 @@ public class TraceMethodVisitor extends AdviceAdapter {
         } else if (NoticeSqlVisitor.isNoticeSqlMethod(owner, name, desc)) {
             // Replace calls to DatastoreMetrics.noticeSql() with  instructions to set parameter values on the SqlTracer
             rewriteNoticeSqlCall();
+        } else if (NoticeSqlVisitor.isNoticeBatchSqlMethod(owner, name, desc)) {
+            // Replace calls to DatastoreMetrics.noticeBatchSql()
+            rewriteNoticeBatchSqlCall();
         } else {
             super.visitMethodInsn(opcode, owner, name, desc, itf);
         }
@@ -269,6 +272,18 @@ public class TraceMethodVisitor extends AdviceAdapter {
 
         visitLabel(doWorkLabel);
         setSqlTracerData();
+
+        visitLabel(endLabel);
+    }
+
+    private void rewriteNoticeBatchSqlCall() {
+        Label doWorkLabel = newLabel(), endLabel = newLabel();
+        int parameterCount = NoticeSqlVisitor.getBatchSqlTracerSettersCount();
+
+        skipIfNotSqlTracer(parameterCount, doWorkLabel, endLabel);
+
+        visitLabel(doWorkLabel);
+        setBatchSqlTracerData();  // Use batch-specific setter
 
         visitLabel(endLabel);
     }
@@ -290,6 +305,23 @@ public class TraceMethodVisitor extends AdviceAdapter {
     private void setSqlTracerData() {
         // Iterate in reverse order since parameters will be in reverse order on the stack
         Iterator<Map.Entry<String, Type>> iterator = NoticeSqlVisitor.getSqlTracerSettersInReverseOrder();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Type> entry = iterator.next();
+
+            // Load the SqlTracer and swap order with the parameter
+            // value since we will be calling invoke on the SqlTracer
+            loadTracer();
+            swap();
+
+            // Call the setter on the SqlTracer with the correct name & method type
+            invokeInterface(Type.getType(SqlTracer.class), new Method(entry.getKey(), Type.VOID_TYPE,
+                    new Type[] { entry.getValue() }));
+        }
+    }
+
+    private void setBatchSqlTracerData() {
+        // Iterate in reverse order since parameters will be in reverse order on the stack
+        Iterator<Map.Entry<String, Type>> iterator = NoticeSqlVisitor.getBatchSqlTracerSettersInReverseOrder();
         while (iterator.hasNext()) {
             Map.Entry<String, Type> entry = iterator.next();
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultSqlTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/DefaultSqlTracer.java
@@ -64,6 +64,7 @@ public class DefaultSqlTracer extends DefaultTracer implements SqlTracer, Compar
     private Integer port = null;
     private String identifier = null;
     private String databaseName = null;
+    private int batchSize = 0;
 
     public DefaultSqlTracer(Transaction transaction, ClassMethodSignature sig, Object object,
             MetricNameFormat metricNameFormatter, int tracerFlags) {
@@ -236,6 +237,9 @@ public class DefaultSqlTracer extends DefaultTracer implements SqlTracer, Compar
                 this.sqlObject = getSql();
             }
             parseStatement(returnValue, transaction.getRPMService().getConnectionTimestamp());
+            if (batchSize > 0) {
+                setAgentAttribute("batch_size", batchSize);
+            }
 
             if (isTransactionSegment() && sql != null) {
                 if (transactionTracerConfig.isExplainEnabled()) {
@@ -379,6 +383,15 @@ public class DefaultSqlTracer extends DefaultTracer implements SqlTracer, Compar
             rpmConnectTimestamp = System.nanoTime();
             parsedDatabaseStatement = tx.getDatabaseStatementParser().getParsedDatabaseStatement(getDatabaseVendor(),
                     getRawSql(),  metaData);
+
+            if (batchSize > 0 && parsedDatabaseStatement != null) {
+                String batchOperation = "batch_" + parsedDatabaseStatement.getOperation();
+                parsedDatabaseStatement = new ParsedDatabaseStatement(
+                        parsedDatabaseStatement.getModel(),
+                        batchOperation,
+                        parsedDatabaseStatement.recordMetric()
+                );
+            }
         } else if (configTimestamp > rpmConnectTimestamp) {
             parsedDatabaseStatement = null;
             rpmConnectTimestamp = 0;
@@ -463,6 +476,17 @@ public class DefaultSqlTracer extends DefaultTracer implements SqlTracer, Compar
 
     public String getDatabaseName() {
         return databaseName;
+    }
+
+    @Override
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+        AgentBridge.getAgent().getLogger().log(Level.FINEST, "Setting batch size to {0} for {1}", this.batchSize, this);
+    }
+
+    @Override
+    public int getBatchSize() {
+        return batchSize;
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/tracers/SqlTracer.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/tracers/SqlTracer.java
@@ -101,4 +101,18 @@ public interface SqlTracer extends SqlTracerExplainInfo, Tracer {
      */
     Integer getPort();
 
+    /**
+     * Returns the batch size for this SQL operation if it was executed as a batch.
+     *
+     * @return the number of operations in the batch, or 0 if not a batch operation
+     */
+    int getBatchSize();
+
+    /**
+     * Store the batch size for this SQL operation.
+     * The call to this method is automatically wired up in {@link com.newrelic.agent.instrumentation.tracing.NoticeSqlVisitor}
+     *
+     * @param batchSize the number of operations in the batch
+     */
+    void setBatchSize(int batchSize);
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/sql/NoOpTrackingSqlTracer.java
@@ -9,6 +9,7 @@ package com.newrelic.agent.instrumentation.sql;
 
 import com.newrelic.agent.Transaction;
 import com.newrelic.agent.TransactionActivity;
+import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.TracedMethod;
 import com.newrelic.agent.bridge.TransactionNamePriority;
 import com.newrelic.agent.bridge.datastore.ConnectionFactory;
@@ -31,12 +32,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 
 public class NoOpTrackingSqlTracer implements SqlTracer {
     public Connection connection = null;
     public ConnectionFactory connectionFactory = null;
     public String rawSql = null;
     public Object[] params = null;
+    public int batchSize = 0;
 
     public Transaction tx = null;
     public Object sql = null;
@@ -447,5 +450,14 @@ public class NoOpTrackingSqlTracer implements SqlTracer {
 
     @Override
     public void excludeLeaf() {
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public int getBatchSize() {
+        return batchSize;
     }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/tracers/DefaultSqlTracerTest.java
@@ -722,6 +722,41 @@ public class DefaultSqlTracerTest {
         assertClmAbsent(spanEvent);
     }
 
+    @Test
+    public void testBatchSizeStoredAndRetrieved() throws Exception {
+        DefaultSqlTracer tracer = newTracer("insert into users values (?, ?)");
+        tracer.setBatchSize(50);
+
+        assertEquals(50, tracer.getBatchSize());
+    }
+
+    @Test
+    public void testBatchOperationNaming() throws Exception {
+        DefaultSqlTracer tracer = newTracer("insert into users values (?, ?)");
+        tracer.setBatchSize(50);
+
+        // Simulate what happens in parseStatement
+        tracer.finish(Opcodes.RETURN, null);
+
+        // operation must have includes "batch_" prefix
+        String metricName = tracer.getMetricName();
+        assertTrue("Metric should contain 'batch_insert'",
+                metricName.contains("batch_insert") || metricName.contains("batch insert"));
+    }
+
+    @Test
+    public void testBatchSizeAgentAttribute() throws Exception {
+        DefaultSqlTracer tracer = newTracer("update orders set status = ?");
+        tracer.setBatchSize(25);
+        tracer.finish(Opcodes.RETURN, null);
+
+        // Verify batch_size was set as agent attribute
+        Map<String, Object> agentAttrs = tracer.getAgentAttributes();
+        assertTrue("Agent attributes should contain batch_size",
+                agentAttrs.containsKey("batch_size"));
+        assertEquals(25, agentAttrs.get("batch_size"));
+    }
+
     private static void assertClmAbsent(Tracer tracer) {
         assertNull(tracer.getAgentAttribute(AttributeNames.CLM_NAMESPACE));
         assertNull(tracer.getAgentAttribute(AttributeNames.CLM_FUNCTION));


### PR DESCRIPTION
### Overview
Resolves #2773 

Adds support for capturing JDBC batch operations; specifically the `addBatch()` and `executeBatch()` methods.

This change adds a new method `noticeBatchSql()` which behaves the same as the existing `noticeSql()` method. It is wired up in the `TraceClassVisitor` class at runtime and allows the storage of a batch_size field which will indicate to the SQLTracer that a batch operation was executed.

If a batch operation was executed, the operation name will be modified to: `batch_xxxx`. For example, `batch_insert` or `batch_delete`.

A sample of the executed SQL is stored the first time `addBatch` is invoked, and this value is utilized as the `sql` attribute on the segement. In addition, a `batch_size` agent attribute is added to the segment.

### Named segment:
<img width="711" height="33" alt="Screenshot 2026-04-15 at 8 19 14 AM" src="https://github.com/user-attachments/assets/8fc0ed64-3804-4290-a537-c313e36d65e4" />


### New Attribute:
<img width="335" height="192" alt="Screenshot 2026-04-15 at 8 19 27 AM" src="https://github.com/user-attachments/assets/fb93b3c1-bfab-4d96-8d7d-9b0f47a73678" />
