### PR TITLE
Cap wildfly-PORT-8 module

### DIFF
--- a/instrumentation/wildfly-8-PORT/build.gradle
+++ b/instrumentation/wildfly-8-PORT/build.gradle
@@ -13,12 +13,12 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.wildfly:wildfly-undertow:[8.0.0.Final,)'
+    passesOnly 'org.wildfly:wildfly-undertow:[8.0.0.Final,41.0.1.Final)'
     excludeRegex '.*(Alpha|Beta|CR).*'
 }
 
 site {
     title 'Wildfly'
     type 'Appserver'
-    versionOverride '[8.0.0.Final,)'
+    versionOverride '[8.0.0.Final,41.0.1.Final)'
 }


### PR DESCRIPTION
Cap wildfly-PORT-8 module to `org.wildfly:wildfly-undertow:41.0.1.Final`