### PR TITLE
Resolution of Mule 4.9 IllegalAccessError issue

### DIFF
--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/JpmsModuleHelper.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/JpmsModuleHelper.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.weave.weavepackage;
+
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class JpmsModuleHelper {
+
+    private static final Method GET_MODULE;
+    private static final Method IS_NAMED;
+    private static final Method GET_ALL_LOADED;
+    private static final Method GET_UNNAMED;
+    private static final Method REDEFINE_MODULE;
+
+    private static final AtomicBoolean mulePatched = new AtomicBoolean();
+
+    static {
+        Method getModule = null, isNamed = null, getAllLoaded = null,
+               getUnnamed = null, redefineModule = null;
+        try {
+            Class<?> modCls = Class.forName("java.lang.Module");
+            getModule = Class.class.getMethod("getModule");
+            isNamed = modCls.getMethod("isNamed");
+            getAllLoaded = Instrumentation.class.getMethod("getAllLoadedClasses");
+            getUnnamed = ClassLoader.class.getMethod("getUnnamedModule");
+            redefineModule = Instrumentation.class.getMethod("redefineModule",
+                    modCls, Set.class, Map.class, Map.class, Set.class, Map.class);
+        } catch (Throwable ignored) {
+            // Java 8: leave null
+        }
+
+        GET_MODULE = getModule;
+        IS_NAMED = isNamed;
+        GET_ALL_LOADED = getAllLoaded;
+        GET_UNNAMED = getUnnamed;
+        REDEFINE_MODULE = redefineModule;
+    }
+
+    /**
+     * Triggers a one-shot Mule module patch on the first {@code org/mule/runtime/} class.
+     * No-op on Java 8, for non-Mule classes, and after the first call.
+     */
+    static void addReadsToUnnamedModule(Instrumentation inst, String className, ClassLoader cl) {
+        if (GET_MODULE == null || inst == null || cl == null || className == null) return;
+        if (!className.startsWith("org/mule/runtime/")) return;
+        if (!mulePatched.compareAndSet(false, true)) return;
+        try {
+            patchMuleModules(unwrap(inst), cl);
+        } catch (Throwable ignored) {}
+    }
+
+    // Single-pass scan: adds reads(unnamed + all named modules) to every named org.mule.runtime.* module.
+    private static void patchMuleModules(Instrumentation inst, ClassLoader cl) throws Exception {
+        Object unnamed = GET_UNNAMED.invoke(cl);
+        Set<Object> reads = new HashSet<>(Collections.singleton(unnamed));
+        Set<Object> muleModules = new HashSet<>();
+
+        for (Class<?> cls : loadedClasses(inst)) {
+            Object module = moduleOf(cls);
+            if (!isNamed(module)) continue;
+
+            reads.add(module);
+            if (cls.getName().startsWith("org.mule.runtime.")) {
+                muleModules.add(module);
+            }
+        }
+
+        for (Object module : muleModules) {
+            REDEFINE_MODULE.invoke(inst, module, reads,
+                    Collections.emptyMap(), Collections.emptyMap(),
+                    Collections.emptySet(), Collections.emptyMap());
+        }
+    }
+
+    private static Instrumentation unwrap(Instrumentation inst) {
+        for (Class<?> cls = inst.getClass(); cls != null && cls != Object.class; cls = cls.getSuperclass()) {
+            try {
+                Field field = cls.getDeclaredField("delegate");
+                field.setAccessible(true);
+                Object delegate = field.get(inst);
+                return delegate instanceof Instrumentation ? unwrap((Instrumentation) delegate) : inst;
+            } catch (NoSuchFieldException ignored) {
+            } catch (Throwable t) { break; }
+        }
+        return inst;
+    }
+
+    private static Class<?>[] loadedClasses(Instrumentation inst) throws Exception {
+        return (Class<?>[]) GET_ALL_LOADED.invoke(inst);
+    }
+
+    private static Object moduleOf(Class<?> cls) throws Exception {
+        return GET_MODULE.invoke(cls);
+    }
+
+    private static boolean isNamed(Object module) throws Exception {
+        return (boolean) IS_NAMED.invoke(module);
+    }
+
+    private JpmsModuleHelper() {}
+}

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/JpmsModuleHelper.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/JpmsModuleHelper.java
@@ -61,18 +61,16 @@ class JpmsModuleHelper {
         } catch (Throwable ignored) {}
     }
 
