### PR TITLE
Cap Mule module upper limit to 4.0.0.

### DIFF
--- a/instrumentation/mule-3.7/build.gradle
+++ b/instrumentation/mule-3.7/build.gradle
@@ -30,7 +30,7 @@ verifyInstrumentation {
     passes('org.mule:mule-core:3.7.0') {
         implementation("org.mule.modules:mule-module-http:3.7.0")
     }
-    passes('org.mule:mule-core:[3.8.0,)') {
+    passes('org.mule:mule-core:[3.8.0,4.0.0)') {
         implementation("org.mule.modules:mule-module-http:3.7.0")
     }
 

--- a/instrumentation/mule-ei2/build.gradle
+++ b/instrumentation/mule-ei2/build.gradle
@@ -27,7 +27,7 @@ jar {
 // but we can't verify that because the artifacts are enterprise only (behind auth)
 verifyInstrumentation {
     passes('org.mule:mule-core:3.7.0')
-    passes('org.mule:mule-core:[3.8.0,)')
+    passes('org.mule:mule-core:[3.8.0,4.0.0)')
 
     // these versions cause problems getting artifacts
     exclude 'org.mule:mule-core:3.8.2'


### PR DESCRIPTION
### Overview
The mule-3.7 and mule-ei2 instrumentation modules declared an unbounded upper version range ([3.8.0,)) for `org.mule:mule-core`. This causes the agent to apply Mule 3.7+ weave code to Mule 4.x runtimes which contain breaking API changes.

### Related Github Issue
Resolves #2942 

### Testing
`verifyInstrumentation` [passes](https://github.com/newrelic/newrelic-java-agent/actions/runs/27564892090)

