### PR TITLE
Use Jakarta servlet exception attribute in WildFly 27

### DIFF
--- a/instrumentation/wildfly-27/src/main/java/com/nr/agent/instrumentation/wildfly27/WildflyServletRequestListener.java
+++ b/instrumentation/wildfly-27/src/main/java/com/nr/agent/instrumentation/wildfly27/WildflyServletRequestListener.java
@@ -23,7 +23,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public final class WildflyServletRequestListener implements ServletRequestListener {
 
-    private static final String EXCEPTION_ATTRIBUTE_NAME = "javax.servlet.error.exception";
+    private static final String EXCEPTION_ATTRIBUTE_NAME = "jakarta.servlet.error.exception";
 
     @CatchAndLog
     @Override


### PR DESCRIPTION
Fixes #2857.

WildFly 27 uses Jakarta Servlet APIs, but the listener still looks up the exception using the legacy javax.servlet.error.exception request attribute.

This change updates the attribute key to:

jakarta.servlet.error.exception

which matches the Jakarta Servlet environment used by WildFly 27 and aligns with the corresponding implementations used in other Jakarta-based containers.

Validation:
- GRADLE_USER_HOME="$PWD/.gradle-local" ./gradlew :instrumentation:wildfly-27:compileJava
- git diff --check

Notes:
- The WildFly 27 module does not contain its own test sources.
- verifyInstrumentation requires the full agent build environment and did not complete locally because WeavePackageVerifier was unavailable.
- No behavior changes beyond the attribute lookup key.
