### PR TITLE
New license key obfuscation algorithm

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
@@ -8,7 +8,6 @@
 package com.newrelic.agent.util;
 
 import com.newrelic.agent.Agent;
-import com.newrelic.agent.service.ServiceFactory;
 
 import java.util.Collections;
 import java.util.regex.Matcher;
@@ -33,50 +32,38 @@ public class LicenseKeyUtil {
             Agent.LOG.finest("Unable to obfuscate the license_key in a null or empty string.");
             return originalString;
         }
-        String licenseKey = ServiceFactory.getConfigService().getDefaultAgentConfig().getLicenseKey();
-        if (licenseKey == null) {
-            Agent.LOG.finest("Unable to obfuscate a null license_key.");
+
+        Matcher matcher = LICENSE_KEY_PATTERN.matcher(originalString);
+        if (!matcher.find()) {
             return originalString;
-        } else {
-            String obfuscatedKey = partialObfuscation(licenseKey);
-            Matcher matcher = LICENSE_KEY_PATTERN.matcher(originalString);
-            if (!matcher.find()) {
-                return originalString;
-            }
-
-            // It's not clear this can happen in the real world, but there was a test against
-            // a String with multiple "license_key=" fields. This loop iterates over the matcher
-            // and does the replacement for all matches.
-            // appendReplacement: copies text between matches into sb, then appends the replacement string.
-            // quoteReplacement: escapes $ and \ in the replacement so they're treated as literals, not regex tokens.
-            // group(1): returns the prefix captured by group 1 (everything up to and including the delimiter).
-            // find(): advances the matcher to the next occurrence of the pattern.
-            // appendTail: flushes any remaining text after the last match into sb.
-            StringBuffer sb = new StringBuffer();
-            do {
-                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(1) + obfuscatedKey));
-            } while (matcher.find());
-            matcher.appendTail(sb);
-
-            return sb.toString();
         }
