### PR TITLE
Modify scala API publish code to support gradle 8.3

### DIFF
--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -32,7 +32,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew $GRADLE_OPTIONS publish -x :newrelic-scala3-api:publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish -x :newrelic-scala-zio2-api:publish -x :agent-bridge:publish -x :agent-bridge-datastore:publish -x :newrelic-weaver:publish -x :newrelic-weaver-api:publish -x :newrelic-weaver-scala:publish -x :newrelic-weaver-scala-api:publish -x :newrelic-opentelemetry-agent-extension:publish
+        run: ./gradlew $GRADLE_OPTIONS publish -x :newrelic-scala3-api:publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish -x :newrelic-scala-zio2-api:publish -x :newrelic-scala-monix-api:publish -x :agent-bridge:publish -x :agent-bridge-datastore:publish -x :newrelic-weaver:publish -x :newrelic-weaver-api:publish -x :newrelic-weaver-scala:publish -x :newrelic-weaver-scala-api:publish -x :newrelic-opentelemetry-agent-extension:publish
       - name: Publish snapshot scala apis
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -40,7 +40,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew $GRADLE_OPTIONS :newrelic-scala3-api:publish :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish :newrelic-scala-zio2-api:publish
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-scala3-api:publish :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish :newrelic-scala-zio2-api:publish :newrelic-scala-monix-api:publish
       - name: Publish snapshot apis for Security agent
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -33,7 +33,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew $GRADLE_OPTIONS publish -x :newrelic-scala3-api:publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish -x :newrelic-scala-zio2-api:publish -x :agent-bridge:publish -x :agent-bridge-datastore:publish -x :newrelic-weaver:publish -x :newrelic-weaver-api:publish -x :newrelic-weaver-scala:publish -x :newrelic-weaver-scala-api:publish -x :newrelic-opentelemetry-agent-extension:publish -Prelease=true
+        run: ./gradlew $GRADLE_OPTIONS publish -x :newrelic-scala3-api:publish -x :newrelic-scala-api:publish -x :newrelic-scala-cats-api:publish -x :newrelic-cats-effect3-api:publish -x :newrelic-scala-zio-api:publish -x :newrelic-scala-zio2-api:publish -x :newrelic-scala-monix-api:publish -x :agent-bridge:publish -x :agent-bridge-datastore:publish -x :newrelic-weaver:publish -x :newrelic-weaver-api:publish -x :newrelic-weaver-scala:publish -x :newrelic-weaver-scala-api:publish -x :newrelic-opentelemetry-agent-extension:publish -Prelease=true
       - name: Publish release scala apis
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -41,7 +41,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew $GRADLE_OPTIONS :newrelic-scala3-api:publish :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish :newrelic-scala-zio2-api:publish -Prelease=true
+        run: ./gradlew $GRADLE_OPTIONS :newrelic-scala3-api:publish :newrelic-scala-api:publish :newrelic-scala-cats-api:publish :newrelic-cats-effect3-api:publish :newrelic-scala-zio-api:publish :newrelic-scala-zio2-api:publish :newrelic-scala-monix-api:publish -Prelease=true
       - name: Publish apis for Security agent
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/newrelic-cats-effect3-api/build.gradle.kts
+++ b/newrelic-cats-effect3-api/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.nr.builder.publish.PublishConfig
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.plugins.signing.Sign
 
 plugins {
     `maven-publish`
@@ -45,6 +47,10 @@ listOf("2.12", "2.13").forEach { scalaVersion ->
         artifact(sourcesJar)
         artifact(javadocJar)
     }
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    mustRunAfter(tasks.withType<Sign>())
 }
 
 tasks {

--- a/newrelic-scala-api/build.gradle.kts
+++ b/newrelic-scala-api/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.nr.builder.publish.PublishConfig
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.plugins.signing.Sign
 
 plugins {
     `maven-publish`
@@ -45,6 +47,10 @@ listOf("2.10", "2.11", "2.12", "2.13").forEach { scalaVersion ->
         artifact(sourcesJar)
         artifact(javadocJar)
     }
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    mustRunAfter(tasks.withType<Sign>())
 }
 
 tasks {

--- a/newrelic-scala-cats-api/build.gradle.kts
+++ b/newrelic-scala-cats-api/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.nr.builder.publish.PublishConfig
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.plugins.signing.Sign
 
 plugins {
     `maven-publish`
@@ -44,6 +46,10 @@ listOf("2.12", "2.13").forEach { scalaVersion ->
         artifact(sourcesJar)
         artifact(javadocJar)
     }
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    mustRunAfter(tasks.withType<Sign>())
 }
 
 tasks {

--- a/newrelic-scala-monix-api/build.gradle.kts
+++ b/newrelic-scala-monix-api/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.nr.builder.publish.PublishConfig
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.plugins.signing.Sign
 
 plugins {
     `maven-publish`
@@ -49,6 +51,10 @@ listOf("2.11", "2.12", "2.13").forEach { scalaVersion ->
         artifact(sourcesJar)
         artifact(javadocJar)
     }
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    mustRunAfter(tasks.withType<Sign>())
 }
 
 tasks {

--- a/newrelic-scala-zio-api/build.gradle.kts
+++ b/newrelic-scala-zio-api/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.nr.builder.publish.PublishConfig
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.plugins.signing.Sign
 
 plugins {
     `maven-publish`
@@ -46,6 +48,10 @@ listOf("2.11", "2.12", "2.13").forEach { scalaVersion ->
         artifact(sourcesJar)
         artifact(javadocJar)
     }
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    mustRunAfter(tasks.withType<Sign>())
 }
 
 tasks {

--- a/newrelic-scala-zio2-api/build.gradle.kts
+++ b/newrelic-scala-zio2-api/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.nr.builder.publish.PublishConfig
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.plugins.signing.Sign
 
 plugins {
     `maven-publish`
@@ -46,6 +48,10 @@ listOf("2.12", "2.13").forEach { scalaVersion ->
         artifact(sourcesJar)
         artifact(javadocJar)
     }
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    mustRunAfter(tasks.withType<Sign>())
 }
 
 tasks {

--- a/newrelic-weaver-scala-api/build.gradle
+++ b/newrelic-weaver-scala-api/build.gradle
@@ -1,3 +1,4 @@
+
 import com.nr.builder.publish.PublishConfig
 
 plugins {


### PR DESCRIPTION
Moves newrelic-scala-monix-api out of the main publish step and into the dedicated Scala APIs publish step, matching the pattern used by all other cross-build Scala modules. Adds explicit mustRunAfter(Sign) ordering to all six cross-build Scala API modules so Gradle 8.3's implicit dependency validation no longer chokes.