### PR TITLE
Add ConcurrentHashMap factory method

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/CollectionFactory.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/CollectionFactory.java
@@ -192,4 +192,24 @@ public interface CollectionFactory {
             java.util.concurrent.TimeUnit unit,
             int initialCapacity,
             CacheRemovalListener<K, V> listener);
+
+    /**
+     * Creates a {@link java.util.concurrent.ConcurrentHashMap} using the standard JDK implementation.
+     *
+     * <p>Note that instances of this class do not perform any automatic evictions. It is the
+     * responsibility of the caller to invoke {@link java.util.Map#remove(Object)} when entries are
+     * no longer needed.
+     *
+     * <p>Supply an appropriate initial capacity and load factor. The standard load factor used by the
+     * JDK is {@code 0.75}.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     * @param initialCapacity the initial capacity of the map
+     * @param loadFactor the load factor threshold for resizing
+     *
+     * @return a new {@link java.util.concurrent.ConcurrentHashMap}
+     * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html">ConcurrentHashMap (Java 8)</a>
+     */
+    <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor);
 }

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/CollectionFactory.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/CollectionFactory.java
@@ -200,16 +200,14 @@ public interface CollectionFactory {
      * responsibility of the caller to invoke {@link java.util.Map#remove(Object)} when entries are
      * no longer needed.
      *
-     * <p>Supply an appropriate initial capacity and load factor. The standard load factor used by the
-     * JDK is {@code 0.75}.
+     * <p>Supply an appropriate initial capacity.
      *
      * @param <K> the type of keys
      * @param <V> the type of values
      * @param initialCapacity the initial capacity of the map
-     * @param loadFactor the load factor threshold for resizing
      *
      * @return a new {@link java.util.concurrent.ConcurrentHashMap}
      * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html">ConcurrentHashMap (Java 8)</a>
      */
-    <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor);
+    <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity);
 }

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/DefaultCollectionFactory.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/DefaultCollectionFactory.java
@@ -168,8 +168,8 @@ public class DefaultCollectionFactory implements CollectionFactory {
     }
 
     @Override
-    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
-        return new ConcurrentHashMap<K, V>(initialCapacity, loadFactor);
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity) {
+        return new ConcurrentHashMap<K, V>(initialCapacity);
     }
 
     /**

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/DefaultCollectionFactory.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/DefaultCollectionFactory.java
@@ -167,6 +167,11 @@ public class DefaultCollectionFactory implements CollectionFactory {
         return new DefaultCleanableMap<>(Collections.synchronizedMap(new HashMap<>()));
     }
 
+    @Override
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
+        return new ConcurrentHashMap<K, V>(initialCapacity, loadFactor);
+    }
+
     /**
      * Simple wrapper that delegates all Map operations and provides a no-op cleanUp().
      */

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
@@ -8,6 +8,7 @@
 package com.newrelic.agent.util;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -163,5 +164,10 @@ public class AgentCollectionFactory implements CollectionFactory {
             int initialCapacity,
             CacheRemovalListener<K, V> listener) {
         return getDelegate().createCacheWithAccessExpirationAndRemovalListener(age, unit, initialCapacity, listener);
+    }
+
+    @Override
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
+        return getDelegate().createVanillaJavaConcurrentHashMap(initialCapacity, loadFactor);
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/AgentCollectionFactory.java
@@ -167,7 +167,7 @@ public class AgentCollectionFactory implements CollectionFactory {
     }
 
     @Override
-    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
-        return getDelegate().createVanillaJavaConcurrentHashMap(initialCapacity, loadFactor);
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity) {
+        return getDelegate().createVanillaJavaConcurrentHashMap(initialCapacity);
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/Caffeine2CollectionFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/Caffeine2CollectionFactory.java
@@ -8,6 +8,7 @@
 package com.newrelic.agent.util;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -179,6 +180,10 @@ public class Caffeine2CollectionFactory implements CollectionFactory {
                 })
                 .build();
         return new CaffeineCleanableMap<>(cache);
+    }
+    @Override
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
+        return new ConcurrentHashMap<K, V>(initialCapacity, loadFactor);
     }
 
     private CacheRemovalListener.RemovalReason convertRemovalCause(

--- a/newrelic-agent/src/main/java/com/newrelic/agent/util/Caffeine2CollectionFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/util/Caffeine2CollectionFactory.java
@@ -182,8 +182,8 @@ public class Caffeine2CollectionFactory implements CollectionFactory {
         return new CaffeineCleanableMap<>(cache);
     }
     @Override
-    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
-        return new ConcurrentHashMap<K, V>(initialCapacity, loadFactor);
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity) {
+        return new ConcurrentHashMap<K, V>(initialCapacity);
     }
 
     private CacheRemovalListener.RemovalReason convertRemovalCause(

--- a/newrelic-agent/src/main/java11/com/newrelic/agent/util/Caffeine3CollectionFactory.java
+++ b/newrelic-agent/src/main/java11/com/newrelic/agent/util/Caffeine3CollectionFactory.java
@@ -9,6 +9,7 @@ package com.newrelic.agent.util;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 // Import from SHADED Caffeine 3.2.3
@@ -189,6 +190,11 @@ public class Caffeine3CollectionFactory implements CollectionFactory {
                 })
                 .build();
         return new CaffeineCleanableMap<>(cache);
+    }
+
+    @Override
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
+        return new ConcurrentHashMap<K, V>(initialCapacity, loadFactor);
     }
 
     private CacheRemovalListener.RemovalReason convertRemovalCause(

--- a/newrelic-agent/src/main/java11/com/newrelic/agent/util/Caffeine3CollectionFactory.java
+++ b/newrelic-agent/src/main/java11/com/newrelic/agent/util/Caffeine3CollectionFactory.java
@@ -193,8 +193,8 @@ public class Caffeine3CollectionFactory implements CollectionFactory {
     }
 
     @Override
-    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity, float loadFactor) {
-        return new ConcurrentHashMap<K, V>(initialCapacity, loadFactor);
+    public <K, V> Map<K, V> createVanillaJavaConcurrentHashMap(int initialCapacity) {
+        return new ConcurrentHashMap<K, V>(initialCapacity);
     }
 
     private CacheRemovalListener.RemovalReason convertRemovalCause(


### PR DESCRIPTION
This adds a collection factory method to create a vanilla, JDK based ConcurrentHashMap. This map avoids the cache maintenance issues we see for really high volume write/evict scenarios but obviously requires the caller to manually remove entries from the Map when necessary.