### PR TITLE
Properly handle exceptions thrown from the normalizer flow

### DIFF
--- a/newrelic-agent/src/main/java/com/newrelic/agent/normalization/NormalizerImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/normalization/NormalizerImpl.java
@@ -10,6 +10,7 @@ package com.newrelic.agent.normalization;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 
 import com.newrelic.agent.Agent;
@@ -26,7 +27,7 @@ public class NormalizerImpl implements Normalizer {
 
     public NormalizerImpl(String appName, List<NormalizationRule> rules) {
         this.appName = appName;
-        this.rules = Collections.unmodifiableList(rules);
+        this.rules = new CopyOnWriteArrayList<>(rules);  // Thread safe mutable list
     }
 
     @Override
@@ -38,10 +39,24 @@ public class NormalizerImpl implements Normalizer {
 
         String normalizedName = name;
         for (NormalizationRule rule : rules) {
-            RuleResult result = rule.normalize(normalizedName);
-            if (!result.isMatch()) {
+            // This call can throw exceptions, specifically if the replacement String uses a grouping
+            // index value for a non-existent group in the normalization rule pattern
+            RuleResult result;
+            try {
+                result = rule.normalize(normalizedName);
+                if (!result.isMatch()) {
+                    continue;
+                }
+            } catch (Exception e) {
+                // Log the exception and remove this rule from the rule list so it doesn't execute again
+                String msg = MessageFormat.format("Rule \"{0}\" has thrown an exception during normalization. " +
+                                "It will be removed for this agent run but it should be corrected/deleted prior " +
+                                "to the next restart. Exception: {1}", rule, e.getMessage());
+                Agent.LOG.warning(msg);
+                rules.remove(rule);
                 continue;
             }
+
             if (rule.isIgnore()) {
                 if (Agent.LOG.isLoggable(Level.FINER)) {
                     String msg = MessageFormat.format("Ignoring \"{0}\" for \"{1}\" because it matched rule \"{2}\"",
@@ -50,6 +65,7 @@ public class NormalizerImpl implements Normalizer {
                 }
                 return null;
             }
+
             String replacement = result.getReplacement();
             if (replacement != null) {
                 if (Agent.LOG.isLoggable(Level.FINER)) {
@@ -68,7 +84,7 @@ public class NormalizerImpl implements Normalizer {
 
     @Override
     public List<NormalizationRule> getRules() {
-        return rules;
+        return Collections.unmodifiableList(rules);
     }
 
 }

--- a/newrelic-agent/src/test/java/com/newrelic/agent/normalization/NormalizerTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/normalization/NormalizerTest.java
@@ -21,6 +21,71 @@ public class NormalizerTest {
 
     private static final String APP_NAME = "Unit Test";
 
+    @Test
+    public void normalize_withInvalidReplacementString_doesNotThrow() {
+        // If the replacement string is a correct format but a group index is out of bounds
+        // This rule is from the actual support case
+        String match =
+                "^MessageBroker/Kafka/Internal/(consumer-metrics|producer-metrics)/client/[^/]+/(.+)$";
+        String replace = "MessageBroker/Kafka/Internal/\\1/client/Kafka-Producers/\\3";  // No group 3 in match String
+        NormalizationRule rule = new NormalizationRule(match, replace, false, 1, true, false, false);
+        List<NormalizationRule> rules = Collections.singletonList(rule);
+
+        Normalizer normalizer = new NormalizerImpl("foo", rules);
+        Assert.assertTrue(normalizer.getRules().contains(rule));
+
+        // This should not throw an exception and the target String should be returned unmodified
+        String result = normalizer.normalize(
+                "MessageBroker/Kafka/Internal/producer-metrics/client/my-producer-id/record-send-rate");
+        Assert.assertEquals(
+                "MessageBroker/Kafka/Internal/producer-metrics/client/my-producer-id/record-send-rate", result);
+
+        // ... and the list should now be empty since the bad rule gets removed
+        Assert.assertTrue(normalizer.getRules().isEmpty());
+    }
+
+    @Test
+    public void normalize_withBadRuleInMiddleOfChain_appliesRemainingRulesAndRemovesOnlyBadRule() {
+        NormalizationRule goodRule1 = new NormalizationRule("^foo/(.*)$", "baz/\\1", false, 1, false, false, false);
+        // Matches "baz/bar/baz" with 2 groups but the replacement references a non-existent group 3
+        NormalizationRule badRule = new NormalizationRule("^baz/(.*)/(.*)$", "baz/\\1/\\2/\\3", false, 2, false, false,
+                false);
+        NormalizationRule goodRule2 = new NormalizationRule("^baz/(.*)$", "final/\\1", false, 3, true, false, false);
+        List<NormalizationRule> rules = Arrays.asList(goodRule1, badRule, goodRule2);
+
+        Normalizer normalizer = new NormalizerImpl("foo", rules);
+
+        // both good rules should apply, in order, despite the bad rule throwing in between them
+        Assert.assertEquals("final/bar/baz", normalizer.normalize("foo/bar/baz"));
+
+        // only the bad rule should have been removed, in place, leaving the good rules intact
+        Assert.assertEquals(Arrays.asList(goodRule1, goodRule2), normalizer.getRules());
+
+        // a second call must not re-throw and should produce the same result using only the surviving rules
+        Assert.assertEquals("final/bar/baz", normalizer.normalize("foo/bar/baz"));
+        Assert.assertEquals(2, normalizer.getRules().size());
+    }
+
+    @Test
+    public void normalize_withBadRuleMarkedTerminateChain_stillAppliesSubsequentRules() {
+        NormalizationRule goodRule1 = new NormalizationRule("^foo/(.*)$", "bar/\\1", false, 1, false, false, false);
+        // terminateChain is true here, but that flag must not take effect because the rule throws instead of matching
+        NormalizationRule badRule = new NormalizationRule("^bar/(.*)/(.*)$", "bar/\\1/\\2/\\3", false, 2, true,
+                false, false);
+        NormalizationRule goodRule2 = new NormalizationRule("^bar/(.*)$", "baz/\\1", false, 3, false, false, false);
+        List<NormalizationRule> rules = Arrays.asList(goodRule1, badRule, goodRule2);
+
+        Normalizer normalizer = new NormalizerImpl("foo", rules);
+
+        // goodRule2 must still run even though the removed rule ahead of it was marked terminateChain=true
+        Assert.assertEquals("baz/boo/fizz", normalizer.normalize("foo/boo/fizz"));
+        Assert.assertEquals(Arrays.asList(goodRule1, goodRule2), normalizer.getRules());
+
+        // a second call must not re-throw and should produce the same result using only the surviving rules
+        Assert.assertEquals("baz/boo/fizz", normalizer.normalize("foo/boo/fizz"));
+        Assert.assertEquals(2, normalizer.getRules().size());
+    }
+
     @SuppressWarnings({ "unchecked", "serial" })
     @Test
     public void emptyUrlRules() {


### PR DESCRIPTION
Resolves #3022 

### Overview
This add a `try/catch` to the `NormalizationRule.normilze` call in NormalizerImpl. If an exception is caught, we log the rule details and exception as a `WARN` and also remove the problem rule from the Rules list.

Added test coverage as well.

Prior, any exceptions thrown at that spot would cause all metrics to stop reporting.