### PR TITLE
Use non early access Java 26 versions for GH workflows

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         distribution: 'temurin'
         java-version: |
-          26-ea
+          26
           25
           21
           17

--- a/.github/workflows/Test-AITs.yml
+++ b/.github/workflows/Test-AITs.yml
@@ -256,7 +256,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: |
-            26-ea
+            26
             25
             21
             17
@@ -276,7 +276,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            26-ea
+            26
             25
             21
             17


### PR DESCRIPTION
Resolves #2809 
Drop the `ea` from the setup-java action for Java 26 in workflows.