### PR TITLE
Add GHA permission monitor to workflows

### DIFF
--- a/.github/workflows/Create-Custom-Jar.yml
+++ b/.github/workflows/Create-Custom-Jar.yml
@@ -19,7 +19,7 @@ jobs:
       # we use this in env var for conditionals (secrets can't be used in conditionals)
       AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
-
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/Create-Custom-Jar.yml
+++ b/.github/workflows/Create-Custom-Jar.yml
@@ -1,5 +1,9 @@
 name: Create custom jar
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -19,7 +23,7 @@ jobs:
       # we use this in env var for conditionals (secrets can't be used in conditionals)
       AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/Create-Init-Container-Release-Tags.yml
+++ b/.github/workflows/Create-Init-Container-Release-Tags.yml
@@ -10,6 +10,7 @@ jobs:
   create_release_tags:
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Create release tags for K8s Init Container
         run: |
           RELEASE_TITLE="New Relic Java Agent ${{ inputs.agent-version }}.0"

--- a/.github/workflows/GHA-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Functional-Tests.yaml
@@ -1,5 +1,9 @@
 name: Java Functional Tests
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -30,7 +34,7 @@ jobs:
       matrix:
         java-version: [ 8, 11, 17, 21, 25, 26 ]
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Functional-Tests.yaml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         java-version: [ 8, 11, 17, 21, 25, 26 ]
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -1,5 +1,9 @@
 name: Scala Functional Tests
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -27,7 +31,7 @@ jobs:
       matrix:
         java-version: [ 8, 11 ]
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Scala-Functional-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Functional-Tests.yaml
@@ -27,6 +27,7 @@ jobs:
       matrix:
         java-version: [ 8, 11 ]
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -1,5 +1,9 @@
 name: Scala Instrumentation Tests
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -36,7 +40,7 @@ jobs:
           - java-version: 11
             scala: 2.11
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
+++ b/.github/workflows/GHA-Scala-Instrumentation-Tests.yaml
@@ -36,6 +36,7 @@ jobs:
           - java-version: 11
             scala: 2.11
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Spotbugs.yml
+++ b/.github/workflows/GHA-Spotbugs.yml
@@ -3,6 +3,11 @@
 # The XML file can be analyzed inside the Spotbugs GUI: https://spotbugs.readthedocs.io/en/stable/running.html
 name: Execute Spotbugs
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -19,7 +24,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.agent-ref || github.ref || 'main' }}
@@ -84,7 +89,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ inputs.agent-ref || 'main' }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout GhPages branch
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Spotbugs.yml
+++ b/.github/workflows/GHA-Spotbugs.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.agent-ref || github.ref || 'main' }}
@@ -83,7 +84,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ inputs.agent-ref || 'main' }}
     steps:
