### PR TITLE
Jfr labels

### DIFF
--- a/.fleetControl/schemaGeneration/reference-newrelic.yml
+++ b/.fleetControl/schemaGeneration/reference-newrelic.yml
@@ -812,6 +812,11 @@ common: &default_settings
     # resolution logic will be used. Default is false.
     use_display_name: false
 
+    labels:
+      # If true, JFR data will be decorated with APM labels. This will add labels as attributes prefixed with "tags."
+      # Default is false.
+      enabled: false
+
   # Infinite Tracing configuration.
   infinite_tracing:
     trace_observer:

--- a/.fleetControl/schemas/config.json
+++ b/.fleetControl/schemas/config.json
@@ -1290,6 +1290,17 @@
                     "type": "boolean",
                     "default": false,
                     "description": "If true, the JFR host name will be set to the value in the process_host.display_name config. Note that if the process_host.display_name value is empty/null, the default hostname resolution logic will be used. Default is false."
+                },
+                "labels": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, JFR data will be decorated with APM labels. This will add labels as attributes prefixed with \"tags.\" Default is false."
+                        }
+                    },
+                    "additionalProperties": true
                 }
             },
             "additionalProperties": true,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
@@ -61,11 +61,6 @@ public interface JfrConfig {
     /**
      * If true, all JFR Event and Metric data will be decorated with labels. These labels are added as custom attributes prefixed
      * with "tags", eg "tags.team".
-     * <p>
-     * This is NOT a hot setting - it cannot be changed after agent startup.
-     * <p>
-     * Labels, however, are hot. If labels are updated locally in config, or via the UI, and this setting is "true", JFR Events
-     * and Metrics will be decorated with the new labels.
      *
      * @return <code>true</code> if JFR data should be decorated with labels, else <code>false</code> (default).
      */

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfig.java
@@ -57,4 +57,17 @@ public interface JfrConfig {
      * @return <code>true</code> if the configured display name should be used for the JFR host name, else <code>false</code>.
      */
     boolean useDisplayName();
+
+    /**
+     * If true, all JFR Event and Metric data will be decorated with labels. These labels are added as custom attributes prefixed
+     * with "tags", eg "tags.team".
+     * <p>
+     * This is NOT a hot setting - it cannot be changed after agent startup.
+     * <p>
+     * Labels, however, are hot. If labels are updated locally in config, or via the UI, and this setting is "true", JFR Events
+     * and Metrics will be decorated with the new labels.
+     *
+     * @return <code>true</code> if JFR data should be decorated with labels, else <code>false</code> (default).
+     */
+    boolean labelsEnabled();
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/JfrConfigImpl.java
@@ -21,9 +21,11 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     public static final Boolean AUDIT_LOGGING_DEFAULT = Boolean.FALSE;
     public static final Boolean USE_LICENSE_KEY_DEFAULT = Boolean.TRUE;
     public static final Boolean USE_DISPLAY_NAME_DEFAULT = Boolean.FALSE;
+    public static final Boolean LABELS_ENABLED_DEFAULT = Boolean.FALSE;
     public static final String HARVEST_INTERVAL = "harvest_interval";   //In seconds
     public static final String QUEUE_SIZE = "queue_size";
     public static final String USE_DISPLAY_NAME = "use_display_name";
+    public static final String LABELS = "labels";
 
     private boolean isEnabled;
     private final Integer harvestInterval;
@@ -76,5 +78,11 @@ class JfrConfigImpl extends BaseConfig implements JfrConfig {
     @Override
     public boolean useDisplayName() {
         return getProperty(USE_DISPLAY_NAME, USE_DISPLAY_NAME_DEFAULT);
+    }
+
+    @Override
+    public boolean labelsEnabled() {
+        BaseConfig labelsConfig = new BaseConfig(nestedProps(LABELS), SYSTEM_PROPERTY_ROOT + LABELS + ".");
+        return labelsConfig.getProperty(ENABLED, LABELS_ENABLED_DEFAULT);
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/jfr/JfrService.java
@@ -25,6 +25,7 @@ import com.newrelic.telemetry.Attributes;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -36,8 +37,8 @@ import static com.newrelic.jfr.daemon.SetupUtils.buildUploader;
 
 public class JfrService extends AbstractService implements AgentConfigListener {
 
-    private final JfrConfig jfrConfig;
-    private final AgentConfig defaultAgentConfig;
+    private JfrConfig jfrConfig;
+    private AgentConfig defaultAgentConfig;
     private JfrController jfrController;
 
     private final String JFR_SERVICE_THREAD_NAME = "New Relic JFR Service";
@@ -66,6 +67,7 @@ public class JfrService extends AbstractService implements AgentConfigListener {
                 commonAttrs.put(ENTITY_GUID, entityGuid);
                 final String hostname = getJfrHostnameOrDisplayName();
                 commonAttrs.put(HOSTNAME, hostname);
+                addLabelsIfEnabled(commonAttrs);
                 final JFRUploader uploader = buildUploader(daemonConfig);
                 String pattern = defaultAgentConfig.getValue(ThreadService.NAME_PATTERN_CFG_KEY, ThreadNameNormalizer.DEFAULT_PATTERN);
                 uploader.readyToSend(new EventConverter(commonAttrs, pattern));
@@ -187,16 +189,32 @@ public class JfrService extends AbstractService implements AgentConfigListener {
     @Override
     public void configChanged(String appName, AgentConfig agentConfig) {
         boolean newJfrEnabledVal = agentConfig.getJfrConfig().isEnabled();
-
         if (newJfrEnabledVal != jfrConfig.isEnabled()) {
             Agent.LOG.log(Level.INFO, "JFR enabled flag changed to {0}", newJfrEnabledVal);
-            jfrConfig.setEnabled(newJfrEnabledVal);
-
+            defaultAgentConfig = agentConfig;
+            jfrConfig = agentConfig.getJfrConfig();
             if (newJfrEnabledVal) {
                 doStart();
             } else {
                 doStop();
             }
         }
+    }
+
+    @VisibleForTesting
+    void addLabelsIfEnabled(Attributes commonAttrs){
+        if (jfrConfig.labelsEnabled()) {
+            Agent.LOG.log(Level.FINE, "APM labels for JFR data is enabled.");
+            Map<String, String> labels = defaultAgentConfig.getLabelsConfig().getLabels();
+            if (labels != null) {
+                labels.forEach((label, value) -> commonAttrs.put(labelAttrName(label), value));
+            }
+        } else {
+            Agent.LOG.log(Level.FINE, "APM labels for JFR data is disabled.");
+        }
+    }
+
+    private String labelAttrName(String label) {
+        return "tags." + label;
     }
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/JfrConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/JfrConfigTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/JfrConfigTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/JfrConfigTest.java
@@ -1,0 +1,112 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.agent.config;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.newrelic.agent.SaveSystemPropertyProviderRule.TestEnvironmentFacade;
+import static com.newrelic.agent.SaveSystemPropertyProviderRule.TestSystemProps;
+import static com.newrelic.agent.config.JfrConfigImpl.*;
+import static org.junit.Assert.*;
+
+public class JfrConfigTest {
+
+    @Before
+    public void setup() {
+        //clear the SystemPropertyProvider after each test.
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new TestSystemProps(),
+                new TestEnvironmentFacade()));
+    }
+
+    @Test
+    public void jfrLabelsDisabledByDefault() {
+        Map<String, Object> jfrSettings = new HashMap<>();
+        JfrConfig config = new JfrConfigImpl(jfrSettings);
+        assertFalse(config.labelsEnabled());
+    }
+
+    @Test
+    public void jfrLabelsSettingsObeyLocalConfig() {
+        /*
+         * jfr:
+         *   labels:
+         *     enabled: true
+         */
+        Map<String, Object> jfrSettings = new HashMap<>();
+        Map<String, Object> labelsSettings = new HashMap<>();
+        labelsSettings.put(ENABLED, true);
+        jfrSettings.put(LABELS, labelsSettings);
+        JfrConfig config = new JfrConfigImpl(jfrSettings);
+        assertTrue(config.labelsEnabled());
+
+        /*
+         * jfr:
+         *   labels:
+         *     enabled: false
+         */
+        labelsSettings.put(ENABLED, false);
+        config = new JfrConfigImpl(jfrSettings);
+        assertFalse(config.labelsEnabled());
+    }
+
+    @Test
+    public void jfrLabelsSettingsObeySystemProperty() {
+        //Enabled
+        Properties props = new Properties();
+        props.setProperty("newrelic.config.jfr.labels.enabled", "true");
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new TestSystemProps(props),
+                new TestEnvironmentFacade()
+        ));
+        Map<String, Object> jfrSettings = new HashMap<>();
+        JfrConfig config = new JfrConfigImpl(jfrSettings);
+        assertTrue(config.labelsEnabled());
+
+        //Disabled
+        props.setProperty("newrelic.config.jfr.labels.enabled", "false");
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new TestSystemProps(props),
+                new TestEnvironmentFacade()
+        ));
+        config = new JfrConfigImpl(jfrSettings);
+        assertFalse(config.labelsEnabled());
+    }
+
+    @Test
+    public void jfrLabelsSettingsObeyEnvironmentVariable() {
+        //Enabled
+        TestEnvironmentFacade environmentFacade = new TestEnvironmentFacade(ImmutableMap.of(
+                "NEW_RELIC_JFR_LABELS_ENABLED", "true"
+        ));
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new TestSystemProps(),
+                environmentFacade
+        ));
+        Map<String, Object> jfrSettings = new HashMap<>();
+        JfrConfig config = new JfrConfigImpl(jfrSettings);
+        assertTrue(config.labelsEnabled());
+
+        //Disabled
+        environmentFacade = new TestEnvironmentFacade(ImmutableMap.of(
+                "NEW_RELIC_JFR_LABELS_ENABLED", "false"
+        ));
+        SystemPropertyFactory.setSystemPropertyProvider(new SystemPropertyProvider(
+                new TestSystemProps(),
+                environmentFacade
+        ));
+        config = new JfrConfigImpl(jfrSettings);
+        assertFalse(config.labelsEnabled());
+    }
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -352,9 +352,7 @@ public class JfrServiceTest {
 
         spyJfr.configChanged("my-app", newAgentConfig);
 
-        // Verify doStop was called and doStart was not.
         verify(spyJfr).doStop();
-        verify(spyJfr, times(0)).doStart();
     }
 
     @Test
