### PR TITLE
Add OTLP cardinality property

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
@@ -46,6 +46,8 @@ public class OpenTelemetryConfig {
     public static final int OPEN_TELEMETRY_METRICS_EXPORT_INTERVAL_DEFAULT = 60_000; // export interval in milliseconds
     public static final String OPEN_TELEMETRY_METRICS_EXPORT_TIMEOUT = "opentelemetry.metrics.export_timeout";
     public static final int OPEN_TELEMETRY_METRICS_EXPORT_TIMEOUT_DEFAULT = 10_000; // export timeout in milliseconds
+    public static final String OPEN_TELEMETRY_METRICS_CARDINALITY= "opentelemetry.metrics.cardinality";
+    public static final int OPEN_TELEMETRY_METRICS_CARDINALITY_DEFAULT = 2_000; // maximum number of distinct points per metric
     private static Integer exportTimeout = getOpenTelemetryMetricsExportTimeout();
     private static Integer exportInterval;
 
@@ -243,6 +245,16 @@ public class OpenTelemetryConfig {
 
         return exportTimeout;
     }
+
+    /**
+     * Get the OTLP cardinality limit
+     *
+     * @return int cardinality limit. Maximum number of distinct points per metric
+     */
+    public static int getOpenTelemetryMetricsCardinality() {
+        return NewRelic.getAgent().getConfig().getValue(OPEN_TELEMETRY_METRICS_CARDINALITY, OPEN_TELEMETRY_METRICS_CARDINALITY_DEFAULT);
+    }
+
 
     /**
      * Splits the given values String into a collection of Strings based on the provided separator character.

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizer.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizer.java
@@ -70,6 +70,7 @@ final class OpenTelemetrySDKCustomizer {
                     String.valueOf(OpenTelemetryConfig.getOpenTelemetryMetricsExportInterval())); // metric reporting interval in milliseconds
             properties.put("otel.exporter.otlp.metrics.timeout",
                     String.valueOf(OpenTelemetryConfig.getOpenTelemetryMetricsExportTimeout())); // metric reporting timeout in milliseconds
+            properties.put("otel.java.metrics.cardinality.limit", String.valueOf(OpenTelemetryConfig.getOpenTelemetryMetricsCardinality()));
             properties.put("otel.exporter.otlp.protocol", "http/protobuf");
             properties.put("otel.span.attribute.value.length.limit", "4095");
             properties.put("otel.exporter.otlp.compression", "gzip");

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfigTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfigTest.java
@@ -38,6 +38,8 @@ import static com.nr.agent.instrumentation.utils.config.OpenTelemetryConfig.OPEN
 import static com.nr.agent.instrumentation.utils.config.OpenTelemetryConfig.OPEN_TELEMETRY_METRICS_EXPORT_INTERVAL_DEFAULT;
 import static com.nr.agent.instrumentation.utils.config.OpenTelemetryConfig.OPEN_TELEMETRY_METRICS_EXPORT_TIMEOUT;
 import static com.nr.agent.instrumentation.utils.config.OpenTelemetryConfig.OPEN_TELEMETRY_METRICS_EXPORT_TIMEOUT_DEFAULT;
+import static com.nr.agent.instrumentation.utils.config.OpenTelemetryConfig.OPEN_TELEMETRY_METRICS_CARDINALITY;
+import static com.nr.agent.instrumentation.utils.config.OpenTelemetryConfig.OPEN_TELEMETRY_METRICS_CARDINALITY_DEFAULT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -85,6 +87,7 @@ public class OpenTelemetryConfigTest {
         OpenTelemetryConfig.resetSdkMetricExporterConfigForTests();
         assertEquals(OPEN_TELEMETRY_METRICS_EXPORT_INTERVAL_DEFAULT, OpenTelemetryConfig.getOpenTelemetryMetricsExportInterval());
         assertEquals(OPEN_TELEMETRY_METRICS_EXPORT_TIMEOUT_DEFAULT, OpenTelemetryConfig.getOpenTelemetryMetricsExportTimeout());
+        assertEquals(OPEN_TELEMETRY_METRICS_CARDINALITY_DEFAULT, OpenTelemetryConfig.getOpenTelemetryMetricsCardinality());
     }
 
     @Test
@@ -411,6 +414,20 @@ public class OpenTelemetryConfigTest {
             OpenTelemetryConfig.resetSdkMetricExporterConfigForTests();
             // reverts to default export_timeout
             assertEquals(OPEN_TELEMETRY_METRICS_EXPORT_TIMEOUT_DEFAULT, OpenTelemetryConfig.getOpenTelemetryMetricsExportTimeout());
+        }
+    }
+
+    @Test
+    public void testGetOpenTelemetryMetricsCardinality() {
+        int expectedCardinality = 4_000;
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(mockAgent.getConfig().getValue(OPEN_TELEMETRY_METRICS_CARDINALITY, OPEN_TELEMETRY_METRICS_CARDINALITY_DEFAULT))
+                .thenReturn(expectedCardinality);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+            // configured cardinality should be respected
+            assertEquals(expectedCardinality, OpenTelemetryConfig.getOpenTelemetryMetricsCardinality());
         }
     }
 }


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview
Adds the [otlp cardinality](https://opentelemetry.io/docs/languages/java/configuration/#properties-metrics) property for metrics. This allows folks using the java agent to set cardinality (currently, if that value is set via another method it gets overwritten by the `OpenTelemetrySDKCustomizer`).

### Checks

- [x] Your contributions are backwards compatible with relevant frameworks and APIs.
- [x] Your code does not contain any breaking changes. Otherwise please describe. 
- [x] Your code does not introduce any new dependencies. Otherwise please describe.