-
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout GhPages branch
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -1,5 +1,9 @@
 name: Unit Tests
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -28,7 +32,7 @@ jobs:
         java-version: [ 8, 11, 17, 21, 25, 26 ]
         group: [flaky, nonForkedTests, forkedTests]
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
@@ -140,7 +144,7 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout GhPages branch
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHA-Unit-Tests.yaml
+++ b/.github/workflows/GHA-Unit-Tests.yaml
@@ -28,6 +28,7 @@ jobs:
         java-version: [ 8, 11, 17, 21, 25, 26 ]
         group: [flaky, nonForkedTests, forkedTests]
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
@@ -139,7 +140,7 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:
-
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout GhPages branch
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/GHPages-Cleanup.yml
+++ b/.github/workflows/GHPages-Cleanup.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       DAYS: ${{ inputs.days || '5' }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout GH Pages
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/Generate-Compatibility-Doc.yml
+++ b/.github/workflows/Generate-Compatibility-Doc.yml
@@ -1,5 +1,9 @@
 name: Generate Compatibility Doc
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   push:
     branches:
@@ -31,7 +35,7 @@ jobs:
       PUBLIC_DOC_FILE: build/docs/site/compatibility-requirements-java-agent.mdx
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
       - name: Setup environment
@@ -64,7 +68,7 @@ jobs:
       INTERNAL_FILEPATH: COMPATIBILITY.md
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
       - name: Download internal doc
@@ -106,7 +110,7 @@ jobs:
       DESTINATION_FILEPATH: src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout external docs repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/Generate-Compatibility-Doc.yml
+++ b/.github/workflows/Generate-Compatibility-Doc.yml
@@ -31,6 +31,7 @@ jobs:
       PUBLIC_DOC_FILE: build/docs/site/compatibility-requirements-java-agent.mdx
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
       - name: Setup environment
@@ -63,6 +64,7 @@ jobs:
       INTERNAL_FILEPATH: COMPATIBILITY.md
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
       - name: Download internal doc
@@ -104,6 +106,7 @@ jobs:
       DESTINATION_FILEPATH: src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout external docs repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/Java-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-Instrumentation-Tests.yml
@@ -1,5 +1,9 @@
 name: Java Instrumentation Tests
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -30,7 +34,7 @@ jobs:
       AWS_KEY: ${{ secrets.aws-secret-access-key }}
       GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx2048m'"
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/Java-Instrumentation-Tests.yml
+++ b/.github/workflows/Java-Instrumentation-Tests.yml
@@ -30,6 +30,7 @@ jobs:
       AWS_KEY: ${{ secrets.aws-secret-access-key }}
       GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx2048m'"
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/Release-CopyToS3-prod.yml
+++ b/.github/workflows/Release-CopyToS3-prod.yml
@@ -13,6 +13,7 @@ jobs:
     name: Copy ${{ inputs.version_number }} to S3 (Prod)
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Self
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         # This always checkouts main. So the script will be run from main.

--- a/.github/workflows/Release-CopyToS3-staging.yml
+++ b/.github/workflows/Release-CopyToS3-staging.yml
@@ -17,6 +17,7 @@ jobs:
     name: Copy ${{ inputs.version_number }} to S3 (Staging)
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Self
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         # This always checkouts main. So the script will be run from main.

--- a/.github/workflows/Release-UpdateSystemConfig.yml
+++ b/.github/workflows/Release-UpdateSystemConfig.yml
@@ -13,6 +13,7 @@ jobs:
     name: Set java_agent_version to ${{ inputs.version_number }} in system config
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Update system configuration page
         run: |
           PAYLOAD="{

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -1,5 +1,9 @@
 name: Test - AITs
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -83,7 +87,7 @@ jobs:
     outputs:
       tests: ${{ steps.read-single-test.outputs.tests || steps.read-tests.outputs.tests }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout AIT repo test
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
@@ -159,7 +163,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.list-tests.outputs.tests) }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Retrieve agent from cache
         id: retrieve-agent
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0 # pin@v4
@@ -458,7 +462,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Download all raw ingest files
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # pin@v4
         with:
@@ -562,7 +566,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout repository for scripts
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
@@ -636,7 +640,7 @@ jobs:
     needs: [ tests ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Download artifact(s) # surely there is a way to only download the negative_value_*.txt artifacts?
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # pin@v4
         env:

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -83,6 +83,7 @@ jobs:
     outputs:
       tests: ${{ steps.read-single-test.outputs.tests || steps.read-tests.outputs.tests }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout AIT repo test
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
@@ -158,6 +159,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.list-tests.outputs.tests) }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Retrieve agent from cache
         id: retrieve-agent
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0 # pin@v4
@@ -456,6 +458,7 @@ jobs:
       contents: write
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Download all raw ingest files
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # pin@v4
         with:
@@ -559,6 +562,7 @@ jobs:
       contents: write
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout repository for scripts
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
@@ -632,6 +636,7 @@ jobs:
     needs: [ tests ]
     runs-on: ubuntu-22.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Download artifact(s) # surely there is a way to only download the negative_value_*.txt artifacts?
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # pin@v4
         env:

--- a/.github/workflows/VerifyInstrumentation-Single.yml
+++ b/.github/workflows/VerifyInstrumentation-Single.yml
@@ -1,4 +1,9 @@
 name: Verify Instrumentation (single)
