### PR TITLE
Support ConverseStream API

### DIFF
--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseModelInvocation.java
@@ -53,19 +53,18 @@ public class ConverseModelInvocation implements ModelInvocation {
         this.modelResponse = new ConverseModelResponse(converseResponse);
     }
 
-    // TODO Stream support not implemented
     /**
      * Construct a ConverseModelInvocation representing the
      * request and response for a streaming API.
      *
-     * @param linkingMetadata       agent's context linking data
-     * @param userCustomAttributes  user custom attributes
-     * @param converseStreamRequest stream request
-     * @param converseResponse      response
-     * @param timeToFirstToken      duration in milliseconds from request start to the first token being streamed.
+     * @param linkingMetadata            agent's context linking data
+     * @param userCustomAttributes       user custom attributes
+     * @param converseStreamRequest      stream request
+     * @param converseStreamModelResponse response accumulated from the stream events
+     * @param timeToFirstToken           duration in milliseconds from request start to the first token being streamed.
      */
     public ConverseModelInvocation(Map<String, String> linkingMetadata, Map<String, Object> userCustomAttributes, ConverseStreamRequest converseStreamRequest,
-            ConverseResponse converseResponse, long timeToFirstToken) {
+            ConverseStreamModelResponse converseStreamModelResponse, long timeToFirstToken) {
         this.linkingMetadata = linkingMetadata;
         this.userAttributes = userCustomAttributes;
         this.modelRequest = new ConverseModelStreamRequest(converseStreamRequest);
@@ -75,9 +74,7 @@ public class ConverseModelInvocation implements ModelInvocation {
             this.timeToFirstToken = 0;
             NewRelic.getAgent().getLogger().log(Level.WARNING, "AIM: The time_to_first_token value overflowed the maximum int size. Setting to 0 instead.");
         }
-
-        // TODO figure out strategy for creating modelResponse from stream chunks - See Spring AI instrumentation for example
-        this.modelResponse = new ConverseModelResponse(converseResponse);
+        this.modelResponse = converseStreamModelResponse;
     }
 
     @Override

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseModelInvocation.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseModelInvocation.java
@@ -57,11 +57,11 @@ public class ConverseModelInvocation implements ModelInvocation {
      * Construct a ConverseModelInvocation representing the
      * request and response for a streaming API.
      *
-     * @param linkingMetadata            agent's context linking data
-     * @param userCustomAttributes       user custom attributes
-     * @param converseStreamRequest      stream request
+     * @param linkingMetadata             agent's context linking data
+     * @param userCustomAttributes        user custom attributes
+     * @param converseStreamRequest       stream request
      * @param converseStreamModelResponse response accumulated from the stream events
-     * @param timeToFirstToken           duration in milliseconds from request start to the first token being streamed.
+     * @param timeToFirstToken            duration in milliseconds from request start to the first token being streamed.
      */
     public ConverseModelInvocation(Map<String, String> linkingMetadata, Map<String, Object> userCustomAttributes, ConverseStreamRequest converseStreamRequest,
             ConverseStreamModelResponse converseStreamModelResponse, long timeToFirstToken) {

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseModelStreamRequest.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseModelStreamRequest.java
@@ -18,13 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
-// TODO nothing in this class has been tested as streaming support isn't yet implemented. It seems that
-//  ConverseStreamRequest provides the same APIs as ConverseRequest, so perhaps this class isn't necessary
-//  and ConverseModelRequest can just handle both request types (ConverseStreamRequest and ConverseRequest).
-//  Might just need to modify the constructor of ConverseModelRequest to accept a more generic
-//  shared interface/abstract class (e.g. BedrockRuntimeRequest, AwsRequest, or SdkRequest) and
-//  just cast to the appropriate request type if need be.
-
 /**
  * Stores the required info from the Bedrock ConverseRequest.
  * Avoids holding a reference to the request object to prevent potential memory issues.

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseStreamModelResponse.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseStreamModelResponse.java
@@ -1,0 +1,213 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package llm.converse.models.converse;
+
+import com.newrelic.api.agent.NewRelic;
+import llm.converse.models.ModelResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockStartEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockStopEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetadataEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStartEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStopEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
+
+import java.util.Optional;
+import java.util.logging.Level;
+
+import static llm.converse.models.ModelInvocation.getRandomGuid;
+
+public class ConverseStreamModelResponse implements ModelResponse, ConverseStreamResponseHandler.Visitor {
+    private String amznRequestId = "";
+    private String responseOrganization = "";
+
+    private String operationType = COMPLETION;
+
+    private boolean isSuccessfulResponse = false;
+    private int statusCode = 0;
+    private String statusText = "";
+
+    private boolean streamErrorOccurred = false;
+
+    private final String llmChatCompletionSummaryId = getRandomGuid();
+    private String stopReason = "";
+    private String role = "";
+    private final StringBuilder content = new StringBuilder();
+    private Integer inputTokens = 0;
+    private Integer outputTokens = 0;
+    private Integer totalTokens = 0;
+
+    /**
+     * Apply the initial HTTP response info delivered via {@code responseReceived}.
+     * Mirrors what {@link ConverseModelResponse} extracts from a non-streaming ConverseResponse.
+     *
+     * @param converseStreamResponse the initial response delivered before any stream events
+     */
+    public void applyHttpResponse(ConverseStreamResponse converseStreamResponse) {
+        if (converseStreamResponse != null) {
+            SdkHttpResponse sdkHttpResponse = converseStreamResponse.sdkHttpResponse();
+            if (sdkHttpResponse != null) {
+                isSuccessfulResponse = sdkHttpResponse.isSuccessful();
+                statusCode = sdkHttpResponse.statusCode();
+                Optional<String> statusTextOptional = sdkHttpResponse.statusText();
+                statusTextOptional.ifPresent(s -> statusText = s);
+            }
+            if (converseStreamResponse.responseMetadata() != null) {
+                amznRequestId = converseStreamResponse.responseMetadata().requestId();
+            }
+        } else {
+            NewRelic.getAgent().getLogger().log(Level.INFO, "AIM: Received null ConverseStreamResponse");
+        }
+    }
+
+    public void markStreamError() {
+        streamErrorOccurred = true;
+    }
+
+    /**
+     * Dispatches a single streamed event to the matching visit method above, based on the
+     * event's runtime type rather than {@code output.accept(Visitor)} or {@code sdkEventType()}.
+     * The SDK's generated event classes throw UnsupportedOperationException from accept(), and
+     * sdkEventType() is not populated on these event instances, so dispatch is done here instead.
+     *
+     * @param output a single event delivered via the event publisher
+     */
+    public void apply(ConverseStreamOutput output) {
+        if (output instanceof MessageStartEvent) {
+            visitMessageStart((MessageStartEvent) output);
+        } else if (output instanceof ContentBlockStartEvent) {
+            visitContentBlockStart((ContentBlockStartEvent) output);
+        } else if (output instanceof ContentBlockDeltaEvent) {
+            visitContentBlockDelta((ContentBlockDeltaEvent) output);
+        } else if (output instanceof ContentBlockStopEvent) {
+            visitContentBlockStop((ContentBlockStopEvent) output);
+        } else if (output instanceof MessageStopEvent) {
+            visitMessageStop((MessageStopEvent) output);
+        } else if (output instanceof ConverseStreamMetadataEvent) {
+            visitMetadata((ConverseStreamMetadataEvent) output);
+        } else {
+            visitDefault(output);
+        }
+    }
+
+    @Override
+    public void visitDefault(ConverseStreamOutput event) {
+        // No-op, unrecognized event types are ignored
+    }
+
+    @Override
+    public void visitMessageStart(MessageStartEvent event) {
+        role = event.roleAsString();
+    }
+
+    @Override
+    public void visitContentBlockStart(ContentBlockStartEvent event) {
+        // No-op, only text deltas are accumulated
+    }
+
+    @Override
+    public void visitContentBlockDelta(ContentBlockDeltaEvent event) {
+        if (event.delta() != null && event.delta().text() != null) {
+            content.append(event.delta().text());
+        }
+    }
+
+    @Override
+    public void visitContentBlockStop(ContentBlockStopEvent event) {
+        // No-op, only text deltas are accumulated
+    }
+
+    @Override
+    public void visitMessageStop(MessageStopEvent event) {
+        stopReason = event.stopReasonAsString();
+    }
+
+    @Override
+    public void visitMetadata(ConverseStreamMetadataEvent event) {
+        TokenUsage usage = event.usage();
+        if (usage != null) {
+            inputTokens = usage.inputTokens();
+            outputTokens = usage.outputTokens();
+            totalTokens = usage.totalTokens();
+        }
+    }
+
+    @Override
+    public String getResponseMessage(int index) {
+        return content.toString();
+    }
+
+    @Override
+    public int getNumberOfResponseMessages() {
+        return 1;
+    }
+
+    @Override
+    public String getStopReason() {
+        return stopReason;
+    }
+
+    @Override
+    public String getAmznRequestId() {
+        return amznRequestId;
+    }
+
+    @Override
+    public String getOperationType() {
+        return operationType;
+    }
+
+    @Override
+    public String getLlmChatCompletionSummaryId() {
+        return llmChatCompletionSummaryId;
+    }
+
+    @Override
+    public boolean isErrorResponse() {
+        return !isSuccessfulResponse || streamErrorOccurred;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String getStatusText() {
+        return statusText;
+    }
+
+    @Override
+    public boolean isUser() {
+        return role.equalsIgnoreCase("user");
+    }
+
+    @Override
+    public String getResponseOrganization() {
+        return responseOrganization;
+    }
+
+    @Override
+    public Integer getResponseUsagePromptTokens() {
+        return inputTokens;
+    }
+
+    @Override
+    public Integer getResponseUsageCompletionTokens() {
+        return outputTokens;
+    }
+
+    @Override
+    public Integer getResponseUsageTotalTokens() {
+        return totalTokens;
+    }
+}

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseStreamResponseHandlerWrapper.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/llm/converse/models/converse/ConverseStreamResponseHandlerWrapper.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package llm.converse.models.converse;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.Token;
+import com.newrelic.api.agent.Segment;
+import llm.converse.models.ModelInvocation;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Wraps the supplied {@link ConverseStreamResponseHandler}, delegating every call
+ * so the customer's own handling is unaffected, while tapping the event publisher to accumulate
+ * the info needed to record LlmEvents once the stream completes or fails.
+ */
+public class ConverseStreamResponseHandlerWrapper implements ConverseStreamResponseHandler {
+    private final ConverseStreamResponseHandler delegate;
+    private final ConverseStreamRequest converseStreamRequest;
+    private final Map<String, String> linkingMetadata;
+    private final Map<String, Object> userAttributes;
+    private final Segment segment;
+    private final Token token;
+    private final long startTime;
+    private final String implementationTitle;
+    private final ConverseStreamModelResponse modelResponse = new ConverseStreamModelResponse();
+
+    private boolean firstEventSeen = false;
+    private long timeToFirstToken = 0;
+
+    public ConverseStreamResponseHandlerWrapper(ConverseStreamResponseHandler delegate, ConverseStreamRequest converseStreamRequest,
+            Map<String, String> linkingMetadata, Map<String, Object> userAttributes, Segment segment, Token token, long startTime,
+            String implementationTitle) {
+        this.delegate = delegate;
+        this.converseStreamRequest = converseStreamRequest;
+        this.linkingMetadata = linkingMetadata;
+        this.userAttributes = userAttributes;
+        this.segment = segment;
+        this.token = token;
+        this.startTime = startTime;
+        this.implementationTitle = implementationTitle;
+    }
+
+    @Override
+    public void responseReceived(ConverseStreamResponse response) {
+        modelResponse.applyHttpResponse(response);
+        delegate.responseReceived(response);
+    }
+
+    @Override
+    public void onEventStream(SdkPublisher<ConverseStreamOutput> publisher) {
+        SdkPublisher<ConverseStreamOutput> tappedPublisher = publisher.map(new Function<ConverseStreamOutput, ConverseStreamOutput>() {
+            @Override
+            public ConverseStreamOutput apply(ConverseStreamOutput output) {
+                if (!firstEventSeen) {
+                    firstEventSeen = true;
+                    timeToFirstToken = System.currentTimeMillis() - startTime;
+                }
+                modelResponse.apply(output);
+                return output;
+            }
+        });
+        delegate.onEventStream(tappedPublisher);
+    }
+
+    @Override
+    public void exceptionOccurred(Throwable throwable) {
+        try {
+            delegate.exceptionOccurred(throwable);
+        } finally {
+            modelResponse.markStreamError();
+            finish();
+        }
+    }
+
+    @Override
+    public void complete() {
+        try {
+            delegate.complete();
+        } finally {
+            finish();
+        }
+    }
+
+    private void finish() {
+        try {
+            ModelInvocation converseModelInvocation = new ConverseModelInvocation(linkingMetadata, userAttributes, converseStreamRequest,
+                    modelResponse, timeToFirstToken);
+            converseModelInvocation.recordLlmEventsAsync(startTime, token);
+        } catch (Throwable t) {
+            AgentBridge.instrumentation.noticeInstrumentationError(t, implementationTitle);
+        } finally {
+            if (segment != null) {
+                segment.endAsync();
+            }
+        }
+    }
+}

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/software/amazon/awssdk/services/bedrockruntime/BedrockRuntimeAsyncClient_Instrumentation.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/main/java/software/amazon/awssdk/services/bedrockruntime/BedrockRuntimeAsyncClient_Instrumentation.java
@@ -18,7 +18,9 @@ import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 import llm.converse.models.ModelInvocation;
+import llm.converse.models.ModelResponse;
 import llm.converse.models.converse.ConverseModelInvocation;
+import llm.converse.models.converse.ConverseStreamResponseHandlerWrapper;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
@@ -29,6 +31,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 import static com.newrelic.agent.bridge.aimonitoring.AiMonitoringUtils.isAiMonitoringEnabled;
+import static com.newrelic.agent.bridge.aimonitoring.AiMonitoringUtils.isAiMonitoringStreamingEnabled;
+import static llm.converse.vendor.Vendor.BEDROCK;
 import static llm.converse.vendor.Vendor.VENDOR_VERSION;
 
 /**
@@ -92,11 +96,31 @@ public abstract class BedrockRuntimeAsyncClient_Instrumentation {
     @Trace
     public CompletableFuture<Void> converseStream(ConverseStreamRequest converseStreamRequest, ConverseStreamResponseHandler asyncResponseHandler) {
         long startTime = System.currentTimeMillis();
-        CompletableFuture<Void> voidFuture = Weaver.callOriginal();
 
-        // TODO figure out strategy for creating modelResponse from stream chunks - See Spring AI instrumentation for example
-        //  If streaming support is not possible, then log that as we do in the aws-bedrock-runtime-2.20 instrumentation module
+        if (isAiMonitoringEnabled()) {
+            Transaction txn = AgentBridge.getAgent().getTransaction();
+            ModelInvocation.incrementInstrumentedSupportabilityMetric(VENDOR_VERSION);
 
-        return voidFuture;
+            if (!(txn instanceof NoOpTransaction)) {
+                Segment segment = txn.startSegment("");
+                ModelInvocation.setLlmTrueAgentAttribute(txn);
+                segment.setMetricName("Llm", ModelResponse.COMPLETION, BEDROCK, "converseStream");
+
+                if (asyncResponseHandler == null) {
+                    segment.end();
+                } else if (isAiMonitoringStreamingEnabled()) {
+                    Map<String, Object> userAttributes = txn.getUserAttributes();
+                    Map<String, String> linkingMetadata = NewRelic.getAgent().getLinkingMetadata();
+                    Token token = txn.getToken();
+
+                    asyncResponseHandler = new ConverseStreamResponseHandlerWrapper(asyncResponseHandler, converseStreamRequest, linkingMetadata,
+                            userAttributes, segment, token, startTime, Weaver.getImplementationTitle());
+                } else {
+                    segment.end();
+                }
+            }
+        }
+
+        return Weaver.callOriginal();
     }
 }

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/llm/converse/models/TestUtil.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/llm/converse/models/TestUtil.java
@@ -134,6 +134,23 @@ public class TestUtil {
         }
     }
 
+    public static void assertStreamErrorEvent(boolean isError, Collection<ErrorEvent> errorEvents) {
+        if (isError) {
+            assertEquals(1, errorEvents.size());
+            ErrorEvent errorEvent = errorEvents.iterator().next();
+
+            assertEquals("LlmError: " + SUCCESS_STATUS_TEXT, errorEvent.getErrorClass());
+            assertEquals("LlmError: " + SUCCESS_STATUS_TEXT, errorEvent.getErrorMessage());
+
+            Map<String, Object> errorEventAttributes = errorEvent.getAttributes();
+            assertFalse(errorEventAttributes.isEmpty());
+            assertEquals(SUCCESS_STATUS_CODE, errorEventAttributes.get("error.code"));
+            assertEquals(SUCCESS_STATUS_CODE, errorEventAttributes.get("http.statusCode"));
+        } else {
+            assertTrue(errorEvents.isEmpty());
+        }
+    }
+
     public static ConverseModelInvocation mockConverseModelInvocation(String modelId, String requestBody, String responseBody, boolean isError, boolean completeUsage) {
         // Given
         Map<String, String> linkingMetadata = new HashMap<>();

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/AIM_StreamingDisabled_BedrockRuntimeAsyncClient_InstrumentationTest.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/AIM_StreamingDisabled_BedrockRuntimeAsyncClient_InstrumentationTest.java
@@ -17,8 +17,6 @@ import com.newrelic.api.agent.Trace;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
-import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
 
@@ -31,17 +29,14 @@ import java.util.concurrent.TimeUnit;
 import static llm.converse.events.LlmEvent.LLM_CHAT_COMPLETION_MESSAGE;
 import static llm.converse.events.LlmEvent.LLM_CHAT_COMPLETION_SUMMARY;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static software.amazon.awssdk.services.bedrockruntime.MockConverseRequest.converseRequest;
 import static software.amazon.awssdk.services.bedrockruntime.MockConverseRequest.converseStreamRequest;
 
 @RunWith(InstrumentationTestRunner.class)
-@InstrumentationTestConfig(includePrefixes = { "software.amazon.awssdk.services.bedrockruntime" }, configName = "llm_disabled_server_side.yml")
+@InstrumentationTestConfig(includePrefixes = { "software.amazon.awssdk.services.bedrockruntime" }, configName = "llm_streaming_disabled.yml")
 
-public class AIM_Disabled_ServerSide_BedrockRuntimeAsyncClient_InstrumentationTest {
+public class AIM_StreamingDisabled_BedrockRuntimeAsyncClient_InstrumentationTest {
     private static final BedrockRuntimeAsyncClientMock mockBedrockRuntimeAsyncClient = new BedrockRuntimeAsyncClientMock();
     private final Introspector introspector = InstrumentationTestRunner.getIntrospector();
 
@@ -51,52 +46,12 @@ public class AIM_Disabled_ServerSide_BedrockRuntimeAsyncClient_InstrumentationTe
     }
 
     @Test
-    public void testConverseAsyncCompletion() throws ExecutionException, InterruptedException {
-        boolean isError = false;
-        ConverseResponse converseResponse = converseAsyncRequestInTransaction(converseRequest(isError));
-        assertNotNull(converseResponse);
-        assertNoLlmTransaction();
-        assertNoLlmSupportabilityMetrics();
-        assertNoLlmEvents();
-        assertTrue(introspector.getErrorEvents().isEmpty());
-    }
-
-    @Test
-    public void testConverseAsyncCompletionError() throws ExecutionException, InterruptedException {
-        boolean isError = true;
-        ConverseResponse converseResponse = converseAsyncRequestInTransaction(converseRequest(isError));
-        assertNotNull(converseResponse);
-        assertNoLlmTransaction();
-        assertNoLlmSupportabilityMetrics();
-        assertNoLlmEvents();
-        assertTrue(introspector.getErrorEvents().isEmpty());
-    }
-
-    @Trace(dispatcher = true)
-    private ConverseResponse converseAsyncRequestInTransaction(ConverseRequest converseRequest) throws ExecutionException, InterruptedException {
-        addCustomParameters();
-        CompletableFuture<ConverseResponse> converseResponseFuture = mockBedrockRuntimeAsyncClient.converse(converseRequest);
-        return converseResponseFuture.get();
-    }
-
-    @Test
     public void testConverseStreamCompletion() throws ExecutionException, InterruptedException {
         boolean isError = false;
         Void unused = converseStreamRequestInTransaction(converseStreamRequest(isError));
         assertNull(unused);
-        assertNoLlmTransaction();
-        assertNoLlmSupportabilityMetrics();
-        assertNoLlmEvents();
-        assertTrue(introspector.getErrorEvents().isEmpty());
-    }
-
-    @Test
-    public void testConverseStreamCompletionError() throws ExecutionException, InterruptedException {
-        boolean isError = true;
-        Void unused = converseStreamRequestInTransaction(converseStreamRequest(isError));
-        assertNull(unused);
-        assertNoLlmTransaction();
-        assertNoLlmSupportabilityMetrics();
+        assertStreamTransaction();
+        assertSupportabilityMetrics();
         assertNoLlmEvents();
         assertTrue(introspector.getErrorEvents().isEmpty());
     }
@@ -104,38 +59,38 @@ public class AIM_Disabled_ServerSide_BedrockRuntimeAsyncClient_InstrumentationTe
     @Trace(dispatcher = true)
     private Void converseStreamRequestInTransaction(ConverseStreamRequest converseStreamRequest) throws ExecutionException, InterruptedException {
         addCustomParameters();
-        // A subscriber (or onEventStream) is required to build a ConverseStreamResponseHandler; a no-op
-        // one is enough here since AI monitoring is disabled and the handler is never wrapped
+
         ConverseStreamResponseHandler converseStreamResponseHandler = ConverseStreamResponseHandler.builder().subscriber(event -> { }).build();
         CompletableFuture<Void> converseResponseFuture = mockBedrockRuntimeAsyncClient.converseStream(converseStreamRequest, converseStreamResponseHandler);
         return converseResponseFuture.get();
     }
 
     private void addCustomParameters() {
-        NewRelic.addCustomParameter("llm.conversation_id", "conversation-id-value"); // Will be added to LLM events
-        NewRelic.addCustomParameter("llm.testPrefix", "testPrefix"); // Will be added to LLM events
-        NewRelic.addCustomParameter("test", "test"); // Will NOT be added to LLM events
+        NewRelic.addCustomParameter("llm.conversation_id", "conversation-id-value");
+        NewRelic.addCustomParameter("llm.testPrefix", "testPrefix");
+        NewRelic.addCustomParameter("test", "test");
     }
 
-    private void assertNoLlmTransaction() {
+    private void assertStreamTransaction() {
         assertEquals(1, introspector.getFinishedTransactionCount(TimeUnit.SECONDS.toMillis(2)));
         Collection<String> transactionNames = introspector.getTransactionNames();
         String transactionName = transactionNames.iterator().next();
         Map<String, TracedMetricData> metrics = introspector.getMetricsForTransaction(transactionName);
-        assertFalse(metrics.containsKey("Llm/completion/Bedrock/converse"));
+
+        assertTrue(metrics.containsKey("Llm/completion/Bedrock/converseStream"));
+        assertEquals(1, metrics.get("Llm/completion/Bedrock/converseStream").getCallCount());
     }
 
-    private void assertNoLlmSupportabilityMetrics() {
+    private void assertSupportabilityMetrics() {
         Map<String, TracedMetricData> unscopedMetrics = introspector.getUnscopedMetrics();
-        assertFalse(unscopedMetrics.containsKey("Supportability/Java/ML/Bedrock/2.26.25"));
+        assertTrue(unscopedMetrics.containsKey("Supportability/Java/ML/Bedrock/2.26.25"));
+        assertTrue(unscopedMetrics.containsKey("Supportability/Java/ML/Streaming/Disabled"));
     }
 
     private void assertNoLlmEvents() {
-        // LlmChatCompletionMessage events
         Collection<Event> llmChatCompletionMessageEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_MESSAGE);
         assertEquals(0, llmChatCompletionMessageEvents.size());
 
-        // LlmCompletionSummary events
         Collection<Event> llmCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
         assertEquals(0, llmCompletionSummaryEvents.size());
     }

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/BedrockRuntimeAsyncClientMock.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/BedrockRuntimeAsyncClientMock.java
@@ -7,6 +7,7 @@
 
 package software.amazon.awssdk.services.bedrockruntime;
 
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
@@ -14,6 +15,8 @@ import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRespon
 
 import java.util.concurrent.CompletableFuture;
 
+import static software.amazon.awssdk.services.bedrockruntime.MockConverseResponse.converseStreamEvents;
+import static software.amazon.awssdk.services.bedrockruntime.MockConverseResponse.converseStreamResponse;
 import static software.amazon.awssdk.services.bedrockruntime.MockConverseResponse.sdkResponse;
 
 public class BedrockRuntimeAsyncClientMock implements BedrockRuntimeAsyncClient {
@@ -35,7 +38,15 @@ public class BedrockRuntimeAsyncClientMock implements BedrockRuntimeAsyncClient 
 
     @Override
     public CompletableFuture<Void> converseStream(ConverseStreamRequest converseStreamRequest, ConverseStreamResponseHandler asyncResponseHandler) {
-        // TODO Stream support not implemented
+        boolean isError = converseStreamRequest.additionalModelRequestFields().asBoolean();
+
+        asyncResponseHandler.responseReceived(converseStreamResponse());
+        if (isError) {
+            asyncResponseHandler.exceptionOccurred(new RuntimeException("Simulated ConverseStream failure"));
+        } else {
+            asyncResponseHandler.onEventStream(SdkPublisher.fromIterable(converseStreamEvents()));
+            asyncResponseHandler.complete();
+        }
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/BedrockRuntimeAsyncClient_InstrumentationTest.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/BedrockRuntimeAsyncClient_InstrumentationTest.java
@@ -38,8 +38,10 @@ import static llm.converse.models.TestUtil.STOP_REASON;
 import static llm.converse.models.TestUtil.assertErrorEvent;
 import static llm.converse.models.TestUtil.assertLlmChatCompletionMessageAttributes;
 import static llm.converse.models.TestUtil.assertLlmChatCompletionSummaryAttributes;
+import static llm.converse.models.TestUtil.assertStreamErrorEvent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static software.amazon.awssdk.services.bedrockruntime.MockConverseRequest.converseRequest;
 import static software.amazon.awssdk.services.bedrockruntime.MockConverseRequest.converseStreamRequest;
@@ -85,38 +87,48 @@ public class BedrockRuntimeAsyncClient_InstrumentationTest {
         return converseResponseFuture.get();
     }
 
-    // TODO Stream support not implemented
-//    @Test
-//    public void testConverseStreamCompletion() throws ExecutionException, InterruptedException {
-//        boolean isError = false;
-//        Void unused = converseStreamRequestInTransaction(converseStreamRequest(isError));
-////        assertNotNull(converseResponse);
-//        assertTransaction();
-//        assertSupportabilityMetrics();
-//        assertLlmEvents();
-//        assertTrue(introspector.getErrorEvents().isEmpty());
-//    }
+    @Test
+    public void testConverseStreamCompletion() throws ExecutionException, InterruptedException {
+        boolean isError = false;
+        Void unused = converseStreamRequestInTransaction(converseStreamRequest(isError));
+        assertNull(unused);
+        assertStreamTransaction();
+        assertSupportabilityMetrics();
+        assertLlmEvents();
+        assertErrorEvent(isError, introspector.getErrorEvents());
+    }
 
-    // TODO Stream support not implemented
-//    @Test
-//    public void testConverseStreamCompletionError() throws ExecutionException, InterruptedException {
-//        boolean isError = true; // TODO might need to add a custom error flag on the request
-//        Void unused = converseStreamRequestInTransaction(converseStreamRequest());
-////        assertNotNull(converseResponse);
-//        assertTransaction();
-//        assertSupportabilityMetrics();
-//        assertLlmEvents();
-//        assertTrue(introspector.getErrorEvents().isEmpty());
-//    }
+    @Test
+    public void testConverseStreamCompletionError() throws ExecutionException, InterruptedException {
+        boolean isError = true;
+        Void unused = converseStreamRequestInTransaction(converseStreamRequest(isError));
+        assertNull(unused);
+        assertStreamTransaction();
+        assertSupportabilityMetrics();
+        assertStreamErrorEvent(isError, introspector.getErrorEvents());
 
-    // TODO Stream support not implemented
-//    @Trace(dispatcher = true)
-//    private Void converseStreamRequestInTransaction(ConverseStreamRequest converseStreamRequest) throws ExecutionException, InterruptedException {
-//        addCustomParameters();
-//        ConverseStreamResponseHandler converseStreamResponseHandler = ConverseStreamResponseHandler.builder().build();
-//        CompletableFuture<Void> converseResponseFuture = mockBedrockRuntimeAsyncClient.converseStream(converseStreamRequest, converseStreamResponseHandler);
-//        return converseResponseFuture.get();
-//    }
+        Collection<Event> llmCompletionSummaryEvents = introspector.getCustomEvents(LLM_CHAT_COMPLETION_SUMMARY);
+        assertEquals(1, llmCompletionSummaryEvents.size());
+        assertEquals(true, llmCompletionSummaryEvents.iterator().next().getAttributes().get("error"));
+    }
+
+    @Trace(dispatcher = true)
+    private Void converseStreamRequestInTransaction(ConverseStreamRequest converseStreamRequest) throws ExecutionException, InterruptedException {
+        addCustomParameters();
+
+        ConverseStreamResponseHandler converseStreamResponseHandler = ConverseStreamResponseHandler.builder().subscriber(event -> { }).build();
+        CompletableFuture<Void> converseResponseFuture = mockBedrockRuntimeAsyncClient.converseStream(converseStreamRequest, converseStreamResponseHandler);
+        return converseResponseFuture.get();
+    }
+
+    private void assertStreamTransaction() {
+        assertEquals(1, introspector.getFinishedTransactionCount(TimeUnit.SECONDS.toMillis(2)));
+        Collection<String> transactionNames = introspector.getTransactionNames();
+        String transactionName = transactionNames.iterator().next();
+        Map<String, TracedMetricData> metrics = introspector.getMetricsForTransaction(transactionName);
+        assertTrue(metrics.containsKey("Llm/completion/Bedrock/converseStream"));
+        assertEquals(1, metrics.get("Llm/completion/Bedrock/converseStream").getCallCount());
+    }
 
     private void addCustomParameters() {
         NewRelic.addCustomParameter("llm.conversation_id", "conversation-id-value"); // Will be added to LLM events

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/MockConverseResponse.java
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/java/software/amazon/awssdk/services/bedrockruntime/MockConverseResponse.java
@@ -12,12 +12,21 @@ import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDelta;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseOutput;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetadataEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStartEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStopEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import static llm.converse.models.TestUtil.AWS_REQUEST_ID;
 import static llm.converse.models.TestUtil.ERROR_STATUS_CODE;
@@ -56,5 +65,41 @@ public class MockConverseResponse {
                 .responseMetadata(awsResponseMetadata)
                 .sdkHttpResponse(sdkHttpFullResponse)
                 .build();
+    }
+
+    /**
+     * Builds the initial response delivered to a ConverseStreamResponseHandler via responseReceived,
+     * before any stream events arrive.
+     */
+    public static ConverseStreamResponse converseStreamResponse() {
+        HashMap<String, String> metadata = new HashMap<>();
+        metadata.put("AWS_REQUEST_ID", AWS_REQUEST_ID);
+        AwsResponseMetadata awsResponseMetadata = new BedrockRuntimeResponseMetadataMock(metadata);
+
+        SdkHttpFullResponse sdkHttpFullResponse = SdkHttpResponse.builder().statusCode(SUCCESS_STATUS_CODE).statusText(SUCCESS_STATUS_TEXT).build();
+
+        return (ConverseStreamResponse) ConverseStreamResponse.builder()
+                .responseMetadata(awsResponseMetadata)
+                .sdkHttpResponse(sdkHttpFullResponse)
+                .build();
+    }
+
+    /**
+     * Builds the sequence of ConverseStreamOutput events a successful ConverseStream call would
+     * deliver via onEventStream: a message start, a single text delta, a message stop with the
+     * finish reason, and a metadata event carrying token usage.
+     */
+    public static List<ConverseStreamOutput> converseStreamEvents() {
+        List<ConverseStreamOutput> events = new ArrayList<>();
+        events.add(MessageStartEvent.builder().role(RESPONSE_ROLE).build());
+        events.add(ContentBlockDeltaEvent.builder()
+                .contentBlockIndex(0)
+                .delta(ContentBlockDelta.builder().text(RESPONSE_CONTENT_TEXT).build())
+                .build());
+        events.add(MessageStopEvent.builder().stopReason(STOP_REASON).build());
+        events.add(ConverseStreamMetadataEvent.builder()
+                .usage(TokenUsage.builder().inputTokens(INPUT_TOKENS).outputTokens(OUTPUT_TOKENS).totalTokens(TOTAL_TOKENS).build())
+                .build());
+        return events;
     }
 }

--- a/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/resources/llm_streaming_disabled.yml
+++ b/instrumentation/aws-bedrock-runtime-converse-api-2.26.25/src/test/resources/llm_streaming_disabled.yml
@@ -1,0 +1,11 @@
+common: &default_settings
+  ai_monitoring:
+    enabled: true
+    record_content:
+      enabled: true
+    streaming:
+      enabled: false
+
+  custom_insights_events:
+    max_samples_stored: 30000
+    max_attribute_value: 255


### PR DESCRIPTION
### Overview
This PR implements `converseStream` instrumentation on `BedrockRuntimeAsyncClient` and adds a new `ConverseStreamModelResponse` to help accumulate response state incrementally from stream events. Other additions include:
- A new `ConverseStreamResponseHandlerWrapper` which wraps `ConverseStreamResponseHandler` and taps the event publisher to observe and record LLM events.
- `converseStream` now starts/names a segment and wraps the handler when streaming is enabled.
- The streaming constructor now takes `ConverseStreamModelResponse` instead of a `ConverseResponse`.

### Related Github Issue
#2056 

### Testing
5 tests have been added to exercise permutations of stream API use.
