### PR TITLE
OTel SDK config refactor

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
@@ -252,9 +252,8 @@ public class OpenTelemetryConfig {
         return Collections.emptyList();
     }
 
-    private static List<String> getUniqueStringsFromCollection(Collection<?> values, String prefix) {
+    private static List<String> getUniqueStringsFromCollection(Collection<?> values) {
         List<String> result = new ArrayList<>(values.size());
-        boolean noPrefix = (prefix == null || prefix.isEmpty());
         for (Object value : values) {
             String val;
             if (value instanceof Integer) {
@@ -266,18 +265,10 @@ public class OpenTelemetryConfig {
             }
             val = val.trim();
             if (val.length() != 0 && !result.contains(val)) {
-                if (noPrefix) {
-                    result.add(val);
-                } else {
-                    result.add(prefix + val);
-                }
+                result.add(val);
             }
         }
         return result;
-    }
-
-    private static List<String> getUniqueStringsFromCollection(Collection<?> values) {
-        return getUniqueStringsFromCollection(values, null);
     }
 
     private static List<String> getUniqueStringsFromString(String valuesString, String separator) {

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
@@ -9,10 +9,7 @@ package com.nr.agent.instrumentation.utils.config;
 
 import com.newrelic.api.agent.NewRelic;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 
 /**
@@ -125,8 +122,7 @@ public class OpenTelemetryConfig {
         getOpenTelemetryMetricsIncludes().forEach(DEFAULT_METER_EXCLUDES::remove);
 
         // Combine the remaining default excludes with the user configured excludes for the final excludes list.
-        String metricsExclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "");
-        List<String> excludedMeters = getUniqueStringsFromString(metricsExclude, COMMA_SEPARATOR);
+        List<String> excludedMeters = getUniqueStrings(OPENTELEMETRY_METRICS_EXCLUDE, COMMA_SEPARATOR);
         excludedMeters.addAll(DEFAULT_METER_EXCLUDES);
         return excludedMeters;
     }
@@ -137,8 +133,7 @@ public class OpenTelemetryConfig {
      * @return list of OpenTelemetry Metrics includes
      */
     public static List<String> getOpenTelemetryMetricsIncludes() {
-        String metricsInclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "");
-        return getUniqueStringsFromString(metricsInclude, COMMA_SEPARATOR);
+        return getUniqueStrings(OPENTELEMETRY_METRICS_INCLUDE, COMMA_SEPARATOR);
     }
 
     /**
@@ -154,8 +149,7 @@ public class OpenTelemetryConfig {
         getOpenTelemetryTracesIncludes().forEach(DEFAULT_TRACER_EXCLUDES::remove);
 
         // Combine the remaining default excludes with the user configured excludes for the final excludes list.
-        String tracesExclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "");
-        List<String> excludedTracers = getUniqueStringsFromString(tracesExclude, COMMA_SEPARATOR);
+        List<String> excludedTracers = getUniqueStrings(OPENTELEMETRY_TRACES_EXCLUDE, COMMA_SEPARATOR);
         excludedTracers.addAll(DEFAULT_TRACER_EXCLUDES);
         return excludedTracers;
     }
@@ -166,8 +160,7 @@ public class OpenTelemetryConfig {
      * @return list of OpenTelemetry Traces includes
      */
     public static List<String> getOpenTelemetryTracesIncludes() {
-        String tracesInclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "");
-        return getUniqueStringsFromString(tracesInclude, COMMA_SEPARATOR);
+        return getUniqueStrings(OPENTELEMETRY_TRACES_INCLUDE, COMMA_SEPARATOR);
     }
 
     /**
@@ -245,18 +238,51 @@ public class OpenTelemetryConfig {
     }
 
     /**
-     * Splits the given values String into a collection of Strings based on the provided separator character.
-     *
-     * @param valuesString A separator delimited string
-     * @param separator    A character delimiter in a string
-     * @return List of string split by the separator delimiter
+     * Returns a collection of strings for the given key.  The property value can be a collection or
+     * a String list that uses a separator character.
      */
-    public static List<String> getUniqueStringsFromString(String valuesString, String separator) {
-        List<String> result = new ArrayList<>();
-        if (valuesString == null || valuesString.isEmpty()) {
-            return result;
+    protected static List<String> getUniqueStrings(String key, String separator) {
+        Object val = NewRelic.getAgent().getConfig().getValue(key);
+        if (val instanceof String && !((String) val).isEmpty()) {
+            return getUniqueStringsFromString((String) val, separator);
         }
+        if (val instanceof Collection<?> && !((Collection<?>) val).isEmpty()) {
+            return getUniqueStringsFromCollection((Collection<?>) val);
+        }
+        return Collections.emptyList();
+    }
+
+    private static List<String> getUniqueStringsFromCollection(Collection<?> values, String prefix) {
+        List<String> result = new ArrayList<>(values.size());
+        boolean noPrefix = (prefix == null || prefix.isEmpty());
+        for (Object value : values) {
+            String val;
+            if (value instanceof Integer) {
+                val = String.valueOf(value);
+            } else if (value instanceof Long) {
+                val = String.valueOf(value);
+            } else {
+                val = (String) value;
+            }
+            val = val.trim();
+            if (val.length() != 0 && !result.contains(val)) {
+                if (noPrefix) {
+                    result.add(val);
+                } else {
+                    result.add(prefix + val);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static List<String> getUniqueStringsFromCollection(Collection<?> values) {
+        return getUniqueStringsFromCollection(values, null);
+    }
+
+    private static List<String> getUniqueStringsFromString(String valuesString, String separator) {
         String[] valuesArray = valuesString.split(separator);
+        List<String> result = new ArrayList<>(valuesArray.length);
         for (String value : valuesArray) {
             value = value.trim();
             if (!value.isEmpty() && !result.contains(value)) {

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfigTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfigTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
@@ -90,8 +91,23 @@ public class OpenTelemetryConfigTest {
     @Test
     public void testGetOpenTelemetryMetricsExcludesFromYamlProps() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn("foo,bar,baz");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "")).thenReturn("");
+
+        // Comma delimited String
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn("foo,bar,baz");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+            List<String> openTelemetryMetricsExcludes = OpenTelemetryConfig.getOpenTelemetryMetricsExcludes();
+            assertEquals(3, openTelemetryMetricsExcludes.size());
+            assertTrue(openTelemetryMetricsExcludes.contains("foo"));
+            assertTrue(openTelemetryMetricsExcludes.contains("bar"));
+            assertTrue(openTelemetryMetricsExcludes.contains("baz"));
+        }
+
+        // List syntax
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(Arrays.asList("foo", "bar", "baz"));
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -106,8 +122,23 @@ public class OpenTelemetryConfigTest {
     @Test
     public void testGetOpenTelemetryTracesExcludesFromYamlProps() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn("foo,bar,baz");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+
+        // Comma delimited String
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn("foo,bar,baz");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+            List<String> openTelemetryTracesExcludes = OpenTelemetryConfig.getOpenTelemetryTracesExcludes();
+            assertEquals(3, openTelemetryTracesExcludes.size());
+            assertTrue(openTelemetryTracesExcludes.contains("foo"));
+            assertTrue(openTelemetryTracesExcludes.contains("bar"));
+            assertTrue(openTelemetryTracesExcludes.contains("baz"));
+        }
+
+        // List
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn(Arrays.asList("foo", "bar", "baz"));
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -131,9 +162,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn(environmentFacade.getenv(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(environmentFacade.getenv(
                 NEW_RELIC_OPENTELEMETRY_METRICS_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -157,9 +188,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn(environmentFacade.getenv(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn(environmentFacade.getenv(
                 NEW_RELIC_OPENTELEMETRY_TRACES_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -183,9 +214,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn(testSystemProps.getSystemProperty(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(testSystemProps.getSystemProperty(
                 NEWRELIC_CONFIG_OPENTELEMETRY_METRICS_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -207,9 +238,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn(testSystemProps.getSystemProperty(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn(testSystemProps.getSystemProperty(
                 NEWRELIC_CONFIG_OPENTELEMETRY_TRACES_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -224,8 +255,8 @@ public class OpenTelemetryConfigTest {
     @Test
     public void testIsOpenTelemetryTracerDisabled() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn("foo");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn("foo");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -238,14 +269,20 @@ public class OpenTelemetryConfigTest {
 
     @Test
     public void testGetUniqueStringsFromString() {
-        List<String> splitStrings = OpenTelemetryConfig.getUniqueStringsFromString("one,two, three , four, five,six", COMMA_SEPARATOR);
-        assertEquals(6, splitStrings.size());
-        assertTrue(splitStrings.contains("one"));
-        assertTrue(splitStrings.contains("two"));
-        assertTrue(splitStrings.contains("three"));
-        assertTrue(splitStrings.contains("four"));
-        assertTrue(splitStrings.contains("five"));
-        assertTrue(splitStrings.contains("six"));
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(mockAgent.getConfig().getValue("test")).thenReturn("one,two, three , four, five,six");
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+            List<String> splitStrings = OpenTelemetryConfig.getUniqueStrings("test", COMMA_SEPARATOR);
+            assertEquals(6, splitStrings.size());
+            assertTrue(splitStrings.contains("one"));
+            assertTrue(splitStrings.contains("two"));
+            assertTrue(splitStrings.contains("three"));
+            assertTrue(splitStrings.contains("four"));
+            assertTrue(splitStrings.contains("five"));
+            assertTrue(splitStrings.contains("six"));
+        }
     }
 
     @Test

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
@@ -130,7 +130,7 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         Agent agent = mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
         Logger logger = mock(Logger.class);
         when(agent.getLogger()).thenReturn(logger);
-        Mockito.when(agent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn(excludedMeters);
+        Mockito.when(agent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(excludedMeters);
         SdkMeterProviderBuilder customizedBuilder;
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(agent);

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/io/opentelemetry/sdk/trace/NRTracerBuilderTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/io/opentelemetry/sdk/trace/NRTracerBuilderTest.java
@@ -36,8 +36,8 @@ public class NRTracerBuilderTest extends TestCase {
 
     public void testBuildDisabled() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn("test-lib");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn("test-lib");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
@@ -252,9 +252,8 @@ public class OpenTelemetryConfig {
         return Collections.emptyList();
     }
 
-    private static List<String> getUniqueStringsFromCollection(Collection<?> values, String prefix) {
+    private static List<String> getUniqueStringsFromCollection(Collection<?> values) {
         List<String> result = new ArrayList<>(values.size());
-        boolean noPrefix = (prefix == null || prefix.isEmpty());
         for (Object value : values) {
             String val;
             if (value instanceof Integer) {
@@ -266,18 +265,10 @@ public class OpenTelemetryConfig {
             }
             val = val.trim();
             if (val.length() != 0 && !result.contains(val)) {
-                if (noPrefix) {
-                    result.add(val);
-                } else {
-                    result.add(prefix + val);
-                }
+                result.add(val);
             }
         }
         return result;
-    }
-
-    private static List<String> getUniqueStringsFromCollection(Collection<?> values) {
-        return getUniqueStringsFromCollection(values, null);
     }
 
     private static List<String> getUniqueStringsFromString(String valuesString, String separator) {

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfig.java
@@ -9,10 +9,7 @@ package com.nr.agent.instrumentation.utils.config;
 
 import com.newrelic.api.agent.NewRelic;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 
 /**
@@ -125,8 +122,7 @@ public class OpenTelemetryConfig {
         getOpenTelemetryMetricsIncludes().forEach(DEFAULT_METER_EXCLUDES::remove);
 
         // Combine the remaining default excludes with the user configured excludes for the final excludes list.
-        String metricsExclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "");
-        List<String> excludedMeters = getUniqueStringsFromString(metricsExclude, COMMA_SEPARATOR);
+        List<String> excludedMeters = getUniqueStrings(OPENTELEMETRY_METRICS_EXCLUDE, COMMA_SEPARATOR);
         excludedMeters.addAll(DEFAULT_METER_EXCLUDES);
         return excludedMeters;
     }
@@ -137,8 +133,7 @@ public class OpenTelemetryConfig {
      * @return list of OpenTelemetry Metrics includes
      */
     public static List<String> getOpenTelemetryMetricsIncludes() {
-        String metricsInclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "");
-        return getUniqueStringsFromString(metricsInclude, COMMA_SEPARATOR);
+        return getUniqueStrings(OPENTELEMETRY_METRICS_INCLUDE, COMMA_SEPARATOR);
     }
 
     /**
@@ -154,8 +149,7 @@ public class OpenTelemetryConfig {
         getOpenTelemetryTracesIncludes().forEach(DEFAULT_TRACER_EXCLUDES::remove);
 
         // Combine the remaining default excludes with the user configured excludes for the final excludes list.
-        String tracesExclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "");
-        List<String> excludedTracers = getUniqueStringsFromString(tracesExclude, COMMA_SEPARATOR);
+        List<String> excludedTracers = getUniqueStrings(OPENTELEMETRY_TRACES_EXCLUDE, COMMA_SEPARATOR);
         excludedTracers.addAll(DEFAULT_TRACER_EXCLUDES);
         return excludedTracers;
     }
@@ -166,8 +160,7 @@ public class OpenTelemetryConfig {
      * @return list of OpenTelemetry Traces includes
      */
     public static List<String> getOpenTelemetryTracesIncludes() {
-        String tracesInclude = NewRelic.getAgent().getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "");
-        return getUniqueStringsFromString(tracesInclude, COMMA_SEPARATOR);
+        return getUniqueStrings(OPENTELEMETRY_TRACES_INCLUDE, COMMA_SEPARATOR);
     }
 
     /**
@@ -245,18 +238,51 @@ public class OpenTelemetryConfig {
     }
 
     /**
-     * Splits the given values String into a collection of Strings based on the provided separator character.
-     *
-     * @param valuesString A separator delimited string
-     * @param separator    A character delimiter in a string
-     * @return List of string split by the separator delimiter
+     * Returns a collection of strings for the given key.  The property value can be a collection or
+     * a String list that uses a separator character.
      */
-    public static List<String> getUniqueStringsFromString(String valuesString, String separator) {
-        List<String> result = new ArrayList<>();
-        if (valuesString == null || valuesString.isEmpty()) {
-            return result;
+    protected static List<String> getUniqueStrings(String key, String separator) {
+        Object val = NewRelic.getAgent().getConfig().getValue(key);
+        if (val instanceof String && !((String) val).isEmpty()) {
+            return getUniqueStringsFromString((String) val, separator);
         }
+        if (val instanceof Collection<?> && !((Collection<?>) val).isEmpty()) {
+            return getUniqueStringsFromCollection((Collection<?>) val);
+        }
+        return Collections.emptyList();
+    }
+
+    private static List<String> getUniqueStringsFromCollection(Collection<?> values, String prefix) {
+        List<String> result = new ArrayList<>(values.size());
+        boolean noPrefix = (prefix == null || prefix.isEmpty());
+        for (Object value : values) {
+            String val;
+            if (value instanceof Integer) {
+                val = String.valueOf(value);
+            } else if (value instanceof Long) {
+                val = String.valueOf(value);
+            } else {
+                val = (String) value;
+            }
+            val = val.trim();
+            if (val.length() != 0 && !result.contains(val)) {
+                if (noPrefix) {
+                    result.add(val);
+                } else {
+                    result.add(prefix + val);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static List<String> getUniqueStringsFromCollection(Collection<?> values) {
+        return getUniqueStringsFromCollection(values, null);
+    }
+
+    private static List<String> getUniqueStringsFromString(String valuesString, String separator) {
         String[] valuesArray = valuesString.split(separator);
+        List<String> result = new ArrayList<>(valuesArray.length);
         for (String value : valuesArray) {
             value = value.trim();
             if (!value.isEmpty() && !result.contains(value)) {

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfigTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/com/nr/agent/instrumentation/utils/config/OpenTelemetryConfigTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
@@ -90,8 +91,23 @@ public class OpenTelemetryConfigTest {
     @Test
     public void testGetOpenTelemetryMetricsExcludesFromYamlProps() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn("foo,bar,baz");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "")).thenReturn("");
+
+        // Comma delimited String
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn("foo,bar,baz");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+            List<String> openTelemetryMetricsExcludes = OpenTelemetryConfig.getOpenTelemetryMetricsExcludes();
+            assertEquals(3, openTelemetryMetricsExcludes.size());
+            assertTrue(openTelemetryMetricsExcludes.contains("foo"));
+            assertTrue(openTelemetryMetricsExcludes.contains("bar"));
+            assertTrue(openTelemetryMetricsExcludes.contains("baz"));
+        }
+
+        // List syntax
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(Arrays.asList("foo", "bar", "baz"));
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -106,8 +122,23 @@ public class OpenTelemetryConfigTest {
     @Test
     public void testGetOpenTelemetryTracesExcludesFromYamlProps() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn("foo,bar,baz");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+
+        // Comma delimited String
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn("foo,bar,baz");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+            List<String> openTelemetryTracesExcludes = OpenTelemetryConfig.getOpenTelemetryTracesExcludes();
+            assertEquals(3, openTelemetryTracesExcludes.size());
+            assertTrue(openTelemetryTracesExcludes.contains("foo"));
+            assertTrue(openTelemetryTracesExcludes.contains("bar"));
+            assertTrue(openTelemetryTracesExcludes.contains("baz"));
+        }
+
+        // List
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn(Arrays.asList("foo", "bar", "baz"));
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -131,9 +162,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn(environmentFacade.getenv(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(environmentFacade.getenv(
                 NEW_RELIC_OPENTELEMETRY_METRICS_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -157,9 +188,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn(environmentFacade.getenv(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn(environmentFacade.getenv(
                 NEW_RELIC_OPENTELEMETRY_TRACES_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -183,9 +214,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn(testSystemProps.getSystemProperty(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(testSystemProps.getSystemProperty(
                 NEWRELIC_CONFIG_OPENTELEMETRY_METRICS_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_METRICS_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -207,9 +238,9 @@ public class OpenTelemetryConfigTest {
         setSystemPropertyProvider(systemPropertyProvider);
 
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn(testSystemProps.getSystemProperty(
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn(testSystemProps.getSystemProperty(
                 NEWRELIC_CONFIG_OPENTELEMETRY_TRACES_EXCLUDE));
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -224,8 +255,8 @@ public class OpenTelemetryConfigTest {
     @Test
     public void testIsOpenTelemetryTracerDisabled() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn("foo");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn("foo");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
@@ -238,14 +269,20 @@ public class OpenTelemetryConfigTest {
 
     @Test
     public void testGetUniqueStringsFromString() {
-        List<String> splitStrings = OpenTelemetryConfig.getUniqueStringsFromString("one,two, three , four, five,six", COMMA_SEPARATOR);
-        assertEquals(6, splitStrings.size());
-        assertTrue(splitStrings.contains("one"));
-        assertTrue(splitStrings.contains("two"));
-        assertTrue(splitStrings.contains("three"));
-        assertTrue(splitStrings.contains("four"));
-        assertTrue(splitStrings.contains("five"));
-        assertTrue(splitStrings.contains("six"));
+        Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(mockAgent.getConfig().getValue("test")).thenReturn("one,two, three , four, five,six");
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);
+            List<String> splitStrings = OpenTelemetryConfig.getUniqueStrings("test", COMMA_SEPARATOR);
+            assertEquals(6, splitStrings.size());
+            assertTrue(splitStrings.contains("one"));
+            assertTrue(splitStrings.contains("two"));
+            assertTrue(splitStrings.contains("three"));
+            assertTrue(splitStrings.contains("four"));
+            assertTrue(splitStrings.contains("five"));
+            assertTrue(splitStrings.contains("six"));
+        }
     }
 
     @Test

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
@@ -130,7 +130,7 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         Agent agent = mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
         Logger logger = mock(Logger.class);
         when(agent.getLogger()).thenReturn(logger);
-        Mockito.when(agent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE, "")).thenReturn(excludedMeters);
+        Mockito.when(agent.getConfig().getValue(OPENTELEMETRY_METRICS_EXCLUDE)).thenReturn(excludedMeters);
         SdkMeterProviderBuilder customizedBuilder;
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(agent);

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/io/opentelemetry/sdk/trace/NRTracerBuilderTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/io/opentelemetry/sdk/trace/NRTracerBuilderTest.java
@@ -39,8 +39,8 @@ public class NRTracerBuilderTest extends TestCase {
 
     public void testBuildDisabled() {
         Agent mockAgent = Mockito.mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE, "")).thenReturn("test-lib");
-        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE, "")).thenReturn("");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_EXCLUDE)).thenReturn("test-lib");
+        Mockito.when(mockAgent.getConfig().getValue(OPENTELEMETRY_TRACES_INCLUDE)).thenReturn("");
 
         try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
             mockNewRelic.when(NewRelic::getAgent).thenReturn(mockAgent);


### PR DESCRIPTION
Resolves #2908 

The following config keys can now support comma delimited format and YAML list format:

```
opentelemetry.metrics.include 
opentelemetry.metrics.exclude
opentelemetry.traces.include
opentelemetry.traces.exclude
```

It turns out that the `error_collector.ignore_classes` and `error_collector.expected_classes` have special parsing because they can support formats like the following:
```
  expected_classes:                                                                                                                                                                                                                                     
      - class_name: "com.example.RateLimitException"                                                                                                                                                                                                      
        message: "Too many requests"                                                                                                                                                                                                                      
      - class_name: "com.example.CircuitBreakerException"
        message: "High heap usage"
```

so these aren't included in the refactor even though they are mentioned in the ticket.