### PR TITLE
Cap micronaut-http-client-4.0.0 passesOnly range

### DIFF
--- a/instrumentation/micronaut-http-client-4.0.0/build.gradle
+++ b/instrumentation/micronaut-http-client-4.0.0/build.gradle
@@ -13,9 +13,8 @@ jar {
 
 verifyInstrumentation {
 
-    passesOnly 'io.micronaut:micronaut-http-client:[4.0.0,)'
-    excludeRegex '.*RC[0-9]'
-    excludeRegex '.*M[0-9]'
+    passesOnly 'io.micronaut:micronaut-http-client:[4.0.0,5.0.0)'
+    excludeRegex 'io.micronaut:micronaut-http-client:.*(RC|M)[0-9]*$'
 }
 
 java {


### PR DESCRIPTION
### Overview
The `passesOnly` range `[4.0.0,)` caused the verifier to test against `5.0.0-M25` (and future 5.x milestones), which fail. Per this PR, we've capped the version range to `[4.0.0,5.0.0)` so 5.x versions are excluded  from verification until a dedicated 5.x module is created.

### Testing
[Failing](https://github.com/newrelic/newrelic-java-agent/actions/runs/25486310218/job/74812471409) instrumentation verification for `micronaut-http-client-4.0.0`

[Passing](https://github.com/newrelic/newrelic-java-agent/actions/runs/25508643052/job/74861127091) for this branch.

