### PR TITLE
Update aws-bedrock-runtime-2.20 Module

### DIFF
--- a/instrumentation/aws-bedrock-runtime-2.20/README.md
+++ b/instrumentation/aws-bedrock-runtime-2.20/README.md
@@ -90,6 +90,58 @@ custom attributes added by the `addCustomParameters` API to be added to `LlmEven
 One potential custom attribute with special meaning that customers are encouraged to add is `llm.conversation_id`, which has implications in the UI and can be
 used to group LLM messages into specific conversations.
 
+### Token Counting
+
+The instrumentation implements a three-tier fallback strategy for token counting:
+
+#### Priority Order
+1. **Response Object** (most accurate) - Extracts from the models response when available
+2. **User Callback** - using the `setLlmTokenCountCallback` API
+3. **Backend Tokenization** - Fallback when no token data is provided
+
+#### Model Token Data Availability
+
+| Model | Token Data in Response | Summary Attributes              | Message `token_count`                                                    |
+|-------|-------------------|---------------------------------|--------------------------------------------------------------------------|
+| **AI21 Jurassic** |  Yes | `response.usage.*` fields added | `0`                                                                      |
+| **Amazon Titan** |  Yes | `response.usage.*` fields added | `0`                                                                      |
+| **Meta Llama2** |  Yes | `response.usage.*` fields added | `0`                                                                      |
+| **Anthropic Claude** |  No | None added                      | Callback Value or `token_count` is omitted and the backend will tokenize |
+| **Cohere Command** |  No | None added                      | Callback Value or `token_count` is omitted and the backend will tokenize                                               |
+
+#### Summary Event Usage Attributes
+
+When a model provides complete token usage data, the following attributes are added to `LlmChatCompletionSummary` events:
+
+* `response.usage.prompt_tokens` - Number of tokens in the prompt
+* `response.usage.completion_tokens` - Number of tokens in the completion
+* `response.usage.total_tokens` - Total tokens used (prompt + completion)
+
+These three attributes are only added when ALL token counts are available. If any are missing, NONE are added, and the system falls back to callback or backend tokenization.
+
+#### Message Event Token Counting
+
+The `token_count` attribute on `LlmChatCompletionMessage` events behaves as follows:
+
+* **When summary has complete usage**: `token_count = 0` (signals backend not to tokenize)
+* **When usage incomplete, callback registered**: `token_count = <callback result>`
+* **When usage incomplete, no callback**: Attribute omitted (backend will tokenize from `content`)
+
+#### Using the Token Count Callback
+
+The `setLlmTokenCountCallback` API provides a fallback when models don't include token data:
+
+```java
+NewRelic.getAgent()
+    .getAiMonitoring()
+    .setLlmTokenCountCallback((model, content) -> {
+        // Your tokenization logic
+        return calculateTokens(model, content);
+    });
+```
+
+This callback is only invoked when the model response doesn't include complete token usage data.
+
 ### Metrics
 
 When in an active transaction a named span/segment for each LLM embedding and chat completion call is created using the following format:

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/events/LlmEvent.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/events/LlmEvent.java
@@ -214,17 +214,17 @@ public class LlmEvent {
         }
 
         public Builder responseUsagePromptTokens() {
-            responseUsagePromptTokens = modelResponse.getPromptTokens();
+            responseUsagePromptTokens = modelResponse.getResponseUsagePromptTokens();
             return this;
         }
 
         public Builder responseUsageCompletionTokens() {
-            responseUsageCompletionTokens = modelResponse.getCompletionTokens();
+            responseUsageCompletionTokens = modelResponse.getResponseUsageCompletionTokens();
             return this;
         }
 
         public Builder responseUsageTotalTokens() {
-            responseUsageTotalTokens = modelResponse.getTotalTokens();
+            responseUsageTotalTokens = modelResponse.getResponseUsageTotalTokens();
             return this;
         }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/events/LlmEvent.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/events/LlmEvent.java
@@ -52,6 +52,9 @@ public class LlmEvent {
     private final String requestModel;
     private final Integer tokenCount;
     private final String responseChoicesFinishReason;
+    private final Integer responseUsagePromptTokens;
+    private final Integer responseUsageCompletionTokens;
+    private final Integer responseUsageTotalTokens;
 
     public static class Builder {
         // Required builder parameters
@@ -90,6 +93,9 @@ public class LlmEvent {
         private String requestModel = null;
         private Integer tokenCount = null;
         private String responseChoicesFinishReason = null;
+        private Integer responseUsagePromptTokens = null;
+        private Integer responseUsageCompletionTokens = null;
+        private Integer responseUsageTotalTokens = null;
 
         public Builder(ModelInvocation modelInvocation) {
             userAttributes = modelInvocation.getUserAttributes();
@@ -207,6 +213,21 @@ public class LlmEvent {
             return this;
         }
 
+        public Builder responseUsagePromptTokens() {
+            responseUsagePromptTokens = modelResponse.getPromptTokens();
+            return this;
+        }
+
+        public Builder responseUsageCompletionTokens() {
+            responseUsageCompletionTokens = modelResponse.getCompletionTokens();
+            return this;
+        }
+
+        public Builder responseUsageTotalTokens() {
+            responseUsageTotalTokens = modelResponse.getTotalTokens();
+            return this;
+        }
+
         public LlmEvent build() {
             return new LlmEvent(this);
         }
@@ -316,13 +337,28 @@ public class LlmEvent {
         }
 
         tokenCount = builder.tokenCount;
-        if (tokenCount != null && tokenCount > 0) {
+        if (tokenCount != null && tokenCount >= 0) {
             eventAttributes.put("token_count", tokenCount);
         }
 
         responseChoicesFinishReason = builder.responseChoicesFinishReason;
         if (responseChoicesFinishReason != null && !responseChoicesFinishReason.isEmpty()) {
             eventAttributes.put("response.choices.finish_reason", responseChoicesFinishReason);
+        }
+
+        responseUsagePromptTokens = builder.responseUsagePromptTokens;
+        if (responseUsagePromptTokens != null && responseUsagePromptTokens >= 0) {
+            eventAttributes.put("response.usage.prompt_tokens", responseUsagePromptTokens);
+        }
+
+        responseUsageCompletionTokens = builder.responseUsageCompletionTokens;
+        if (responseUsageCompletionTokens != null && responseUsageCompletionTokens >= 0) {
+            eventAttributes.put("response.usage.completion_tokens", responseUsageCompletionTokens);
+        }
+
+        responseUsageTotalTokens = builder.responseUsageTotalTokens;
+        if (responseUsageTotalTokens != null && responseUsageTotalTokens >= 0) {
+            eventAttributes.put("response.usage.total_tokens", responseUsageTotalTokens);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ModelInvocation.java
@@ -178,19 +178,4 @@ public interface ModelInvocation {
         return UUID.randomUUID().toString();
     }
 
-    /**
-     * Calculates the tokenCount based on a user provided callback
-     *
-     * @param model   String representation of the LLM model
-     * @param content String representation of the message content or prompt
-     * @return int representing the tokenCount
-     */
-    static int getTokenCount(String model, String content) {
-        if (LlmTokenCountCallbackHolder.getLlmTokenCountCallback() == null || Objects.equals(content, "")) {
-            return 0;
-        }
-        return LlmTokenCountCallbackHolder
-                .getLlmTokenCountCallback()
-                .calculateLlmTokenCount(model, content);
-    }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ModelResponse.java
@@ -107,19 +107,19 @@ public interface ModelResponse {
      *
      * @return Integer representing the prompt token count or null if not provided by the model
      */
-    Integer getPromptTokens();
+    Integer getResponseUsagePromptTokens();
 
     /**
      * Get the number of tokens in the completion/response from the LLM response usage metadata.
      *
      * @return Integer representing the completion token count or null if not provided by the model
      */
-    Integer getCompletionTokens();
+    Integer getResponseUsageCompletionTokens();
 
     /**
      * Get the total number of tokens (prompt + completion) from the LLM response usage metadata.
      *
      * @return Integer representing the total token count or null if not provided by the model
      */
-    Integer getTotalTokens();
+    Integer getResponseUsageTotalTokens();
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ModelResponse.java
@@ -101,4 +101,25 @@ public interface ModelResponse {
             NewRelic.getAgent().getLogger().log(Level.FINEST, "AIM: Unable to parse empty/null " + fieldBeingParsed + " from ModelResponse");
         }
     }
+
+    /**
+     * Get the number of tokens in the prompt/request from the LLM response usage metadata.
+     *
+     * @return Integer representing the prompt token count or null if not provided by the model
+     */
+    Integer getPromptTokens();
+
+    /**
+     * Get the number of tokens in the completion/response from the LLM response usage metadata.
+     *
+     * @return Integer representing the completion token count or null if not provided by the model
+     */
+    Integer getCompletionTokens();
+
+    /**
+     * Get the total number of tokens (prompt + completion) from the LLM response usage metadata.
+     *
+     * @return Integer representing the total token count or null if not provided by the model
+     */
+    Integer getTotalTokens();
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelInvocation.java
@@ -89,7 +89,7 @@ public class JurassicModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
-        // Calculate hasCompleteUsage here for interface compatibility
+
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
                 modelResponse.getPromptTokens(),
                 modelResponse.getCompletionTokens(),
@@ -121,7 +121,6 @@ public class JurassicModelInvocation implements ModelInvocation {
                 .error()
                 .duration(System.currentTimeMillis() - startTime);
 
-        // Only add usage fields if complete (all-or-nothing rule)
         if (hasCompleteUsage) {
             summaryBuilder
                     .responseUsagePromptTokens()
@@ -136,7 +135,7 @@ public class JurassicModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
-        // Calculate hasCompleteUsage here for interface compatibility
+
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
                 modelResponse.getPromptTokens(),
                 modelResponse.getCompletionTokens(),
@@ -214,7 +213,6 @@ public class JurassicModelInvocation implements ModelInvocation {
         int numberOfResponseMessages = modelResponse.getNumberOfResponseMessages();
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
-        // Check once for complete usage data to avoid redundant calls
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
                 modelResponse.getPromptTokens(),
                 modelResponse.getCompletionTokens(),

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelInvocation.java
@@ -9,6 +9,7 @@ package llm.models.ai21labs.jurassic;
 
 import com.newrelic.agent.bridge.Token;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.agent.bridge.aimonitoring.LlmTokenCountResolver;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Trace;
@@ -23,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
-import static llm.models.ModelInvocation.getTokenCount;
 import static llm.models.ModelResponse.COMPLETION;
 import static llm.models.ModelResponse.EMBEDDING;
 import static llm.vendor.Vendor.BEDROCK;
@@ -58,6 +58,12 @@ public class JurassicModelInvocation implements ModelInvocation {
             reportLlmError();
         }
 
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
         LlmEvent llmEmbeddingEvent = builder
@@ -70,7 +76,10 @@ public class JurassicModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), modelRequest.getInputText(index)))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        modelRequest.getInputText(index)))
                 .error()
                 .duration(System.currentTimeMillis() - startTime)
                 .build();
@@ -80,13 +89,23 @@ public class JurassicModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
+        // Calculate hasCompleteUsage here for interface compatibility
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmChatCompletionSummaryEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -100,14 +119,33 @@ public class JurassicModelInvocation implements ModelInvocation {
                 .responseNumberOfMessages(numberOfMessages)
                 .responseChoicesFinishReason()
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
+
+        // Only add usage fields if complete (all-or-nothing rule)
+        if (hasCompleteUsage) {
+            summaryBuilder
+                    .responseUsagePromptTokens()
+                    .responseUsageCompletionTokens()
+                    .responseUsageTotalTokens();
+        }
+
+        LlmEvent llmChatCompletionSummaryEvent = summaryBuilder.build();
 
         llmChatCompletionSummaryEvent.recordLlmChatCompletionSummaryEvent();
     }
 
     @Override
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
+        // Calculate hasCompleteUsage here for interface compatibility
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser, boolean hasCompleteUsage) {
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
         LlmEvent llmChatCompletionMessageEvent = builder
@@ -123,7 +161,10 @@ public class JurassicModelInvocation implements ModelInvocation {
                 .responseModel()
                 .sequence(sequence)
                 .completionId()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), message))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        message))
                 .build();
 
         llmChatCompletionMessageEvent.recordLlmChatCompletionMessageEvent();
@@ -173,22 +214,29 @@ public class JurassicModelInvocation implements ModelInvocation {
         int numberOfResponseMessages = modelResponse.getNumberOfResponseMessages();
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
+        // Check once for complete usage data to avoid redundant calls
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         int sequence = 0;
 
         // First, record all LlmChatCompletionMessage events representing the user input prompt
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true);
+            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true, hasCompleteUsage);
             sequence++;
         }
 
         // Second, record all LlmChatCompletionMessage events representing the completion message from the LLM response
         for (int i = 0; i < numberOfResponseMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false);
+            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false, hasCompleteUsage);
             sequence++;
         }
 
         // Finally, record a summary event representing all LlmChatCompletionMessage events
-        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages);
+        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages, hasCompleteUsage);
     }
 
     /**

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelInvocation.java
@@ -58,15 +58,9 @@ public class JurassicModelInvocation implements ModelInvocation {
             reportLlmError();
         }
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmEmbeddingEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -76,14 +70,15 @@ public class JurassicModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
-                        hasCompleteUsage,
-                        modelRequest.getModelId(),
-                        modelRequest.getInputText(index)))
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
 
+        Integer totalTokens = modelResponse.getResponseUsageTotalTokens();
+        if (totalTokens != null && totalTokens >= 0) {
+            summaryBuilder.responseUsageTotalTokens();
+        }
+
+        LlmEvent llmEmbeddingEvent = summaryBuilder.build();
         llmEmbeddingEvent.recordLlmEmbeddingEvent();
     }
 
@@ -91,9 +86,9 @@ public class JurassicModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
         recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
     }
@@ -137,9 +132,9 @@ public class JurassicModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
         recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
     }
@@ -214,9 +209,9 @@ public class JurassicModelInvocation implements ModelInvocation {
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         int sequence = 0;

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelResponse.java
@@ -254,7 +254,7 @@ public class JurassicModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getPromptTokens() {
+    public Integer getResponseUsagePromptTokens() {
         try {
             if (!getResponseBodyJsonMap().isEmpty()) {
                 JsonNode promptNode = getResponseBodyJsonMap().get("prompt");
@@ -275,7 +275,7 @@ public class JurassicModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getCompletionTokens() {
+    public Integer getResponseUsageCompletionTokens() {
         try {
             if (!getResponseBodyJsonMap().isEmpty()) {
                 JsonNode completionsNode = getResponseBodyJsonMap().get(COMPLETIONS);
@@ -302,9 +302,9 @@ public class JurassicModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getTotalTokens() {
-        Integer promptTokens = getPromptTokens();
-        Integer completionTokens = getCompletionTokens();
+    public Integer getResponseUsageTotalTokens() {
+        Integer promptTokens = getResponseUsagePromptTokens();
+        Integer completionTokens = getResponseUsageCompletionTokens();
 
         // Only return total if both values are available
         if (promptTokens != null && completionTokens != null) {

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/ai21labs/jurassic/JurassicModelResponse.java
@@ -252,4 +252,64 @@ public class JurassicModelResponse implements ModelResponse {
     public String getStatusText() {
         return statusText;
     }
+
+    @Override
+    public Integer getPromptTokens() {
+        try {
+            if (!getResponseBodyJsonMap().isEmpty()) {
+                JsonNode promptNode = getResponseBodyJsonMap().get("prompt");
+                if (promptNode != null && promptNode.isObject()) {
+                    Map<String, JsonNode> promptObject = promptNode.asObject();
+                    if (promptObject != null) {
+                        JsonNode tokensNode = promptObject.get("tokens");
+                        if (tokensNode != null && tokensNode.isArray()) {
+                            return tokensNode.asArray().size();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logParsingFailure(e, "prompt tokens");
+        }
+        return null;
+    }
+
+    @Override
+    public Integer getCompletionTokens() {
+        try {
+            if (!getResponseBodyJsonMap().isEmpty()) {
+                JsonNode completionsNode = getResponseBodyJsonMap().get(COMPLETIONS);
+                if (completionsNode.isArray()) {
+                    List<JsonNode> completionsArray = completionsNode.asArray();
+                    if (!completionsArray.isEmpty()) {
+                        JsonNode firstCompletion = completionsArray.get(0);
+                        if (firstCompletion.isObject()) {
+                            JsonNode dataNode = firstCompletion.asObject().get(DATA);
+                            if (dataNode.isObject()) {
+                                JsonNode tokensNode = dataNode.asObject().get("tokens");
+                                if (tokensNode.isArray()) {
+                                    return tokensNode.asArray().size();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logParsingFailure(e, "completion tokens");
+        }
+        return null;
+    }
+
+    @Override
+    public Integer getTotalTokens() {
+        Integer promptTokens = getPromptTokens();
+        Integer completionTokens = getCompletionTokens();
+
+        // Only return total if both values are available
+        if (promptTokens != null && completionTokens != null) {
+            return promptTokens + completionTokens;
+        }
+        return null;
+    }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
@@ -56,22 +56,13 @@ public class TitanModelInvocation implements ModelInvocation {
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
-    }
-
-    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmEmbeddingEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -81,14 +72,15 @@ public class TitanModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
-                        hasCompleteUsage,
-                        modelRequest.getModelId(),
-                        modelRequest.getInputText(index)))
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
 
+        Integer totalTokens = modelResponse.getResponseUsageTotalTokens();
+        if (totalTokens != null && totalTokens >= 0) {
+            summaryBuilder.responseUsageTotalTokens();
+        }
+
+        LlmEvent llmEmbeddingEvent = summaryBuilder.build();
         llmEmbeddingEvent.recordLlmEmbeddingEvent();
     }
 
@@ -96,9 +88,9 @@ public class TitanModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
         recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
     }
@@ -142,9 +134,9 @@ public class TitanModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
         recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
     }
@@ -219,9 +211,9 @@ public class TitanModelInvocation implements ModelInvocation {
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         int sequence = 0;
@@ -249,15 +241,9 @@ public class TitanModelInvocation implements ModelInvocation {
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
+            recordLlmEmbeddingEvent(startTime, i);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
@@ -9,6 +9,7 @@ package llm.models.amazon.titan;
 
 import com.newrelic.agent.bridge.Token;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.agent.bridge.aimonitoring.LlmTokenCountResolver;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Trace;
@@ -24,7 +25,6 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import static llm.models.ModelInvocation.getRandomGuid;
-import static llm.models.ModelInvocation.getTokenCount;
 import static llm.models.ModelResponse.COMPLETION;
 import static llm.models.ModelResponse.EMBEDDING;
 import static llm.vendor.Vendor.BEDROCK;
@@ -55,6 +55,16 @@ public class TitanModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
+        // Calculate hasCompleteUsage here for interface compatibility
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
+    }
+
+    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
@@ -71,7 +81,10 @@ public class TitanModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), modelRequest.getInputText(index)))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        modelRequest.getInputText(index)))
                 .error()
                 .duration(System.currentTimeMillis() - startTime)
                 .build();
@@ -81,13 +94,23 @@ public class TitanModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
+        // Calculate hasCompleteUsage here for interface compatibility
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmChatCompletionSummaryEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -101,14 +124,33 @@ public class TitanModelInvocation implements ModelInvocation {
                 .responseNumberOfMessages(numberOfMessages)
                 .responseChoicesFinishReason()
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
+
+        // Only add usage fields if complete (all-or-nothing rule)
+        if (hasCompleteUsage) {
+            summaryBuilder
+                    .responseUsagePromptTokens()
+                    .responseUsageCompletionTokens()
+                    .responseUsageTotalTokens();
+        }
+
+        LlmEvent llmChatCompletionSummaryEvent = summaryBuilder.build();
 
         llmChatCompletionSummaryEvent.recordLlmChatCompletionSummaryEvent();
     }
 
     @Override
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser, boolean hasCompleteUsage) {
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
         LlmEvent llmChatCompletionMessageEvent = builder
@@ -124,7 +166,10 @@ public class TitanModelInvocation implements ModelInvocation {
                 .responseModel()
                 .sequence(sequence)
                 .completionId()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), message))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        message))
                 .build();
 
         llmChatCompletionMessageEvent.recordLlmChatCompletionMessageEvent();
@@ -174,22 +219,28 @@ public class TitanModelInvocation implements ModelInvocation {
         int numberOfResponseMessages = modelResponse.getNumberOfResponseMessages();
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         int sequence = 0;
 
         // First, record all LlmChatCompletionMessage events representing the user input prompt
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true);
+            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true, hasCompleteUsage);
             sequence++;
         }
 
         // Second, record all LlmChatCompletionMessage events representing the completion message from the LLM response
         for (int i = 0; i < numberOfResponseMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false);
+            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false, hasCompleteUsage);
             sequence++;
         }
 
         // Finally, record a summary event representing all LlmChatCompletionMessage events
-        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages);
+        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages, hasCompleteUsage);
     }
 
     /**
@@ -198,9 +249,16 @@ public class TitanModelInvocation implements ModelInvocation {
      */
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i);
+            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
@@ -126,7 +126,6 @@ public class TitanModelInvocation implements ModelInvocation {
                 .error()
                 .duration(System.currentTimeMillis() - startTime);
 
-        // Only add usage fields if complete (all-or-nothing rule)
         if (hasCompleteUsage) {
             summaryBuilder
                     .responseUsagePromptTokens()

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelInvocation.java
@@ -55,7 +55,7 @@ public class TitanModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
-        // Calculate hasCompleteUsage here for interface compatibility
+
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
                 modelResponse.getPromptTokens(),
                 modelResponse.getCompletionTokens(),
@@ -94,7 +94,7 @@ public class TitanModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
-        // Calculate hasCompleteUsage here for interface compatibility
+
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
                 modelResponse.getPromptTokens(),
                 modelResponse.getCompletionTokens(),

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelResponse.java
@@ -239,4 +239,64 @@ public class TitanModelResponse implements ModelResponse {
     public String getStatusText() {
         return statusText;
     }
+
+    @Override
+    public Integer getPromptTokens() {
+        try {
+            if (!getResponseBodyJsonMap().isEmpty()) {
+                JsonNode inputTextTokenCountNode = getResponseBodyJsonMap().get("inputTextTokenCount");
+
+                if  (inputTextTokenCountNode != null && inputTextTokenCountNode.isNumber()) {
+                    return Integer.parseInt(inputTextTokenCountNode.text());
+                }
+            }
+        } catch (Exception e) {
+            logParsingFailure(e, "prompt tokens");
+        }
+        return null;
+    }
+
+    @Override
+    public Integer getCompletionTokens() {
+        try {
+            if (!getResponseBodyJsonMap().isEmpty()) {
+                JsonNode resultsNode = getResponseBodyJsonMap().get("results");
+
+                if (resultsNode != null && resultsNode.isArray()) {
+                    List<JsonNode> resultsArray = resultsNode.asArray();
+
+                    if (!resultsArray.isEmpty()) {
+                        JsonNode firstResult = resultsArray.get(0);
+
+                        if (firstResult != null && firstResult.isObject()) {
+                            Map<String, JsonNode> resultMap = firstResult.asObject();
+
+                            if (resultMap != null && !resultMap.isEmpty()) {
+                                JsonNode tokenCountNode = resultMap.get("tokenCount");
+
+                                if  (tokenCountNode != null && tokenCountNode.isNumber()) {
+                                    return Integer.parseInt(tokenCountNode.text());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logParsingFailure(e, "completion tokens");
+        }
+        return null;
+    }
+
+    @Override
+    public Integer getTotalTokens() {
+        Integer promptTokens = getPromptTokens();
+        Integer completionTokens = getCompletionTokens();
+
+        // Only return total if both values are available
+        if (promptTokens != null && completionTokens != null) {
+            return promptTokens + completionTokens;
+        }
+        return null;
+    }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/amazon/titan/TitanModelResponse.java
@@ -241,7 +241,7 @@ public class TitanModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getPromptTokens() {
+    public Integer getResponseUsagePromptTokens() {
         try {
             if (!getResponseBodyJsonMap().isEmpty()) {
                 JsonNode inputTextTokenCountNode = getResponseBodyJsonMap().get("inputTextTokenCount");
@@ -257,7 +257,7 @@ public class TitanModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getCompletionTokens() {
+    public Integer getResponseUsageCompletionTokens() {
         try {
             if (!getResponseBodyJsonMap().isEmpty()) {
                 JsonNode resultsNode = getResponseBodyJsonMap().get("results");
@@ -289,14 +289,15 @@ public class TitanModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getTotalTokens() {
-        Integer promptTokens = getPromptTokens();
-        Integer completionTokens = getCompletionTokens();
+    public Integer getResponseUsageTotalTokens() {
+        Integer promptTokens = getResponseUsagePromptTokens();
+        Integer completionTokens = getResponseUsageCompletionTokens();
 
-        // Only return total if both values are available
+        // Completion: return sum of prompt AND completion tokens
+        // Embedding: completion tokens not present, return only prompt tokens
         if (promptTokens != null && completionTokens != null) {
             return promptTokens + completionTokens;
         }
-        return null;
+        return promptTokens;
     }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
@@ -128,7 +128,6 @@ public class ClaudeModelInvocation implements ModelInvocation {
                 .error()
                 .duration(System.currentTimeMillis() - startTime);
 
-        // Only add usage fields if complete (all-or-nothing rule)
         if (hasCompleteUsage) {
             summaryBuilder
                     .responseUsagePromptTokens()

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
@@ -9,6 +9,7 @@ package llm.models.anthropic.claude;
 
 import com.newrelic.agent.bridge.Token;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.agent.bridge.aimonitoring.LlmTokenCountResolver;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Trace;
@@ -55,6 +56,17 @@ public class ClaudeModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
+        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
+    }
+
+    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
@@ -71,7 +83,10 @@ public class ClaudeModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), modelRequest.getInputText(index)))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        modelRequest.getInputText(index)))
                 .error()
                 .duration(System.currentTimeMillis() - startTime)
                 .build();
@@ -81,13 +96,24 @@ public class ClaudeModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
+        recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmChatCompletionSummaryEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -101,14 +127,34 @@ public class ClaudeModelInvocation implements ModelInvocation {
                 .responseNumberOfMessages(numberOfMessages)
                 .responseChoicesFinishReason()
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
+
+        // Only add usage fields if complete (all-or-nothing rule)
+        if (hasCompleteUsage) {
+            summaryBuilder
+                    .responseUsagePromptTokens()
+                    .responseUsageCompletionTokens()
+                    .responseUsageTotalTokens();
+        }
+
+        LlmEvent llmChatCompletionSummaryEvent = summaryBuilder.build();
 
         llmChatCompletionSummaryEvent.recordLlmChatCompletionSummaryEvent();
     }
 
     @Override
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
+        recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser, boolean hasCompleteUsage) {
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
         LlmEvent llmChatCompletionMessageEvent = builder
@@ -124,7 +170,10 @@ public class ClaudeModelInvocation implements ModelInvocation {
                 .responseModel()
                 .sequence(sequence)
                 .completionId()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), message))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        message))
                 .build();
 
         llmChatCompletionMessageEvent.recordLlmChatCompletionMessageEvent();
@@ -174,22 +223,28 @@ public class ClaudeModelInvocation implements ModelInvocation {
         int numberOfResponseMessages = modelResponse.getNumberOfResponseMessages();
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         int sequence = 0;
 
         // First, record all LlmChatCompletionMessage events representing the user input prompt
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true);
+            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true,  hasCompleteUsage);
             sequence++;
         }
 
         // Second, record all LlmChatCompletionMessage events representing the completion message from the LLM response
         for (int i = 0; i < numberOfResponseMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false);
+            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false, hasCompleteUsage);
             sequence++;
         }
 
         // Finally, record a summary event representing all LlmChatCompletionMessage events
-        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages);
+        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages, hasCompleteUsage);
     }
 
     /**
@@ -198,9 +253,16 @@ public class ClaudeModelInvocation implements ModelInvocation {
      */
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i);
+            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
@@ -56,23 +56,13 @@ public class ClaudeModelInvocation implements ModelInvocation {
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-
-        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
-    }
-
-    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmEmbeddingEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -82,14 +72,15 @@ public class ClaudeModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
-                        hasCompleteUsage,
-                        modelRequest.getModelId(),
-                        modelRequest.getInputText(index)))
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
 
+        Integer totalTokens = modelResponse.getResponseUsageTotalTokens();
+        if (totalTokens != null && totalTokens >= 0) {
+            summaryBuilder.responseUsageTotalTokens();
+        }
+
+        LlmEvent llmEmbeddingEvent = summaryBuilder.build();
         llmEmbeddingEvent.recordLlmEmbeddingEvent();
     }
 
@@ -97,9 +88,9 @@ public class ClaudeModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
@@ -144,9 +135,9 @@ public class ClaudeModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
@@ -222,9 +213,9 @@ public class ClaudeModelInvocation implements ModelInvocation {
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         int sequence = 0;
@@ -252,15 +243,9 @@ public class ClaudeModelInvocation implements ModelInvocation {
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
+            recordLlmEmbeddingEvent(startTime, i);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelInvocation.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import static llm.models.ModelInvocation.getRandomGuid;
-import static llm.models.ModelInvocation.getTokenCount;
 import static llm.models.ModelResponse.COMPLETION;
 import static llm.models.ModelResponse.EMBEDDING;
 import static llm.vendor.Vendor.BEDROCK;

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelResponse.java
@@ -187,17 +187,17 @@ public class ClaudeModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getPromptTokens() {
+    public Integer getResponseUsagePromptTokens() {
         return null;
     }
 
     @Override
-    public Integer getCompletionTokens() {
+    public Integer getResponseUsageCompletionTokens() {
         return null;
     }
 
     @Override
-    public Integer getTotalTokens() {
+    public Integer getResponseUsageTotalTokens() {
         return null;
     }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/anthropic/claude/ClaudeModelResponse.java
@@ -185,4 +185,19 @@ public class ClaudeModelResponse implements ModelResponse {
     public String getStatusText() {
         return statusText;
     }
+
+    @Override
+    public Integer getPromptTokens() {
+        return null;
+    }
+
+    @Override
+    public Integer getCompletionTokens() {
+        return null;
+    }
+
+    @Override
+    public Integer getTotalTokens() {
+        return null;
+    }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelInvocation.java
@@ -56,23 +56,13 @@ public class CommandModelInvocation implements ModelInvocation {
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-
-        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
-    }
-
-    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmEmbeddingEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -82,14 +72,15 @@ public class CommandModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
-                        hasCompleteUsage,
-                        modelRequest.getModelId(),
-                        modelRequest.getInputText(index)))
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
 
+        Integer totalTokens = modelResponse.getResponseUsageTotalTokens();
+        if (totalTokens != null && totalTokens >= 0) {
+            summaryBuilder.responseUsageTotalTokens();
+        }
+
+        LlmEvent llmEmbeddingEvent = summaryBuilder.build();
         llmEmbeddingEvent.recordLlmEmbeddingEvent();
     }
 
@@ -97,9 +88,9 @@ public class CommandModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
@@ -144,9 +135,9 @@ public class CommandModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
@@ -222,9 +213,9 @@ public class CommandModelInvocation implements ModelInvocation {
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         int sequence = 0;
@@ -252,15 +243,9 @@ public class CommandModelInvocation implements ModelInvocation {
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
+            recordLlmEmbeddingEvent(startTime, i);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelInvocation.java
@@ -9,6 +9,7 @@ package llm.models.cohere.command;
 
 import com.newrelic.agent.bridge.Token;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.agent.bridge.aimonitoring.LlmTokenCountResolver;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Trace;
@@ -24,7 +25,6 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import static llm.models.ModelInvocation.getRandomGuid;
-import static llm.models.ModelInvocation.getTokenCount;
 import static llm.models.ModelResponse.COMPLETION;
 import static llm.models.ModelResponse.EMBEDDING;
 import static llm.vendor.Vendor.BEDROCK;
@@ -55,6 +55,17 @@ public class CommandModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
+        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
+    }
+
+    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
@@ -71,7 +82,10 @@ public class CommandModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), modelRequest.getInputText(index)))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        modelRequest.getInputText(index)))
                 .error()
                 .duration(System.currentTimeMillis() - startTime)
                 .build();
@@ -81,13 +95,24 @@ public class CommandModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
+        recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
+    }
+
+    private void  recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmChatCompletionSummaryEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -101,14 +126,34 @@ public class CommandModelInvocation implements ModelInvocation {
                 .responseNumberOfMessages(numberOfMessages)
                 .responseChoicesFinishReason()
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
+
+        // Only add usage fields if complete (all-or-nothing rule)
+        if (hasCompleteUsage) {
+            summaryBuilder
+                    .responseUsagePromptTokens()
+                    .responseUsageCompletionTokens()
+                    .responseUsageTotalTokens();
+        }
+
+        LlmEvent llmChatCompletionSummaryEvent = summaryBuilder.build();
 
         llmChatCompletionSummaryEvent.recordLlmChatCompletionSummaryEvent();
     }
 
     @Override
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
+        recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser, boolean hasCompleteUsage) {
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
         LlmEvent llmChatCompletionMessageEvent = builder
@@ -124,7 +169,10 @@ public class CommandModelInvocation implements ModelInvocation {
                 .responseModel()
                 .sequence(sequence)
                 .completionId()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), message))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        message))
                 .build();
 
         llmChatCompletionMessageEvent.recordLlmChatCompletionMessageEvent();
@@ -174,22 +222,28 @@ public class CommandModelInvocation implements ModelInvocation {
         int numberOfResponseMessages = modelResponse.getNumberOfResponseMessages();
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         int sequence = 0;
 
         // First, record all LlmChatCompletionMessage events representing the user input prompt
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true);
+            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true, hasCompleteUsage);
             sequence++;
         }
 
         // Second, record all LlmChatCompletionMessage events representing the completion message from the LLM response
         for (int i = 0; i < numberOfResponseMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false);
+            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false, hasCompleteUsage);
             sequence++;
         }
 
         // Finally, record a summary event representing all LlmChatCompletionMessage events
-        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages);
+        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages, hasCompleteUsage);
     }
 
     /**
@@ -198,9 +252,16 @@ public class CommandModelInvocation implements ModelInvocation {
      */
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i);
+            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelInvocation.java
@@ -128,7 +128,6 @@ public class CommandModelInvocation implements ModelInvocation {
                 .error()
                 .duration(System.currentTimeMillis() - startTime);
 
-        // Only add usage fields if complete (all-or-nothing rule)
         if (hasCompleteUsage) {
             summaryBuilder
                     .responseUsagePromptTokens()

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelResponse.java
@@ -242,17 +242,17 @@ public class CommandModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getPromptTokens() {
+    public Integer getResponseUsagePromptTokens() {
         return null;
     }
 
     @Override
-    public Integer getCompletionTokens() {
+    public Integer getResponseUsageCompletionTokens() {
         return null;
     }
 
     @Override
-    public Integer getTotalTokens() {
+    public Integer getResponseUsageTotalTokens() {
         return null;
     }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/cohere/command/CommandModelResponse.java
@@ -240,4 +240,19 @@ public class CommandModelResponse implements ModelResponse {
     public String getStatusText() {
         return statusText;
     }
+
+    @Override
+    public Integer getPromptTokens() {
+        return null;
+    }
+
+    @Override
+    public Integer getCompletionTokens() {
+        return null;
+    }
+
+    @Override
+    public Integer getTotalTokens() {
+        return null;
+    }
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelInvocation.java
@@ -9,6 +9,7 @@ package llm.models.meta.llama2;
 
 import com.newrelic.agent.bridge.Token;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.agent.bridge.aimonitoring.LlmTokenCountResolver;
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
 import com.newrelic.api.agent.Trace;
@@ -24,7 +25,6 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import static llm.models.ModelInvocation.getRandomGuid;
-import static llm.models.ModelInvocation.getTokenCount;
 import static llm.models.ModelResponse.COMPLETION;
 import static llm.models.ModelResponse.EMBEDDING;
 import static llm.vendor.Vendor.BEDROCK;
@@ -55,6 +55,16 @@ public class Llama2ModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
+    }
+
+    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
@@ -71,7 +81,11 @@ public class Llama2ModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), modelRequest.getInputText(index)))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        modelRequest.getInputText(index)
+                ))
                 .error()
                 .duration(System.currentTimeMillis() - startTime)
                 .build();
@@ -81,13 +95,23 @@ public class Llama2ModelInvocation implements ModelInvocation {
 
     @Override
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmChatCompletionSummaryEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -101,14 +125,33 @@ public class Llama2ModelInvocation implements ModelInvocation {
                 .responseNumberOfMessages(numberOfMessages)
                 .responseChoicesFinishReason()
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
+
+        // Only add usage fields if complete (all-or-nothing rule)
+        if (hasCompleteUsage) {
+            summaryBuilder
+                    .responseUsagePromptTokens()
+                    .responseUsageCompletionTokens()
+                    .responseUsageTotalTokens();
+        }
+
+        LlmEvent llmChatCompletionSummaryEvent = summaryBuilder.build();
 
         llmChatCompletionSummaryEvent.recordLlmChatCompletionSummaryEvent();
     }
 
     @Override
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+        recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
+    }
+
+    private void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser, boolean hasCompleteUsage) {
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
         LlmEvent llmChatCompletionMessageEvent = builder
@@ -124,7 +167,10 @@ public class Llama2ModelInvocation implements ModelInvocation {
                 .responseModel()
                 .sequence(sequence)
                 .completionId()
-                .tokenCount(getTokenCount(modelRequest.getModelId(), message))
+                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
+                        hasCompleteUsage,
+                        modelRequest.getModelId(),
+                        message))
                 .build();
 
         llmChatCompletionMessageEvent.recordLlmChatCompletionMessageEvent();
@@ -174,22 +220,28 @@ public class Llama2ModelInvocation implements ModelInvocation {
         int numberOfResponseMessages = modelResponse.getNumberOfResponseMessages();
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         int sequence = 0;
 
         // First, record all LlmChatCompletionMessage events representing the user input prompt
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true);
+            recordLlmChatCompletionMessageEvent(sequence, modelRequest.getRequestMessage(i), true, hasCompleteUsage);
             sequence++;
         }
 
         // Second, record all LlmChatCompletionMessage events representing the completion message from the LLM response
         for (int i = 0; i < numberOfResponseMessages; i++) {
-            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false);
+            recordLlmChatCompletionMessageEvent(sequence, modelResponse.getResponseMessage(i), false, hasCompleteUsage);
             sequence++;
         }
 
         // Finally, record a summary event representing all LlmChatCompletionMessage events
-        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages);
+        recordLlmChatCompletionSummaryEvent(startTime, totalNumberOfMessages, hasCompleteUsage);
     }
 
     /**
@@ -198,9 +250,16 @@ public class Llama2ModelInvocation implements ModelInvocation {
      */
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
+
+        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
+                modelResponse.getPromptTokens(),
+                modelResponse.getCompletionTokens(),
+                modelResponse.getTotalTokens()
+        );
+
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i);
+            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelInvocation.java
@@ -127,7 +127,6 @@ public class Llama2ModelInvocation implements ModelInvocation {
                 .error()
                 .duration(System.currentTimeMillis() - startTime);
 
-        // Only add usage fields if complete (all-or-nothing rule)
         if (hasCompleteUsage) {
             summaryBuilder
                     .responseUsagePromptTokens()

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelInvocation.java
@@ -56,22 +56,13 @@ public class Llama2ModelInvocation implements ModelInvocation {
     @Override
     public void recordLlmEmbeddingEvent(long startTime, int index) {
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-        recordLlmEmbeddingEvent(startTime, index, hasCompleteUsage);
-    }
-
-    private void recordLlmEmbeddingEvent(long startTime, int index, boolean hasCompleteUsage) {
         if (modelResponse.isErrorResponse()) {
             reportLlmError();
         }
 
         LlmEvent.Builder builder = new LlmEvent.Builder(this);
 
-        LlmEvent llmEmbeddingEvent = builder
+        LlmEvent.Builder summaryBuilder = builder
                 .spanId()
                 .traceId()
                 .vendor()
@@ -81,15 +72,15 @@ public class Llama2ModelInvocation implements ModelInvocation {
                 .input(index)
                 .requestModel()
                 .responseModel()
-                .tokenCount(LlmTokenCountResolver.getMessageTokenCount(
-                        hasCompleteUsage,
-                        modelRequest.getModelId(),
-                        modelRequest.getInputText(index)
-                ))
                 .error()
-                .duration(System.currentTimeMillis() - startTime)
-                .build();
+                .duration(System.currentTimeMillis() - startTime);
 
+        Integer tokens = modelResponse.getResponseUsageTotalTokens();
+        if (tokens != null && tokens >= 0) {
+            summaryBuilder.responseUsageTotalTokens();
+        }
+
+        LlmEvent llmEmbeddingEvent = summaryBuilder.build();
         llmEmbeddingEvent.recordLlmEmbeddingEvent();
     }
 
@@ -97,9 +88,9 @@ public class Llama2ModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionSummaryEvent(long startTime, int numberOfMessages) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
         recordLlmChatCompletionSummaryEvent(startTime, numberOfMessages, hasCompleteUsage);
     }
@@ -143,9 +134,9 @@ public class Llama2ModelInvocation implements ModelInvocation {
     public void recordLlmChatCompletionMessageEvent(int sequence, String message, boolean isUser) {
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
         recordLlmChatCompletionMessageEvent(sequence, message, isUser, hasCompleteUsage);
     }
@@ -220,9 +211,9 @@ public class Llama2ModelInvocation implements ModelInvocation {
         int totalNumberOfMessages = numberOfRequestMessages + numberOfResponseMessages;
 
         boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
+                modelResponse.getResponseUsagePromptTokens(),
+                modelResponse.getResponseUsageCompletionTokens(),
+                modelResponse.getResponseUsageTotalTokens()
         );
 
         int sequence = 0;
@@ -250,15 +241,9 @@ public class Llama2ModelInvocation implements ModelInvocation {
     private void recordLlmEmbeddingEvents(long startTime) {
         int numberOfRequestMessages = modelRequest.getNumberOfInputTextMessages();
 
-        boolean hasCompleteUsage = LlmTokenCountResolver.hasCompleteUsageData(
-                modelResponse.getPromptTokens(),
-                modelResponse.getCompletionTokens(),
-                modelResponse.getTotalTokens()
-        );
-
         // Record an LlmEmbedding event for each input message in the request
         for (int i = 0; i < numberOfRequestMessages; i++) {
-            recordLlmEmbeddingEvent(startTime, i, hasCompleteUsage);
+            recordLlmEmbeddingEvent(startTime, i);
         }
     }
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelResponse.java
@@ -188,7 +188,7 @@ public class Llama2ModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getPromptTokens() {
+    public Integer getResponseUsagePromptTokens() {
         try {
             if (!getResponseBodyJsonMap().isEmpty()) {
                 JsonNode promptTokenCountNode = getResponseBodyJsonMap().get("prompt_token_count");
@@ -204,7 +204,7 @@ public class Llama2ModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getCompletionTokens() {
+    public Integer getResponseUsageCompletionTokens() {
         try {
             if (!getResponseBodyJsonMap().isEmpty()) {
                 JsonNode generationTokenCountNode = getResponseBodyJsonMap().get("generation_token_count");
@@ -220,9 +220,9 @@ public class Llama2ModelResponse implements ModelResponse {
     }
 
     @Override
-    public Integer getTotalTokens() {
-        Integer promptTokens = getPromptTokens();
-        Integer completionTokens = getCompletionTokens();
+    public Integer getResponseUsageTotalTokens() {
+        Integer promptTokens = getResponseUsagePromptTokens();
+        Integer completionTokens = getResponseUsageCompletionTokens();
 
         // Only return total if both values are available
         if (promptTokens != null && completionTokens != null) {

--- a/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/main/java/llm/models/meta/llama2/Llama2ModelResponse.java
@@ -186,4 +186,49 @@ public class Llama2ModelResponse implements ModelResponse {
     public String getStatusText() {
         return statusText;
     }
+
+    @Override
+    public Integer getPromptTokens() {
+        try {
+            if (!getResponseBodyJsonMap().isEmpty()) {
+                JsonNode promptTokenCountNode = getResponseBodyJsonMap().get("prompt_token_count");
+
+                if  (promptTokenCountNode != null && promptTokenCountNode.isNumber()) {
+                    return Integer.parseInt(promptTokenCountNode.text());
+                }
+            }
+        } catch (Exception e) {
+            logParsingFailure(e, "prompt tokens");
+        }
+        return null;
+    }
+
+    @Override
+    public Integer getCompletionTokens() {
+        try {
+            if (!getResponseBodyJsonMap().isEmpty()) {
+                JsonNode generationTokenCountNode = getResponseBodyJsonMap().get("generation_token_count");
+
+                if (generationTokenCountNode != null && generationTokenCountNode.isNumber()) {
+                    return Integer.parseInt(generationTokenCountNode.text());
+                }
+            }
+        } catch (Exception e) {
+            logParsingFailure(e, "completion tokens");
+        }
+        return null;
+    }
+
+    @Override
+    public Integer getTotalTokens() {
+        Integer promptTokens = getPromptTokens();
+        Integer completionTokens = getCompletionTokens();
+
+        // Only return total if both values are available
+        if (promptTokens != null && completionTokens != null) {
+            return promptTokens + completionTokens;
+        }
+        return null;
+    }
+
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/events/LlmEventTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/events/LlmEventTest.java
@@ -36,6 +36,7 @@ import static llm.events.LlmEvent.LLM_CHAT_COMPLETION_SUMMARY;
 import static llm.events.LlmEvent.LLM_EMBEDDING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -323,4 +324,266 @@ public class LlmEventTest {
         assertEquals("conversation-id-890", attributes.get("llm.conversation_id"));
         assertEquals("testPrefix", attributes.get("llm.testPrefix"));
     }
+
+    @Test
+    public void testRecordLlmChatCompletionSummaryEventWithCompleteUsage() {
+
+        Map<String, String> linkingMetadata = new HashMap<>();
+        linkingMetadata.put("span.id", "span-id-123");
+        linkingMetadata.put("trace.id", "trace-id-xyz");
+
+        Map<String, Object> userAttributes = new HashMap<>();
+        userAttributes.put("llm.conversation_id", "conversation-id-890");
+        userAttributes.put("llm.testPrefix", "testPrefix");
+        userAttributes.put("test", "test");
+
+        InvokeModelRequest mockInvokeModelRequest = mock(InvokeModelRequest.class);
+        SdkBytes mockRequestSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelRequest.body()).thenReturn(mockRequestSdkBytes);
+        when(mockRequestSdkBytes.asUtf8String()).thenReturn("{\"inputText\":\"What is the color of the\n" +
+                "  sky?\",\"textGenerationConfig\":{\"temperature\":0.5,\"maxTokenCount\":1000}}");
+        when(mockInvokeModelRequest.modelId()).thenReturn("amazon.titan-text-express-v1");
+
+        InvokeModelResponse mockInvokeModelResponse = mock(InvokeModelResponse.class);
+        SdkBytes mockResponseSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelResponse.body()).thenReturn(mockResponseSdkBytes);
+        when(mockResponseSdkBytes.asUtf8String()).thenReturn("{\"results\":[{\"tokenCount\":9,\"outputText\":\"The sky is blue.\",\"completionReason\":\"FINISH\"}],\"inputTextTokenCount\":8}");
+
+        SdkHttpResponse mockSdkHttpResponse = mock(SdkHttpResponse.class);
+        when(mockInvokeModelResponse.sdkHttpResponse()).thenReturn(mockSdkHttpResponse);
+        when(mockSdkHttpResponse.isSuccessful()).thenReturn(true);
+        when(mockSdkHttpResponse.statusCode()).thenReturn(200);
+        when(mockSdkHttpResponse.statusText()).thenReturn(Optional.of("OK"));
+
+        BedrockRuntimeResponseMetadata mockBedrockRuntimeResponseMetadata = mock(BedrockRuntimeResponseMetadata.class);
+        when(mockInvokeModelResponse.responseMetadata()).thenReturn(mockBedrockRuntimeResponseMetadata);
+        when(mockBedrockRuntimeResponseMetadata.requestId()).thenReturn("90a22e92-db1d-4474-97a9-28b143846301");
+
+        TitanModelInvocation titanModelInvocation = new TitanModelInvocation(linkingMetadata, userAttributes, mockInvokeModelRequest,
+                mockInvokeModelResponse);
+
+        LlmEvent.Builder builder = new LlmEvent.Builder(titanModelInvocation);
+        LlmEvent llmChatCompletionSummaryEvent = builder
+                .spanId()
+                .traceId()
+                .vendor()
+                .ingestSource()
+                .id(titanModelInvocation.getModelResponse().getLlmChatCompletionSummaryId())
+                .requestId()
+                .requestTemperature()
+                .requestModel()
+                .responseModel()
+                .responseNumberOfMessages(2)
+                .responseChoicesFinishReason()
+                .duration(9000f)
+                .responseUsagePromptTokens()
+                .responseUsageCompletionTokens()
+                .responseUsageTotalTokens()
+                .build();
+
+        llmChatCompletionSummaryEvent.recordLlmChatCompletionSummaryEvent();
+
+        Collection<Event> customEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, customEvents.size());
+
+        Event event = customEvents.iterator().next();
+        Map<String, Object> attributes = event.getAttributes();
+
+        assertEquals(17, attributes.size());
+        assertEquals(8, attributes.get("response.usage.prompt_tokens"));
+        assertEquals(9, attributes.get("response.usage.completion_tokens"));
+        assertEquals(17,  attributes.get("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testResponseUsageFieldsOmittedWhenNull() {
+
+        Map<String, String> linkingMetadata = new HashMap<>();
+        linkingMetadata.put("span.id", "span-id-123");
+        linkingMetadata.put("trace.id", "trace-id-xyz");
+
+        Map<String, Object> userAttributes = new HashMap<>();
+        userAttributes.put("llm.conversation_id", "conversation-id-890");
+        userAttributes.put("llm.testPrefix", "testPrefix");
+        userAttributes.put("test", "test");
+
+        String expectedUserPrompt = "Human: What is the color of the sky?\n\nAssistant:";
+
+        InvokeModelRequest mockInvokeModelRequest = mock(InvokeModelRequest.class);
+        SdkBytes mockRequestSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelRequest.body()).thenReturn(mockRequestSdkBytes);
+        when(mockRequestSdkBytes.asUtf8String()).thenReturn(
+                        "{\"stop_sequences\":[\"\\n\\nHuman:\"],\"max_tokens_to_sample\":1000,\"temperature\":0.5,\"prompt\":\"Human: What is the color of the sky?\\n\\nAssistant:\"}");
+        when(mockInvokeModelRequest.modelId()).thenReturn("anthropic.claude-v2");
+
+        InvokeModelResponse mockInvokeModelResponse = mock(InvokeModelResponse.class);
+        SdkBytes mockResponseSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelResponse.body()).thenReturn(mockResponseSdkBytes);
+        when(mockResponseSdkBytes.asUtf8String()).thenReturn("{\"completion\":\" The sky appears blue during the day because of how sunlight interacts with the gases in Earth's atmosphere.\",\"stop_reason\":\"stop_sequence\",\"stop\":\"\\n\\nHuman:\"}");
+
+        SdkHttpResponse mockSdkHttpResponse = mock(SdkHttpResponse.class);
+        when(mockInvokeModelResponse.sdkHttpResponse()).thenReturn(mockSdkHttpResponse);
+        when(mockSdkHttpResponse.isSuccessful()).thenReturn(true);
+        when(mockSdkHttpResponse.statusCode()).thenReturn(200);
+        when(mockSdkHttpResponse.statusText()).thenReturn(Optional.of("OK"));
+
+        BedrockRuntimeResponseMetadata mockBedrockRuntimeResponseMetadata = mock(BedrockRuntimeResponseMetadata.class);
+        when(mockInvokeModelResponse.responseMetadata()).thenReturn(mockBedrockRuntimeResponseMetadata);
+        when(mockBedrockRuntimeResponseMetadata.requestId()).thenReturn("90a22e92-db1d-4474-97a9-28b143846301");
+
+        ClaudeModelInvocation claudeModelInvocation = new ClaudeModelInvocation(linkingMetadata, userAttributes, mockInvokeModelRequest,
+                mockInvokeModelResponse);
+
+        LlmEvent.Builder builder = new LlmEvent.Builder(claudeModelInvocation);
+        LlmEvent event = builder
+                .spanId()
+                .traceId()
+                .vendor()
+                .ingestSource()
+                .id(ModelInvocation.getRandomGuid())
+                .content(expectedUserPrompt)
+                .role(true)
+                .isResponse(true)
+                .requestId()
+                .responseModel()
+                .sequence(0)
+                .completionId()
+                .responseUsagePromptTokens()
+                .responseUsageCompletionTokens()
+                .responseUsageTotalTokens()
+                .tokenCount(LlmTokenCountCallbackHolder.getLlmTokenCountCallback().calculateLlmTokenCount("model", "content"))
+                .build();
+
+        event.recordLlmChatCompletionSummaryEvent();
+
+        Collection<Event> customEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        Event recordedEvent = customEvents.iterator().next();
+        Map<String, Object> attributes = recordedEvent.getAttributes();
+
+        assertFalse(attributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(attributes.containsKey("response.usage.completion_tokens"));
+        assertFalse(attributes.containsKey("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testResponseUsageFieldsIncludedWhenZero() {
+
+        Map<String, String> linkingMetadata = new HashMap<>();
+        Map<String, Object> userAttributes = new HashMap<>();
+
+        InvokeModelRequest mockInvokeModelRequest = mock(InvokeModelRequest.class);
+        SdkBytes mockRequestSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelRequest.body()).thenReturn(mockRequestSdkBytes);
+        when(mockRequestSdkBytes.asUtf8String()).thenReturn("{\"inputText\":\"test\"}");
+        when(mockInvokeModelRequest.modelId()).thenReturn("amazon.titan-text-express-v1");
+
+        InvokeModelResponse mockInvokeModelResponse = mock(InvokeModelResponse.class);
+        SdkBytes mockResponseSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelResponse.body()).thenReturn(mockResponseSdkBytes);
+
+        when(mockResponseSdkBytes.asUtf8String()).thenReturn(
+                "{\"results\":[{\"tokenCount\":0,\"outputText\":\"test\"}],\"inputTextTokenCount\":0}"
+        );
+
+        SdkHttpResponse mockSdkHttpResponse = mock(SdkHttpResponse.class);
+        when(mockInvokeModelResponse.sdkHttpResponse()).thenReturn(mockSdkHttpResponse);
+        when(mockSdkHttpResponse.isSuccessful()).thenReturn(true);
+
+        BedrockRuntimeResponseMetadata mockMetadata = mock(BedrockRuntimeResponseMetadata.class);
+        when(mockInvokeModelResponse.responseMetadata()).thenReturn(mockMetadata);
+        when(mockMetadata.requestId()).thenReturn("test-id");
+
+        TitanModelInvocation titanModelInvocation = new TitanModelInvocation(
+                linkingMetadata,
+                userAttributes,
+                mockInvokeModelRequest,
+                mockInvokeModelResponse
+        );
+
+        LlmEvent.Builder builder = new LlmEvent.Builder(titanModelInvocation);
+        LlmEvent event = builder
+                .spanId()
+                .responseUsagePromptTokens()
+                .responseUsageCompletionTokens()
+                .responseUsageTotalTokens()
+                .build();
+
+        event.recordLlmChatCompletionSummaryEvent();
+
+        Collection<Event> customEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        Event recordedEvent = customEvents.iterator().next();
+        Map<String, Object> attributes = recordedEvent.getAttributes();
+
+        assertTrue(attributes.containsKey("response.usage.prompt_tokens"));
+        assertTrue(attributes.containsKey("response.usage.completion_tokens"));
+        assertTrue(attributes.containsKey("response.usage.total_tokens"));
+        assertEquals(0, attributes.get("response.usage.prompt_tokens"));
+        assertEquals(0, attributes.get("response.usage.completion_tokens"));
+        assertEquals(0, attributes.get("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testRecordLlmEmbeddingEventWithPartialUsageOmitted() {
+
+        Map<String, String> linkingMetadata = new HashMap<>();
+        Map<String, Object> userAttributes = new HashMap<>();
+
+        InvokeModelRequest mockInvokeModelRequest = mock(InvokeModelRequest.class);
+        SdkBytes mockRequestSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelRequest.body()).thenReturn(mockRequestSdkBytes);
+        when(mockRequestSdkBytes.asUtf8String()).thenReturn("{\"inputText\":\"test embedding\"}");
+        when(mockInvokeModelRequest.modelId()).thenReturn("amazon.titan-embed-text-v1");
+
+        InvokeModelResponse mockInvokeModelResponse = mock(InvokeModelResponse.class);
+        SdkBytes mockResponseSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelResponse.body()).thenReturn(mockResponseSdkBytes);
+
+        when(mockResponseSdkBytes.asUtf8String()).thenReturn(
+                "{\"embedding\":[0.1,0.2,0.3],\"inputTextTokenCount\":8}"
+        );
+
+        SdkHttpResponse mockSdkHttpResponse = mock(SdkHttpResponse.class);
+        when(mockInvokeModelResponse.sdkHttpResponse()).thenReturn(mockSdkHttpResponse);
+        when(mockSdkHttpResponse.isSuccessful()).thenReturn(true);
+
+        BedrockRuntimeResponseMetadata mockMetadata = mock(BedrockRuntimeResponseMetadata.class);
+        when(mockInvokeModelResponse.responseMetadata()).thenReturn(mockMetadata);
+        when(mockMetadata.requestId()).thenReturn("test-id");
+
+        TitanModelInvocation titanModelInvocation = new TitanModelInvocation(
+                linkingMetadata,
+                userAttributes,
+                mockInvokeModelRequest,
+                mockInvokeModelResponse
+        );
+
+        LlmEvent.Builder builder = new LlmEvent.Builder(titanModelInvocation);
+        LlmEvent llmEmbeddingEvent = builder
+                .spanId()
+                .traceId()
+                .vendor()
+                .ingestSource()
+                .id(titanModelInvocation.getModelResponse().getLlmEmbeddingId())
+                .requestId()
+                .input(0)
+                .requestModel()
+                .responseModel()
+                .tokenCount(13)
+                .duration(9000f)
+                .build();
+
+        llmEmbeddingEvent.recordLlmEmbeddingEvent();
+
+        Collection<Event> customEvents = introspector.getCustomEvents(LLM_EMBEDDING);
+        Event event = customEvents.iterator().next();
+        Map<String, Object> attributes = event.getAttributes();
+
+        assertFalse(attributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(attributes.containsKey("response.usage.completion_tokens"));
+        assertFalse(attributes.containsKey("response.usage.total_tokens"));
+
+        // token_count should use callback value (13) since usage is incomplete
+        assertEquals(13, attributes.get("token_count"));
+    }
+
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/TestUtil.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/TestUtil.java
@@ -34,7 +34,6 @@ public class TestUtil {
         assertEquals(modelId, attributes.get("response.model"));
         assertEquals("testPrefix", attributes.get("llm.testPrefix"));
         assertEquals("conversation-id-value", attributes.get("llm.conversation_id"));
-        assertEquals(13, attributes.get("token_count"));
 
         if (isResponse) {
             assertEquals("assistant", attributes.get("role"));
@@ -46,6 +45,11 @@ public class TestUtil {
             assertEquals(requestInput, attributes.get("content"));
             assertEquals(false, attributes.get("is_response"));
             assertEquals(0, attributes.get("sequence"));
+        }
+
+        if (attributes.containsKey("token_count")) {
+            Object tokenCount = attributes.get("token_count");
+            assertTrue("token_count should be 0 or 13, was: " + tokenCount, tokenCount.equals(0) || tokenCount.equals(13));
         }
     }
 
@@ -66,6 +70,12 @@ public class TestUtil {
         assertEquals(1000, attributes.get("request.max_tokens"));
         assertEquals("testPrefix", attributes.get("llm.testPrefix"));
         assertEquals("conversation-id-value", attributes.get("llm.conversation_id"));
+
+        if (attributes.containsKey("response.usage.prompt_tokens")) {
+            assertTrue((Integer) attributes.get("response.usage.prompt_tokens") > 0);
+            assertTrue((Integer) attributes.get("response.usage.completion_tokens") > 0);
+            assertTrue((Integer) attributes.get("response.usage.total_tokens") > 0);
+        }
     }
 
     public static void assertLlmEmbeddingAttributes(Event event, String modelId, String requestInput) {
@@ -82,7 +92,11 @@ public class TestUtil {
         assertFalse(((String) attributes.get("request_id")).isEmpty());
         assertEquals("testPrefix", attributes.get("llm.testPrefix"));
         assertEquals("conversation-id-value", attributes.get("llm.conversation_id"));
-        assertEquals(13, attributes.get("token_count"));
+
+        if (attributes.containsKey("token_count")) {
+            Object tokenCount = attributes.get("token_count");
+            assertTrue("token_count should be 0 or 13, was: " + tokenCount, tokenCount.equals(0) || tokenCount.equals(13));
+        }
     }
 
     public static void assertErrorEvent(boolean isError, Collection<ErrorEvent> errorEvents) {

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/TestUtil.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/TestUtil.java
@@ -92,11 +92,9 @@ public class TestUtil {
         assertFalse(((String) attributes.get("request_id")).isEmpty());
         assertEquals("testPrefix", attributes.get("llm.testPrefix"));
         assertEquals("conversation-id-value", attributes.get("llm.conversation_id"));
-
-        if (attributes.containsKey("token_count")) {
-            Object tokenCount = attributes.get("token_count");
-            assertTrue("token_count should be 0 or 13, was: " + tokenCount, tokenCount.equals(0) || tokenCount.equals(13));
-        }
+        assertFalse("LlmEmbedding must not have token_count attribute", attributes.containsKey("token_count"));
+        assertFalse("LlmEmbedding must not have response.usage.prompt_tokens attribute", attributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse("LlmEmbedding must not have response.usage.completion_tokens attribute", attributes.containsKey("response.usage.completion_tokens"));
     }
 
     public static void assertErrorEvent(boolean isError, Collection<ErrorEvent> errorEvents) {

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/ai21labs/jurassic/JurassicModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/ai21labs/jurassic/JurassicModelInvocationTest.java
@@ -34,6 +34,7 @@ import static llm.models.TestUtil.assertErrorEvent;
 import static llm.models.TestUtil.assertLlmChatCompletionMessageAttributes;
 import static llm.models.TestUtil.assertLlmChatCompletionSummaryAttributes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,12 +47,32 @@ public class JurassicModelInvocationTest {
     // Completion
     private final String completionModelId = "ai21.j2-mid-v1";
     private final String completionRequestBody = "{\"temperature\":0.5,\"maxTokens\":1000,\"prompt\":\"What is the color of the sky?\"}";
-    private final String completionResponseBody =
-            "{\"id\":1234,\"prompt\":{\"text\":\"What is the color of the sky?\",\"tokens\":[{\"generatedToken\":{\"token\":\"▁What▁is▁the\",\"logprob\":-9.992481231689453,\"raw_logprob\":-9.992481231689453}\n" +
-                    ",\"topTokens\":null,\"textRange\":{\"start\":0,\"end\":11}}]},\"completions\":[{\"data\":{\"text\":\"\\nThe color of the sky is blue.\",\"tokens\":[{\"generatedToken\":{\"token\":\"<|newline|>\",\"logprob\":0.0,\"raw_logprob\":-1.389883691444993E-4},\"topTokens\":null,\"textRange\":{\"start\":0,\"end\":1}}]},\"finishReason\":{\"reason\":\"endoftext\"}}]}";
     private final String completionRequestInput = "What is the color of the sky?";
     private final String completionResponseContent = "\nThe color of the sky is blue.";
     private final String finishReason = "endoftext";
+
+    // Completion with token arrays for testing usage extraction
+    private final String completionResponseBodyWithTokens =
+            "{\"id\":1234,\"prompt\":{\"text\":\"What is the color of the sky?\",\"tokens\":[" +
+                    "{\"generatedToken\":{\"token\":\"▁What\"},\"textRange\":{\"start\":0,\"end\":5}}," +
+                    "{\"generatedToken\":{\"token\":\"▁is\"},\"textRange\":{\"start\":5,\"end\":8}}," +
+                    "{\"generatedToken\":{\"token\":\"▁the\"},\"textRange\":{\"start\":8,\"end\":12}}," +
+                    "{\"generatedToken\":{\"token\":\"▁color\"},\"textRange\":{\"start\":12,\"end\":18}}" +
+                    "]},\"completions\":[{\"data\":{\"text\":\"\\nThe color of the sky is blue.\",\"tokens\":[" +
+                    "{\"generatedToken\":{\"token\":\"<|newline|>\"},\"textRange\":{\"start\":0,\"end\":1}}," +
+                    "{\"generatedToken\":{\"token\":\"▁The\"},\"textRange\":{\"start\":1,\"end\":5}}," +
+                    "{\"generatedToken\":{\"token\":\"▁color\"},\"textRange\":{\"start\":5,\"end\":11}}," +
+                    "{\"generatedToken\":{\"token\":\"▁of\"},\"textRange\":{\"start\":11,\"end\":14}}," +
+                    "{\"generatedToken\":{\"token\":\"▁the\"},\"textRange\":{\"start\":14,\"end\":18}}," +
+                    "{\"generatedToken\":{\"token\":\"▁sky\"},\"textRange\":{\"start\":18,\"end\":22}}," +
+                    "{\"generatedToken\":{\"token\":\"▁is\"},\"textRange\":{\"start\":22,\"end\":25}}," +
+                    "{\"generatedToken\":{\"token\":\"▁blue\"},\"textRange\":{\"start\":25,\"end\":30}}," +
+                    "{\"generatedToken\":{\"token\":\".\"},\"textRange\":{\"start\":30,\"end\":31}}" +
+                    "]},\"finishReason\":{\"reason\":\"endoftext\"}}]}";
+
+    // Completion with missing token arrays (incomplete usage data)
+    private final String completionResponseBodyWithoutTokens =
+            "{\"id\":1234,\"prompt\":{\"text\":\"What is the color of the sky?\"},\"completions\":[{\"data\":{\"text\":\"\\nThe color of the sky is blue.\"},\"finishReason\":{\"reason\":\"endoftext\"}}]}";
 
     @Before
     public void before() {
@@ -64,8 +85,8 @@ public class JurassicModelInvocationTest {
     public void testCompletion() {
         boolean isError = false;
 
-        JurassicModelInvocation jurassicModelInvocation = mockJurassicModelInvocation(completionModelId, completionRequestBody, completionResponseBody,
-                isError);
+        JurassicModelInvocation jurassicModelInvocation = mockJurassicModelInvocation(completionModelId, completionRequestBody,
+                completionResponseBodyWithoutTokens, isError);
         jurassicModelInvocation.recordLlmEvents(System.currentTimeMillis());
 
         Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
@@ -93,8 +114,8 @@ public class JurassicModelInvocationTest {
     public void testCompletionError() {
         boolean isError = true;
 
-        JurassicModelInvocation jurassicModelInvocation = mockJurassicModelInvocation(completionModelId, completionRequestBody, completionResponseBody,
-                isError);
+        JurassicModelInvocation jurassicModelInvocation = mockJurassicModelInvocation(completionModelId, completionRequestBody,
+                completionResponseBodyWithoutTokens, isError);
         jurassicModelInvocation.recordLlmEvents(System.currentTimeMillis());
 
         Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
@@ -116,6 +137,78 @@ public class JurassicModelInvocationTest {
         assertLlmChatCompletionSummaryAttributes(llmChatCompletionSummaryEvent, completionModelId, finishReason);
 
         assertErrorEvent(isError, introspector.getErrorEvents());
+    }
+
+    @Test
+    public void testCompletionWithCompleteUsageData() {
+
+        boolean isError = false;
+
+        JurassicModelInvocation jurassicModelInvocation = mockJurassicModelInvocation(completionModelId, completionRequestBody,
+                completionResponseBodyWithTokens, isError);
+        jurassicModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(0, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertEquals(4, summaryAttributes.get("response.usage.prompt_tokens"));
+        assertEquals(9, summaryAttributes.get("response.usage.completion_tokens"));
+        assertEquals(13, summaryAttributes.get("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithIncompleteUsageData() {
+        boolean isError = false;
+
+        JurassicModelInvocation jurassicModelInvocation = mockJurassicModelInvocation(completionModelId, completionRequestBody,
+                completionResponseBodyWithoutTokens, isError);
+        jurassicModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(13, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertFalse(summaryAttributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.completion_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithNoCallback() {
+        boolean isError = false;
+
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(null);
+
+        JurassicModelInvocation jurassicModelInvocation = mockJurassicModelInvocation(completionModelId, completionRequestBody,
+                completionResponseBodyWithoutTokens, isError);
+        jurassicModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertFalse(attributes.containsKey("token_count"));
+        }
     }
 
     private JurassicModelInvocation mockJurassicModelInvocation(String modelId, String requestBody, String responseBody, boolean isError) {

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/ai21labs/jurassic/JurassicModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/ai21labs/jurassic/JurassicModelInvocationTest.java
@@ -51,7 +51,7 @@ public class JurassicModelInvocationTest {
     private final String completionResponseContent = "\nThe color of the sky is blue.";
     private final String finishReason = "endoftext";
 
-    // Completion with token arrays for testing usage extraction
+    // Completion with token arrays (complete usage data))
     private final String completionResponseBodyWithTokens =
             "{\"id\":1234,\"prompt\":{\"text\":\"What is the color of the sky?\",\"tokens\":[" +
                     "{\"generatedToken\":{\"token\":\"▁What\"},\"textRange\":{\"start\":0,\"end\":5}}," +

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/amazon/titan/TitanModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/amazon/titan/TitanModelInvocationTest.java
@@ -36,6 +36,7 @@ import static llm.models.TestUtil.assertLlmChatCompletionMessageAttributes;
 import static llm.models.TestUtil.assertLlmChatCompletionSummaryAttributes;
 import static llm.models.TestUtil.assertLlmEmbeddingAttributes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,10 +55,15 @@ public class TitanModelInvocationTest {
     // Completion
     private final String completionModelId = "amazon.titan-text-lite-v1";
     private final String completionRequestBody = "{\"inputText\":\"What is the color of the sky?\",\"textGenerationConfig\":{\"maxTokenCount\":1000,\"stopSequences\":[\"User:\"],\"temperature\":0.5,\"topP\":0.9}}";
-    private final String completionResponseBody = "{\"inputTextTokenCount\":8,\"results\":[{\"tokenCount\":9,\"outputText\":\"\\nThe color of the sky is blue.\",\"completionReason\":\"FINISH\"}]}";
     private final String completionRequestInput = "What is the color of the sky?";
     private final String completionResponseContent = "\nThe color of the sky is blue.";
     private final String finishReason = "FINISH";
+
+    // Completion with token data (complete usage data)
+    private final String completionResponseBodyWithTokens = "{\"inputTextTokenCount\":8,\"results\":[{\"tokenCount\":9,\"outputText\":\"\\nThe color of the sky is blue.\",\"completionReason\":\"FINISH\"}]}";
+
+    // Completion without token data (incomplete usage data)
+    private final String completionResponseBodyWithoutTokens = "{\"results\":[{\"outputText\":\"\\nThe color of the sky is blue.\",\"completionReason\":\"FINISH\"}]}";
 
     @Before
     public void before() {
@@ -87,7 +93,7 @@ public class TitanModelInvocationTest {
     public void testCompletion() {
         boolean isError = false;
 
-        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(completionModelId, completionRequestBody, completionResponseBody, isError);
+        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
         titanModelInvocation.recordLlmEvents(System.currentTimeMillis());
 
         Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
@@ -132,7 +138,7 @@ public class TitanModelInvocationTest {
     public void testCompletionError() {
         boolean isError = true;
 
-        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(completionModelId, completionRequestBody, completionResponseBody, isError);
+        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
         titanModelInvocation.recordLlmEvents(System.currentTimeMillis());
 
         Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
@@ -201,4 +207,73 @@ public class TitanModelInvocationTest {
         return new TitanModelInvocation(linkingMetadata, userAttributes, mockInvokeModelRequest,
                 mockInvokeModelResponse);
     }
+
+    @Test
+    public void testCompletionWithCompleteUsageData() {
+        boolean isError = false;
+
+        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithTokens, isError);
+        titanModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(0, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertEquals(8, summaryAttributes.get("response.usage.prompt_tokens"));
+        assertEquals(9, summaryAttributes.get("response.usage.completion_tokens"));
+        assertEquals(17, summaryAttributes.get("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithIncompleteUsageData() {
+        boolean isError = false;
+
+        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
+        titanModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(13, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertFalse(summaryAttributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.completion_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithNoCallback() {
+        boolean isError = false;
+
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(null);
+
+        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
+        titanModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertFalse(attributes.containsKey("token_count"));
+        }
+    }
+
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/amazon/titan/TitanModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/amazon/titan/TitanModelInvocationTest.java
@@ -50,6 +50,7 @@ public class TitanModelInvocationTest {
     private final String embeddingModelId = "amazon.titan-embed-text-v1";
     private final String embeddingRequestBody = "{\"inputText\":\"What is the color of the sky?\"}";
     private final String embeddingResponseBody = "{\"embedding\":[0.328125,0.44335938],\"inputTextTokenCount\":8}";
+    private final String embeddingResponseBodyWithoutTokens = "{\"embedding\":[0.328125,0.44335938]}";
     private final String embeddingRequestInput = "What is the color of the sky?";
 
     // Completion
@@ -256,6 +257,42 @@ public class TitanModelInvocationTest {
         assertFalse(summaryAttributes.containsKey("response.usage.prompt_tokens"));
         assertFalse(summaryAttributes.containsKey("response.usage.completion_tokens"));
         assertFalse(summaryAttributes.containsKey("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testEmbeddingWithTotalTokens() {
+        boolean isError = false;
+
+        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(embeddingModelId, embeddingRequestBody, embeddingResponseBody, isError);
+        titanModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmEmbeddingEvents = introspector.getCustomEvents(LLM_EMBEDDING);
+        assertEquals(1, llmEmbeddingEvents.size());
+        Event llmEmbeddingEvent = llmEmbeddingEvents.iterator().next();
+        Map<String, Object> attributes = llmEmbeddingEvent.getAttributes();
+
+        assertEquals(8, attributes.get("response.usage.total_tokens"));
+        assertFalse(attributes.containsKey("token_count"));
+        assertFalse(attributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(attributes.containsKey("response.usage.completion_tokens"));
+    }
+
+    @Test
+    public void testEmbeddingWithoutTotalTokens() {
+        boolean isError = false;
+
+        TitanModelInvocation titanModelInvocation = mockTitanModelInvocation(embeddingModelId, embeddingRequestBody, embeddingResponseBodyWithoutTokens, isError);
+        titanModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmEmbeddingEvents = introspector.getCustomEvents(LLM_EMBEDDING);
+        assertEquals(1, llmEmbeddingEvents.size());
+        Event llmEmbeddingEvent = llmEmbeddingEvents.iterator().next();
+        Map<String, Object> attributes = llmEmbeddingEvent.getAttributes();
+
+        assertFalse(attributes.containsKey("token_count"));
+        assertFalse(attributes.containsKey("response.usage.total_tokens"));
+        assertFalse(attributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(attributes.containsKey("response.usage.completion_tokens"));
     }
 
     @Test

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/anthropic/claude/ClaudeModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/anthropic/claude/ClaudeModelInvocationTest.java
@@ -34,6 +34,7 @@ import static llm.models.TestUtil.assertErrorEvent;
 import static llm.models.TestUtil.assertLlmChatCompletionMessageAttributes;
 import static llm.models.TestUtil.assertLlmChatCompletionSummaryAttributes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -114,6 +115,49 @@ public class ClaudeModelInvocationTest {
         assertLlmChatCompletionSummaryAttributes(llmChatCompletionSummaryEvent, completionModelId, finishReason);
 
         assertErrorEvent(isError, introspector.getErrorEvents());
+    }
+
+    @Test
+    public void testCompletionWithIncompleteUsageData() {
+        boolean isError = false;
+
+        ClaudeModelInvocation claudeModelInvocation = mockClaudeModelInvocation(completionModelId, completionRequestBody, completionResponseBody, isError);
+        claudeModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(13, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertFalse(summaryAttributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.completion_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithNoCallback() {
+        boolean isError = false;
+
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(null);
+
+        ClaudeModelInvocation claudeModelInvocation = mockClaudeModelInvocation(completionModelId, completionRequestBody, completionResponseBody, isError);
+        claudeModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertFalse(attributes.containsKey("token_count"));
+        }
     }
 
     private ClaudeModelInvocation mockClaudeModelInvocation(String modelId, String requestBody, String responseBody, boolean isError) {

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/cohere/command/CommandModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/cohere/command/CommandModelInvocationTest.java
@@ -113,6 +113,24 @@ public class CommandModelInvocationTest {
     }
 
     @Test
+    public void testEmbeddingTokenAttributes() {
+        boolean isError = false;
+
+        CommandModelInvocation commandModelInvocation = mockCommandModelInvocation(embeddingModelId, embeddingRequestBody, embeddingResponseBody, isError);
+        commandModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmEmbeddingEvents = introspector.getCustomEvents(LLM_EMBEDDING);
+        assertEquals(1, llmEmbeddingEvents.size());
+        Event llmEmbeddingEvent = llmEmbeddingEvents.iterator().next();
+        Map<String, Object> attributes = llmEmbeddingEvent.getAttributes();
+
+        assertFalse(attributes.containsKey("token_count"));
+        assertFalse(attributes.containsKey("response.usage.total_tokens"));
+        assertFalse(attributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(attributes.containsKey("response.usage.completion_tokens"));
+    }
+
+    @Test
     public void testEmbeddingError() {
         boolean isError = true;
 

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/cohere/command/CommandModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/cohere/command/CommandModelInvocationTest.java
@@ -36,6 +36,7 @@ import static llm.models.TestUtil.assertLlmChatCompletionMessageAttributes;
 import static llm.models.TestUtil.assertLlmChatCompletionSummaryAttributes;
 import static llm.models.TestUtil.assertLlmEmbeddingAttributes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -154,6 +155,49 @@ public class CommandModelInvocationTest {
         assertLlmChatCompletionSummaryAttributes(llmChatCompletionSummaryEvent, completionModelId, finishReason);
 
         assertErrorEvent(isError, introspector.getErrorEvents());
+    }
+
+    @Test
+    public void testCompletionWithIncompleteUsageData() {
+        boolean isError = false;
+
+        CommandModelInvocation commandModelInvocation = mockCommandModelInvocation(completionModelId, completionRequestBody, completionResponseBody, isError);
+        commandModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(13, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertFalse(summaryAttributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.completion_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithNoCallback() {
+        boolean isError = false;
+
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(null);
+
+        CommandModelInvocation commandModelInvocation = mockCommandModelInvocation(completionModelId, completionRequestBody, completionResponseBody, isError);
+        commandModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertFalse(attributes.containsKey("token_count"));
+        }
     }
 
     private CommandModelInvocation mockCommandModelInvocation(String modelId, String requestBody, String responseBody, boolean isError) {

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/meta/llama2/Llama2ModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/meta/llama2/Llama2ModelInvocationTest.java
@@ -34,6 +34,7 @@ import static llm.models.TestUtil.assertErrorEvent;
 import static llm.models.TestUtil.assertLlmChatCompletionMessageAttributes;
 import static llm.models.TestUtil.assertLlmChatCompletionSummaryAttributes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,10 +47,15 @@ public class Llama2ModelInvocationTest {
     // Completion
     private final String completionModelId = "meta.llama2-13b-chat-v1";
     private final String completionRequestBody = "{\"top_p\":0.9,\"max_gen_len\":1000,\"temperature\":0.5,\"prompt\":\"What is the color of the sky?\"}";
-    private final String completionResponseBody = "{\"generation\":\"\\n\\nThe color of the sky is blue.\",\"prompt_token_count\":9,\"generation_token_count\":306,\"stop_reason\":\"stop\"}";
     private final String completionRequestInput = "What is the color of the sky?";
     private final String completionResponseContent = "\n\nThe color of the sky is blue.";
     private final String finishReason = "stop";
+
+    // Completion with token data (complete usage data)
+    private final String completionResponseBodyWithTokens = "{\"generation\":\"\\n\\nThe color of the sky is blue.\",\"prompt_token_count\":9,\"generation_token_count\":306,\"stop_reason\":\"stop\"}";
+
+    // Completion without token data (incomplete usage data)
+    private final String completionResponseBodyWithoutTokens = "{\"generation\":\"\\n\\nThe color of the sky is blue.\",\"stop_reason\":\"stop\"}";
 
     @Before
     public void before() {
@@ -62,8 +68,7 @@ public class Llama2ModelInvocationTest {
     public void testCompletion() {
         boolean isError = false;
 
-        Llama2ModelInvocation llama2ModelInvocation = mockLlama2ModelInvocation(completionModelId, completionRequestBody, completionResponseBody,
-                isError);
+        Llama2ModelInvocation llama2ModelInvocation = mockLlama2ModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
         llama2ModelInvocation.recordLlmEvents(System.currentTimeMillis());
 
         Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
@@ -91,8 +96,7 @@ public class Llama2ModelInvocationTest {
     public void testCompletionError() {
         boolean isError = true;
 
-        Llama2ModelInvocation llama2ModelInvocation = mockLlama2ModelInvocation(completionModelId, completionRequestBody, completionResponseBody,
-                isError);
+        Llama2ModelInvocation llama2ModelInvocation = mockLlama2ModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
         llama2ModelInvocation.recordLlmEvents(System.currentTimeMillis());
 
         Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
@@ -161,4 +165,74 @@ public class Llama2ModelInvocationTest {
         return new Llama2ModelInvocation(linkingMetadata, userAttributes, mockInvokeModelRequest,
                 mockInvokeModelResponse);
     }
+
+    @Test
+    public void testCompletionWithCompleteUsageData() {
+
+        boolean isError = false;
+
+        Llama2ModelInvocation llama2ModelInvocation = mockLlama2ModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithTokens, isError);
+        llama2ModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(0, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertEquals(9, summaryAttributes.get("response.usage.prompt_tokens"));
+        assertEquals(306, summaryAttributes.get("response.usage.completion_tokens"));
+        assertEquals(315, summaryAttributes.get("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithIncompleteUsageData() {
+        boolean isError = false;
+
+        Llama2ModelInvocation llama2ModelInvocation = mockLlama2ModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
+        llama2ModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertEquals(13, attributes.get("token_count"));
+        }
+
+        Collection<Event> llmChatCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmChatCompletionSummaryEvents.size());
+        Event summaryEvent = llmChatCompletionSummaryEvents.iterator().next();
+        Map<String, Object> summaryAttributes = summaryEvent.getAttributes();
+
+        assertFalse(summaryAttributes.containsKey("response.usage.prompt_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.completion_tokens"));
+        assertFalse(summaryAttributes.containsKey("response.usage.total_tokens"));
+    }
+
+    @Test
+    public void testCompletionWithNoCallback() {
+        boolean isError = false;
+
+        LlmTokenCountCallbackHolder.setLlmTokenCountCallback(null);
+
+        Llama2ModelInvocation llama2ModelInvocation = mockLlama2ModelInvocation(completionModelId, completionRequestBody, completionResponseBodyWithoutTokens, isError);
+        llama2ModelInvocation.recordLlmEvents(System.currentTimeMillis());
+
+        Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
+        assertEquals(2, llmChatCompletionMessageEvents.size());
+
+        for (Event messageEvent : llmChatCompletionMessageEvents) {
+            Map<String, Object> attributes = messageEvent.getAttributes();
+            assertFalse(attributes.containsKey("token_count"));
+        }
+    }
+
 }

--- a/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/meta/llama2/Llama2ModelInvocationTest.java
+++ b/instrumentation/aws-bedrock-runtime-2.20/src/test/java/llm/models/meta/llama2/Llama2ModelInvocationTest.java
@@ -120,52 +120,6 @@ public class Llama2ModelInvocationTest {
         assertErrorEvent(isError, introspector.getErrorEvents());
     }
 
-    private Llama2ModelInvocation mockLlama2ModelInvocation(String modelId, String requestBody, String responseBody, boolean isError) {
-        // Given
-        Map<String, String> linkingMetadata = new HashMap<>();
-        linkingMetadata.put("span.id", "span-id-123");
-        linkingMetadata.put("trace.id", "trace-id-xyz");
-
-        Map<String, Object> userAttributes = new HashMap<>();
-        userAttributes.put("llm.conversation_id", "conversation-id-value");
-        userAttributes.put("llm.testPrefix", "testPrefix");
-        userAttributes.put("test", "test");
-
-        // Mock out ModelRequest
-        InvokeModelRequest mockInvokeModelRequest = mock(InvokeModelRequest.class);
-        SdkBytes mockRequestSdkBytes = mock(SdkBytes.class);
-        when(mockInvokeModelRequest.body()).thenReturn(mockRequestSdkBytes);
-        when(mockRequestSdkBytes.asUtf8String()).thenReturn(requestBody);
-        when(mockInvokeModelRequest.modelId()).thenReturn(modelId);
-
-        // Mock out ModelResponse
-        InvokeModelResponse mockInvokeModelResponse = mock(InvokeModelResponse.class);
-        SdkBytes mockResponseSdkBytes = mock(SdkBytes.class);
-        when(mockInvokeModelResponse.body()).thenReturn(mockResponseSdkBytes);
-        when(mockResponseSdkBytes.asUtf8String()).thenReturn(responseBody);
-
-        SdkHttpResponse mockSdkHttpResponse = mock(SdkHttpResponse.class);
-        when(mockInvokeModelResponse.sdkHttpResponse()).thenReturn(mockSdkHttpResponse);
-
-        if (isError) {
-            when(mockSdkHttpResponse.statusCode()).thenReturn(400);
-            when(mockSdkHttpResponse.statusText()).thenReturn(Optional.of("BAD_REQUEST"));
-            when(mockSdkHttpResponse.isSuccessful()).thenReturn(false);
-        } else {
-            when(mockSdkHttpResponse.statusCode()).thenReturn(200);
-            when(mockSdkHttpResponse.statusText()).thenReturn(Optional.of("OK"));
-            when(mockSdkHttpResponse.isSuccessful()).thenReturn(true);
-        }
-
-        BedrockRuntimeResponseMetadata mockBedrockRuntimeResponseMetadata = mock(BedrockRuntimeResponseMetadata.class);
-        when(mockInvokeModelResponse.responseMetadata()).thenReturn(mockBedrockRuntimeResponseMetadata);
-        when(mockBedrockRuntimeResponseMetadata.requestId()).thenReturn("90a22e92-db1d-4474-97a9-28b143846301");
-
-        // Instantiate ModelInvocation
-        return new Llama2ModelInvocation(linkingMetadata, userAttributes, mockInvokeModelRequest,
-                mockInvokeModelResponse);
-    }
-
     @Test
     public void testCompletionWithCompleteUsageData() {
 
@@ -233,6 +187,52 @@ public class Llama2ModelInvocationTest {
             Map<String, Object> attributes = messageEvent.getAttributes();
             assertFalse(attributes.containsKey("token_count"));
         }
+    }
+
+    private Llama2ModelInvocation mockLlama2ModelInvocation(String modelId, String requestBody, String responseBody, boolean isError) {
+        // Given
+        Map<String, String> linkingMetadata = new HashMap<>();
+        linkingMetadata.put("span.id", "span-id-123");
+        linkingMetadata.put("trace.id", "trace-id-xyz");
+
+        Map<String, Object> userAttributes = new HashMap<>();
+        userAttributes.put("llm.conversation_id", "conversation-id-value");
+        userAttributes.put("llm.testPrefix", "testPrefix");
+        userAttributes.put("test", "test");
+
+        // Mock out ModelRequest
+        InvokeModelRequest mockInvokeModelRequest = mock(InvokeModelRequest.class);
+        SdkBytes mockRequestSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelRequest.body()).thenReturn(mockRequestSdkBytes);
+        when(mockRequestSdkBytes.asUtf8String()).thenReturn(requestBody);
+        when(mockInvokeModelRequest.modelId()).thenReturn(modelId);
+
+        // Mock out ModelResponse
+        InvokeModelResponse mockInvokeModelResponse = mock(InvokeModelResponse.class);
+        SdkBytes mockResponseSdkBytes = mock(SdkBytes.class);
+        when(mockInvokeModelResponse.body()).thenReturn(mockResponseSdkBytes);
+        when(mockResponseSdkBytes.asUtf8String()).thenReturn(responseBody);
+
+        SdkHttpResponse mockSdkHttpResponse = mock(SdkHttpResponse.class);
+        when(mockInvokeModelResponse.sdkHttpResponse()).thenReturn(mockSdkHttpResponse);
+
+        if (isError) {
+            when(mockSdkHttpResponse.statusCode()).thenReturn(400);
+            when(mockSdkHttpResponse.statusText()).thenReturn(Optional.of("BAD_REQUEST"));
+            when(mockSdkHttpResponse.isSuccessful()).thenReturn(false);
+        } else {
+            when(mockSdkHttpResponse.statusCode()).thenReturn(200);
+            when(mockSdkHttpResponse.statusText()).thenReturn(Optional.of("OK"));
+            when(mockSdkHttpResponse.isSuccessful()).thenReturn(true);
+        }
+
+        BedrockRuntimeResponseMetadata mockBedrockRuntimeResponseMetadata = mock(BedrockRuntimeResponseMetadata.class);
+        when(mockInvokeModelResponse.responseMetadata()).thenReturn(mockBedrockRuntimeResponseMetadata);
+        when(mockBedrockRuntimeResponseMetadata.requestId()).thenReturn("90a22e92-db1d-4474-97a9-28b143846301");
+
+        // Instantiate ModelInvocation
+        return new Llama2ModelInvocation(linkingMetadata, userAttributes, mockInvokeModelRequest,
+                mockInvokeModelResponse);
     }
 
 }


### PR DESCRIPTION
Updates the token counting strategy for each of the models. 


Follows the requirements outlined in the [agent spec]([Agent Spec](https://source.datanerd.us/agents/agent-specs/pull/737)). 
Resolves [#2839](https://github.com/newrelic/newrelic-java-agent/issues/2839)