+
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -20,7 +25,7 @@ jobs:
       MODULE: ${{ github.event.inputs.module || inputs.module }}
       AWS_KEY: ${{ secrets.aws-secret-access-key }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/VerifyInstrumentation-Single.yml
+++ b/.github/workflows/VerifyInstrumentation-Single.yml
@@ -20,6 +20,7 @@ jobs:
       MODULE: ${{ github.event.inputs.module || inputs.module }}
       AWS_KEY: ${{ secrets.aws-secret-access-key }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/VerifyInstrumentation.yml
+++ b/.github/workflows/VerifyInstrumentation.yml
@@ -56,6 +56,7 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Send failure message to Slack
         id: slack
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # pin@v1.25.0

--- a/.github/workflows/VerifyInstrumentation.yml
+++ b/.github/workflows/VerifyInstrumentation.yml
@@ -1,5 +1,9 @@
 name: Verify Instrumentation
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -56,7 +60,7 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Send failure message to Slack
         id: slack
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # pin@v1.25.0

--- a/.github/workflows/VerifyUnshadowedJars.yml
+++ b/.github/workflows/VerifyUnshadowedJars.yml
@@ -1,4 +1,9 @@
 name: Verify Unshadowed Jars
+
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -22,7 +27,7 @@ jobs:
     env:
       AWS_KEY: ${{ secrets.aws-secret-access-key }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.agent-ref }}

--- a/.github/workflows/VerifyUnshadowedJars.yml
+++ b/.github/workflows/VerifyUnshadowedJars.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       AWS_KEY: ${{ secrets.aws-secret-access-key }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.agent-ref }}

--- a/.github/workflows/X-Reusable-BuildAgent.yml
+++ b/.github/workflows/X-Reusable-BuildAgent.yml
@@ -21,6 +21,7 @@ jobs:
       # we use this in env var for conditionals (secrets can't be used in conditionals)
       AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/X-Reusable-BuildAgent.yml
+++ b/.github/workflows/X-Reusable-BuildAgent.yml
@@ -1,5 +1,9 @@
 name: Build agent
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -21,7 +25,7 @@ jobs:
       # we use this in env var for conditionals (secrets can't be used in conditionals)
       AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout Java agent
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.ref }}
@@ -56,6 +57,7 @@ jobs:
       # GHA's IDE think the line below is broken. It is not.
       matrix: ${{ fromJson(needs.read-modules.outputs.modules) }}
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/X-Reusable-VerifyInstrumentation.yml
+++ b/.github/workflows/X-Reusable-VerifyInstrumentation.yml
@@ -5,6 +5,11 @@
 # and when many runners do that at the same time, the cache server returns 429s (Too many requests).
 
 name: X - Reusable Verify Instrumentation
+
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -26,7 +31,7 @@ jobs:
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.ref }}
@@ -57,7 +62,7 @@ jobs:
       # GHA's IDE think the line below is broken. It is not.
       matrix: ${{ fromJson(needs.read-modules.outputs.modules) }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -19,6 +19,7 @@ jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     steps:
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Checkout sources
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
         with:

--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -8,6 +8,7 @@ jobs:
   publish_snapshot:
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
       - name: Configure AWS Credentials

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -9,6 +9,7 @@ jobs:
   publish_release:
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # pin@v4
 
       - name: Configure AWS Credentials

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -13,6 +13,7 @@ jobs:
     name: Run Repolinter
     runs-on: ubuntu-24.04
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Test Default Branch
         id: default-branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin@v7

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -2,6 +2,10 @@
 # workflow_dispatch to work properly
 name: Repolinter Action
 
+# Permissions granted to all jobs in the workflow.
+# Permissions that aren't explicitly defined here will default to a value of none.
+permissions: {}
+
 # NOTE: This workflow will ONLY check the default branch!
 # Currently there is no elegant way to specify the default
 # branch in the event filtering, so branches are instead
@@ -13,7 +17,7 @@ jobs:
     name: Run Repolinter
     runs-on: ubuntu-24.04
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
+#      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Test Default Branch
         id: default-branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin@v7


### PR DESCRIPTION
Adds the permissions monitor action which tracks the usage of the temporary GitHub repository token and gives recommendations on the minimum permissions required to run the workflow based on the actual detected workflow activity.

Can be disabled once permissions have been determined and explicitly configured in the workflow.

https://github.com/GitHubSecurityLab/actions-permissions

This will help to resolve https://new-relic.atlassian.net/browse/NR-560222