-    // Single-pass scan: adds reads(unnamed + all named modules) to every named org.mule.runtime.* module.
+    // Single-pass scan: grants reads(unnamed) to every named org.mule.runtime.* module.
     private static void patchMuleModules(Instrumentation inst, ClassLoader cl) throws Exception {
         Object unnamed = GET_UNNAMED.invoke(cl);
-        Set<Object> reads = new HashSet<>(Collections.singleton(unnamed));
+        Set<Object> reads = Collections.singleton(unnamed);
         Set<Object> muleModules = new HashSet<>();
 
         for (Class<?> cls : loadedClasses(inst)) {
+            if (!cls.getName().startsWith("org.mule.runtime.")) continue;
             Object module = moduleOf(cls);
-            if (!isNamed(module)) continue;
-
-            reads.add(module);
-            if (cls.getName().startsWith("org.mule.runtime.")) {
+            if (isNamed(module)) {
                 muleModules.add(module);
             }
         }
@@ -85,16 +83,16 @@ class JpmsModuleHelper {
     }
 
     private static Instrumentation unwrap(Instrumentation inst) {
-        for (Class<?> cls = inst.getClass(); cls != null && cls != Object.class; cls = cls.getSuperclass()) {
-            try {
-                Field field = cls.getDeclaredField("delegate");
-                field.setAccessible(true);
-                Object delegate = field.get(inst);
-                return delegate instanceof Instrumentation ? unwrap((Instrumentation) delegate) : inst;
-            } catch (NoSuchFieldException ignored) {
-            } catch (Throwable t) { break; }
+        try {
+            Class<?> delegatingCls = Class.forName("com.newrelic.agent.util.DelegatingInstrumentation");
+            if (!delegatingCls.isInstance(inst)) return inst;
+            Field field = delegatingCls.getDeclaredField("delegate");
+            field.setAccessible(true);
+            Object delegate = field.get(inst);
+            return delegate instanceof Instrumentation ? unwrap((Instrumentation) delegate) : inst;
+        } catch (Throwable t) {
+            return inst;
         }
-        return inst;
     }
 
     private static Class<?>[] loadedClasses(Instrumentation inst) throws Exception {

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/JpmsModuleHelper.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/JpmsModuleHelper.java
@@ -88,8 +88,7 @@ class JpmsModuleHelper {
             if (!delegatingCls.isInstance(inst)) return inst;
             Field field = delegatingCls.getDeclaredField("delegate");
             field.setAccessible(true);
-            Object delegate = field.get(inst);
-            return delegate instanceof Instrumentation ? unwrap((Instrumentation) delegate) : inst;
+            return (Instrumentation) field.get(inst);
         } catch (Throwable t) {
             return inst;
         }

--- a/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageManager.java
+++ b/newrelic-weaver/src/main/java/com/newrelic/weave/weavepackage/WeavePackageManager.java
@@ -540,6 +540,7 @@ public class WeavePackageManager {
                         } else {
                             NewClassAppender.appendClasses(className, superName, interfaceNames, classloader,
                                     verificationResult.computeUtilityClassBytes(cache));
+                            JpmsModuleHelper.addReadsToUnnamedModule(instrumentation, className, classloader);
                         }
                         result.put(weavePackage, verificationResult);
                     } catch (Throwable t) {

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/JpmsModuleHelperTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/JpmsModuleHelperTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarFile;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -82,7 +84,7 @@ public class JpmsModuleHelperTest {
         Instrumentation inst = mock(Instrumentation.class);
         when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
 
-        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Test", getClass().getClassLoader());
 
         verify(inst, times(1)).getAllLoadedClasses();
     }
@@ -94,9 +96,9 @@ public class JpmsModuleHelperTest {
         when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
         ClassLoader cl = getClass().getClassLoader();
 
-        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Foo", cl);
-        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/api/Bar", cl);
-        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Baz", cl);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Test", cl);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/api/Test2", cl);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Test3", cl);
 
         verify(inst, times(1)).getAllLoadedClasses();
     }
@@ -135,7 +137,7 @@ public class JpmsModuleHelperTest {
 
         DelegatingInstrumentation proxy = new DelegatingInstrumentation(real);
 
-        JpmsModuleHelper.addReadsToUnnamedModule(proxy, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+        JpmsModuleHelper.addReadsToUnnamedModule(proxy, "org/mule/runtime/core/Test", getClass().getClassLoader());
 
         verify(real, times(1)).getAllLoadedClasses();
     }
@@ -149,16 +151,38 @@ public class JpmsModuleHelperTest {
         DelegatingInstrumentation proxy1 = new DelegatingInstrumentation(real);
         DelegatingInstrumentation proxy2 = new DelegatingInstrumentation(proxy1);
 
-        JpmsModuleHelper.addReadsToUnnamedModule(proxy2, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+        JpmsModuleHelper.addReadsToUnnamedModule(proxy2, "org/mule/runtime/core/Test", getClass().getClassLoader());
 
         verify(real, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void scanLoopSkipsUnnamedModuleClasses() {
+        requireJpms();
+        Instrumentation inst = mock(Instrumentation.class);
+        when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[]{JpmsModuleHelperTest.class});
+
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Test", getClass().getClassLoader());
+
+        verify(inst, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void scanLoopAddsNamedModulesToReadsSet() {
+        requireJpms();
+        Instrumentation inst = mock(Instrumentation.class);
+        when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[]{String.class});
+
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Test", getClass().getClassLoader());
+
+        verify(inst, times(1)).getAllLoadedClasses();
     }
 
     @Test
     public void mulePatched_falseBeforeFirstCall() throws Exception {
         Field f = JpmsModuleHelper.class.getDeclaredField("mulePatched");
         f.setAccessible(true);
-        assertEquals(false, ((AtomicBoolean) f.get(null)).get());
+        assertFalse(((AtomicBoolean) f.get(null)).get());
     }
 
     @Test
@@ -167,21 +191,21 @@ public class JpmsModuleHelperTest {
         Instrumentation inst = mock(Instrumentation.class);
         when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
 
-        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Test", getClass().getClassLoader());
 
         Field f = JpmsModuleHelper.class.getDeclaredField("mulePatched");
         f.setAccessible(true);
-        assertEquals(true, ((AtomicBoolean) f.get(null)).get());
+        assertTrue(((AtomicBoolean) f.get(null)).get());
     }
 
     @Test
     public void mulePatched_remainsFalseForNonMuleClass() throws Exception {
         Instrumentation inst = mock(Instrumentation.class);
-        JpmsModuleHelper.addReadsToUnnamedModule(inst, "com/example/Foo", getClass().getClassLoader());
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "com/example/Test", getClass().getClassLoader());
 
         Field f = JpmsModuleHelper.class.getDeclaredField("mulePatched");
         f.setAccessible(true);
-        assertEquals(false, ((AtomicBoolean) f.get(null)).get());
+        assertFalse(((AtomicBoolean) f.get(null)).get());
     }
 
     private static class DelegatingInstrumentation implements Instrumentation {

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/JpmsModuleHelperTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/JpmsModuleHelperTest.java
@@ -1,0 +1,211 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.weave.weavepackage;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.jar.JarFile;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class JpmsModuleHelperTest {
+
+    // Skip the test if running on Java 8, where JPMS is unavailable.
+    private static void requireJpms() {
+        Assume.assumeFalse("Requires Java 9+ (JPMS)", "1.8".equals(System.getProperty("java.specification.version")));
+    }
+
+    @After
+    public void resetMulePatched() throws Exception {
+        Field f = JpmsModuleHelper.class.getDeclaredField("mulePatched");
+        f.setAccessible(true);
+        ((AtomicBoolean) f.get(null)).set(false);
+    }
+
+    @Test
+    public void noOpWhenInstrumentationIsNull() {
+        // Must not throw regardless of className/classloader
+        JpmsModuleHelper.addReadsToUnnamedModule(null, "org/mule/runtime/Core", getClass().getClassLoader());
+    }
+
+    @Test
+    public void noOpWhenClassNameIsNull() {
+        Instrumentation inst = mock(Instrumentation.class);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, null, getClass().getClassLoader());
+        verifyNoInteractions(inst);
+    }
+
+    @Test
+    public void noOpWhenClassLoaderIsNull() {
+        Instrumentation inst = mock(Instrumentation.class);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/Core", null);
+        verifyNoInteractions(inst);
+    }
+
+    @Test
+    public void noOpForNonMuleClass() {
+        Instrumentation inst = mock(Instrumentation.class);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "com/example/SomeClass", getClass().getClassLoader());
+        verifyNoInteractions(inst);
+    }
+
+    @Test
+    public void noOpForMule3PackagePrefix() {
+        // org.mule.* (Mule 3.x) must NOT trigger the patch, only org.mule.runtime.*
+        Instrumentation inst = mock(Instrumentation.class);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/api/processor/MessageProcessor", getClass().getClassLoader());
+        verifyNoInteractions(inst);
+    }
+
+    @Test
+    public void muleClassTriggersScan() {
+        requireJpms();
+        Instrumentation inst = mock(Instrumentation.class);
+        when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
+
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+
+        verify(inst, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void bulkPatchRunsOnlyOnce() {
+        requireJpms();
+        Instrumentation inst = mock(Instrumentation.class);
+        when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
+        ClassLoader cl = getClass().getClassLoader();
+
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Foo", cl);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/api/Bar", cl);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Baz", cl);
+
+        verify(inst, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void concurrentMuleCallsOnlyPatchOnce() throws Exception {
+        requireJpms();
+        Instrumentation inst = mock(Instrumentation.class);
+        when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
+        ClassLoader cl = getClass().getClassLoader();
+
+        int threadCount = 20;
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            new Thread(() -> {
+                ready.countDown();
+                try { ready.await(); } catch (InterruptedException ignored) {}
+                JpmsModuleHelper.addReadsToUnnamedModule(inst,
+                        "org/mule/runtime/core/Thread" + idx, cl);
+                done.countDown();
+            }).start();
+        }
+
+        done.await();
+        verify(inst, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void unwrapTraversesDelegateChain() {
+        requireJpms();
+        Instrumentation real = mock(Instrumentation.class);
+        when(real.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
+
+        DelegatingInstrumentation proxy = new DelegatingInstrumentation(real);
+
+        JpmsModuleHelper.addReadsToUnnamedModule(proxy, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+
+        verify(real, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void unwrapHandlesMultipleDelegateLevels() {
+        requireJpms();
+        Instrumentation real = mock(Instrumentation.class);
+        when(real.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
+
+        DelegatingInstrumentation proxy1 = new DelegatingInstrumentation(real);
+        DelegatingInstrumentation proxy2 = new DelegatingInstrumentation(proxy1);
+
+        JpmsModuleHelper.addReadsToUnnamedModule(proxy2, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+
+        verify(real, times(1)).getAllLoadedClasses();
+    }
+
+    @Test
+    public void mulePatched_falseBeforeFirstCall() throws Exception {
+        Field f = JpmsModuleHelper.class.getDeclaredField("mulePatched");
+        f.setAccessible(true);
+        assertEquals(false, ((AtomicBoolean) f.get(null)).get());
+    }
+
+    @Test
+    public void mulePatched_trueAfterFirstMuleCall() throws Exception {
+        requireJpms();
+        Instrumentation inst = mock(Instrumentation.class);
+        when(inst.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
+
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "org/mule/runtime/core/Foo", getClass().getClassLoader());
+
+        Field f = JpmsModuleHelper.class.getDeclaredField("mulePatched");
+        f.setAccessible(true);
+        assertEquals(true, ((AtomicBoolean) f.get(null)).get());
+    }
+
+    @Test
+    public void mulePatched_remainsFalseForNonMuleClass() throws Exception {
+        Instrumentation inst = mock(Instrumentation.class);
+        JpmsModuleHelper.addReadsToUnnamedModule(inst, "com/example/Foo", getClass().getClassLoader());
+
+        Field f = JpmsModuleHelper.class.getDeclaredField("mulePatched");
+        f.setAccessible(true);
+        assertEquals(false, ((AtomicBoolean) f.get(null)).get());
+    }
+
+    private static class DelegatingInstrumentation implements Instrumentation {
+        @SuppressWarnings("unused")
+        private final Instrumentation delegate;
+
+        DelegatingInstrumentation(Instrumentation delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override public void addTransformer(ClassFileTransformer t, boolean b) {}
+        @Override public void addTransformer(ClassFileTransformer t) {}
+        @Override public boolean removeTransformer(ClassFileTransformer t) { return false; }
+        @Override public boolean isRetransformClassesSupported() { return false; }
+        @Override public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {}
+        @Override public boolean isRedefineClassesSupported() { return false; }
+        @Override public void redefineClasses(ClassDefinition... d) throws ClassNotFoundException, UnmodifiableClassException {}
+        @Override public boolean isModifiableClass(Class<?> c) { return false; }
+        @Override public Class<?>[] getAllLoadedClasses() { return null; }
+        @Override public Class<?>[] getInitiatedClasses(ClassLoader l) { return new Class<?>[0]; }
+        @Override public long getObjectSize(Object o) { return 0; }
+        @Override public void appendToBootstrapClassLoaderSearch(JarFile j) {}
+        @Override public void appendToSystemClassLoaderSearch(JarFile j) {}
+        @Override public boolean isNativeMethodPrefixSupported() { return false; }
+        @Override public void setNativeMethodPrefix(ClassFileTransformer t, String p) {}
+    }
+}

--- a/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/JpmsModuleHelperTest.java
+++ b/newrelic-weaver/src/test/java/com/newrelic/weave/weavepackage/JpmsModuleHelperTest.java
@@ -11,16 +11,11 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Test;
 
-import java.lang.instrument.ClassDefinition;
-import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
-import java.lang.instrument.UnmodifiableClassException;
 import java.lang.reflect.Field;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.jar.JarFile;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -130,33 +125,6 @@ public class JpmsModuleHelperTest {
     }
 
     @Test
-    public void unwrapTraversesDelegateChain() {
-        requireJpms();
-        Instrumentation real = mock(Instrumentation.class);
-        when(real.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
-
-        DelegatingInstrumentation proxy = new DelegatingInstrumentation(real);
-
-        JpmsModuleHelper.addReadsToUnnamedModule(proxy, "org/mule/runtime/core/Test", getClass().getClassLoader());
-
-        verify(real, times(1)).getAllLoadedClasses();
-    }
-
-    @Test
-    public void unwrapHandlesMultipleDelegateLevels() {
-        requireJpms();
-        Instrumentation real = mock(Instrumentation.class);
-        when(real.getAllLoadedClasses()).thenReturn(new Class<?>[0]);
-
-        DelegatingInstrumentation proxy1 = new DelegatingInstrumentation(real);
-        DelegatingInstrumentation proxy2 = new DelegatingInstrumentation(proxy1);
-
-        JpmsModuleHelper.addReadsToUnnamedModule(proxy2, "org/mule/runtime/core/Test", getClass().getClassLoader());
-
-        verify(real, times(1)).getAllLoadedClasses();
-    }
-
-    @Test
     public void scanLoopSkipsUnnamedModuleClasses() {
         requireJpms();
         Instrumentation inst = mock(Instrumentation.class);
@@ -208,28 +176,4 @@ public class JpmsModuleHelperTest {
         assertFalse(((AtomicBoolean) f.get(null)).get());
     }
 
-    private static class DelegatingInstrumentation implements Instrumentation {
-        @SuppressWarnings("unused")
-        private final Instrumentation delegate;
-
-        DelegatingInstrumentation(Instrumentation delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override public void addTransformer(ClassFileTransformer t, boolean b) {}
-        @Override public void addTransformer(ClassFileTransformer t) {}
-        @Override public boolean removeTransformer(ClassFileTransformer t) { return false; }
-        @Override public boolean isRetransformClassesSupported() { return false; }
-        @Override public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {}
-        @Override public boolean isRedefineClassesSupported() { return false; }
-        @Override public void redefineClasses(ClassDefinition... d) throws ClassNotFoundException, UnmodifiableClassException {}
-        @Override public boolean isModifiableClass(Class<?> c) { return false; }
-        @Override public Class<?>[] getAllLoadedClasses() { return null; }
-        @Override public Class<?>[] getInitiatedClasses(ClassLoader l) { return new Class<?>[0]; }
-        @Override public long getObjectSize(Object o) { return 0; }
-        @Override public void appendToBootstrapClassLoaderSearch(JarFile j) {}
-        @Override public void appendToSystemClassLoaderSearch(JarFile j) {}
-        @Override public boolean isNativeMethodPrefixSupported() { return false; }
-        @Override public void setNativeMethodPrefix(ClassFileTransformer t, String p) {}
-    }
 }


### PR DESCRIPTION
### Overview
POC to fix `IllegalAccessError`s when instrumenting Mule 4.9 on Java 17+ by bypassing JPMS. 

Technical outline(s) of issue: [Jira](https://new-relic.atlassian.net/browse/NR-518055?focusedCommentId=1578052), [Google Docs](https://docs.google.com/document/d/1znPkF1DVyYDIr8VtW0Frdn7JshEU1Evo_jvPrHI1ISo/edit?tab=t.0).

Example error: 
```
 java.lang.IllegalAccessError:                                                                                                                                                                                     
    class org.mule.runtime.core.internal.event.AbstractEventContext                                       
    (in module org.mule.runtime.core)                                                                                                                                                                               
    cannot access class                                                                                   
    com.newrelic.weave.org.mule.runtime.core.internal.event.AbstractEventContext_1827233194_nr_ext
    (in unnamed module @0x44ca8399)
    because module org.mule.runtime.core does not read unnamed module @0x44ca8399
```

Lab's experimental Mule 4.9 instrumentation throws `IllegalAccessException`s when attempting to access Mule runtime classes across module boundaries.

This POC adds a `JpmsModuleHelper` class, which serves as a helper called from `WeavePackageManager` right after utility class injection. On the first `org.mule.runtime.*` class instrumented, it scans loaded classes and collects named Mule modules, then calls `Instrumentation.redefineModule` to help grant these modules read access. For Java 8 compatibility these JPMS calls are reflection-based. 

### Related Github Issue
Resolves #2836 

### Testing
15 unit tests have been added to cover new scenarios.
