### PR TITLE
Update the Scala API cross build flow to support gradle 8.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.prokod.gradle-crossbuild' version '0.14.1' apply false
+    id 'com.github.prokod.gradle-crossbuild' version '0.17.0' apply false
     id "org.jetbrains.kotlin.jvm" version "1.8.21" apply false
     id "com.newrelic.gradle-verify-instrumentation-plugin" version "4.0" apply false
     id "com.newrelic.gradle-compatibility-doc-plugin" version "1.4" apply false

--- a/newrelic-cats-effect3-api/build.gradle.kts
+++ b/newrelic-cats-effect3-api/build.gradle.kts
@@ -30,25 +30,20 @@ dependencies {
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))
 }
 
-val crossBuildScala_212Jar by tasks.getting
-val crossBuildScala_213Jar by tasks.getting
-
 val javadocJar by tasks.getting
 val sourcesJar by tasks.getting
 
-mapOf(
-    "2.12" to crossBuildScala_212Jar,
-    "2.13" to crossBuildScala_213Jar
-).forEach { (scalaVersion, versionedClassJar) ->
+listOf("2.12", "2.13").forEach { scalaVersion ->
+    val componentName = "crossBuildScala_${scalaVersion.replace(".", "")}"
     PublishConfig.config(
-        "crossBuildScala_${scalaVersion.replace(".", "")}",
+        componentName,
         project,
         "New Relic Java agent Scala $scalaVersion Cats effect API",
         "The public Scala $scalaVersion API of the Java agent for Cats effect."
     ) {
+        from(components[componentName])
         artifact(sourcesJar)
         artifact(javadocJar)
-        artifact(versionedClassJar)
     }
 }
 

--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -30,29 +30,20 @@ dependencies {
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))
 }
 
-val crossBuildScala_210Jar by tasks.getting
-val crossBuildScala_211Jar by tasks.getting
-val crossBuildScala_212Jar by tasks.getting
-val crossBuildScala_213Jar by tasks.getting
-
 val javadocJar by tasks.getting
 val sourcesJar by tasks.getting
 
-mapOf(
-    "2.10" to crossBuildScala_210Jar,
-    "2.11" to crossBuildScala_211Jar,
-    "2.12" to crossBuildScala_212Jar,
-    "2.13" to crossBuildScala_213Jar
-).forEach { (scalaVersion, versionedClassJar) ->
+listOf("2.10", "2.11", "2.12", "2.13").forEach { scalaVersion ->
+    val componentName = "crossBuildScala_${scalaVersion.replace(".", "")}"
     PublishConfig.config(
-        "crossBuildScala_${scalaVersion.replace(".", "")}",
+        componentName,
         project,
         "New Relic Java agent Scala $scalaVersion API",
         "The public Scala $scalaVersion API of the Java agent, and no-op implementations for safe usage without the agent."
     ) {
+        from(components[componentName])
         artifact(sourcesJar)
         artifact(javadocJar)
-        artifact(versionedClassJar)
     }
 }
 

--- a/newrelic-scala-cats-api/build.gradle.kts
+++ b/newrelic-scala-cats-api/build.gradle.kts
@@ -29,25 +29,20 @@ dependencies {
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))
 }
 
-val crossBuildScala_212Jar by tasks.getting
-val crossBuildScala_213Jar by tasks.getting
-
 val javadocJar by tasks.getting
 val sourcesJar by tasks.getting
 
-mapOf(
-    "2.12" to crossBuildScala_212Jar,
-    "2.13" to crossBuildScala_213Jar
-).forEach { (scalaVersion, versionedClassJar) ->
+listOf("2.12", "2.13").forEach { scalaVersion ->
+    val componentName = "crossBuildScala_${scalaVersion.replace(".", "")}"
     PublishConfig.config(
-        "crossBuildScala_${scalaVersion.replace(".", "")}",
+        componentName,
         project,
         "New Relic Java agent Scala $scalaVersion Cats effect API",
         "The public Scala $scalaVersion API of the Java agent for Cats effect."
     ) {
+        from(components[componentName])
         artifact(sourcesJar)
         artifact(javadocJar)
-        artifact(versionedClassJar)
     }
 }
 

--- a/newrelic-scala-monix-api/build.gradle.kts
+++ b/newrelic-scala-monix-api/build.gradle.kts
@@ -34,27 +34,20 @@ dependencies {
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))
 }
 