@@ -372,137 +370,7 @@ public class JfrServiceTest {
 
         spyJfr.configChanged("my-app", newAgentConfig);
 
-        // Verify doStart was called
         verify(spyJfr).doStart();
-        verify(spyJfr, times(0)).doStop();
-    }
-
-    @Test
-    public void configChanged_NoChange_DoesNotCallStartOrStop() {
-        when(jfrConfig.isEnabled()).thenReturn(true);
-        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
-        JfrService spyJfr = spy(jfrService);
-
-        AgentConfig newAgentConfig = mock(AgentConfig.class);
-        JfrConfig newJfrConfig = mock(JfrConfig.class);
-        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
-        when(newJfrConfig.isEnabled()).thenReturn(true);
-
-        spyJfr.configChanged("my-app", newAgentConfig);
-
-        // Verify neither doStart nor doStop was called
-        verify(spyJfr, times(0)).doStart();
-        verify(spyJfr, times(0)).doStop();
-    }
-
-    @Test
-    public void configChanged_ReplacesJfrConfigReference() {
-        when(jfrConfig.isEnabled()).thenReturn(false);
-        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
-        JfrService spyJfr = spy(jfrService);
-
-        // Prevent actual execution
-        when(spyJfr.coreApisExist()).thenReturn(false);
-
-        AgentConfig newAgentConfig = mock(AgentConfig.class);
-        JfrConfig newJfrConfig = mock(JfrConfig.class);
-        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
-        when(newJfrConfig.isEnabled()).thenReturn(true);
-
-        spyJfr.configChanged("my-app", newAgentConfig);
-
-        // Verify the new jfrConfig was retrieved from newAgentConfig
-        verify(newAgentConfig, times(2)).getJfrConfig(); // Called twice: once for check, once for assignment
-    }
-
-    @Test
-    public void configChanged_ReplacesDefaultAgentConfig() {
-        when(jfrConfig.isEnabled()).thenReturn(false);
-        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
-        JfrService spyJfr = spy(jfrService);
-
-        // Prevent actual execution
-        when(spyJfr.coreApisExist()).thenReturn(false);
-
-        AgentConfig newAgentConfig = mock(AgentConfig.class);
-        JfrConfig newJfrConfig = mock(JfrConfig.class);
-        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
-        when(newJfrConfig.isEnabled()).thenReturn(true);
-
-        spyJfr.configChanged("my-app", newAgentConfig);
-
-        // Verify the new agentConfig is retrieved
-        verify(newAgentConfig, times(2)).getJfrConfig(); // Once to check enabled, once to replace
-    }
-
-    @Test
-    public void configChanged_MultipleConfigChanges_HandlesCorrectly() {
-        when(jfrConfig.isEnabled()).thenReturn(false);
-        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
-        JfrService spyJfr = spy(jfrService);
-
-        // Prevent actual execution
-        when(spyJfr.coreApisExist()).thenReturn(false);
-
-        // First change: disabled -> enabled
-        AgentConfig newAgentConfig1 = mock(AgentConfig.class);
-        JfrConfig newJfrConfig1 = mock(JfrConfig.class);
-        when(newAgentConfig1.getJfrConfig()).thenReturn(newJfrConfig1);
-        when(newJfrConfig1.isEnabled()).thenReturn(true);
-
-        spyJfr.configChanged("my-app", newAgentConfig1);
-        verify(spyJfr, times(1)).doStart();
-        verify(spyJfr, times(0)).doStop();
-
-        // Second change: enabled -> disabled
-        AgentConfig newAgentConfig2 = mock(AgentConfig.class);
-        JfrConfig newJfrConfig2 = mock(JfrConfig.class);
-        when(newAgentConfig2.getJfrConfig()).thenReturn(newJfrConfig2);
-        when(newJfrConfig2.isEnabled()).thenReturn(false);
-
-        spyJfr.configChanged("my-app", newAgentConfig2);
-        verify(spyJfr, times(1)).doStart();
-        verify(spyJfr, times(1)).doStop();
-    }
-
-    @Test
-    public void configChanged_WithNewLabels_LabelsAvailableForNewStart() {
-        when(jfrConfig.isEnabled()).thenReturn(false);
-        when(jfrConfig.labelsEnabled()).thenReturn(true);
-
-        // Initial labels
-        LabelsConfig initialLabelsConfig = mock(LabelsConfig.class);
-        Map<String, String> initialLabels = new HashMap<>();
-        initialLabels.put("team", "old-team");
-        when(initialLabelsConfig.getLabels()).thenReturn(initialLabels);
-        when(agentConfig.getLabelsConfig()).thenReturn(initialLabelsConfig);
-
-        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
-        JfrService spyJfr = spy(jfrService);
-
-        // Prevent actual execution
-        when(spyJfr.coreApisExist()).thenReturn(false);
-
-        // New config with updated labels
-        AgentConfig newAgentConfig = mock(AgentConfig.class);
-        JfrConfig newJfrConfig = mock(JfrConfig.class);
-        LabelsConfig newLabelsConfig = mock(LabelsConfig.class);
-        Map<String, String> newLabels = new HashMap<>();
-        newLabels.put("team", "new-team");
-        newLabels.put("region", "us-west-2");
-        when(newLabelsConfig.getLabels()).thenReturn(newLabels);
-
-        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
-        when(newAgentConfig.getLabelsConfig()).thenReturn(newLabelsConfig);
-        when(newJfrConfig.isEnabled()).thenReturn(true);
-        when(newJfrConfig.labelsEnabled()).thenReturn(true);
-
-        spyJfr.configChanged("my-app", newAgentConfig);
-
-        // After configChanged, doStart should be called
-        verify(spyJfr).doStart();
-        // Verify the new jfrConfig was retrieved
-        verify(newAgentConfig, times(2)).getJfrConfig();
     }
 
     private Map<String, String> mockLabelsMap(){

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -355,24 +355,6 @@ public class JfrServiceTest {
         verify(spyJfr).doStop();
     }
 
-    @Test
-    public void configChangedFromDisabledToEnabledDoesStart() {
-        //Initial config: JFR disabled.
-        when(jfrConfig.isEnabled()).thenReturn(false);
-        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
-        JfrService spyJfr = spy(jfrService);
-
-        //Updated config: JFR enabled.
-        AgentConfig newAgentConfig = mock(AgentConfig.class);
-        JfrConfig newJfrConfig = mock(JfrConfig.class);
-        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
-        when(newJfrConfig.isEnabled()).thenReturn(true);
-
-        spyJfr.configChanged("my-app", newAgentConfig);
-
-        verify(spyJfr).doStart();
-    }
-
     private Map<String, String> mockLabelsMap(){
         Map<String, String> labels = new HashMap<>();
         labels.put("team", "java-agent");

--- a/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/jfr/JfrServiceTest.java
@@ -6,11 +6,13 @@ import com.newrelic.agent.RPMServiceManager;
 import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.JfrConfig;
+import com.newrelic.agent.config.LabelsConfig;
 import com.newrelic.agent.config.ServerlessConfig;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.jfr.ThreadNameNormalizer;
 import com.newrelic.jfr.daemon.DaemonConfig;
 import com.newrelic.jfr.daemon.JfrRecorderException;
+import com.newrelic.telemetry.Attributes;
 import com.newrelic.test.marker.Flaky;
 import com.newrelic.test.marker.IBMJ9IncompatibleTest;
 import org.junit.Before;
@@ -19,10 +21,15 @@ import org.junit.experimental.categories.Category;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static com.newrelic.agent.config.AgentConfigImpl.DEFAULT_EVENT_INGEST_URI;
 import static com.newrelic.agent.config.AgentConfigImpl.DEFAULT_METRIC_INGEST_URI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
@@ -228,5 +235,281 @@ public class JfrServiceTest {
 
         String result = spyJfr.getJfrHostnameOrDisplayName();
         assertEquals(defaultHostname, result);
+    }
+
+    @Test
+    public void addLabelsEnabledAddsLabelsAsAttrs() {
+        /*
+         * labels:
+         *   team: java-agent
+         *   environment: production
+         *   region: us-east-1
+         *
+         * jfr:
+         *   labels:
+         *     enabled: true
+         */
+        LabelsConfig labelsConfig = mock(LabelsConfig.class);
+        Map<String, String> labels = mockLabelsMap();
+        when(labelsConfig.getLabels()).thenReturn(labels);
+        when(agentConfig.getLabelsConfig()).thenReturn(labelsConfig);
+        when(jfrConfig.labelsEnabled()).thenReturn(true);
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+
+        Attributes attrsToModify = new Attributes();
+        jfrService.addLabelsIfEnabled(attrsToModify);
+
+        assertEquals(3, attrsToModify.asMap().size());
+        assertEquals("java-agent", attrsToModify.asMap().get("tags.team"));
+        assertEquals("production", attrsToModify.asMap().get("tags.environment"));
+        assertEquals("us-east-1", attrsToModify.asMap().get("tags.region"));
+    }
+
+    @Test
+    public void addLabelsDisabledDoesNotAddLabelsAsAttrs() {
+        /*
+         * labels:
+         *   team: java-agent
+         *   environment: production
+         *   region: us-east-1
+         *
+         * jfr:
+         *   labels:
+         *     enabled: false
+         */
+        LabelsConfig labelsConfig = mock(LabelsConfig.class);
+        Map<String, String> labels = mockLabelsMap();
+        when(labelsConfig.getLabels()).thenReturn(labels);
+        when(agentConfig.getLabelsConfig()).thenReturn(labelsConfig);
+        when(jfrConfig.labelsEnabled()).thenReturn(false);
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+
+        // Test addLabelsIfEnabled
+        Attributes attrs = new Attributes();
+        jfrService.addLabelsIfEnabled(attrs);
+
+        // Verify no labels are added
+        assertEquals(0, attrs.asMap().size());
+    }
+
+    @Test
+    public void addLabelsEnabledLabelsEmptyIsNoop(){
+        /*
+        * labels:
+        *   //nothing
+        *
+        * jfr:
+        *   labels:
+        *     enabled: true
+         */
+
+        LabelsConfig labelsConfig = mock(LabelsConfig.class);
+        when(labelsConfig.getLabels()).thenReturn(Collections.emptyMap());
+        when(agentConfig.getLabelsConfig()).thenReturn(labelsConfig);
+        when(jfrConfig.labelsEnabled()).thenReturn(true);
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+
+        Attributes attrs = new Attributes();
+        jfrService.addLabelsIfEnabled(attrs);
+
+        assertEquals(0, attrs.asMap().size());
+    }
+
+    @Test
+    public void addLabelsEnabledNullLabelsDoesNotThrow() {
+        //The labels map should never be null, but still good to check.
+        LabelsConfig labelsConfig = mock(LabelsConfig.class);
+        when(labelsConfig.getLabels()).thenReturn(null);
+        when(agentConfig.getLabelsConfig()).thenReturn(labelsConfig);
+        when(jfrConfig.labelsEnabled()).thenReturn(true);
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+
+        Attributes attrs = new Attributes();
+        try {
+            jfrService.addLabelsIfEnabled(attrs);
+            assertEquals(0, attrs.asMap().size());
+        } catch (NullPointerException e) {
+            fail("Should not throw if labels map is null.");
+        }
+    }
+
+    @Test
+    public void configChangedFromEnabledToDisabledDoesStop() {
+        //Initial config: JFR enabled
+        when(jfrConfig.isEnabled()).thenReturn(true);
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        //Updated config: JFR disabled
+        AgentConfig newAgentConfig = mock(AgentConfig.class);
+        JfrConfig newJfrConfig = mock(JfrConfig.class);
+        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
+        when(newJfrConfig.isEnabled()).thenReturn(false);
+
+        spyJfr.configChanged("my-app", newAgentConfig);
+
+        // Verify doStop was called and doStart was not.
+        verify(spyJfr).doStop();
+        verify(spyJfr, times(0)).doStart();
+    }
+
+    @Test
+    public void configChangedFromDisabledToEnabledDoesStart() {
+        //Initial config: JFR disabled.
+        when(jfrConfig.isEnabled()).thenReturn(false);
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        //Updated config: JFR enabled.
+        AgentConfig newAgentConfig = mock(AgentConfig.class);
+        JfrConfig newJfrConfig = mock(JfrConfig.class);
+        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
+        when(newJfrConfig.isEnabled()).thenReturn(true);
+
+        spyJfr.configChanged("my-app", newAgentConfig);
+
+        // Verify doStart was called
+        verify(spyJfr).doStart();
+        verify(spyJfr, times(0)).doStop();
+    }
+
+    @Test
+    public void configChanged_NoChange_DoesNotCallStartOrStop() {
+        when(jfrConfig.isEnabled()).thenReturn(true);
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        AgentConfig newAgentConfig = mock(AgentConfig.class);
+        JfrConfig newJfrConfig = mock(JfrConfig.class);
+        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
+        when(newJfrConfig.isEnabled()).thenReturn(true);
+
+        spyJfr.configChanged("my-app", newAgentConfig);
+
+        // Verify neither doStart nor doStop was called
+        verify(spyJfr, times(0)).doStart();
+        verify(spyJfr, times(0)).doStop();
+    }
+
+    @Test
+    public void configChanged_ReplacesJfrConfigReference() {
+        when(jfrConfig.isEnabled()).thenReturn(false);
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        // Prevent actual execution
+        when(spyJfr.coreApisExist()).thenReturn(false);
+
+        AgentConfig newAgentConfig = mock(AgentConfig.class);
+        JfrConfig newJfrConfig = mock(JfrConfig.class);
+        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
+        when(newJfrConfig.isEnabled()).thenReturn(true);
+
+        spyJfr.configChanged("my-app", newAgentConfig);
+
+        // Verify the new jfrConfig was retrieved from newAgentConfig
+        verify(newAgentConfig, times(2)).getJfrConfig(); // Called twice: once for check, once for assignment
+    }
+
+    @Test
+    public void configChanged_ReplacesDefaultAgentConfig() {
+        when(jfrConfig.isEnabled()).thenReturn(false);
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        // Prevent actual execution
+        when(spyJfr.coreApisExist()).thenReturn(false);
+
+        AgentConfig newAgentConfig = mock(AgentConfig.class);
+        JfrConfig newJfrConfig = mock(JfrConfig.class);
+        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
+        when(newJfrConfig.isEnabled()).thenReturn(true);
+
+        spyJfr.configChanged("my-app", newAgentConfig);
+
+        // Verify the new agentConfig is retrieved
+        verify(newAgentConfig, times(2)).getJfrConfig(); // Once to check enabled, once to replace
+    }
+
+    @Test
+    public void configChanged_MultipleConfigChanges_HandlesCorrectly() {
+        when(jfrConfig.isEnabled()).thenReturn(false);
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        // Prevent actual execution
+        when(spyJfr.coreApisExist()).thenReturn(false);
+
+        // First change: disabled -> enabled
+        AgentConfig newAgentConfig1 = mock(AgentConfig.class);
+        JfrConfig newJfrConfig1 = mock(JfrConfig.class);
+        when(newAgentConfig1.getJfrConfig()).thenReturn(newJfrConfig1);
+        when(newJfrConfig1.isEnabled()).thenReturn(true);
+
+        spyJfr.configChanged("my-app", newAgentConfig1);
+        verify(spyJfr, times(1)).doStart();
+        verify(spyJfr, times(0)).doStop();
+
+        // Second change: enabled -> disabled
+        AgentConfig newAgentConfig2 = mock(AgentConfig.class);
+        JfrConfig newJfrConfig2 = mock(JfrConfig.class);
+        when(newAgentConfig2.getJfrConfig()).thenReturn(newJfrConfig2);
+        when(newJfrConfig2.isEnabled()).thenReturn(false);
+
+        spyJfr.configChanged("my-app", newAgentConfig2);
+        verify(spyJfr, times(1)).doStart();
+        verify(spyJfr, times(1)).doStop();
+    }
+
+    @Test
+    public void configChanged_WithNewLabels_LabelsAvailableForNewStart() {
+        when(jfrConfig.isEnabled()).thenReturn(false);
+        when(jfrConfig.labelsEnabled()).thenReturn(true);
+
+        // Initial labels
+        LabelsConfig initialLabelsConfig = mock(LabelsConfig.class);
+        Map<String, String> initialLabels = new HashMap<>();
+        initialLabels.put("team", "old-team");
+        when(initialLabelsConfig.getLabels()).thenReturn(initialLabels);
+        when(agentConfig.getLabelsConfig()).thenReturn(initialLabelsConfig);
+
+        JfrService jfrService = new JfrService(jfrConfig, agentConfig);
+        JfrService spyJfr = spy(jfrService);
+
+        // Prevent actual execution
+        when(spyJfr.coreApisExist()).thenReturn(false);
+
+        // New config with updated labels
+        AgentConfig newAgentConfig = mock(AgentConfig.class);
+        JfrConfig newJfrConfig = mock(JfrConfig.class);
+        LabelsConfig newLabelsConfig = mock(LabelsConfig.class);
+        Map<String, String> newLabels = new HashMap<>();
+        newLabels.put("team", "new-team");
+        newLabels.put("region", "us-west-2");
+        when(newLabelsConfig.getLabels()).thenReturn(newLabels);
+
+        when(newAgentConfig.getJfrConfig()).thenReturn(newJfrConfig);
+        when(newAgentConfig.getLabelsConfig()).thenReturn(newLabelsConfig);
+        when(newJfrConfig.isEnabled()).thenReturn(true);
+        when(newJfrConfig.labelsEnabled()).thenReturn(true);
+
+        spyJfr.configChanged("my-app", newAgentConfig);
+
+        // After configChanged, doStart should be called
+        verify(spyJfr).doStart();
+        // Verify the new jfrConfig was retrieved
+        verify(newAgentConfig, times(2)).getJfrConfig();
+    }
+
+    private Map<String, String> mockLabelsMap(){
+        Map<String, String> labels = new HashMap<>();
+        labels.put("team", "java-agent");
+        labels.put("environment", "production");
+        labels.put("region", "us-east-1");
+        return labels;
     }
 }


### PR DESCRIPTION
Resolves https://github.com/newrelic/newrelic-jfr-core/issues/271

This PR adds support for decorating JFR data with APM labels (as configured in the java agent)

- This mirrors the same feature for log data. It is behind a config (like we did for log data):
```yml
jfr:
  labels:
    enabled: false (default), true
```
- Labels are passed as part of the common attrs builder to JFR at startup. This means that they are fixed per-JFR startup; they will be UTD with whatever is in config at the time JFR starts, but are not hot while JFR is running. 
- I made a small correction to `configChanged` in `JfrService` - when the config changes, we should be saving the default and jfr configs at that time, so that whatever we read off of them during a possible `doStart` is up-to-date (as opposed to whatever was in the original config). 
