### PR TITLE
Eliminate OOMs during certain verifier runs

### DIFF
--- a/gradle.properties.gha
+++ b/gradle.properties.gha
@@ -4,3 +4,7 @@ jdk17=17
 jdk21=21
 jdk25=25
 jdk26=26
+
+# Bump the configured heap for the gradle process to avoid OOMs during
+# long running module verifications
+org.gradle.jvmargs=-Xmx4096m

--- a/instrumentation/aws-java-sdk-kinesis-2.1.0/build.gradle
+++ b/instrumentation/aws-java-sdk-kinesis-2.1.0/build.gradle
@@ -69,6 +69,23 @@ verifyInstrumentation {
     exclude 'software.amazon.awssdk:kinesis:[2.31.0,2.31.77]'
     exclude 'software.amazon.awssdk:kinesis:[2.32.0,2.32.32]'
     exclude 'software.amazon.awssdk:kinesis:[2.33.0,2.33.12]'
+    exclude 'software.amazon.awssdk:kinesis:[2.34.0,2.34.8]'
+    exclude 'software.amazon.awssdk:kinesis:[2.35.0,2.35.10]'
+    exclude 'software.amazon.awssdk:kinesis:[2.36.0,2.36.2]'
+    exclude 'software.amazon.awssdk:kinesis:[2.37.0,2.37.4]'
+    exclude 'software.amazon.awssdk:kinesis:[2.38.0,2.38.8]'
+    exclude 'software.amazon.awssdk:kinesis:[2.39.0,2.39.5]'
+    exclude 'software.amazon.awssdk:kinesis:[2.40.0,2.40.16]'
+    exclude 'software.amazon.awssdk:kinesis:[2.41.0,2.41.33]'
+    exclude 'software.amazon.awssdk:kinesis:[2.42.0,2.42.40]'
+    exclude 'software.amazon.awssdk:kinesis:[2.43.0,2.43.1]'
+    exclude 'software.amazon.awssdk:kinesis:[2.44.0,2.44.13]'
+    exclude 'software.amazon.awssdk:kinesis:[2.45.0,2.45.0]'
+    exclude 'software.amazon.awssdk:kinesis:[2.46.0,2.46.20]'
+    exclude 'software.amazon.awssdk:kinesis:[2.47.0,2.47.5]'
+    exclude 'software.amazon.awssdk:kinesis:[2.48.0,2.48.3]'
+    exclude 'software.amazon.awssdk:kinesis:[2.49.0,2.49.5]'
+    // 2.50 is the current latest minor as of this update - left open-ended to catch new releases
 }
 
 site {

--- a/instrumentation/aws-java-sdk-kinesis-2.18.40/build.gradle
+++ b/instrumentation/aws-java-sdk-kinesis-2.18.40/build.gradle
@@ -10,6 +10,42 @@ jar {
 verifyInstrumentation {
     passes 'software.amazon.awssdk:kinesis:[2.18.40,)'
     excludeRegex '.*-preview-[0-9a-f]+'
+
+    // Same pattern as aws-java-sdk-kinesis-2.1.0: keep only the last known revision of each minor
+    // version verified, to avoid downloading/resolving hundreds of AWS SDK artifacts per run.
+    exclude 'software.amazon.awssdk:kinesis:[2.18.40,2.18.40]'
+    exclude 'software.amazon.awssdk:kinesis:[2.19.0,2.19.32]'
+    exclude 'software.amazon.awssdk:kinesis:[2.20.0,2.20.161]'
+    exclude 'software.amazon.awssdk:kinesis:[2.21.0,2.21.45]'
+    exclude 'software.amazon.awssdk:kinesis:[2.22.0,2.22.12]'
+    exclude 'software.amazon.awssdk:kinesis:[2.23.0,2.23.20]'
+    exclude 'software.amazon.awssdk:kinesis:[2.24.0,2.24.12]'
+    exclude 'software.amazon.awssdk:kinesis:[2.25.0,2.25.69]'
+    exclude 'software.amazon.awssdk:kinesis:[2.26.0,2.26.30]'
+    exclude 'software.amazon.awssdk:kinesis:[2.27.0,2.27.23]'
+    exclude 'software.amazon.awssdk:kinesis:[2.28.0,2.28.28]'
+    exclude 'software.amazon.awssdk:kinesis:[2.29.0,2.29.51]'
+    exclude 'software.amazon.awssdk:kinesis:[2.30.0,2.30.37]'
+    exclude 'software.amazon.awssdk:kinesis:[2.31.0,2.31.77]'
+    exclude 'software.amazon.awssdk:kinesis:[2.32.0,2.32.32]'
+    exclude 'software.amazon.awssdk:kinesis:[2.33.0,2.33.12]'
+    exclude 'software.amazon.awssdk:kinesis:[2.34.0,2.34.8]'
+    exclude 'software.amazon.awssdk:kinesis:[2.35.0,2.35.10]'
+    exclude 'software.amazon.awssdk:kinesis:[2.36.0,2.36.2]'
+    exclude 'software.amazon.awssdk:kinesis:[2.37.0,2.37.4]'
+    exclude 'software.amazon.awssdk:kinesis:[2.38.0,2.38.8]'
+    exclude 'software.amazon.awssdk:kinesis:[2.39.0,2.39.5]'
+    exclude 'software.amazon.awssdk:kinesis:[2.40.0,2.40.16]'
+    exclude 'software.amazon.awssdk:kinesis:[2.41.0,2.41.33]'
+    exclude 'software.amazon.awssdk:kinesis:[2.42.0,2.42.40]'
+    exclude 'software.amazon.awssdk:kinesis:[2.43.0,2.43.1]'
+    exclude 'software.amazon.awssdk:kinesis:[2.44.0,2.44.13]'
+    exclude 'software.amazon.awssdk:kinesis:[2.45.0,2.45.0]'
+    exclude 'software.amazon.awssdk:kinesis:[2.46.0,2.46.20]'
+    exclude 'software.amazon.awssdk:kinesis:[2.47.0,2.47.5]'
+    exclude 'software.amazon.awssdk:kinesis:[2.48.0,2.48.3]'
+    exclude 'software.amazon.awssdk:kinesis:[2.49.0,2.49.5]'
+    // 2.50 is the current latest minor as of this update - left open-ended to catch new releases
 }
 
 site {

--- a/instrumentation/quarkus-resteasy-2.14.1/build.gradle
+++ b/instrumentation/quarkus-resteasy-2.14.1/build.gradle
@@ -49,6 +49,22 @@ verifyInstrumentation {
     exclude 'io.quarkus:quarkus-resteasy:[3.20.0,3.20.1)'
     exclude 'io.quarkus:quarkus-resteasy:[3.21.0,3.21.4)'
     exclude 'io.quarkus:quarkus-resteasy:[3.22.0,3.22.3)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.23.0,3.23.4)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.24.0,3.24.5)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.25.0,3.25.4)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.26.0,3.26.4)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.27.0,3.27.5.1)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.28.0,3.28.5)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.29.0,3.29.4)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.30.0,3.30.8)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.31.0,3.31.4)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.32.0,3.32.4)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.33.0,3.33.3.1)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.34.0,3.34.7)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.35.0,3.35.4)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.36.0,3.36.3)'
+    exclude 'io.quarkus:quarkus-resteasy:[3.37.0,3.37.4)'
+    // 3.38 is the current latest minor as of this update - left open-ended to catch new releases
 }
 
 java {


### PR DESCRIPTION
Adjust the exclude range for...
- aws-java-sdk-kinesis-2.1.0
- aws-java-sdk-kinesis-2.18.40
- quarkus-resteasy-2.14.1

Bump the available heap for the gradle process to 4gb
