### PR TITLE
Move tokens from oldTx to newTx during linking

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/TimedSet.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TimedSet.java
@@ -7,6 +7,8 @@
 
 package com.newrelic.agent;
 
+import java.util.Set;
+
 /**
  * A timed set interface that should act like a set that can time out values. The time out period is set during
  * creation, and all entries adhere to it.
@@ -50,4 +52,17 @@ interface TimedSet<K> {
      * Refresh the last access time of a token.
      */
     void refresh(TokenImpl token);
+
+
+    /**
+     * Get the set of active tokens held by this cache.
+     */
+    Set<TokenImpl> getTokens();
+
+    /**
+     * Remove the Token from this TimedSet and put it into the target TimedSet.
+     * @param token The Token to transfer
+     * @param targetTimedSet The TimedSet the Token should be moved to.
+     */
+    void transferToken(TokenImpl token, TimedSet<K> targetTimedSet);
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TimedTokenSet.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TimedTokenSet.java
@@ -13,6 +13,7 @@ import com.newrelic.agent.bridge.CleanableMap;
 import com.newrelic.agent.model.TimeoutCause;
 import com.newrelic.agent.util.TimeConversion;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -65,7 +66,9 @@ public class TimedTokenSet implements TimedSet<TokenImpl> {
                         // In the case of a token being expired we *must* spin off the work on to a
                         // second thread in order to prevent a possible deadlock between the expire code
                         // and other tx usages.
-                        expirationService.expireToken(token::markExpired);
+                        if (!token.isInTransfer.get()) {
+                            expirationService.expireToken(() -> token.markExpired(tx));
+                        }
                     }
                 });
     }
