### PR TITLE
Use containerd prefix

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DockerData.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DockerData.java
@@ -57,7 +57,7 @@ public class DockerData {
 
     private static final Pattern VALID_CONTAINER_ID = Pattern.compile("^[0-9a-f]{64}$");
     private static final Pattern DOCKER_CONTAINER_STRING_V1 = Pattern.compile("^.*[^0-9a-f]+([0-9a-f]{64,}).*");
-    private static final Pattern DOCKER_CONTAINER_STRING_V2 = Pattern.compile(".*(?/docker/containers/|containerd-)([0-9a-f]{64,}).*");
+    private static final Pattern DOCKER_CONTAINER_STRING_V2 = Pattern.compile(".*(?:/docker/containers/|containerd-)([0-9a-f]{64,}).*");
 
     private final CloudConfig cloudConfig;
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DockerData.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/utilization/DockerData.java
@@ -57,7 +57,7 @@ public class DockerData {
 
     private static final Pattern VALID_CONTAINER_ID = Pattern.compile("^[0-9a-f]{64}$");
     private static final Pattern DOCKER_CONTAINER_STRING_V1 = Pattern.compile("^.*[^0-9a-f]+([0-9a-f]{64,}).*");
-    private static final Pattern DOCKER_CONTAINER_STRING_V2 = Pattern.compile(".*/docker/containers/([0-9a-f]{64,}).*");
+    private static final Pattern DOCKER_CONTAINER_STRING_V2 = Pattern.compile(".*(?/docker/containers/|containerd-)([0-9a-f]{64,}).*");
 
     private final CloudConfig cloudConfig;
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/utilization/DockerDataTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/utilization/DockerDataTest.java
@@ -61,6 +61,11 @@ public class DockerDataTest {
         line = "886 322 5:997 /docker/containers/d340a98bd7761414d6b3b8fabd2917c74d85155af1477b584bcc4adf4b94eaf1 / rw - opts ro";
         Assert.assertTrue(dockerData.checkLineAndGetResult(line, sb, CGroup.V2));
         Assert.assertEquals("d340a98bd7761414d6b3b8fabd2917c74d85155af1477b584bcc4adf4b94eaf1", sb.toString());
+
+        sb = new StringBuilder();
+        line = "3798 3797 0:25 /kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod01c130b2_45db_44b3_9f82_782cf91c1219.slice/cri-containerd-bff561381c85069f7b48c507556d799376ef8a16e88abe4779332aae7ab5fa16.scope /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:9 - cgroup cgroup rw,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd";
+        Assert.assertTrue(dockerData.checkLineAndGetResult(line, sb, CGroup.V2));
+        Assert.assertEquals("bff561381c85069f7b48c507556d799376ef8a16e88abe4779332aae7ab5fa16", sb.toString());
     }
 
     @Test


### PR DESCRIPTION
### Overview

AL2023 cgroup v2 no longer has the cgroup v1 file. And containerd uses a different format in the `mountinfo` file compared to dockerd.

I've verified that the updated regex matches the container ID reported by the infra agent for this pod.

### Related Github Issue
n/a

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
