### PR TITLE
Optionally use display_name for JFR hostname

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
@@ -48,4 +48,13 @@ public interface JfrConfig {
      * @return <code>true</code> is use_license_key is enabled for the JFR service is enabled, else <code>false</code>.
      */
     boolean useLicenseKey();
+
+    /**
+     * If true, the JFR host name will be set to the value in the <code>process_host.display_name</code> config.
+     * Note that if the <code>process_host.display_name</code> value is empty/null, the default hostname
+     * resolution logic will be used.
+     *
+     * @return <code>true</code> if the configured display name should be used for the JFR host name, else <code>false</code>.
+     */
+    boolean useDisplayName();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
@@ -20,8 +20,10 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     public static final String AUDIT_LOGGING = "audit_logging";
     public static final Boolean AUDIT_LOGGING_DEFAULT = Boolean.FALSE;
     public static final Boolean USE_LICENSE_KEY_DEFAULT = Boolean.TRUE;
+    public static final Boolean USE_DISPLAY_NAME_DEFAULT = Boolean.FALSE;
     public static final String HARVEST_INTERVAL = "harvest_interval";   //In seconds
     public static final String QUEUE_SIZE = "queue_size";
+    public static final String USE_DISPLAY_NAME = "use_display_name";
 
     private boolean isEnabled;
     private final Integer harvestInterval;
@@ -69,5 +71,10 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     @Override
     public boolean useLicenseKey() {
         return USE_LICENSE_KEY_DEFAULT;
+    }
+
+    @Override
+    public boolean useDisplayName() {
+        return getProperty(USE_DISPLAY_NAME, USE_DISPLAY_NAME_DEFAULT);
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -131,8 +131,8 @@ public class JfrService extends AbstractService implements AgentConfigListener {
     }
 
     /**
-     * This will return the configured "process_host.display_name" config property if set; otherwise
-     * it will utilize the standard hostname resolution logic.
+     * This will return the configured "process_host.display_name" config property if
+     * jfr.use_display_name is true; otherwise it will utilize the standard hostname resolution logic.
      *
      * @return the configured display name String or host name from the environment
      */

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -13,6 +13,7 @@ import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.AgentConfigListener;
+import com.newrelic.agent.config.Hostname;
 import com.newrelic.agent.config.JfrConfig;
 import com.newrelic.agent.service.AbstractService;
 import com.newrelic.agent.service.ServiceFactory;
@@ -63,7 +64,7 @@ public class JfrService extends AbstractService implements AgentConfigListener {
                 final String entityGuid = ServiceFactory.getRPMService().getEntityGuid();
                 Agent.LOG.log(Level.INFO, "JFR Monitor obtained entity guid from agent: " + entityGuid);
                 commonAttrs.put(ENTITY_GUID, entityGuid);
-                final String hostname = getHostname();
+                final String hostname = getJfrHostnameOrDisplayName();
                 commonAttrs.put(HOSTNAME, hostname);
                 final JFRUploader uploader = buildUploader(daemonConfig);
                 String pattern = defaultAgentConfig.getValue(ThreadService.NAME_PATTERN_CFG_KEY, ThreadNameNormalizer.DEFAULT_PATTERN);
@@ -129,7 +130,21 @@ public class JfrService extends AbstractService implements AgentConfigListener {
         return true;
     }
 
-    private String getHostname() {
+    /**
+     * This will return the configured "process_host.display_name" config property if set; otherwise
+     * it will utilize the standard hostname resolution logic.
+     *
+     * @return the configured display name String or host name from the environment
+     */
+    @VisibleForTesting
+    String getJfrHostnameOrDisplayName() {
+        String hostnameFromEnvironment = getHostname();
+        return jfrConfig.useDisplayName() ?
+                Hostname.getDisplayHostname(defaultAgentConfig, hostnameFromEnvironment) : hostnameFromEnvironment;
+    }
+
+    @VisibleForTesting
+    String getHostname() {
         String host;
         Integer appPort = ServiceFactory
             .getEnvironmentService()

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -531,6 +531,11 @@ common: &default_settings
     # Default is 250000
     queue_size: 250000
 
+    # If true, the JFR host name will be set to the value in the process_host.display_name config.
+    # Note that if the process_host.display_name value is empty/null, the default hostname
+    # resolution logic will be used. Default is false.
+    use_display_name: false
+
   # User-configurable custom labels for this agent.  Labels are name-value pairs.
   # There is a maximum of 64 labels per agent.  Names and values are limited to 255 characters.
   # Names and values may not contain colons (:) or semicolons (;).

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -183,4 +183,50 @@ public class JfrServiceTest {
         spyJfr.configChanged("my-app", newAgentConfig);
         verify(spyJfr).doStop();
     }
+
+    @Test
+    public void getJfrHostnameOrDisplayName_UseDisplayNameFalse_ReturnsDefaultHostname() {
+        when(jfrConfig.useDisplayName()).thenReturn(false);
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        when(spyJfr.getHostname()).thenReturn("test-hostname:8080");
+
+        String result = spyJfr.getJfrHostnameOrDisplayName();
+        assertEquals("test-hostname:8080", result);
+        verify(spyJfr).getHostname();
+    }
+
+    @Test
+    public void getJfrHostnameOrDisplayName_UseDisplayNameTrue_WithDisplayNameSet_ReturnsDisplayName() {
+        when(jfrConfig.useDisplayName()).thenReturn(true);
+        when(agentConfig.getValue("process_host.display_name", "test-hostname:8080"))
+                .thenReturn("my-custom-display-name");
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        when(spyJfr.getHostname()).thenReturn("test-hostname:8080");
+
+        String result = spyJfr.getJfrHostnameOrDisplayName();
+        assertEquals("my-custom-display-name", result);
+    }
+
+    @Test
+    public void getJfrHostnameOrDisplayName_UseDisplayNameTrue_WithDisplayNameEmpty_ReturnsDefaultHostname() {
+        when(jfrConfig.useDisplayName()).thenReturn(true);
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        String defaultHostname = "test-hostname:8080";
+        when(spyJfr.getHostname()).thenReturn(defaultHostname);
+
+        when(agentConfig.getValue("process_host.display_name", defaultHostname))
+                .thenReturn(defaultHostname);
+
+        String result = spyJfr.getJfrHostnameOrDisplayName();
+        assertEquals(defaultHostname, result);
+    }
 }


### PR DESCRIPTION
Resolves #2825 

This adds a new JFR specific config `jfr.use_display_name`. If set to `true`, the agent will set the JFR host name to the value in the `process_host.display_name` configuration. The default is `false` to preserve old behavior.

If `jfr.use_display_name` is `true` but the `display_name` config is empty, the JfrService will fallback to the old behavior for the host name.

yml config:
```
common: &default_settings
  jfr:
    use_display_name: true
```

System property:
`newrelic.config.jfr.use_display_name=true`

Environment variable:
`NEW_RELIC_JFR_USE_DISPLAY_NAME=true`