@@ -107,6 +110,19 @@ public class TimedTokenSet implements TimedSet<TokenImpl> {
     @Override
     public void refresh(TokenImpl token) {
         activeTokens.get(token);
+    }
+
+    @Override
+    public Set<TokenImpl> getTokens() {
+        return activeTokens.keySet();
+    }
+
+    @Override
+    public void transferToken(TokenImpl token, TimedSet<TokenImpl> targetCache){
+        token.isInTransfer.set(true);
+        activeTokens.remove(token);
+        targetCache.put(token);
+        token.isInTransfer.set(false);
     }
 
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/TokenImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/TokenImpl.java
@@ -20,10 +20,16 @@ public class TokenImpl implements Token {
 
     private volatile Tracer initiatingTracer;
     private final AtomicBoolean active;
+    /**
+     * Whether this token is in the process of being moved from one transaction to another.
+     * Used to prevent this token from being prematurely expired when it is removed from the old transaction's cache.
+     */
+    protected final AtomicBoolean isInTransfer;
 
     public TokenImpl(Tracer tracer) {
         initiatingTracer = tracer;
         active = new AtomicBoolean(Boolean.TRUE);
+        isInTransfer = new AtomicBoolean(false);
 
         WeakRefTransaction weakRefTransaction = getTransaction();
         Transaction tx = weakRefTransaction == null ? null : weakRefTransaction.getTransactionIfExists();
@@ -141,10 +147,17 @@ public class TokenImpl implements Token {
 
     /**
      * This is used by the transaction to expire tokens when removed from its token cache.
+     * <p>
+     * When an old transaction migrates its state onto a new transaction as the result of a token link, there is a rare race condition
+     * where a token begins its expiration on the oldTx, but completes it here on the newTx.
+     * <p>
+     * To patch this loophole, txAtExpiration is passed in as the transaction on which the expiration actually started. The vast majority of the time,
+     * this should be the same transaction obtained by Token.getTransaction().getTransactionIfExists(). In the case of the race condition described above,
+     * they may be different, and txAtExpiration should be used.
      */
-    void markExpired() {
+    void markExpired(Transaction txAtExpiration) {
         active.set(Boolean.FALSE);
-        Transaction tx = getTransaction().getTransactionIfExists();
+        Transaction tx = txAtExpiration != null ? txAtExpiration : getTransaction().getTransactionIfExists();
         if (tx != null) {
             tx.onRemoval();
         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -1543,12 +1543,15 @@ public class Transaction {
                         //finishing.
                         //
                         //The downstream effect is a transaction and memory leak.
-                        for (TokenImpl oldToken : oldTx.activeTokensCache.get().getTokens()) {
-                            //Only move over the tokens that were updated to point to newTx.
-                            if (oldToken.getTransaction().getTransactionIfExists() == newTx) {
-                                oldTx.activeCount.decrementAndGet();
-                                newTx.activeCount.incrementAndGet();
-                                oldTx.activeTokensCache.get().transferToken(oldToken, newTx.activeTokensCache.get());
+                        TimedSet<TokenImpl> oldTokensCache = oldTx.activeTokensCache.get();
+                        if (oldTokensCache != null) {
+                            for (TokenImpl oldToken : oldTokensCache.getTokens()) {
+                                //Only move over the tokens that were updated to point to newTx.
+                                if (oldToken.getTransaction().getTransactionIfExists() == newTx) {
+                                    oldTx.activeCount.decrementAndGet();
+                                    newTx.activeCount.incrementAndGet();
+                                    oldTx.activeTokensCache.get().transferToken(oldToken, newTx.activeTokensCache.get());
+                                }
                             }
                         }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -1544,13 +1544,14 @@ public class Transaction {
                         //
                         //The downstream effect is a transaction and memory leak.
                         TimedSet<TokenImpl> oldTokensCache = oldTx.activeTokensCache.get();
-                        if (oldTokensCache != null) {
+                        TimedSet<TokenImpl> newTokensCache = newTx.activeTokensCache.get();
+                        if (oldTokensCache != null && newTokensCache != null) {
                             for (TokenImpl oldToken : oldTokensCache.getTokens()) {
                                 //Only move over the tokens that were updated to point to newTx.
                                 if (oldToken.getTransaction().getTransactionIfExists() == newTx) {
                                     oldTx.activeCount.decrementAndGet();
                                     newTx.activeCount.incrementAndGet();
-                                    oldTx.activeTokensCache.get().transferToken(oldToken, newTx.activeTokensCache.get());
+                                    oldTokensCache.transferToken(oldToken, newTokensCache);
                                 }
                             }
                         }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/Transaction.java
@@ -285,7 +285,6 @@ public class Transaction {
         return Math.max(transportDurationInMillis, 0);
     }
 
-    // TODO does this contract work for everyone?
     public enum PartialSampleType {
         REDUCED("Reduced"),
         ESSENTIAL("Essential"),
@@ -1535,6 +1534,24 @@ public class Transaction {
                     int oldTxaId = oldTxa.hashCode();
                     oldTxa.startAsyncActivity(newTx, newTx.nextActivityId.getAndIncrement(), tracer);
                     if (oldTx != null) {
+                        //We MUST move tokens and their counts from oldTx to newTx where applicable.
+                        //
+                        //Any active tokens from oldTx that reside on oldTxa (token.getInitiatingTracer().getTransactionActivity() == oldTxa)
+                        //will have been reparented in the preceding line of code (oldTxa.startAsyncActivity(newTx)) to point to newTx.
+                        //When these tokens finish (whether properly expired or via timeout) they will do so on newTx instead of oldTx.
+                        //This messes up our accounting of the number of active tokens on both newTx and oldTx, which can prevent one or both transactions from
+                        //finishing.
+                        //
+                        //The downstream effect is a transaction and memory leak.
+                        for (TokenImpl oldToken : oldTx.activeTokensCache.get().getTokens()) {
+                            //Only move over the tokens that were updated to point to newTx.
+                            if (oldToken.getTransaction().getTransactionIfExists() == newTx) {
+                                oldTx.activeCount.decrementAndGet();
+                                newTx.activeCount.incrementAndGet();
+                                oldTx.activeTokensCache.get().transferToken(oldToken, newTx.activeTokensCache.get());
+                            }
+                        }
+
                         // We migrate state from the source to the target transactions of the migration.
                         // It's never been completely clear whether or not this is the correct behavior.
                         PriorityApplicationName pan = oldTx.getPriorityApplicationName();


### PR DESCRIPTION
This PR corrects a bug caused by improper handling of tokens when one transaction has its state merged onto another during a linking operation. This is going to be a long description, as the bug is complicated, but the fix for it is fairly simple. 

## The Bug 

The issue arises in async environments where a primary transaction (called here and in code `newTx`) and a secondary transaction (`oldTx`) are started simultaneously on separate threads and are joined together via `token.link()`. 

### Part 1: Transaction states are merged
When we merge the two transactions, we lift a bunch of state off of `oldTx` and put it onto `newTx`. The bit that’s important for the bug is this:
- We reassign `oldTx`’s underlying TransactionActivity, `oldTxa`, to point to `newTx` instead via `oldTxa.startAsyncActivity(newTx)`. 
- All of `oldTx`’s tokens living on `oldTxa` will automatically identify their transaction as `newTx`. 

That means that after the link is complete, **any active tokens that started on `oldTx` will try to finish on `newTx`**. 

### Part 2: The Tokens throw off the counts
We count every token as it is created and expired, incrementing/decrementing the `activeCount` of each transaction accordingly. **A transaction is only able to finish when its activeCount returns to 0.**

In the scenario above, the tokens created on `oldTx` **increment** `oldTx.activeCount`, but ultimately **decrement** `newTx.activeCount` when they finish. This inconsistency makes the counts of both transactions inaccurate, causing various unwanted side effects, including:
- `oldTx` never has its count decremented back to 0, so it is unable to finish and is perpetually held in memory. **This causes a memory leak**. (*The main symptom we observed in our investigation*)
- `newTx` has its count decremented too low, past 0 and into negative numbers. This is also a problem - it can prevent `newTx` from finishing, cause it to finish too soon, or force it to finish multiple times, as its activeCount oscillates between negative numbers and 0 when new children of `newTx` start and increment the count back up. **This has the potential to cause a memory leak, strange metrics to be reported, or the same Transaction to be reported multiple times**. (*We did not observe this happening in our investigation, but it is theoretically possible and I’m mentioning here in case this happens in the future*). 

## The Fix

To fix this, we have to migrate over all the tokens that will now point to `newTx` when the two transaction states are merged. This basically means:
- Update the transactions’ `activeCounts` up/down respectively. 
- Actually move the tokens from `oldTx.activeTokensCache` to `newTx.activeTokensCache`. 

There are a few fiddly edge cases that are handled in the code and we’ve tried to leave a good trail of comments describing them.