### PR TITLE
Fix verifyInstrumentation failures for vertx-core-5.0.0 and vertx-web-5.0.0

### DIFF
--- a/instrumentation/vertx-core-5.0.0/build.gradle
+++ b/instrumentation/vertx-core-5.0.0/build.gradle
@@ -10,7 +10,8 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.vertx:vertx-core:[5.0.0,6.0.0)'
+    passesOnly 'io.vertx:vertx-core:[5.0.0,5.1.0)'
+    excludeRegex '.*CR[0-9]*'
 }
 
 java {

--- a/instrumentation/vertx-web-5.0.0/build.gradle
+++ b/instrumentation/vertx-web-5.0.0/build.gradle
@@ -16,7 +16,8 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.vertx:vertx-web:[5.0.0,6.0.0)'
+    passesOnly 'io.vertx:vertx-web:[5.0.0,5.1.0)'
+    excludeRegex '.*CR[0-9]*'
 }
 
 java {


### PR DESCRIPTION
### Overview

Both modules declared `passesOnly` ranges covering 5.0.x through 6.0.0, but breaking API changes in Vert.x 5.1.0 caused violations that prevented the instrumentation from applying. This PR narrows the range.

Passing tests per this PR can be found [here](https://github.com/newrelic/newrelic-java-agent/actions/runs/27218757520).
