### PR TITLE
Remove rmi namespaced exceptions

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/ConnectionResponseException.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/ConnectionResponseException.java
@@ -1,0 +1,13 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.newrelic.agent;
+
+public class ConnectionResponseException extends Exception {
+    public  ConnectionResponseException(String message) {
+        super(message);
+    }
+}

--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -52,7 +52,6 @@ import org.json.simple.JSONStreamAware;
 
 import java.lang.management.ManagementFactory;
 import java.net.ConnectException;
-import java.rmi.UnexpectedException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -268,7 +267,7 @@ public class RPMService extends AbstractService implements IRPMService, Environm
             List<String> requiredParams = new ArrayList<>(Arrays.asList(COLLECT_ERRORS_KEY, COLLECT_TRACES_KEY, DATA_REPORT_PERIOD_KEY));
             if (!data.keySet().containsAll(requiredParams) && !serverlessMode) {
                 requiredParams.removeAll(data.keySet());
-                throw new UnexpectedException(MessageFormat.format("Missing the following connection parameters: {0}", requiredParams));
+                throw new ConnectionResponseException(MessageFormat.format("Missing the following connection parameters: {0}", requiredParams));
             }
             Agent.LOG.log(Level.INFO, "Agent {0} connected to {1}", toString(), getHostString());
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
@@ -9,12 +9,7 @@ package com.newrelic.agent.transport;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.newrelic.agent.ForceDisconnectException;
-import com.newrelic.agent.ForceRestartException;
-import com.newrelic.agent.LicenseException;
-import com.newrelic.agent.MaxPayloadException;
-import com.newrelic.agent.MetricData;
-import com.newrelic.agent.MetricNames;
+import com.newrelic.agent.*;
 import com.newrelic.agent.agentcontrol.AgentControlIntegrationUtils;
 import com.newrelic.agent.agentcontrol.AgentHealth;
 import com.newrelic.agent.agentcontrol.HealthDataChangeListener;
@@ -51,7 +46,6 @@ import java.net.MalformedURLException;
 import java.net.SocketException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.rmi.UnexpectedException;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -248,7 +242,7 @@ public class DataSenderImpl implements DataSender, HealthDataProducer {
         params.add(startupOptions);
         Object response = invokeNoRunId(redirectHost, CollectorMethods.CONNECT, compressedEncoding, params);
         if (!(response instanceof Map)) {
-            throw new UnexpectedException(MessageFormat.format("Expected a map of connection data, got {0}", response));
+            throw new ConnectionResponseException(MessageFormat.format("Expected a map of connection data, got {0}", response));
         }
         Map<String, Object> data = (Map<String, Object>) response;
         if (data.containsKey(MAX_PAYLOAD_SIZE_IN_BYTES)) {
@@ -274,7 +268,7 @@ public class DataSenderImpl implements DataSender, HealthDataProducer {
             Object runId = data.get(ConnectionResponse.AGENT_RUN_ID_KEY);
             setAgentRunId(runId);
         } else {
-            throw new UnexpectedException(MessageFormat.format("Missing {0} connection parameter", ConnectionResponse.AGENT_RUN_ID_KEY));
+            throw new ConnectionResponseException(MessageFormat.format("Missing {0} connection parameter", ConnectionResponse.AGENT_RUN_ID_KEY));
         }
         configService.setLaspPolicies(policiesJson);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
@@ -9,7 +9,13 @@ package com.newrelic.agent.transport;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.newrelic.agent.*;
+import com.newrelic.agent.ConnectionResponseException;
+import com.newrelic.agent.ForceDisconnectException;
+import com.newrelic.agent.ForceRestartException;
+import com.newrelic.agent.LicenseException;
+import com.newrelic.agent.MaxPayloadException;
+import com.newrelic.agent.MetricData;
+import com.newrelic.agent.MetricNames;
 import com.newrelic.agent.agentcontrol.AgentControlIntegrationUtils;
 import com.newrelic.agent.agentcontrol.AgentHealth;
 import com.newrelic.agent.agentcontrol.HealthDataChangeListener;


### PR DESCRIPTION
Resolves #2235 

This creates a new, small exception class (`ConnectionResponseException`) to replace usages of `java.rmi.*` exceptions.

Note that there is still a reference to the `java.rmi` packages in the `java.xmlrpc` instrumentation module. However, this module will load very rarely (if at all) since it was removed in Java EE 7 and replaced with JAX-WS (`javax.xml.ws` packages). Modern app servers (Boot, Tomcat, etc) do not ship with any Java EE 6 artifacts.