-val crossBuildScala_211Jar by tasks.getting
-val crossBuildScala_212Jar by tasks.getting
-val crossBuildScala_213Jar by tasks.getting
-
 val javadocJar by tasks.getting
 val sourcesJar by tasks.getting
 
-mapOf(
-    "2.11" to crossBuildScala_211Jar,
-    "2.12" to crossBuildScala_212Jar,
-    "2.13" to crossBuildScala_213Jar
-).forEach { (scalaVersion, versionedClassJar) ->
+listOf("2.11", "2.12", "2.13").forEach { scalaVersion ->
+    val componentName = "crossBuildScala_${scalaVersion.replace(".", "")}"
     PublishConfig.config(
-        "crossBuildScala_${scalaVersion.replace(".", "")}",
+        componentName,
         project,
         "New Relic Java agent Scala $scalaVersion Monix API",
         "The public Scala $scalaVersion API of the Java agent for Monix."
     ) {
+        from(components[componentName])
         artifact(sourcesJar)
         artifact(javadocJar)
-        artifact(versionedClassJar)
     }
 }
 

--- a/newrelic-scala-zio-api/build.gradle.kts
+++ b/newrelic-scala-zio-api/build.gradle.kts
@@ -31,27 +31,20 @@ dependencies {
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))
 }
 
-val crossBuildScala_211Jar by tasks.getting
-val crossBuildScala_212Jar by tasks.getting
-val crossBuildScala_213Jar by tasks.getting
-
 val javadocJar by tasks.getting
 val sourcesJar by tasks.getting
 
-mapOf(
-    "2.11" to crossBuildScala_211Jar,
-    "2.12" to crossBuildScala_212Jar,
-    "2.13" to crossBuildScala_213Jar
-).forEach { (scalaVersion, versionedClassJar) ->
+listOf("2.11", "2.12", "2.13").forEach { scalaVersion ->
+    val componentName = "crossBuildScala_${scalaVersion.replace(".", "")}"
     PublishConfig.config(
-        "crossBuildScala_${scalaVersion.replace(".", "")}",
+        componentName,
         project,
         "New Relic Java agent Scala $scalaVersion API",
         "The public Scala $scalaVersion API of the Java agent, and no-op implementations for safe usage without the agent."
     ) {
+        from(components[componentName])
         artifact(sourcesJar)
         artifact(javadocJar)
-        artifact(versionedClassJar)
     }
 }
 

--- a/newrelic-scala-zio2-api/build.gradle.kts
+++ b/newrelic-scala-zio2-api/build.gradle.kts
@@ -31,25 +31,20 @@ dependencies {
     testImplementation(project(path = ":newrelic-agent", configuration = "tests"))
 }
 
-val crossBuildScala_212Jar by tasks.getting
-val crossBuildScala_213Jar by tasks.getting
-
 val javadocJar by tasks.getting
 val sourcesJar by tasks.getting
 
-mapOf(
-        "2.12" to crossBuildScala_212Jar,
-        "2.13" to crossBuildScala_213Jar
-).forEach { (scalaVersion, versionedClassJar) ->
+listOf("2.12", "2.13").forEach { scalaVersion ->
+    val componentName = "crossBuildScala_${scalaVersion.replace(".", "")}"
     PublishConfig.config(
-            "crossBuildScala_${scalaVersion.replace(".", "")}",
-            project,
-            "New Relic Java agent Scala $scalaVersion API",
-            "The public Scala $scalaVersion API of the Java agent, and no-op implementations for safe usage without the agent."
+        componentName,
+        project,
+        "New Relic Java agent Scala $scalaVersion API",
+        "The public Scala $scalaVersion API of the Java agent, and no-op implementations for safe usage without the agent."
     ) {
+        from(components[componentName])
         artifact(sourcesJar)
         artifact(javadocJar)
-        artifact(versionedClassJar)
     }
 }
 


### PR DESCRIPTION
Corrects issues related to publishing to maven (snapshots and releases).

Updates the Maven publication setup for all Scala API modules to be compatible with Gradle 8. and bumps the gradle-crossbuild plugin from 0.14.1 to 0.17.0

To support the new cross build plugin, the publishing config needed to be updated so that components properly resolved and the resulting POMs were correct. In Gradle 8.3, publications must declare the full software component via `from(components[...])` rather than referencing individual task artifacts. This switches each module to derive the component name dynamically from the Scala version string and uses `from(components[componentName])` and removes the explicit task variable bindings.