### PR TITLE
feat(kafka): add producerServiceName header for producer-topic-consumer entity relationships

### DIFF
--- a/instrumentation/kafka-clients-spans-0.11.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
+++ b/instrumentation/kafka-clients-spans-0.11.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
@@ -27,7 +27,10 @@ public class KafkaProducer_Instrumentation<K, V> {
         if (transaction != null) {
             Headers dtHeaders = new HeadersWrapper(record.headers());
             NewRelic.getAgent().getTransaction().insertDistributedTraceHeaders(dtHeaders);
-            String appName = NewRelic.getAgent().getApplicationName();
+            String appName = NewRelic.getAgent().getConfig().getValue("app_name", null);
+            if (appName == null || appName.isEmpty()) {
+                appName = System.getenv("NEW_RELIC_APP_NAME");
+            }
             if (appName != null && !appName.isEmpty()) {
                 dtHeaders.addHeader("producerServiceName", appName);
             }

--- a/instrumentation/kafka-clients-spans-0.11.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
+++ b/instrumentation/kafka-clients-spans-0.11.0.0/src/main/java/org/apache/kafka/clients/producer/KafkaProducer_Instrumentation.java
@@ -27,6 +27,10 @@ public class KafkaProducer_Instrumentation<K, V> {
         if (transaction != null) {
             Headers dtHeaders = new HeadersWrapper(record.headers());
             NewRelic.getAgent().getTransaction().insertDistributedTraceHeaders(dtHeaders);
+            String appName = NewRelic.getAgent().getApplicationName();
+            if (appName != null && !appName.isEmpty()) {
+                dtHeaders.addHeader("producerServiceName", appName);
+            }
         }
         return Weaver.callOriginal();
     }

--- a/instrumentation/kafka-clients-spans-consumer-2.0.0/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer_Instrumentation.java
+++ b/instrumentation/kafka-clients-spans-consumer-2.0.0/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer_Instrumentation.java
@@ -15,8 +15,9 @@ import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import com.nr.instrumentation.kafka.HeadersWrapper;
 import com.nr.instrumentation.kafka.Utils;
-
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import org.apache.kafka.common.header.Header;
 
 @Weave(originalName = "org.apache.kafka.clients.consumer.KafkaConsumer")
 public class KafkaConsumer_Instrumentation<K, V> {
@@ -34,12 +35,28 @@ public class KafkaConsumer_Instrumentation<K, V> {
     }
 
     private void nrAcceptDtHeaders(ConsumerRecords<K, V> records) {
-        if (Utils.DT_CONSUMER_ENABLED && AgentBridge.getAgent().getTransaction(false) != null) {
-            for (ConsumerRecord<?, ?> record : records) {
+        if (AgentBridge.getAgent().getTransaction(false) == null) {
+            return;
+        }
+        for (ConsumerRecord<?, ?> record : records) {
+            if (Utils.DT_CONSUMER_ENABLED) {
                 Headers dtHeaders = new HeadersWrapper(record.headers());
-                NewRelic.getAgent().getTransaction().acceptDistributedTraceHeaders(TransportType.Kafka, dtHeaders);
-                break;
+                NewRelic.getAgent().getTransaction().acceptDistributedTraceHeaders(
+                        TransportType.Kafka, dtHeaders);
             }
+            Header psnHeader = record.headers().lastHeader("producerServiceName");
+            if (psnHeader != null) {
+                String producerServiceName = new String(psnHeader.value(), StandardCharsets.UTF_8);
+                NewRelic.addCustomParameter("kafka.producer.serviceName", producerServiceName);
+                NewRelic.addCustomParameter("messaging.destination.name", record.topic());
+                NewRelic.recordMetric(
+                        "Message/Kafka/Topic/Named/"
+                                + record.topic()
+                                + "/Producer/"
+                                + producerServiceName,
+                        1.0f);
+            }
+            break;
         }
     }
 }


### PR DESCRIPTION
### Overview
- Adds producerServiceName Kafka message header injection on the producer side and header extraction on the consumer side to enable automatic producer→topic→consumer entity relationships in New Relic without customer code changes.

**Producer**: (KafkaProducer_Instrumentation.java): after inserting distributed trace headers, the agent stamps the NR app name as a producerServiceName header on every outgoing Kafka message. This fires on every send() call regardless of trace sampling or DT configuration.

**Consumer** (KafkaConsumer_Instrumentation.java): when a message carries a producerServiceName header, the agent:

- Adds kafka.producer.serviceName as a transaction custom attribute
- Adds messaging.destination.name (topic) as a transaction custom attribute
- Emits Message/Kafka/Topic/Named/{topic}/Producer/{name} metric — used by a new entity platform relationship rule (separate entity-definitions PR) to create a CONSUMES relationship between the consumer APM entity and the correct INFRA-KAFKATOPIC entity
- The producerServiceName extraction is intentionally independent of DT_CONSUMER_ENABLED — entity relationships should work even when distributed tracing is turned off.

### Related Github Issue
NA

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
