### PR TITLE
Serverless mode sends payload to console if file pipe not written (#2975)

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerlessWriterImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerlessWriterImpl.java
@@ -5,27 +5,38 @@ import com.newrelic.agent.logging.IAgentLogger;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.util.logging.Level;
 
 public class ServerlessWriterImpl implements ServerlessWriter {
     private final IAgentLogger logger;
-    private final File pathFile;
+    private File pathFile;
+    private boolean fileCreated;
 
     public ServerlessWriterImpl(IAgentLogger logger, String filePath) {
         this.logger = logger;
-        pathFile = new File(filePath);
+        try {
+            pathFile = new File(filePath);
+            fileCreated = true;
+        } catch (Throwable t) {
+            fileCreated = false;
+            pathFile = null;
+        }
+
     }
 
     @Override
     public synchronized void write(String filePayload, String consolePayload) {
-        if (pathFile.exists()) {
+        boolean fileWritten = false;
+        if (fileCreated && pathFile.exists()) {
             try (BufferedWriter pipe = new BufferedWriter(new FileWriter(pathFile, false))) {
                 pipe.write(filePayload);
-            } catch (IOException ignored) {
-                logger.log(Level.FINEST, "Failed to write payload", ignored);
+                fileWritten = true;
+            } catch (Throwable ex) {
+                logger.log(Level.FINEST, "Failed to write payload, writing to console instead", ex);
             }
         }
-        System.out.println(consolePayload);
+        if (!fileWritten) {
+            System.out.println(consolePayload);
+        }
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerlessWriterImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/ServerlessWriterImpl.java
@@ -14,12 +14,14 @@ public class ServerlessWriterImpl implements ServerlessWriter {
 
     public ServerlessWriterImpl(IAgentLogger logger, String filePath) {
         this.logger = logger;
+        logger.log(Level.FINEST, "Serverless Writer attempting to create a pipe file of path {0}", filePath);
         try {
             pathFile = new File(filePath);
             fileCreated = true;
         } catch (Throwable t) {
             fileCreated = false;
             pathFile = null;
+            logger.log(Level.FINEST, "Failed to create pipe file " + filePath + " for Serverless Mode, writing to console instead", t);
         }
 
     }


### PR DESCRIPTION
### Overview
Resolves an issue where ServerLess mode writes to both stdout and to the lambda extension file. 
Now in ServerLess mode, writing to file takes precedence and if it fails to write to such a file,  stdout is used instead.

### Related Github Issue
https://github.com/newrelic/newrelic-java-agent/issues/2962
