### PR TITLE
Hybrid Agent - Logging - Allow empty message body when context attributes are present

### DIFF
--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/logs/LogEventUtil.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/com/nr/agent/instrumentation/utils/logs/LogEventUtil.java
@@ -66,7 +66,7 @@ public class LogEventUtil {
             String errorClass = contextAttributes.get(OTEL_EXCEPTION_TYPE);
             String errorMessage = contextAttributes.get(OTEL_EXCEPTION_MESSAGE);
 
-            if (shouldCreateLogEvent(body, errorClass, errorMessage)) {
+            if (shouldCreateLogEvent(body, contextAttributes, errorClass, errorMessage)) {
                 // It is possible that logs are being emitted from OTel instrumentation of a logging framework that we also instrument (e.g. logback, log4j), which could lead to double reporting of LogEvents. We can prevent this by checking if the logs are coming from a known OTel instrumentation source and favoring our own framework instrumentation over it.
                 if (LogDuplicationChecker.shouldRecordLogFromOTelAPI()) {
                     Map<LogAttributeKey, Object> logEventMap = new HashMap<>(calculateInitialMapSize(contextAttributes));
@@ -179,8 +179,11 @@ public class LogEventUtil {
      * @param errorMessage String to validate from OTel exception.message
      * @return true if a LogEvent should be created, otherwise false
      */
-    private static boolean shouldCreateLogEvent(Body body, String errorClass, String errorMessage) {
-        return (body != null) || (ExceptionUtil.getErrorClass(errorClass) != null) || (ExceptionUtil.getErrorMessage(errorMessage) != null);
+    private static boolean shouldCreateLogEvent(Body body, Attributes contextAttributes, String errorClass, String errorMessage) {
+        return (body != null && body.asString() != null && !body.asString().isEmpty()) ||
+                (contextAttributes != null && !contextAttributes.isEmpty()) ||
+                (ExceptionUtil.getErrorClass(errorClass) != null) ||
+                (ExceptionUtil.getErrorMessage(errorMessage) != null);
     }
 
     private static int calculateInitialMapSize(Attributes attributes) {

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/com/nr/agent/instrumentation/utils/logs/LogEventUtil.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/com/nr/agent/instrumentation/utils/logs/LogEventUtil.java
@@ -16,7 +16,6 @@ import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.common.ValueType;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.sdk.logs.NRLogRecord;
-import io.opentelemetry.sdk.logs.data.Body;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 
 import java.util.Arrays;
@@ -67,7 +66,7 @@ public class LogEventUtil {
             Attributes contextAttributes = logRecordData.getAttributes();
             String errorClass = contextAttributes.get(OTEL_EXCEPTION_TYPE);
             String errorMessage = contextAttributes.get(OTEL_EXCEPTION_MESSAGE);
-            if (shouldCreateLogEvent(bodyValue, errorClass, errorMessage)) {
+            if (shouldCreateLogEvent(bodyValue, contextAttributes, errorClass, errorMessage)) {
                 // It is possible that logs are being emitted from OTel instrumentation of a logging framework that we also instrument (e.g. logback, log4j), which could lead to double reporting of LogEvents. We can prevent this by checking if the logs are coming from a known OTel instrumentation source and favoring our own framework instrumentation over it.
                 if (LogDuplicationChecker.shouldRecordLogFromOTelAPI()) {
                     Map<LogAttributeKey, Object> logEventMap = new HashMap<>(calculateInitialMapSize(contextAttributes));
@@ -180,8 +179,11 @@ public class LogEventUtil {
      * @param errorMessage String to validate from OTel exception.message
      * @return true if a LogEvent should be created, otherwise false
      */
-    private static boolean shouldCreateLogEvent(Value<?> bodyValue, String errorClass, String errorMessage) {
-        return (bodyValue != null && bodyValue.getValue() != null) || (ExceptionUtil.getErrorClass(errorClass) != null) || (ExceptionUtil.getErrorMessage(errorMessage) != null);
+    private static boolean shouldCreateLogEvent(Value<?> bodyValue, Attributes contextAttributes, String errorClass, String errorMessage) {
+       return (bodyValue != null && bodyValue.getValue() != null && bodyValue.asString() != null && !bodyValue.asString().isEmpty()) ||
+                (contextAttributes != null && !contextAttributes.isEmpty()) ||
+                (ExceptionUtil.getErrorClass(errorClass) != null) ||
+                (ExceptionUtil.getErrorMessage(errorMessage) != null);
     }
 
     private static int calculateInitialMapSize(Attributes attributes) {


### PR DESCRIPTION
Fixes the empty/null check for message body.  Also allows a LogEvent to be created without a message body, as long as there are context attributes.

Resolves: https://github.com/newrelic/newrelic-java-agent/issues/3041
