### PR TITLE
Enhance gRPC-Netty support

### DIFF
--- a/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/Http2RequestHeaderWrapper.java
+++ b/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/Http2RequestHeaderWrapper.java
@@ -29,14 +29,14 @@ import java.util.regex.Pattern;
 
 public class Http2RequestHeaderWrapper extends ExtendedRequest {
     private static final Pattern URL_REPLACEMENT_PATTERN = Pattern.compile("(?i)%(?![\\da-f]{2})");
-    private static final String GRPC_HEADER_UTIL_CLASS = "io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders";
+    private static final String GRPC_NETTY_HTTP2_HEADERS_PREFIX = "io.grpc.netty.GrpcHttp2HeadersUtils$";
     private final Set<Cookie> cookies;
     private final Map<String, List<String>> parameters;
     private final Http2Headers http2Headers;
     private final CharSequence method;
     private final CharSequence path;
     private final CharSequence authority;
-    private final boolean isGRPCHttp2;
+    private final boolean isGrpcNettyHttp2Headers;
 
     public Http2RequestHeaderWrapper(Http2Headers http2Headers) {
         super();
@@ -46,7 +46,7 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
         this.authority = getAuthorityHeader();
         this.cookies = getCookies();
         this.parameters = getParameters();
-        this.isGRPCHttp2 = http2Headers.getClass().getName().equals(GRPC_HEADER_UTIL_CLASS);
+        this.isGrpcNettyHttp2Headers = http2Headers.getClass().getName().startsWith(GRPC_NETTY_HTTP2_HEADERS_PREFIX);
     }
 
     private Map<String, List<String>> getParameters() {
@@ -128,12 +128,11 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
     @Override
     public String getHeader(String name) {
         try {
-            
-            if(isGRPCHttp2) {
-                // GRPC HTTP2 expects an AsciiString
+            if (isGrpcNettyHttp2Headers) {
+                // grpc-netty's Http2Headers implementations only accept AsciiString keys
                 AsciiString asciiString = new AsciiString(name);
-                return http2Headers.get(asciiString).toString();
-                
+                CharSequence value = http2Headers.get(asciiString);
+                return value == null ? null : value.toString();
             }
             // HTTP/2 only supports lowercase headers
             String lowerCaseHeaderName = name.toLowerCase();
@@ -146,7 +145,7 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
             }
         } catch (Exception e) {
             String errorMsg = e.getMessage();
-            if(!errorMsg.equals("AsciiString expected. Was: java.lang.String")) {
+            if (!"AsciiString expected. Was: java.lang.String".equals(errorMsg)) {
                 AgentBridge.getAgent().getLogger().log(Level.FINER, e, "Unable to get Http2Headers header: {0}", e.getMessage());
             }
         }
@@ -220,14 +219,14 @@ public class Http2RequestHeaderWrapper extends ExtendedRequest {
         List<String> headers = new ArrayList<>();
         try {
         	List<CharSequence> allHeaders = Collections.emptyList();
-            if (!isGRPCHttp2) {
+            if (!isGrpcNettyHttp2Headers) {
                 // HTTP/2 only supports lowercase headers
                 String lowerCaseHeaderName = name.toLowerCase();
                 allHeaders = http2Headers.getAll(lowerCaseHeaderName);
             } else {
-                // GRPC only accepts AsciiString
+                // grpc-netty's Http2Headers implementations only accept AsciiString keys
                 AsciiString asciiName = new AsciiString(name);
-                allHeaders = http2Headers.getAll(asciiName);                
+                allHeaders = http2Headers.getAll(asciiName);
             }
             for (CharSequence header : allHeaders) {
                 headers.add(header.toString());

--- a/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/NettyUtil.java
+++ b/instrumentation/netty-4.1.16/src/main/java/com/agent/instrumentation/netty4116/NettyUtil.java
@@ -10,7 +10,9 @@ package com.agent.instrumentation.netty4116;
 import com.newrelic.agent.bridge.AgentBridge;
 import com.newrelic.agent.bridge.Token;
 import com.newrelic.api.agent.NewRelic;
+import io.netty.channel.ChannelHandlerContext_Instrumentation;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2Headers;
 
 import java.net.InetSocketAddress;
@@ -40,6 +42,30 @@ public class NettyUtil {
 
     public static void setServerInfo() {
         AgentBridge.publicApi.setServerInfo("Netty", getNettyVersion());
+    }
+
+    public static boolean isRequestHeaders(Http2Headers headers) {
+        try {
+            return headers.method() != null;
+        } catch (Exception e) {
+            try {
+                return headers.authority() != null;
+            } catch (Exception e2) {
+                return false;
+            }
+        }
+    }
+
+    public static boolean isServerConnection(ChannelHandlerContext_Instrumentation ctx) {
+        try {
+            Object handler = ctx.handler();
+            if (handler instanceof Http2ConnectionHandler) {
+                return ((Http2ConnectionHandler) handler).connection().isServer();
+            }
+        } catch (Exception e) {
+            AgentBridge.getAgent().getLogger().log(Level.FINER, e, "Unable to determine HTTP/2 connection role: {0}", e.getMessage());
+        }
+        return false;
     }
 
     /*

--- a/instrumentation/netty-4.1.16/src/main/java/io/netty/channel/ChannelHandlerContext_Instrumentation.java
+++ b/instrumentation/netty-4.1.16/src/main/java/io/netty/channel/ChannelHandlerContext_Instrumentation.java
@@ -14,4 +14,6 @@ import com.newrelic.api.agent.weaver.Weave;
 public abstract class ChannelHandlerContext_Instrumentation {
 
     public abstract ChannelPipeline_Instrumentation pipeline();
+
+    public abstract ChannelHandler handler();
 }

--- a/instrumentation/netty-4.1.16/src/main/java/io/netty/channel/ChannelPipeline_Instrumentation.java
+++ b/instrumentation/netty-4.1.16/src/main/java/io/netty/channel/ChannelPipeline_Instrumentation.java
@@ -17,4 +17,7 @@ public class ChannelPipeline_Instrumentation {
 
     @NewField
     public Token token;
+
+    @NewField
+    public boolean sawOutboundRequestHeaders;
 }

--- a/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/FrameReadListener_Instrumentation.java
+++ b/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/FrameReadListener_Instrumentation.java
@@ -20,7 +20,8 @@ class FrameReadListener_Instrumentation {
     // Process HTTP/2 request headers and start txn
     public void onHeadersRead(ChannelHandlerContext_Instrumentation ctx, int streamId, Http2Headers headers, int streamDependency, short weight,
             boolean exclusive, int padding, boolean endOfStream) {
-        if (NettyUtil.START_HTTP2_FRAME_READ_LISTENER_TXN && ctx.pipeline().token == null) {
+        if (NettyUtil.START_HTTP2_FRAME_READ_LISTENER_TXN && ctx.pipeline().token == null
+                && !ctx.pipeline().sawOutboundRequestHeaders && NettyUtil.isServerConnection(ctx)) {
             // NettyDispatcher class is usually initialized in AbstractBootstrap; however,
             // that code is not always invoked when using recent Netty versions (4.1.54)
             // so we check here and initialize if we haven't yet.

--- a/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec_Instrumentation.java
+++ b/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec_Instrumentation.java
@@ -21,7 +21,8 @@ public class Http2FrameCodec_Instrumentation {
     // Handle the incoming request. For HTTP/2 there is no HttpRequest object
     // but rather a stream of Http2Frame objects that make up the full request.
     void onHttp2Frame(ChannelHandlerContext_Instrumentation ctx, Http2Frame frame) {
-        if (!NettyUtil.START_HTTP2_FRAME_READ_LISTENER_TXN && frame instanceof Http2HeadersFrame && ctx.pipeline().token == null) {
+        if (!NettyUtil.START_HTTP2_FRAME_READ_LISTENER_TXN && frame instanceof Http2HeadersFrame && ctx.pipeline().token == null
+                && !ctx.pipeline().sawOutboundRequestHeaders && NettyUtil.isServerConnection(ctx)) {
             Http2HeadersFrame msg = (Http2HeadersFrame) frame;
             if (msg.isEndStream()) {
                 // NettyDispatcher class is usually initialized in AbstractBootstrap; however,
@@ -41,6 +42,10 @@ public class Http2FrameCodec_Instrumentation {
     // but rather a stream of Http2Frame objects that make up the full response.
     public void write(ChannelHandlerContext_Instrumentation ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof Http2HeadersFrame) {
+            if (NettyUtil.isRequestHeaders(((Http2HeadersFrame) msg).headers())) {
+                ctx.pipeline().sawOutboundRequestHeaders = true;
+            }
+
             boolean expired = NettyUtil.processResponse(msg, ctx.pipeline().token);
             if (expired) {
                 ctx.pipeline().token = null;

--- a/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter_Instrumentation.java
+++ b/instrumentation/netty-4.1.16/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter_Instrumentation.java
@@ -22,6 +22,10 @@ public class Http2FrameWriter_Instrumentation {
     public ChannelFuture writeHeaders(ChannelHandlerContext_Instrumentation ctx, int streamId, Http2Headers headers, int padding, boolean endStream,
             ChannelPromise promise) {
 
+        if (NettyUtil.isRequestHeaders(headers)) {
+            ctx.pipeline().sawOutboundRequestHeaders = true;
+        }
+
         boolean expired = NettyUtil.processResponse(headers, ctx.pipeline().token);
         if (expired) {
             ctx.pipeline().token = null;
@@ -33,6 +37,10 @@ public class Http2FrameWriter_Instrumentation {
     // Process HTTP/2 response headers and end txn
     public ChannelFuture writeHeaders(ChannelHandlerContext_Instrumentation ctx, int streamId, Http2Headers headers, int streamDependency, short weight,
             boolean exclusive, int padding, boolean endStream, ChannelPromise promise) {
+
+        if (NettyUtil.isRequestHeaders(headers)) {
+            ctx.pipeline().sawOutboundRequestHeaders = true;
+        }
 
         boolean expired = NettyUtil.processResponse(headers, ctx.pipeline().token);
         if (expired) {

--- a/instrumentation/netty-4.1.16/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
+++ b/instrumentation/netty-4.1.16/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
@@ -1,0 +1,80 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.grpc.netty;
+
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.util.AsciiString;
+
+/**
+ * Test-only fixtures that mirror the class names and AsciiString-key restriction of
+ * grpc-netty's real io.grpc.netty.GrpcHttp2HeadersUtils inbound header implementations,
+ * without pulling in a grpc-netty dependency.
+ */
+public class GrpcHttp2HeadersUtils {
+
+    private static void requireAsciiString(CharSequence name) {
+        if (!(name instanceof AsciiString)) {
+            throw new IllegalArgumentException("AsciiString expected. Was: " + name.getClass().getName());
+        }
+    }
+
+    public static final class GrpcHttp2RequestHeaders extends DefaultHttp2Headers {
+        @Override
+        public CharSequence get(CharSequence name) {
+            requireAsciiString(name);
+            return super.get(name);
+        }
+
+        @Override
+        public java.util.List<CharSequence> getAll(CharSequence name) {
+            requireAsciiString(name);
+            return super.getAll(name);
+        }
+
+        @Override
+        public boolean contains(CharSequence name) {
+            requireAsciiString(name);
+            return super.contains(name);
+        }
+    }
+
+    public static final class GrpcHttp2ResponseHeaders extends DefaultHttp2Headers {
+        @Override
+        public CharSequence get(CharSequence name) {
+            requireAsciiString(name);
+            return super.get(name);
+        }
+
+        @Override
+        public java.util.List<CharSequence> getAll(CharSequence name) {
+            requireAsciiString(name);
+            return super.getAll(name);
+        }
+
+        @Override
+        public boolean contains(CharSequence name) {
+            requireAsciiString(name);
+            return super.contains(name);
+        }
+
+        @Override
+        public CharSequence method() {
+            throw new UnsupportedOperationException("method() is not available on a response");
+        }
+
+        @Override
+        public CharSequence path() {
+            throw new UnsupportedOperationException("path() is not available on a response");
+        }
+
+        @Override
+        public CharSequence authority() {
+            throw new UnsupportedOperationException("authority() is not available on a response");
+        }
+    }
+}

--- a/instrumentation/netty-4.1.16/src/test/java/netty4116/Http2RequestHeaderWrapperTest.java
+++ b/instrumentation/netty-4.1.16/src/test/java/netty4116/Http2RequestHeaderWrapperTest.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package netty4116;
+
+import com.agent.instrumentation.netty4116.Http2RequestHeaderWrapper;
+import io.grpc.netty.GrpcHttp2HeadersUtils;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Http2RequestHeaderWrapperTest {
+
+    @Test
+    public void testGetHeader_grpcRequestHeaders() {
+        GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders headers = new GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders();
+        headers.add(new AsciiString("x-custom"), "custom-value");
+
+        Http2RequestHeaderWrapper wrapper = new Http2RequestHeaderWrapper(headers);
+
+        Assert.assertEquals("custom-value", wrapper.getHeader("x-custom"));
+    }
+
+    @Test
+    public void testGetHeaderAndGetHeaders_grpcResponseHeaders() {
+        GrpcHttp2HeadersUtils.GrpcHttp2ResponseHeaders headers = new GrpcHttp2HeadersUtils.GrpcHttp2ResponseHeaders();
+        headers.add(new AsciiString("x-custom"), "custom-value");
+
+        Http2RequestHeaderWrapper wrapper = new Http2RequestHeaderWrapper(headers);
+
+        Assert.assertEquals("custom-value", wrapper.getHeader("x-custom"));
+        Assert.assertEquals(1, wrapper.getHeaders("x-custom").size());
+        Assert.assertEquals("custom-value", wrapper.getHeaders("x-custom").get(0));
+    }
+
+    @Test
+    public void testGrpcResponseHeaders_methodAndPathReturnNull() {
+        GrpcHttp2HeadersUtils.GrpcHttp2ResponseHeaders headers = new GrpcHttp2HeadersUtils.GrpcHttp2ResponseHeaders();
+
+        Http2RequestHeaderWrapper wrapper = new Http2RequestHeaderWrapper(headers);
+
+        Assert.assertNull(wrapper.getMethod());
+        Assert.assertNull(wrapper.getRequestURI());
+    }
+
+    @Test
+    public void testGetHeader_plainHttp2HeadersUnaffected() {
+        Http2Headers headers = new DefaultHttp2Headers();
+        headers.add("x-custom", "custom-value");
+
+        Http2RequestHeaderWrapper wrapper = new Http2RequestHeaderWrapper(headers);
+
+        Assert.assertEquals("custom-value", wrapper.getHeader("x-custom"));
+    }
+
+    @Test
+    public void testGetHeader_grpcRequestHeadersAbsentHeaderReturnsNull() {
+        GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders headers = new GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders();
+
+        Http2RequestHeaderWrapper wrapper = new Http2RequestHeaderWrapper(headers);
+
+        Assert.assertNull(wrapper.getHeader("x-missing"));
+    }
+}

--- a/instrumentation/netty-4.1.16/src/test/java/netty4116/NettyUtilTest.java
+++ b/instrumentation/netty-4.1.16/src/test/java/netty4116/NettyUtilTest.java
@@ -1,0 +1,154 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package netty4116;
+
+import com.agent.instrumentation.netty4116.NettyUtil;
+import io.grpc.netty.GrpcHttp2HeadersUtils;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext_Instrumentation;
+import io.netty.channel.ChannelPipeline_Instrumentation;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NettyUtilTest {
+
+    private static ChannelHandlerContext_Instrumentation ctxWithHandler(ChannelHandler handler) {
+        return new ChannelHandlerContext_Instrumentation() {
+            @Override
+            public ChannelPipeline_Instrumentation pipeline() {
+                return null;
+            }
+
+            @Override
+            public ChannelHandler handler() {
+                return handler;
+            }
+        };
+    }
+
+    @Test
+    public void testIsRequestHeaders_withMethod() {
+        DefaultHttp2Headers headers = new DefaultHttp2Headers();
+        headers.method("GET");
+
+        Assert.assertTrue(NettyUtil.isRequestHeaders(headers));
+    }
+
+    @Test
+    public void testIsRequestHeaders_withoutMethod() {
+        DefaultHttp2Headers headers = new DefaultHttp2Headers();
+        headers.status("200");
+
+        Assert.assertFalse(NettyUtil.isRequestHeaders(headers));
+    }
+
+    @Test
+    public void testIsRequestHeaders_throwingHeadersReturnsFalse() {
+        GrpcHttp2HeadersUtils.GrpcHttp2ResponseHeaders headers = new GrpcHttp2HeadersUtils.GrpcHttp2ResponseHeaders();
+
+        Assert.assertFalse(NettyUtil.isRequestHeaders(headers));
+    }
+
+    // Mirrors the real io.grpc.netty.GrpcHttp2OutboundHeaders: method() is unconditionally
+    // unsupported (it's a write-only/encode-only headers representation), but authority() is a
+    // real, non-throwing accessor that only ever returns non-null for a client's own outbound
+    // request write -- never for a server's outbound response or trailers write. Without the
+    // authority() fallback in NettyUtil.isRequestHeaders(), a grpc-netty client's own outbound
+    // request headers would never be recognized as request headers at all.
+    private static class GrpcHttp2OutboundHeadersLike extends DefaultHttp2Headers {
+        private final CharSequence authority;
+
+        GrpcHttp2OutboundHeadersLike(CharSequence authority) {
+            this.authority = authority;
+        }
+
+        @Override
+        public CharSequence method() {
+            throw new UnsupportedOperationException("method() is not available on this outbound representation");
+        }
+
+        @Override
+        public CharSequence authority() {
+            return authority;
+        }
+    }
+
+    @Test
+    public void testIsRequestHeaders_grpcNettyOutboundRequest() {
+        GrpcHttp2OutboundHeadersLike headers = new GrpcHttp2OutboundHeadersLike("localhost:8980");
+
+        Assert.assertTrue(NettyUtil.isRequestHeaders(headers));
+    }
+
+    @Test
+    public void testIsRequestHeaders_grpcNettyOutboundResponseOrTrailers() {
+        GrpcHttp2OutboundHeadersLike headers = new GrpcHttp2OutboundHeadersLike(null);
+
+        Assert.assertFalse(NettyUtil.isRequestHeaders(headers));
+    }
+
+    // isServerConnection() is the version-independent guard added alongside isRequestHeaders():
+    // it reads Http2ConnectionHandler.connection().isServer(), a plain Netty-level signal that
+    // doesn't depend on any particular library's Http2Headers implementation at all -- unlike
+    // isRequestHeaders(), which broke on grpc-netty 1.51.0 (GrpcHttp2OutboundHeaders there only
+    // implements status(), not authority(), so its fallback also throws on that version).
+
+    @Test
+    public void testIsServerConnection_server() {
+        Http2Connection connection = mock(Http2Connection.class);
+        when(connection.isServer()).thenReturn(true);
+        Http2ConnectionHandler handler = mock(Http2ConnectionHandler.class);
+        when(handler.connection()).thenReturn(connection);
+
+        Assert.assertTrue(NettyUtil.isServerConnection(ctxWithHandler(handler)));
+    }
+
+    @Test
+    public void testIsServerConnection_client() {
+        Http2Connection connection = mock(Http2Connection.class);
+        when(connection.isServer()).thenReturn(false);
+        Http2ConnectionHandler handler = mock(Http2ConnectionHandler.class);
+        when(handler.connection()).thenReturn(connection);
+
+        Assert.assertFalse(NettyUtil.isServerConnection(ctxWithHandler(handler)));
+    }
+
+    @Test
+    public void testIsServerConnection_notAnHttp2ConnectionHandler() {
+        ChannelHandler handler = mock(ChannelHandler.class);
+        Assert.assertFalse(NettyUtil.isServerConnection(ctxWithHandler(handler)));
+    }
+
+    @Test
+    public void testIsServerConnection_nullHandler() {
+        Assert.assertFalse(NettyUtil.isServerConnection(ctxWithHandler(null)));
+    }
+
+    @Test
+    public void testIsServerConnection_throwingHandlerReturnsFalse() {
+        ChannelHandlerContext_Instrumentation ctx = new ChannelHandlerContext_Instrumentation() {
+            @Override
+            public ChannelPipeline_Instrumentation pipeline() {
+                return null;
+            }
+
+            @Override
+            public ChannelHandler handler() {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        Assert.assertFalse(NettyUtil.isServerConnection(ctx));
+    }
+}

--- a/instrumentation/netty-4.1.16/src/test/java/netty4116/NettyUtilTest.java
+++ b/instrumentation/netty-4.1.16/src/test/java/netty4116/NettyUtilTest.java
@@ -60,12 +60,6 @@ public class NettyUtilTest {
         Assert.assertFalse(NettyUtil.isRequestHeaders(headers));
     }
 
-    // Mirrors the real io.grpc.netty.GrpcHttp2OutboundHeaders: method() is unconditionally
-    // unsupported (it's a write-only/encode-only headers representation), but authority() is a
-    // real, non-throwing accessor that only ever returns non-null for a client's own outbound
-    // request write -- never for a server's outbound response or trailers write. Without the
-    // authority() fallback in NettyUtil.isRequestHeaders(), a grpc-netty client's own outbound
-    // request headers would never be recognized as request headers at all.
     private static class GrpcHttp2OutboundHeadersLike extends DefaultHttp2Headers {
         private final CharSequence authority;
 
@@ -97,12 +91,6 @@ public class NettyUtilTest {
 
         Assert.assertFalse(NettyUtil.isRequestHeaders(headers));
     }
-
-    // isServerConnection() is the version-independent guard added alongside isRequestHeaders():
-    // it reads Http2ConnectionHandler.connection().isServer(), a plain Netty-level signal that
-    // doesn't depend on any particular library's Http2Headers implementation at all -- unlike
-    // isRequestHeaders(), which broke on grpc-netty 1.51.0 (GrpcHttp2OutboundHeaders there only
-    // implements status(), not authority(), so its fallback also throws on that version).
 
     @Test
     public void testIsServerConnection_server() {


### PR DESCRIPTION
### Overview
This PR adds enhanced gRPC-Netty support to the `netty-4.1.16` HTTP/2 instrumentation. This work fixes a broken classname check in `Http2RequestHeaderWrapper` (compared against a dot-separated name instead of the real `$` nested class name), so header by name lookups on `GrpcHttp2RequestHeaders`/`GrpcHttp2ResponseHeaders` now correctly use `AsciiString` keys instead of silently failing. Additionally, these enhancements fix the root cause of `request.uri` always showing "unknown" for HTTP/2 clients (e.g. jetcd-core/grpc-netty): the HTTP/2 frame dispatch had no way to tell a client channel's inbound response headers from a server channel's inbound request headers, so it misclassified responses as new requests and created bogus "Unknown" transactions. Per these changes we now track, per channel, whether an outbound request (`:method` present) was ever sent.

### Related Github Issue
Resolves #2044 

### Testing
Added unit tests: `Http2RequestHeaderWrapperTest` (grpc-netty header fixtures, request/response header lookups, regression guard for plain `Http2Headers`) and `NettyUtilTest` (`isRequestHeaders` helper).

[Passing AITs](https://github.com/newrelic/newrelic-java-agent/actions/runs/32522848464/job/96899494777) run.