### PR TITLE
When PointCut tracers were created via CompletableFutures, they were …

### DIFF
--- a/instrumentation/java.completable-future-jdk11/src/main/java/util/TokenAwareRunnable.java
+++ b/instrumentation/java.completable-future-jdk11/src/main/java/util/TokenAwareRunnable.java
@@ -2,6 +2,7 @@ package util;
 
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.api.agent.Trace;
 
 import static util.TokenAndRefUtils.*;
 
@@ -20,6 +21,7 @@ public final class TokenAwareRunnable implements Runnable {
     }
 
     @Override
+    @Trace(async=true)
     public void run() {
         try {
             if (delegate != null) {

--- a/instrumentation/java.completable-future-jdk8u40/src/main/java/util/TokenAwareRunnable.java
+++ b/instrumentation/java.completable-future-jdk8u40/src/main/java/util/TokenAwareRunnable.java
@@ -2,6 +2,7 @@ package util;
 
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.api.agent.Trace;
 
 import static util.TokenAndRefUtils.*;
 
@@ -20,6 +21,7 @@ public final class TokenAwareRunnable implements Runnable {
     }
 
     @Override
+    @Trace(async=true)
     public void run() {
         try {
             if (delegate != null) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TracerService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TracerService.java
@@ -19,10 +19,12 @@ import com.newrelic.agent.tracers.PointCutInvocationHandler;
 import com.newrelic.agent.tracers.RetryException;
 import com.newrelic.agent.tracers.Tracer;
 import com.newrelic.agent.tracers.TracerFactory;
+import com.newrelic.api.agent.NewRelic;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 public class TracerService extends AbstractService {
     private final Map<String, TracerFactory> tracerFactories = new ConcurrentHashMap<>();
@@ -138,6 +140,10 @@ public class TracerService extends AbstractService {
             }
             if (transaction == null) {
                 return null;
+            }
+            if (TransactionActivity.get() == null) {
+                NewRelic.getAgent().getLogger().log(Level.FINE, "TracerServiceImpl.getTracer called without a TransactionActivity on the thread");
+                TransactionActivity.create(transaction, Integer.MAX_VALUE);
             }
             try {
                 return transaction.getTransactionState().getTracer(transaction, tracerFactory, signature, object, args);


### PR DESCRIPTION
…not getting their own TransactionActivity, and instead used their parent's.  So, if 2 did that and finished in the "wrong" order, we would get Inconsistent State errors.  If there were more than a couple of threads in that situation, it could cause the transaction to be reported up multiple times, every time a new thread finished.  And any of that could cause Negative and/or Absurd Values to be reported.

Resolves: https://github.com/newrelic/newrelic-java-agent/issues/2844

