### PR TITLE
Log4j module corrections

### DIFF
--- a/instrumentation/apache-log4j-2.11/src/main/java/org/apache/logging/log4j/core/time/Instant_Instrumentation.java
+++ b/instrumentation/apache-log4j-2.11/src/main/java/org/apache/logging/log4j/core/time/Instant_Instrumentation.java
@@ -9,8 +9,8 @@ package org.apache.logging.log4j.core.time;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 
-// Instant was introduced in log4j 2.11.0. The weaver will fail to resolve this class on older
-// versions, preventing the 2.11 module from applying to log4j 2.6-2.10.
+// This is the same `SkipIfPresent` class in the 2.6 module, which we're now using to gate
+// the 2.11 version from applying to anything below 2.11.
 @Weave(originalName = "org.apache.logging.log4j.core.time.Instant", type = MatchType.Interface)
 public abstract class Instant_Instrumentation {
 }

--- a/instrumentation/apache-log4j-2.11/src/main/java/org/apache/logging/log4j/core/time/Instant_Instrumentation.java
+++ b/instrumentation/apache-log4j-2.11/src/main/java/org/apache/logging/log4j/core/time/Instant_Instrumentation.java
@@ -1,0 +1,16 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.apache.logging.log4j.core.time;
+
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+
+// Instant was introduced in log4j 2.11.0. The weaver will fail to resolve this class on older
+// versions, preventing the 2.11 module from applying to log4j 2.6-2.10.
+@Weave(originalName = "org.apache.logging.log4j.core.time.Instant", type = MatchType.Interface)
+public abstract class Instant_Instrumentation {
+}


### PR DESCRIPTION
Small change to restrict the range at which the `apache-log4j-2.11` module applies. This uses the same `SkipIfPresent` class in the 2.6 module to gate the 2.11 version from applying to anything below 2.11.

