### PR TITLE
T4cconn fix

### DIFF
--- a/instrumentation/jdbc-socket-jdk21/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
+++ b/instrumentation/jdbc-socket-jdk21/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
@@ -37,7 +37,6 @@ public abstract class SocketChannel_Instrumentation {
     public boolean connect(SocketAddress remote) throws IOException {
         boolean result = Weaver.callOriginal();
         if (DatastoreInstanceDetection.shouldDetectConnectionAddress() && (remote instanceof InetSocketAddress)) {
-            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=connect, storing address {0}", remote);
             this.address = (InetSocketAddress) remote;
         }
         return result;
@@ -46,7 +45,6 @@ public abstract class SocketChannel_Instrumentation {
     public boolean finishConnect() {
         boolean result = Weaver.callOriginal();
         if (isConnected() && DatastoreInstanceDetection.shouldDetectConnectionAddress() && this.address != null) {
-            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=finishConnect, saving address {0}", this.address);
             DatastoreInstanceDetection.saveAddress(this.address);
         }
         return result;

--- a/instrumentation/jdbc-socket-jdk21/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
+++ b/instrumentation/jdbc-socket-jdk21/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
@@ -9,15 +9,21 @@ package java.nio.channels;
 
 import com.newrelic.agent.bridge.datastore.DatastoreInstanceDetection;
 import com.newrelic.agent.bridge.datastore.JdbcHelper;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.logging.Level;
 
 @Weave(originalName = "java.nio.channels.SocketChannel", type = MatchType.BaseClass)
 public abstract class SocketChannel_Instrumentation {
+    @NewField
+    InetSocketAddress address;
 
     public static SocketChannel_Instrumentation open(SocketAddress remote) {
         SocketChannel_Instrumentation channel = Weaver.callOriginal();
@@ -26,6 +32,24 @@ public abstract class SocketChannel_Instrumentation {
             DatastoreInstanceDetection.saveAddress((InetSocketAddress) remote);
         }
         return channel;
+    }
+
+    public boolean connect(SocketAddress remote) throws IOException {
+        boolean result = Weaver.callOriginal();
+        if (DatastoreInstanceDetection.shouldDetectConnectionAddress() && (remote instanceof InetSocketAddress)) {
+            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=connect, storing address {0}", remote);
+            this.address = (InetSocketAddress) remote;
+        }
+        return result;
+    }
+
+    public boolean finishConnect() {
+        boolean result = Weaver.callOriginal();
+        if (isConnected() && DatastoreInstanceDetection.shouldDetectConnectionAddress() && this.address != null) {
+            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=finishConnect, saving address {0}", this.address);
+            DatastoreInstanceDetection.saveAddress(this.address);
+        }
+        return result;
     }
 
     public abstract boolean isConnected();

--- a/instrumentation/jdbc-socket/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
+++ b/instrumentation/jdbc-socket/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
@@ -9,23 +9,47 @@ package java.nio.channels;
 
 import com.newrelic.agent.bridge.datastore.DatastoreInstanceDetection;
 import com.newrelic.agent.bridge.datastore.JdbcHelper;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.logging.Level;
 
 @Weave(originalName = "java.nio.channels.SocketChannel", type = MatchType.BaseClass)
 public abstract class SocketChannel_Instrumentation {
 
+    @NewField
+    InetSocketAddress address;
+
     public static SocketChannel_Instrumentation open(SocketAddress remote) {
         SocketChannel_Instrumentation channel = Weaver.callOriginal();
-
         if (channel.isConnected() && DatastoreInstanceDetection.shouldDetectConnectionAddress() && (remote instanceof InetSocketAddress)) {
             DatastoreInstanceDetection.saveAddress((InetSocketAddress) remote);
         }
         return channel;
+    }
+
+    public boolean connect(SocketAddress remote) throws IOException {
+        boolean result = Weaver.callOriginal();
+        if (DatastoreInstanceDetection.shouldDetectConnectionAddress() && (remote instanceof InetSocketAddress)) {
+            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=connect, storing address {0}", remote);
+            this.address = (InetSocketAddress) remote;
+        }
+        return result;
+    }
+
+    public boolean finishConnect() {
+        boolean result = Weaver.callOriginal();
+        if (isConnected() && DatastoreInstanceDetection.shouldDetectConnectionAddress() && this.address != null) {
+            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=finishConnect, saving address {0}", this.address);
+            DatastoreInstanceDetection.saveAddress(this.address);
+        }
+        return result;
     }
 
     public abstract boolean isConnected();

--- a/instrumentation/jdbc-socket/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
+++ b/instrumentation/jdbc-socket/src/main/java/java/nio/channels/SocketChannel_Instrumentation.java
@@ -37,7 +37,6 @@ public abstract class SocketChannel_Instrumentation {
     public boolean connect(SocketAddress remote) throws IOException {
         boolean result = Weaver.callOriginal();
         if (DatastoreInstanceDetection.shouldDetectConnectionAddress() && (remote instanceof InetSocketAddress)) {
-            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=connect, storing address {0}", remote);
             this.address = (InetSocketAddress) remote;
         }
         return result;
@@ -46,7 +45,6 @@ public abstract class SocketChannel_Instrumentation {
     public boolean finishConnect() {
         boolean result = Weaver.callOriginal();
         if (isConnected() && DatastoreInstanceDetection.shouldDetectConnectionAddress() && this.address != null) {
-            NewRelic.getAgent().getLogger().log(Level.INFO, "JDBC Connection Debug: method=finishConnect, saving address {0}", this.address);
             DatastoreInstanceDetection.saveAddress(this.address);
         }
         return result;


### PR DESCRIPTION
Resolves #2964 

We discovered that our Datastore Instance Detection mechanism was failing for one of the Oracle drivers (`T4CConnection`) due to an instrumentation gap in `jdbc-socket`. 

Previously, our instrumentation only saved the connection address for connections that go directly through `Socket.connect(address)`, or `SocketChannel.open(address)`. But the `T4CConnection` driver uses the async connection sequence `SocketChannel.connect(address) ---> SocketChannel.finishConnect()`, which was previously uninstrumented. 

So to fill this gap:
- The address is saved as a new field when `SocketChannel.connect(address)` is called.
- The address is retrieved when the connection is finalized in `finishConnect()`. 

We verified that this fixed the issue for a simple Oracle app using the T4C driver. 