+
+        // appendReplacement: copies text between matches into sb, then appends the replacement string.
+        // quoteReplacement: escapes $ and \ in the replacement so they're treated as literals, not regex tokens.
+        // group(1): returns the prefix captured by group 1 (everything up to and including the delimiter).
+        // group(2): returns the license key value found in the string, used to drive the obfuscation.
+        // find(): advances the matcher to the next occurrence of the pattern.
+        // appendTail: flushes any remaining text after the last match into sb.
+        StringBuffer sb = new StringBuffer();
+        do {
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(1) + partialObfuscation(matcher.group(2))));
+        } while (matcher.find());
+        matcher.appendTail(sb);
+
+        return sb.toString();
     }
 
     private static String partialObfuscation(String licenseKey) {
-        // Null / empty check has already occurred
-        int keyLength =  licenseKey.length();
-        String obfuscatedKey;
+        int keyLength = licenseKey.length();
 
         // Per the spec: If length is <= 10, replace the full key with "*"
         // Otherwise, keep the first 10 characters of the key and replace the
         // remaining key characters with "*"
         if (keyLength > KEY_LENGTH_CUTOFF) {
-            obfuscatedKey = licenseKey.substring(0, KEY_LENGTH_CUTOFF) +
+            return licenseKey.substring(0, KEY_LENGTH_CUTOFF) +
                     String.join("", Collections.nCopies(keyLength - KEY_LENGTH_CUTOFF, "*"));
         } else {
-            obfuscatedKey = String.join("", Collections.nCopies(keyLength, "*"));
+            return String.join("", Collections.nCopies(keyLength, "*"));
         }
-
-        return obfuscatedKey;
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
@@ -9,7 +9,7 @@ package com.newrelic.agent.util;
 
 import com.newrelic.agent.Agent;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,6 +30,11 @@ public class LicenseKeyUtil {
     public static String obfuscateLicenseKey(String originalString) {
         if (originalString == null || originalString.isEmpty()) {
             Agent.LOG.finest("Unable to obfuscate the license_key in a null or empty string.");
+            return originalString;
+        }
+
+        // Avoid regex overhead if string doesn't contain "license_key"
+        if (!originalString.contains("license_key")) {
             return originalString;
         }
 
@@ -60,10 +65,15 @@ public class LicenseKeyUtil {
         // Otherwise, keep the first 10 characters of the key and replace the
         // remaining key characters with "*"
         if (keyLength > KEY_LENGTH_CUTOFF) {
-            return licenseKey.substring(0, KEY_LENGTH_CUTOFF) +
-                    String.join("", Collections.nCopies(keyLength - KEY_LENGTH_CUTOFF, "*"));
+            return licenseKey.substring(0, KEY_LENGTH_CUTOFF) + createAsterisks(keyLength - KEY_LENGTH_CUTOFF);
         } else {
-            return String.join("", Collections.nCopies(keyLength, "*"));
+            return createAsterisks(keyLength);
         }
+    }
+
+    private static String createAsterisks(int count) {
+        char[] asterisks = new char[count];
+        Arrays.fill(asterisks, '*');
+        return new String(asterisks);
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
@@ -15,6 +15,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class LicenseKeyUtil {
+    // Matches license_key= (URL) or "license_key":" (JSON) and captures the prefix (group 1) and key value (group 2) separately.
     private static final Pattern LICENSE_KEY_PATTERN = Pattern.compile("(.+?license_key(?:=|\":\"))([^&\"]+)");
     private static final int KEY_LENGTH_CUTOFF = 10;
 
@@ -44,8 +45,13 @@ public class LicenseKeyUtil {
             }
 
             // It's not clear this can happen in the real world, but there was a test against
-            // a String with multiple "license_key=" fields. This loop simply iterates over the matcher
+            // a String with multiple "license_key=" fields. This loop iterates over the matcher
             // and does the replacement for all matches.
+            // appendReplacement: copies text between matches into sb, then appends the replacement string.
+            // quoteReplacement: escapes $ and \ in the replacement so they're treated as literals, not regex tokens.
+            // group(1): returns the prefix captured by group 1 (everything up to and including the delimiter).
+            // find(): advances the matcher to the next occurrence of the pattern.
+            // appendTail: flushes any remaining text after the last match into sb.
             StringBuffer sb = new StringBuffer();
             do {
                 matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(1) + obfuscatedKey));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/LicenseKeyUtil.java
@@ -10,8 +10,13 @@ package com.newrelic.agent.util;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.service.ServiceFactory;
 
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class LicenseKeyUtil {
-    private static final String OBFUSCATED_LICENSE_KEY = "obfuscated";
+    private static final Pattern LICENSE_KEY_PATTERN = Pattern.compile("(.+?license_key(?:=|\":\"))([^&\"]+)");
+    private static final int KEY_LENGTH_CUTOFF = 10;
 
     /**
      * Removes the license_key value from a given string.
@@ -32,7 +37,40 @@ public class LicenseKeyUtil {
             Agent.LOG.finest("Unable to obfuscate a null license_key.");
             return originalString;
         } else {
-            return originalString.replace(licenseKey, OBFUSCATED_LICENSE_KEY);
+            String obfuscatedKey = partialObfuscation(licenseKey);
+            Matcher matcher = LICENSE_KEY_PATTERN.matcher(originalString);
+            if (!matcher.find()) {
+                return originalString;
+            }
+
+            // It's not clear this can happen in the real world, but there was a test against
+            // a String with multiple "license_key=" fields. This loop simply iterates over the matcher
+            // and does the replacement for all matches.
+            StringBuffer sb = new StringBuffer();
+            do {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(1) + obfuscatedKey));
+            } while (matcher.find());
+            matcher.appendTail(sb);
+
+            return sb.toString();
         }
+    }
+
+    private static String partialObfuscation(String licenseKey) {
+        // Null / empty check has already occurred
+        int keyLength =  licenseKey.length();
+        String obfuscatedKey;
+
+        // Per the spec: If length is <= 10, replace the full key with "*"
+        // Otherwise, keep the first 10 characters of the key and replace the
+        // remaining key characters with "*"
+        if (keyLength > KEY_LENGTH_CUTOFF) {
+            obfuscatedKey = licenseKey.substring(0, KEY_LENGTH_CUTOFF) +
+                    String.join("", Collections.nCopies(keyLength - KEY_LENGTH_CUTOFF, "*"));
+        } else {
+            obfuscatedKey = String.join("", Collections.nCopies(keyLength, "*"));
+        }
+
+        return obfuscatedKey;
     }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
@@ -41,9 +41,9 @@ public class LicenseKeyUtilTest extends TestCase {
         String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
 
         // Then
-        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=obfuscated&marshal_format=json&protocol_version=17";
+        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghij**************************&marshal_format=json&protocol_version=17";
 
-        String expectedJsonPayload = "[{\"license_key\":\"obfuscated\"}]";
+        String expectedJsonPayload = "[{\"license_key\":\"abcdefghij**************************\"}]";
 
         Assert.assertEquals(expectedRequestUrl, actualRequestUrl);
         Assert.assertEquals(expectedJsonPayload, actualJsonPayload);
@@ -68,7 +68,7 @@ public class LicenseKeyUtilTest extends TestCase {
 
         // Then
         String expectedJsonPayload = "[" +
-                "{\"license_key\":\"obfuscated\"}, {\"license_key\":\"obfuscated\"}, {\"license_key\":\"obfuscated\"}, {\"license_key\":\"obfuscated\"}]";
+                "{\"license_key\":\"abcdefghij**************************\"}, {\"license_key\":\"abcdefghij**************************\"}, {\"license_key\":\"abcdefghij**************************\"}, {\"license_key\":\"abcdefghij**************************\"}]";
 
         Assert.assertEquals(expectedJsonPayload, actualJsonPayload);
     }
@@ -115,5 +115,60 @@ public class LicenseKeyUtilTest extends TestCase {
         // Then
         Assert.assertEquals("", actualEmptyString);
         Assert.assertNull(actualNullString);
+    }
+
+    public void testObfuscatedLicenseKeyWithSmallLicenseKey() {
+        // License keys <= 10 chars are fully obfuscated with "*"
+        // Given
+        String originalRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcde&marshal_format=json&protocol_version=17";
+
+        String originalJsonPayload = "[{\"license_key\":\"abcde\"}]";
+
+        MockServiceManager serviceManager = new MockServiceManager();
+        ServiceFactory.setServiceManager(serviceManager);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("license_key", "abcde");
+
+        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
+        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
+        serviceManager.setConfigService(configService);
+
+        // When
+        String actualRequestUrl = LicenseKeyUtil.obfuscateLicenseKey(originalRequestUrl);
+        String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
+
+        // Then
+        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=*****&marshal_format=json&protocol_version=17";
+        String expectedJsonPayload = "[{\"license_key\":\"*****\"}]";
+
+        Assert.assertEquals(expectedRequestUrl, actualRequestUrl);
+        Assert.assertEquals(expectedJsonPayload, actualJsonPayload);
+    }
+
+    public void testObfuscatedLicenseKeyIfOriginalLicenseKeyIsChanged() {
+        String originalRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghijklmonpqrstuvwxyz1234567890&marshal_format=json&protocol_version=17";
+
+        String originalJsonPayload = "[{\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}]";
+
+        MockServiceManager serviceManager = new MockServiceManager();
+        ServiceFactory.setServiceManager(serviceManager);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("license_key", "this_is_a_new_license_key1234567890");
+
+        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
+        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
+        serviceManager.setConfigService(configService);
+
+        // When
+        String actualRequestUrl = LicenseKeyUtil.obfuscateLicenseKey(originalRequestUrl);
+        String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
+
+        // Then
+        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=this_is_a_*************************&marshal_format=json&protocol_version=17";
+
+        String expectedJsonPayload = "[{\"license_key\":\"this_is_a_*************************\"}]";
+
+        Assert.assertEquals(expectedRequestUrl, actualRequestUrl);
+        Assert.assertEquals(expectedJsonPayload, actualJsonPayload);
     }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
@@ -74,27 +74,23 @@ public class LicenseKeyUtilTest extends TestCase {
     }
 
     public void testObfuscateLicenseKeyWithNullLicenseKey() {
+        // The configured license key is not used for obfuscation; the value found in the string drives it.
+        // Even with a null configured key, the pattern-based obfuscation still applies.
         // Given
         String originalRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghijklmonpqrstuvwxyz1234567890&marshal_format=json&protocol_version=17";
 
         String originalJsonPayload = "[{\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}]";
-
-        MockServiceManager serviceManager = new MockServiceManager();
-        ServiceFactory.setServiceManager(serviceManager);
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("license_key", null);
-
-        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
-        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
-        serviceManager.setConfigService(configService);
 
         // When
         String actualRequestUrl = LicenseKeyUtil.obfuscateLicenseKey(originalRequestUrl);
         String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
 
         // Then
-        Assert.assertEquals(originalRequestUrl, actualRequestUrl);
-        Assert.assertEquals(originalJsonPayload, actualJsonPayload);
+        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghij**************************&marshal_format=json&protocol_version=17";
+        String expectedJsonPayload = "[{\"license_key\":\"abcdefghij**************************\"}]";
+
+        Assert.assertEquals(expectedRequestUrl, actualRequestUrl);
+        Assert.assertEquals(expectedJsonPayload, actualJsonPayload);
     }
 
     public void testObfuscateLicenseKeyWithNullOrEmptyString() {
@@ -146,27 +142,21 @@ public class LicenseKeyUtilTest extends TestCase {
     }
 
     public void testObfuscatedLicenseKeyIfOriginalLicenseKeyIsChanged() {
+        // If the key is changed in config mid-run, the agent still uses the original key in its requests.
+        // Obfuscation is driven by the value found in the string, not the configured key,
+        // so the original key is always obfuscated regardless of what the config currently holds.
         String originalRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghijklmonpqrstuvwxyz1234567890&marshal_format=json&protocol_version=17";
 
         String originalJsonPayload = "[{\"license_key\":\"abcdefghijklmonpqrstuvwxyz1234567890\"}]";
-
-        MockServiceManager serviceManager = new MockServiceManager();
-        ServiceFactory.setServiceManager(serviceManager);
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("license_key", "this_is_a_new_license_key1234567890");
-
-        AgentConfig config = AgentConfigImpl.createAgentConfig(configMap);
-        ConfigService configService = ConfigServiceFactory.createConfigService(config, configMap);
-        serviceManager.setConfigService(configService);
 
         // When
         String actualRequestUrl = LicenseKeyUtil.obfuscateLicenseKey(originalRequestUrl);
         String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
 
         // Then
-        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=this_is_a_*************************&marshal_format=json&protocol_version=17";
+        String expectedRequestUrl = "https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=connect&license_key=abcdefghij**************************&marshal_format=json&protocol_version=17";
 
-        String expectedJsonPayload = "[{\"license_key\":\"this_is_a_*************************\"}]";
+        String expectedJsonPayload = "[{\"license_key\":\"abcdefghij**************************\"}]";
 
         Assert.assertEquals(expectedRequestUrl, actualRequestUrl);
         Assert.assertEquals(expectedJsonPayload, actualJsonPayload);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/util/LicenseKeyUtilTest.java
@@ -37,7 +37,9 @@ public class LicenseKeyUtilTest extends TestCase {
         serviceManager.setConfigService(configService);
 
         // When
+        long startTime = System.nanoTime();
         String actualRequestUrl = LicenseKeyUtil.obfuscateLicenseKey(originalRequestUrl);
+        System.out.println("Time (ns): " + (System.nanoTime() - startTime));
         String actualJsonPayload = LicenseKeyUtil.obfuscateLicenseKey(originalJsonPayload);
 
         // Then


### PR DESCRIPTION
Resolves #2861 , #2813 

Updates the license key obfuscation rules based on the updated spec.

Addresses edge case where license key can be exposed if it's changed while the agent is running.

Keys will now show up as follows with `audit_mode` on:

Connect: `https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?method=preconnect&license_key=0000000000******************************&marshal_format=json&protocol_version=17`

Config payload: `"license_key":"0000000000******************************"`