### PR TITLE
Oracle explain plan support

### DIFF
--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/DatabaseVendor.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/DatabaseVendor.java
@@ -23,8 +23,8 @@ public interface DatabaseVendor {
 
     /**
      * If explain plans are supported by the vendor, this tells us if a followup query is required
-     * to gets the results. Most systems return the explain result as a ResultSet from the statement
-     * execution, but some (Oracle, for example) require a separate query to another table to
+     * to get the results. Most systems return the explain result as a ResultSet from the initial
+     * statement execution, but some (Oracle, for example) require a separate query to another table to
      * fetch the results.
      *
      * @return true if a separate query is required for explain results

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/DatabaseVendor.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/DatabaseVendor.java
@@ -19,7 +19,26 @@ public interface DatabaseVendor {
 
     boolean isExplainPlanSupported();
 
-    String getExplainPlanSql(String sql) throws SQLException;
+    ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException;
+
+    /**
+     * If explain plans are supported by the vendor, this tells us if a followup query is required
+     * to gets the results. Most systems return the explain result as a ResultSet from the statement
+     * execution, but some (Oracle, for example) require a separate query to another table to
+     * fetch the results.
+     *
+     * @return true if a separate query is required for explain results
+     */
+    boolean isExplainPlanFollowupQueryRequired();
+
+    /**
+     * The SQL for the followup explain query, if required.
+     *
+     * @param statementId optional String that identifies the key used to fetch the explain results
+     *
+     * @return the followup explain plan SQL, or null if no followup query is required
+     */
+    String getFollowupExplainPlanSql(String statementId);
 
     Collection<Collection<Object>> parseExplainPlanResultSet(int columnCount, ResultSet rs, RecordSql recordSql)
             throws SQLException;

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/ExplainPlanSqlInfo.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/ExplainPlanSqlInfo.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.newrelic.agent.bridge.datastore;
+
+/**
+ * Class to hold information about what's required to run an explain plan.
+ */
+public class ExplainPlanSqlInfo {
+    private final String sql;
+
+    private final String statementId;
+
+    public ExplainPlanSqlInfo(String sql, String statementId) {
+        this.sql = sql;
+        this.statementId = statementId;
+    }
+
+    /**
+     * The SQL required to execute the explain plan
+     *
+     * @return the explain plan SQL
+     */
+    public String getSql() {
+        return sql;
+    }
+
+    /**
+     * Optional String that identifies the key used to store and fetch the explain results, if required
+     * by the underlying DBMS
+     *
+     * @return the statement id String or null if it's not required
+     */
+    public String getStatementId() {
+        return statementId;
+    }
+}

--- a/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/JdbcDatabaseVendor.java
+++ b/agent-bridge-datastore/src/main/java/com/newrelic/agent/bridge/datastore/JdbcDatabaseVendor.java
@@ -36,11 +36,21 @@ public abstract class JdbcDatabaseVendor implements DatabaseVendor {
         return explainPlanSupported;
     }
 
-    public String getExplainPlanSql(String sql) throws SQLException {
+    @Override
+    public boolean isExplainPlanFollowupQueryRequired() {
+        return false;
+    }
+
+    @Override
+    public String getFollowupExplainPlanSql(String statementId) {
+        return null;
+    }
+
+    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
         if (!isExplainPlanSupported()) {
             throw new SQLException("Unable to run explain plans for " + getName() + " databases");
         }
-        return "EXPLAIN " + sql;
+        return new ExplainPlanSqlInfo("EXPLAIN " + sqlToExplain, null);
     }
 
     /**

--- a/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcDatabaseVendorTest.java
+++ b/agent-bridge-datastore/src/test/java/com/newrelic/agent/bridge/datastore/JdbcDatabaseVendorTest.java
@@ -29,13 +29,13 @@ public class JdbcDatabaseVendorTest {
     @Test
     public void getExplainSql_withExplainSupport_returnsExplainSql() throws SQLException {
         TestJdbcDatabaseVendor testJdbcDatabaseVendor = new TestJdbcDatabaseVendor("name", "type", true);
-        Assert.assertEquals("EXPLAIN my explain sql", testJdbcDatabaseVendor.getExplainPlanSql("my explain sql"));
+        Assert.assertEquals("EXPLAIN my explain sql", testJdbcDatabaseVendor.getExplainPlanSqlInfo("my explain sql").getSql());
     }
 
     @Test(expected = SQLException.class)
     public void getExplainSql_withoutExplainSupport_throwsException() throws SQLException {
         TestJdbcDatabaseVendor testJdbcDatabaseVendor = new TestJdbcDatabaseVendor("name", "type", false);
-        testJdbcDatabaseVendor.getExplainPlanSql("my explain sql");
+        testJdbcDatabaseVendor.getExplainPlanSqlInfo("my explain sql");
     }
 
     @Test

--- a/instrumentation/jdbc-ojdbc/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -26,9 +26,4 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
     public DatastoreVendor getDatastoreVendor() {
         return DatastoreVendor.Oracle;
     }
-
-    @Override
-    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
-        return new ExplainPlanSqlInfo("EXPLAIN PLAN FOR " + sqlToExplain, null);
-    }
 }

--- a/instrumentation/jdbc-ojdbc/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -9,6 +9,7 @@ package com.nr.agent.instrumentation.jdbc.oracle;
 
 import com.newrelic.agent.bridge.datastore.DatabaseVendor;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.agent.bridge.datastore.ExplainPlanSqlInfo;
 import com.newrelic.agent.bridge.datastore.JdbcDatabaseVendor;
 
 import java.sql.SQLException;
@@ -27,7 +28,7 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
     }
 
     @Override
-    public String getExplainPlanSql(String sql) throws SQLException {
-        return "EXPLAIN PLAN FOR " + sql;
+    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
+        return new ExplainPlanSqlInfo("EXPLAIN PLAN FOR " + sqlToExplain, null);
     }
 }

--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/README.md
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/README.md
@@ -1,0 +1,2 @@
+Note that New Relic agent Oracle EXPLAIN support is only available when running Oracle 11g and one of the
+supported, instrumented drivers: `ojdbc8:12.2.0.1` and `ojdbc8:21.1.0.0`.

--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/README.md
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/README.md
@@ -1,2 +1,2 @@
-Note that New Relic agent Oracle EXPLAIN support is only available when running Oracle 11g and one of the
-supported, instrumented drivers: `ojdbc8:12.2.0.1` and `ojdbc8:21.1.0.0`.
+Note that New Relic agent Oracle EXPLAIN support is only available when running Oracle 11g or higher
+and one of the supported, instrumented drivers: `ojdbc8:12.2.0.1` and `ojdbc8:21.1.0.0`.

--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -46,17 +46,14 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     @Override
     public String getFollowupExplainPlanSql(String statementId) {
-        // DBMS_XPLAN.DISPLAY renders PLAN_TABLE's rows for this statement id into Oracle's own
-        // canonical, human-readable plan report (one line of text per row).
+        // Using DBMS_XPLAN.DISPLAY transforms the PLAN_TABLE rows into
+        // human-readable explain plan text
         return "SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY('PLAN_TABLE', '" + statementId + "', 'TYPICAL'))";
     }
 
     @Override
     public Collection<Collection<Object>> parseExplainPlanResultSet(int columnCount, ResultSet rs, RecordSql recordSql)
             throws SQLException {
-        // Note: unlike the other DatabaseVendor implementations, recordSql/obfuscation isn't
-        // applied here yet. DBMS_XPLAN.DISPLAY's predicate info is embedded inline in free-form
-        // text lines rather than a discrete column, so it can't be scrubbed by clearing a value.
         StringBuilder planText = new StringBuilder();
         while (rs.next()) {
             if (planText.length() > 0) {
@@ -64,6 +61,7 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
             }
             planText.append(rs.getString(1));
         }
+
         return Collections.singletonList(Collections.singletonList(planText.toString()));
     }
 }

--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -9,16 +9,41 @@ package com.nr.agent.instrumentation.jdbc.oracle;
 
 import com.newrelic.agent.bridge.datastore.DatabaseVendor;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.agent.bridge.datastore.ExplainPlanSqlInfo;
 import com.newrelic.agent.bridge.datastore.JdbcDatabaseVendor;
+import com.newrelic.agent.bridge.datastore.RecordSql;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     public static final DatabaseVendor INSTANCE = new OracleDatabaseVendor();
+    private static final AtomicInteger EXPLAIN_PLAN_ID_GENERATOR = new AtomicInteger(0);
+
+    /**
+     * PLAN_TABLE has ~30 columns; these are the ones that we actually care about
+     */
+    private static final List<String> EXPLAIN_PLAN_COLUMNS = Arrays.asList(
+            "ID", "OPERATION", "OPTIONS", "OBJECT_NAME", "COST", "CARDINALITY", "BYTES",
+            "ACCESS_PREDICATES", "FILTER_PREDICATES");
+
+    /**
+     * These columns can contain literal values from the original SQL's WHERE clause, so
+     * we obfuscate these
+     */
+    private static final Set<String> PREDICATE_COLUMNS = new HashSet<>(
+            Arrays.asList("ACCESS_PREDICATES", "FILTER_PREDICATES"));
 
     private OracleDatabaseVendor() {
-        super("Oracle", "oracle", false); // Explain plans not currently supported.
+        super("Oracle", "oracle", true);
     }
 
     @Override
@@ -27,7 +52,43 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
     }
 
     @Override
-    public String getExplainPlanSql(String sql) throws SQLException {
-        return "EXPLAIN PLAN FOR " + sql;
+    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
+        String statementId = Integer.toString(EXPLAIN_PLAN_ID_GENERATOR.getAndIncrement());
+        return new ExplainPlanSqlInfo("EXPLAIN PLAN SET STATEMENT_ID = '" + statementId + "' FOR " + sqlToExplain, statementId);
+    }
+
+    @Override
+    public boolean isExplainPlanFollowupQueryRequired() {
+        return true;
+    }
+
+    @Override
+    public String getFollowupExplainPlanSql(String statementId) {
+        return "SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '" + statementId + "'";
+    }
+
+    @Override
+    public Collection<Collection<Object>> parseExplainPlanResultSet(int columnCount, ResultSet rs, RecordSql recordSql)
+            throws SQLException {
+        boolean obfuscate = RecordSql.obfuscated.equals(recordSql);
+        Collection<Collection<Object>> explainPlan = new LinkedList<>();
+
+        while (rs.next()) {
+            Collection<Object> row = new LinkedList<>();
+            for (String column : EXPLAIN_PLAN_COLUMNS) {
+
+                // This replaces the entire predicate column value with a "?"
+                // which matches the behavior of postgres explain plans
+                if (obfuscate && PREDICATE_COLUMNS.contains(column)) {
+                    row.add("?");
+                    continue;
+                }
+                Object value = rs.getObject(column);
+                row.add(value == null ? "" : value.toString());
+            }
+            explainPlan.add(row);
+        }
+
+        return explainPlan;
     }
 }

--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -15,32 +15,14 @@ import com.newrelic.agent.bridge.datastore.RecordSql;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     public static final DatabaseVendor INSTANCE = new OracleDatabaseVendor();
     private static final AtomicInteger EXPLAIN_PLAN_ID_GENERATOR = new AtomicInteger(0);
-
-    /**
-     * PLAN_TABLE has ~30 columns; these are the ones that we actually care about
-     */
-    private static final List<String> EXPLAIN_PLAN_COLUMNS = Arrays.asList(
-            "ID", "OPERATION", "OPTIONS", "OBJECT_NAME", "COST", "CARDINALITY", "BYTES",
-            "ACCESS_PREDICATES", "FILTER_PREDICATES");
-
-    /**
-     * These columns can contain literal values from the original SQL's WHERE clause, so
-     * we obfuscate these
-     */
-    private static final Set<String> PREDICATE_COLUMNS = new HashSet<>(
-            Arrays.asList("ACCESS_PREDICATES", "FILTER_PREDICATES"));
 
     private OracleDatabaseVendor() {
         super("Oracle", "oracle", true);
@@ -64,31 +46,24 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     @Override
     public String getFollowupExplainPlanSql(String statementId) {
-        return "SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '" + statementId + "'";
+        // DBMS_XPLAN.DISPLAY renders PLAN_TABLE's rows for this statement id into Oracle's own
+        // canonical, human-readable plan report (one line of text per row).
+        return "SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY('PLAN_TABLE', '" + statementId + "', 'TYPICAL'))";
     }
 
     @Override
     public Collection<Collection<Object>> parseExplainPlanResultSet(int columnCount, ResultSet rs, RecordSql recordSql)
             throws SQLException {
-        boolean obfuscate = RecordSql.obfuscated.equals(recordSql);
-        Collection<Collection<Object>> explainPlan = new LinkedList<>();
-
+        // Note: unlike the other DatabaseVendor implementations, recordSql/obfuscation isn't
+        // applied here yet. DBMS_XPLAN.DISPLAY's predicate info is embedded inline in free-form
+        // text lines rather than a discrete column, so it can't be scrubbed by clearing a value.
+        StringBuilder planText = new StringBuilder();
         while (rs.next()) {
-            Collection<Object> row = new LinkedList<>();
-            for (String column : EXPLAIN_PLAN_COLUMNS) {
-
-                // This replaces the entire predicate column value with a "?"
-                // which matches the behavior of postgres explain plans
-                if (obfuscate && PREDICATE_COLUMNS.contains(column)) {
-                    row.add("?");
-                    continue;
-                }
-                Object value = rs.getObject(column);
-                row.add(value == null ? "" : value.toString());
+            if (planText.length() > 0) {
+                planText.append('\n');
             }
-            explainPlan.add(row);
+            planText.append(rs.getString(1));
         }
-
-        return explainPlan;
+        return Collections.singletonList(Collections.singletonList(planText.toString()));
     }
 }

--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
@@ -13,9 +13,7 @@ import org.junit.Test;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -41,81 +39,28 @@ public class OracleDatabaseVendorTest {
 
     @Test
     public void getFollowupExplainPlanSql_returndCorrectSql() {
-        assertEquals("SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '0'", OracleDatabaseVendor.INSTANCE.getFollowupExplainPlanSql("0"));
+        assertEquals("SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY('PLAN_TABLE', '0', 'TYPICAL'))",
+                OracleDatabaseVendor.INSTANCE.getFollowupExplainPlanSql("0"));
     }
 
     @Test
-    public void parseExplainPlanResultSet_withRawSql_returnsParsedPlan() throws SQLException {
-        // Example SQL and resulting PLAN_TABLE contents used for the test
-        /*
-            EXPLAIN PLAN SET STATEMENT_ID = 'demo_query' FOR
-            SELECT e.employee_id, e.last_name, d.department_name
-            FROM employees e
-            JOIN departments d ON e.department_id = d.department_id
-            WHERE e.salary > 5000;
-         */
-        /*
-            ID  OPERATION         OPTIONS          OBJECT_NAME    COST  CARDINALITY  BYTES  ACCESS_PREDICATES                         FILTER_PREDICATES
-            ---------------------------------------------------------------------------------------------------------------------------------------------
-            0   SELECT STATEMENT  null             null           6     12           480    null                                      null
-            1   HASH JOIN         null             null           6     12           480    "E"."DEPARTMENT_ID"="D"."DEPARTMENT_ID"   null
-            2   TABLE ACCESS      FULL             DEPARTMENTS    2     27           432    null                                      null
-            3   TABLE ACCESS      BY INDEX ROWID   EMPLOYEES      4     12           288    null                                      null
-            4   INDEX             RANGE SCAN       EMP_SALARY_IX  1     15           null   "E"."SALARY">5000                         null
-         */
+    public void parseExplainPlanResultSet_joinsLinesIntoSingleTextBlock() throws SQLException {
+        // Example DBMS_XPLAN.DISPLAY output for:
+        // SELECT e.employee_id, e.last_name FROM employees e WHERE e.salary > 5000
         ResultSet rs = mock(ResultSet.class);
-        when(rs.next()).thenReturn(true, true, true, true, true, false);
+        when(rs.next()).thenReturn(true, true, true, true, false);
+        when(rs.getString(1)).thenReturn(
+                "Plan hash value: 1234567890",
+                "",
+                "-----------------------------------------------------------",
+                "| Id  | Operation         | Name             | Rows  | Cost |");
 
-        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
-        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
-        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
-        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
-        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
-        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
-        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
-        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
-                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
-        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
+        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(1, rs, RecordSql.raw);
 
-        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.raw);
-
-        Iterator<Collection<Object>> rows = explainPlan.iterator();
-        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "", ""), rows.next());
-        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480",
-                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", ""), rows.next());
-        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "", ""), rows.next());
-        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "", ""), rows.next());
-        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "",
-                "\"E\".\"SALARY\">5000", ""), rows.next());
-        assertFalse(rows.hasNext());
-    }
-
-    @Test
-    public void parseExplainPlanResultSet_withObfuscatedRecordSql_removesPredicates() throws SQLException {
-        // Same plan data as test above
-        ResultSet rs = mock(ResultSet.class);
-        when(rs.next()).thenReturn(true, true, true, true, true, false);
-
-        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
-        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
-        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
-        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
-        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
-        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
-        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
-        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
-                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
-        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
-
-        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.obfuscated);
-
-        // Every row's ACCESS_PREDICATES/FILTER_PREDICATES column is replaced with "?", similar to postgres
-        Iterator<Collection<Object>> rows = explainPlan.iterator();
-        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "", "?", "?"), rows.next());
-        assertFalse(rows.hasNext());
+        assertEquals(1, explainPlan.size());
+        Collection<Object> row = explainPlan.iterator().next();
+        assertEquals(1, row.size());
+        assertEquals("Plan hash value: 1234567890\n\n-----------------------------------------------------------\n"
+                + "| Id  | Operation         | Name             | Rows  | Cost |", row.iterator().next());
     }
 }

--- a/instrumentation/jdbc-ojdbc7-12.1.0.2/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
+++ b/instrumentation/jdbc-ojdbc7-12.1.0.2/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
@@ -1,0 +1,121 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.nr.agent.instrumentation.jdbc.oracle;
+
+import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.agent.bridge.datastore.ExplainPlanSqlInfo;
+import com.newrelic.agent.bridge.datastore.RecordSql;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OracleDatabaseVendorTest {
+    @Test
+    public void getDatastoreVendor_returnsOracle() {
+        assertEquals(DatastoreVendor.Oracle, OracleDatabaseVendor.INSTANCE.getDatastoreVendor());
+    }
+
+    @Test
+    public void getExplainPlanSqlInfo_returnsCorrectExplainPlanSqlInfoInstance() throws SQLException {
+        ExplainPlanSqlInfo explainPlanSqlInfo = OracleDatabaseVendor.INSTANCE.getExplainPlanSqlInfo("select * from foo where id = 1");
+        assertEquals("EXPLAIN PLAN SET STATEMENT_ID = '0' FOR select * from foo where id = 1", explainPlanSqlInfo.getSql());
+        assertEquals("0", explainPlanSqlInfo.getStatementId());
+    }
+
+    @Test
+    public void isExplainPlanFollowupQueryRequired_returnsTrue() {
+        assertTrue(OracleDatabaseVendor.INSTANCE.isExplainPlanFollowupQueryRequired());
+    }
+
+    @Test
+    public void getFollowupExplainPlanSql_returndCorrectSql() {
+        assertEquals("SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '0'", OracleDatabaseVendor.INSTANCE.getFollowupExplainPlanSql("0"));
+    }
+
+    @Test
+    public void parseExplainPlanResultSet_withRawSql_returnsParsedPlan() throws SQLException {
+        // Example SQL and resulting PLAN_TABLE contents used for the test
+        /*
+            EXPLAIN PLAN SET STATEMENT_ID = 'demo_query' FOR
+            SELECT e.employee_id, e.last_name, d.department_name
+            FROM employees e
+            JOIN departments d ON e.department_id = d.department_id
+            WHERE e.salary > 5000;
+         */
+        /*
+            ID  OPERATION         OPTIONS          OBJECT_NAME    COST  CARDINALITY  BYTES  ACCESS_PREDICATES                         FILTER_PREDICATES
+            ---------------------------------------------------------------------------------------------------------------------------------------------
+            0   SELECT STATEMENT  null             null           6     12           480    null                                      null
+            1   HASH JOIN         null             null           6     12           480    "E"."DEPARTMENT_ID"="D"."DEPARTMENT_ID"   null
+            2   TABLE ACCESS      FULL             DEPARTMENTS    2     27           432    null                                      null
+            3   TABLE ACCESS      BY INDEX ROWID   EMPLOYEES      4     12           288    null                                      null
+            4   INDEX             RANGE SCAN       EMP_SALARY_IX  1     15           null   "E"."SALARY">5000                         null
+         */
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(true, true, true, true, true, false);
+
+        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
+        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
+        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
+        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
+        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
+        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
+        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
+        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
+                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
+        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
+
+        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.raw);
+
+        Iterator<Collection<Object>> rows = explainPlan.iterator();
+        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "", ""), rows.next());
+        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480",
+                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", ""), rows.next());
+        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "", ""), rows.next());
+        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "", ""), rows.next());
+        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "",
+                "\"E\".\"SALARY\">5000", ""), rows.next());
+        assertFalse(rows.hasNext());
+    }
+
+    @Test
+    public void parseExplainPlanResultSet_withObfuscatedRecordSql_removesPredicates() throws SQLException {
+        // Same plan data as test above
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(true, true, true, true, true, false);
+
+        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
+        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
+        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
+        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
+        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
+        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
+        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
+        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
+                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
+        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
+
+        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.obfuscated);
+
+        // Every row's ACCESS_PREDICATES/FILTER_PREDICATES column is replaced with "?", similar to postgres
+        Iterator<Collection<Object>> rows = explainPlan.iterator();
+        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "", "?", "?"), rows.next());
+        assertFalse(rows.hasNext());
+    }
+}

--- a/instrumentation/jdbc-ojdbc8-21.1.0.0/README.md
+++ b/instrumentation/jdbc-ojdbc8-21.1.0.0/README.md
@@ -1,0 +1,2 @@
+Note that New Relic agent Oracle EXPLAIN support is only available when running Oracle 11g and one of the
+supported, instrumented drivers: `ojdbc8:12.2.0.1` and `ojdbc8:21.1.0.0`.

--- a/instrumentation/jdbc-ojdbc8-21.1.0.0/README.md
+++ b/instrumentation/jdbc-ojdbc8-21.1.0.0/README.md
@@ -1,2 +1,2 @@
-Note that New Relic agent Oracle EXPLAIN support is only available when running Oracle 11g and one of the
-supported, instrumented drivers: `ojdbc8:12.2.0.1` and `ojdbc8:21.1.0.0`.
+Note that New Relic agent Oracle EXPLAIN support is only available when running Oracle 11g or higher
+and one of the supported, instrumented drivers: `ojdbc8:12.2.0.1` and `ojdbc8:21.1.0.0`.

--- a/instrumentation/jdbc-ojdbc8-21.1.0.0/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc8-21.1.0.0/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -46,17 +46,14 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     @Override
     public String getFollowupExplainPlanSql(String statementId) {
-        // DBMS_XPLAN.DISPLAY renders PLAN_TABLE's rows for this statement id into Oracle's own
-        // canonical, human-readable plan report (one line of text per row).
+        // Using DBMS_XPLAN.DISPLAY transforms the PLAN_TABLE rows into
+        // human-readable explain plan text
         return "SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY('PLAN_TABLE', '" + statementId + "', 'TYPICAL'))";
     }
 
     @Override
     public Collection<Collection<Object>> parseExplainPlanResultSet(int columnCount, ResultSet rs, RecordSql recordSql)
             throws SQLException {
-        // Note: unlike the other DatabaseVendor implementations, recordSql/obfuscation isn't
-        // applied here yet. DBMS_XPLAN.DISPLAY's predicate info is embedded inline in free-form
-        // text lines rather than a discrete column, so it can't be scrubbed by clearing a value.
         StringBuilder planText = new StringBuilder();
         while (rs.next()) {
             if (planText.length() > 0) {
@@ -64,6 +61,7 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
             }
             planText.append(rs.getString(1));
         }
+
         return Collections.singletonList(Collections.singletonList(planText.toString()));
     }
 }

--- a/instrumentation/jdbc-ojdbc8-21.1.0.0/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc8-21.1.0.0/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -15,32 +15,14 @@ import com.newrelic.agent.bridge.datastore.RecordSql;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     public static final DatabaseVendor INSTANCE = new OracleDatabaseVendor();
     private static final AtomicInteger EXPLAIN_PLAN_ID_GENERATOR = new AtomicInteger(0);
-
-    /**
-     * PLAN_TABLE has ~30 columns; these are the ones that we actually care about
-     */
-    private static final List<String> EXPLAIN_PLAN_COLUMNS = Arrays.asList(
-            "ID", "OPERATION", "OPTIONS", "OBJECT_NAME", "COST", "CARDINALITY", "BYTES",
-            "ACCESS_PREDICATES", "FILTER_PREDICATES");
-
-    /**
-     * These columns can contain literal values from the original SQL's WHERE clause, so
-     * we obfuscate these
-     */
-    private static final Set<String> PREDICATE_COLUMNS = new HashSet<>(
-            Arrays.asList("ACCESS_PREDICATES", "FILTER_PREDICATES"));
 
     private OracleDatabaseVendor() {
         super("Oracle", "oracle", true);
@@ -64,30 +46,24 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     @Override
     public String getFollowupExplainPlanSql(String statementId) {
-        return "SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '" + statementId + "'";
+        // DBMS_XPLAN.DISPLAY renders PLAN_TABLE's rows for this statement id into Oracle's own
+        // canonical, human-readable plan report (one line of text per row).
+        return "SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY('PLAN_TABLE', '" + statementId + "', 'TYPICAL'))";
     }
 
     @Override
     public Collection<Collection<Object>> parseExplainPlanResultSet(int columnCount, ResultSet rs, RecordSql recordSql)
             throws SQLException {
-        boolean obfuscate = RecordSql.obfuscated.equals(recordSql);
-        Collection<Collection<Object>> explainPlan = new LinkedList<>();
+        // Note: unlike the other DatabaseVendor implementations, recordSql/obfuscation isn't
+        // applied here yet. DBMS_XPLAN.DISPLAY's predicate info is embedded inline in free-form
+        // text lines rather than a discrete column, so it can't be scrubbed by clearing a value.
+        StringBuilder planText = new StringBuilder();
         while (rs.next()) {
-            Collection<Object> row = new LinkedList<>();
-
-            // This replaces the entire predicate column value with a "?"
-            // which matches the behavior of postgres explain plans
-            for (String column : EXPLAIN_PLAN_COLUMNS) {
-                if (obfuscate && PREDICATE_COLUMNS.contains(column)) {
-                    row.add("?");
-                    continue;
-                }
-                Object value = rs.getObject(column);
-                row.add(value == null ? "" : value.toString());
+            if (planText.length() > 0) {
+                planText.append('\n');
             }
-            explainPlan.add(row);
+            planText.append(rs.getString(1));
         }
-
-        return explainPlan;
+        return Collections.singletonList(Collections.singletonList(planText.toString()));
     }
 }

--- a/instrumentation/jdbc-ojdbc8-21.1.0.0/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
+++ b/instrumentation/jdbc-ojdbc8-21.1.0.0/src/main/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendor.java
@@ -9,16 +9,41 @@ package com.nr.agent.instrumentation.jdbc.oracle;
 
 import com.newrelic.agent.bridge.datastore.DatabaseVendor;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.agent.bridge.datastore.ExplainPlanSqlInfo;
 import com.newrelic.agent.bridge.datastore.JdbcDatabaseVendor;
+import com.newrelic.agent.bridge.datastore.RecordSql;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class OracleDatabaseVendor extends JdbcDatabaseVendor {
 
     public static final DatabaseVendor INSTANCE = new OracleDatabaseVendor();
+    private static final AtomicInteger EXPLAIN_PLAN_ID_GENERATOR = new AtomicInteger(0);
+
+    /**
+     * PLAN_TABLE has ~30 columns; these are the ones that we actually care about
+     */
+    private static final List<String> EXPLAIN_PLAN_COLUMNS = Arrays.asList(
+            "ID", "OPERATION", "OPTIONS", "OBJECT_NAME", "COST", "CARDINALITY", "BYTES",
+            "ACCESS_PREDICATES", "FILTER_PREDICATES");
+
+    /**
+     * These columns can contain literal values from the original SQL's WHERE clause, so
+     * we obfuscate these
+     */
+    private static final Set<String> PREDICATE_COLUMNS = new HashSet<>(
+            Arrays.asList("ACCESS_PREDICATES", "FILTER_PREDICATES"));
 
     private OracleDatabaseVendor() {
-        super("Oracle", "oracle", false); // Explain plans not currently supported.
+        super("Oracle", "oracle", true);
     }
 
     @Override
@@ -27,7 +52,42 @@ public class OracleDatabaseVendor extends JdbcDatabaseVendor {
     }
 
     @Override
-    public String getExplainPlanSql(String sql) throws SQLException {
-        return "EXPLAIN PLAN FOR " + sql;
+    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
+        String statementId = Integer.toString(EXPLAIN_PLAN_ID_GENERATOR.getAndIncrement());
+        return new ExplainPlanSqlInfo("EXPLAIN PLAN SET STATEMENT_ID = '" + statementId + "' FOR " + sqlToExplain, statementId);
+    }
+
+    @Override
+    public boolean isExplainPlanFollowupQueryRequired() {
+        return true;
+    }
+
+    @Override
+    public String getFollowupExplainPlanSql(String statementId) {
+        return "SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '" + statementId + "'";
+    }
+
+    @Override
+    public Collection<Collection<Object>> parseExplainPlanResultSet(int columnCount, ResultSet rs, RecordSql recordSql)
+            throws SQLException {
+        boolean obfuscate = RecordSql.obfuscated.equals(recordSql);
+        Collection<Collection<Object>> explainPlan = new LinkedList<>();
+        while (rs.next()) {
+            Collection<Object> row = new LinkedList<>();
+
+            // This replaces the entire predicate column value with a "?"
+            // which matches the behavior of postgres explain plans
+            for (String column : EXPLAIN_PLAN_COLUMNS) {
+                if (obfuscate && PREDICATE_COLUMNS.contains(column)) {
+                    row.add("?");
+                    continue;
+                }
+                Object value = rs.getObject(column);
+                row.add(value == null ? "" : value.toString());
+            }
+            explainPlan.add(row);
+        }
+
+        return explainPlan;
     }
 }

--- a/instrumentation/jdbc-ojdbc8-21.1.0.0/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
+++ b/instrumentation/jdbc-ojdbc8-21.1.0.0/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
@@ -13,9 +13,7 @@ import org.junit.Test;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -41,81 +39,28 @@ public class OracleDatabaseVendorTest {
 
     @Test
     public void getFollowupExplainPlanSql_returndCorrectSql() {
-        assertEquals("SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '0'", OracleDatabaseVendor.INSTANCE.getFollowupExplainPlanSql("0"));
+        assertEquals("SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY('PLAN_TABLE', '0', 'TYPICAL'))",
+                OracleDatabaseVendor.INSTANCE.getFollowupExplainPlanSql("0"));
     }
 
     @Test
-    public void parseExplainPlanResultSet_withRawSql_returnsParsedPlan() throws SQLException {
-        // Example SQL and resulting PLAN_TABLE contents used for the test
-        /*
-            EXPLAIN PLAN SET STATEMENT_ID = 'demo_query' FOR
-            SELECT e.employee_id, e.last_name, d.department_name
-            FROM employees e
-            JOIN departments d ON e.department_id = d.department_id
-            WHERE e.salary > 5000;
-         */
-        /*
-            ID  OPERATION         OPTIONS          OBJECT_NAME    COST  CARDINALITY  BYTES  ACCESS_PREDICATES                         FILTER_PREDICATES
-            ---------------------------------------------------------------------------------------------------------------------------------------------
-            0   SELECT STATEMENT  null             null           6     12           480    null                                      null
-            1   HASH JOIN         null             null           6     12           480    "E"."DEPARTMENT_ID"="D"."DEPARTMENT_ID"   null
-            2   TABLE ACCESS      FULL             DEPARTMENTS    2     27           432    null                                      null
-            3   TABLE ACCESS      BY INDEX ROWID   EMPLOYEES      4     12           288    null                                      null
-            4   INDEX             RANGE SCAN       EMP_SALARY_IX  1     15           null   "E"."SALARY">5000                         null
-         */
+    public void parseExplainPlanResultSet_joinsLinesIntoSingleTextBlock() throws SQLException {
+        // Example DBMS_XPLAN.DISPLAY output for:
+        // SELECT e.employee_id, e.last_name FROM employees e WHERE e.salary > 5000
         ResultSet rs = mock(ResultSet.class);
-        when(rs.next()).thenReturn(true, true, true, true, true, false);
+        when(rs.next()).thenReturn(true, true, true, true, false);
+        when(rs.getString(1)).thenReturn(
+                "Plan hash value: 1234567890",
+                "",
+                "-----------------------------------------------------------",
+                "| Id  | Operation         | Name             | Rows  | Cost |");
 
-        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
-        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
-        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
-        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
-        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
-        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
-        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
-        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
-                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
-        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
+        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(1, rs, RecordSql.raw);
 
-        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.raw);
-
-        Iterator<Collection<Object>> rows = explainPlan.iterator();
-        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "", ""), rows.next());
-        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480",
-                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", ""), rows.next());
-        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "", ""), rows.next());
-        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "", ""), rows.next());
-        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "",
-                "\"E\".\"SALARY\">5000", ""), rows.next());
-        assertFalse(rows.hasNext());
-    }
-
-    @Test
-    public void parseExplainPlanResultSet_withObfuscatedRecordSql_removesPredicates() throws SQLException {
-        // Same plan data as test above
-        ResultSet rs = mock(ResultSet.class);
-        when(rs.next()).thenReturn(true, true, true, true, true, false);
-
-        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
-        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
-        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
-        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
-        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
-        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
-        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
-        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
-                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
-        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
-
-        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.obfuscated);
-
-        // Every row's ACCESS_PREDICATES/FILTER_PREDICATES column is replaced with "?", similar to postgres
-        Iterator<Collection<Object>> rows = explainPlan.iterator();
-        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "?", "?"), rows.next());
-        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "", "?", "?"), rows.next());
-        assertFalse(rows.hasNext());
+        assertEquals(1, explainPlan.size());
+        Collection<Object> row = explainPlan.iterator().next();
+        assertEquals(1, row.size());
+        assertEquals("Plan hash value: 1234567890\n\n-----------------------------------------------------------\n"
+                + "| Id  | Operation         | Name             | Rows  | Cost |", row.iterator().next());
     }
 }

--- a/instrumentation/jdbc-ojdbc8-21.1.0.0/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
+++ b/instrumentation/jdbc-ojdbc8-21.1.0.0/src/test/java/com/nr/agent/instrumentation/jdbc/oracle/OracleDatabaseVendorTest.java
@@ -1,0 +1,121 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.nr.agent.instrumentation.jdbc.oracle;
+
+import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.agent.bridge.datastore.ExplainPlanSqlInfo;
+import com.newrelic.agent.bridge.datastore.RecordSql;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OracleDatabaseVendorTest {
+    @Test
+    public void getDatastoreVendor_returnsOracle() {
+        assertEquals(DatastoreVendor.Oracle, OracleDatabaseVendor.INSTANCE.getDatastoreVendor());
+    }
+
+    @Test
+    public void getExplainPlanSqlInfo_returnsCorrectExplainPlanSqlInfoInstance() throws SQLException {
+        ExplainPlanSqlInfo explainPlanSqlInfo = OracleDatabaseVendor.INSTANCE.getExplainPlanSqlInfo("select * from foo where id = 1");
+        assertEquals("EXPLAIN PLAN SET STATEMENT_ID = '0' FOR select * from foo where id = 1", explainPlanSqlInfo.getSql());
+        assertEquals("0", explainPlanSqlInfo.getStatementId());
+    }
+
+    @Test
+    public void isExplainPlanFollowupQueryRequired_returnsTrue() {
+        assertTrue(OracleDatabaseVendor.INSTANCE.isExplainPlanFollowupQueryRequired());
+    }
+
+    @Test
+    public void getFollowupExplainPlanSql_returndCorrectSql() {
+        assertEquals("SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '0'", OracleDatabaseVendor.INSTANCE.getFollowupExplainPlanSql("0"));
+    }
+
+    @Test
+    public void parseExplainPlanResultSet_withRawSql_returnsParsedPlan() throws SQLException {
+        // Example SQL and resulting PLAN_TABLE contents used for the test
+        /*
+            EXPLAIN PLAN SET STATEMENT_ID = 'demo_query' FOR
+            SELECT e.employee_id, e.last_name, d.department_name
+            FROM employees e
+            JOIN departments d ON e.department_id = d.department_id
+            WHERE e.salary > 5000;
+         */
+        /*
+            ID  OPERATION         OPTIONS          OBJECT_NAME    COST  CARDINALITY  BYTES  ACCESS_PREDICATES                         FILTER_PREDICATES
+            ---------------------------------------------------------------------------------------------------------------------------------------------
+            0   SELECT STATEMENT  null             null           6     12           480    null                                      null
+            1   HASH JOIN         null             null           6     12           480    "E"."DEPARTMENT_ID"="D"."DEPARTMENT_ID"   null
+            2   TABLE ACCESS      FULL             DEPARTMENTS    2     27           432    null                                      null
+            3   TABLE ACCESS      BY INDEX ROWID   EMPLOYEES      4     12           288    null                                      null
+            4   INDEX             RANGE SCAN       EMP_SALARY_IX  1     15           null   "E"."SALARY">5000                         null
+         */
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(true, true, true, true, true, false);
+
+        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
+        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
+        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
+        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
+        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
+        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
+        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
+        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
+                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
+        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
+
+        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.raw);
+
+        Iterator<Collection<Object>> rows = explainPlan.iterator();
+        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "", ""), rows.next());
+        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480",
+                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", ""), rows.next());
+        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "", ""), rows.next());
+        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "", ""), rows.next());
+        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "",
+                "\"E\".\"SALARY\">5000", ""), rows.next());
+        assertFalse(rows.hasNext());
+    }
+
+    @Test
+    public void parseExplainPlanResultSet_withObfuscatedRecordSql_removesPredicates() throws SQLException {
+        // Same plan data as test above
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(true, true, true, true, true, false);
+
+        when(rs.getObject("ID")).thenReturn(0, 1, 2, 3, 4);
+        when(rs.getObject("OPERATION")).thenReturn("SELECT STATEMENT", "HASH JOIN", "TABLE ACCESS", "TABLE ACCESS", "INDEX");
+        when(rs.getObject("OPTIONS")).thenReturn(null, null, "FULL", "BY INDEX ROWID", "RANGE SCAN");
+        when(rs.getObject("OBJECT_NAME")).thenReturn(null, null, "DEPARTMENTS", "EMPLOYEES", "EMP_SALARY_IX");
+        when(rs.getObject("COST")).thenReturn(6, 6, 2, 4, 1);
+        when(rs.getObject("CARDINALITY")).thenReturn(12, 12, 27, 12, 15);
+        when(rs.getObject("BYTES")).thenReturn(480, 480, 432, 288, null);
+        when(rs.getObject("ACCESS_PREDICATES")).thenReturn(null,
+                "\"E\".\"DEPARTMENT_ID\"=\"D\".\"DEPARTMENT_ID\"", null, null, "\"E\".\"SALARY\">5000");
+        when(rs.getObject("FILTER_PREDICATES")).thenReturn(null);
+
+        Collection<Collection<Object>> explainPlan = OracleDatabaseVendor.INSTANCE.parseExplainPlanResultSet(9, rs, RecordSql.obfuscated);
+
+        // Every row's ACCESS_PREDICATES/FILTER_PREDICATES column is replaced with "?", similar to postgres
+        Iterator<Collection<Object>> rows = explainPlan.iterator();
+        assertEquals(Arrays.asList("0", "SELECT STATEMENT", "", "", "6", "12", "480", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("1", "HASH JOIN", "", "", "6", "12", "480", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("2", "TABLE ACCESS", "FULL", "DEPARTMENTS", "2", "27", "432", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("3", "TABLE ACCESS", "BY INDEX ROWID", "EMPLOYEES", "4", "12", "288", "?", "?"), rows.next());
+        assertEquals(Arrays.asList("4", "INDEX", "RANGE SCAN", "EMP_SALARY_IX", "1", "15", "", "?", "?"), rows.next());
+        assertFalse(rows.hasNext());
+    }
+}

--- a/instrumentation/jdbc-postgresql-8.0-312.jdbc3/src/main/java/com/nr/agent/instrumentation/jdbc/postgresql_80_jdbc3/PostgresDatabaseVendor.java
+++ b/instrumentation/jdbc-postgresql-8.0-312.jdbc3/src/main/java/com/nr/agent/instrumentation/jdbc/postgresql_80_jdbc3/PostgresDatabaseVendor.java
@@ -8,10 +8,7 @@
 package com.nr.agent.instrumentation.jdbc.postgresql_80_jdbc3;
 
 import com.newrelic.agent.bridge.AgentBridge;
-import com.newrelic.agent.bridge.datastore.DatabaseVendor;
-import com.newrelic.agent.bridge.datastore.DatastoreVendor;
-import com.newrelic.agent.bridge.datastore.JdbcDatabaseVendor;
-import com.newrelic.agent.bridge.datastore.RecordSql;
+import com.newrelic.agent.bridge.datastore.*;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -73,8 +70,8 @@ public class PostgresDatabaseVendor extends JdbcDatabaseVendor {
      * We use the json format of explain plans which is only supported in Postgres 9.
      * It's easier to prevent obfuscation when it's in this format.
      */
-    public String getExplainPlanSql(String sql) throws SQLException {
-        return "EXPLAIN (FORMAT JSON) " + sql;
+    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
+        return new ExplainPlanSqlInfo("EXPLAIN (FORMAT JSON) " + sqlToExplain, null);
     }
 
     @Override

--- a/instrumentation/jdbc-postgresql-9.4.1207/src/main/java/com/nr/agent/instrumentation/jdbc/postgresql_94_1207/PostgresDatabaseVendor.java
+++ b/instrumentation/jdbc-postgresql-9.4.1207/src/main/java/com/nr/agent/instrumentation/jdbc/postgresql_94_1207/PostgresDatabaseVendor.java
@@ -8,10 +8,7 @@
 package com.nr.agent.instrumentation.jdbc.postgresql_94_1207;
 
 import com.newrelic.agent.bridge.AgentBridge;
-import com.newrelic.agent.bridge.datastore.DatabaseVendor;
-import com.newrelic.agent.bridge.datastore.DatastoreVendor;
-import com.newrelic.agent.bridge.datastore.JdbcDatabaseVendor;
-import com.newrelic.agent.bridge.datastore.RecordSql;
+import com.newrelic.agent.bridge.datastore.*;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -73,8 +70,8 @@ public class PostgresDatabaseVendor extends JdbcDatabaseVendor {
      * We use the json format of explain plans which is only supported in Postgres 9.
      * It's easier to prevent obfuscation when it's in this format.
      */
-    public String getExplainPlanSql(String sql) throws SQLException {
-        return "EXPLAIN (FORMAT JSON) " + sql;
+    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
+        return new ExplainPlanSqlInfo("EXPLAIN (FORMAT JSON) " + sqlToExplain, null);
     }
 
     @Override

--- a/instrumentation/jdbc-postgresql-9.4.1208/src/main/java/com/nr/agent/instrumentation/jdbc/postgresql_94_1208/PostgresDatabaseVendor.java
+++ b/instrumentation/jdbc-postgresql-9.4.1208/src/main/java/com/nr/agent/instrumentation/jdbc/postgresql_94_1208/PostgresDatabaseVendor.java
@@ -8,10 +8,7 @@
 package com.nr.agent.instrumentation.jdbc.postgresql_94_1208;
 
 import com.newrelic.agent.bridge.AgentBridge;
-import com.newrelic.agent.bridge.datastore.DatabaseVendor;
-import com.newrelic.agent.bridge.datastore.DatastoreVendor;
-import com.newrelic.agent.bridge.datastore.JdbcDatabaseVendor;
-import com.newrelic.agent.bridge.datastore.RecordSql;
+import com.newrelic.agent.bridge.datastore.*;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -73,8 +70,8 @@ public class PostgresDatabaseVendor extends JdbcDatabaseVendor {
      * We use the json format of explain plans which is only supported in Postgres 9.
      * It's easier to prevent obfuscation when it's in this format.
      */
-    public String getExplainPlanSql(String sql) throws SQLException {
-        return "EXPLAIN (FORMAT JSON) " + sql;
+    public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
+        return new ExplainPlanSqlInfo("EXPLAIN (FORMAT JSON) " + sqlToExplain, null);
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/database/DefaultExplainPlanExecutor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/database/DefaultExplainPlanExecutor.java
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 import com.google.common.annotations.VisibleForTesting;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.bridge.datastore.DatabaseVendor;
+import com.newrelic.agent.bridge.datastore.ExplainPlanSqlInfo;
 import com.newrelic.agent.bridge.datastore.RecordSql;
 import com.newrelic.agent.tracers.SqlTracerExplainInfo;
 
@@ -45,9 +46,11 @@ public class DefaultExplainPlanExecutor implements ExplainPlanExecutor {
     @Override
     public void runExplainPlan(DatabaseService databaseService, Connection connection, DatabaseVendor vendor)
             throws SQLException {
-        String sql = originalSqlStatement;
+        String sql;
+        ExplainPlanSqlInfo explainPlanSqlInfo;
         try {
-            sql = vendor.getExplainPlanSql(sql);
+            explainPlanSqlInfo = vendor.getExplainPlanSqlInfo(originalSqlStatement);
+            sql = explainPlanSqlInfo.getSql();
         } catch (SQLException e) {
             tracer.setExplainPlan(e.getMessage());
             return;
@@ -65,6 +68,12 @@ public class DefaultExplainPlanExecutor implements ExplainPlanExecutor {
         try {
             statement = createStatement(connection, sql);
             resultSet = executeStatement(statement, sql);
+
+            if (vendor.isExplainPlanFollowupQueryRequired()) {
+                String followupSql = vendor.getFollowupExplainPlanSql(explainPlanSqlInfo.getStatementId());
+                Agent.LOG.finer("Running explain followup query: " + followupSql);
+                resultSet = executeStatement(statement, followupSql);
+            }
             explainPlan = getExplainPlanFromResultSet(vendor, resultSet, recordSql);
         } catch (Exception e) {
             Agent.LOG.log(Level.FINER, "explain plan error", e);

--- a/newrelic-agent/src/main/java/com/newrelic/agent/database/DefaultExplainPlanExecutor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/database/DefaultExplainPlanExecutor.java
@@ -77,9 +77,9 @@ public class DefaultExplainPlanExecutor implements ExplainPlanExecutor {
 
                 String followupSql = vendor.getFollowupExplainPlanSql(explainPlanSqlInfo.getStatementId());
                 Agent.LOG.finer("Running explain followup query: " + followupSql);
-                // Use a fresh, plain Statement for the followup query rather than reusing the one
+                // Use a new, plain Statement for the followup query rather than reusing the one
                 // that ran the primary explain statement. Oracle seems to have issues with statement
-                // on the follow-up query.
+                // reuse on the follow-up query.
                 statement = connection.createStatement();
                 resultSet = statement.executeQuery(followupSql);
             } else {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/database/DefaultExplainPlanExecutor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/database/DefaultExplainPlanExecutor.java
@@ -67,12 +67,23 @@ public class DefaultExplainPlanExecutor implements ExplainPlanExecutor {
         Object[] explainPlan = null;
         try {
             statement = createStatement(connection, sql);
-            resultSet = executeStatement(statement, sql);
 
             if (vendor.isExplainPlanFollowupQueryRequired()) {
+                // If a followup query is required to get results, the primary explain statement's
+                // own result (if any) isn't useful, so run it without treating it as a query.
+                executeStatementIgnoringResult(statement, sql);
+                statement.close();
+                resultSet = null;
+
                 String followupSql = vendor.getFollowupExplainPlanSql(explainPlanSqlInfo.getStatementId());
                 Agent.LOG.finer("Running explain followup query: " + followupSql);
-                resultSet = executeStatement(statement, followupSql);
+                // Use a fresh, plain Statement for the followup query rather than reusing the one
+                // that ran the primary explain statement. Oracle seems to have issues with statement
+                // on the follow-up query.
+                statement = connection.createStatement();
+                resultSet = statement.executeQuery(followupSql);
+            } else {
+                resultSet = executeStatement(statement, sql);
             }
             explainPlan = getExplainPlanFromResultSet(vendor, resultSet, recordSql);
         } catch (Exception e) {
@@ -114,6 +125,15 @@ public class DefaultExplainPlanExecutor implements ExplainPlanExecutor {
 
     protected ResultSet executeStatement(Statement statement, String sql) throws SQLException {
         return statement.executeQuery(sql);
+    }
+
+    /**
+     * Run a statement where we don't care about the result (if any). Initially written
+     * for Oracle explain plans since running Oracle explains with executeQuery() doesn't
+     * work.
+     */
+    protected void executeStatementIgnoringResult(Statement statement, String sql) throws SQLException {
+        statement.execute(sql);
     }
 
     protected Statement createStatement(Connection connection, String sql) throws SQLException {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutor.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutor.java
@@ -12,8 +12,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.logging.Level;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.newrelic.agent.Agent;
 import com.newrelic.agent.bridge.datastore.RecordSql;
 import com.newrelic.agent.tracers.SqlTracerExplainInfo;
 
@@ -40,6 +42,14 @@ public class PreparedStatementExplainPlanExecutor extends DefaultExplainPlanExec
         return preparedStatement.executeQuery();
     }
 
+    @Override
+    protected void executeStatementIgnoringResult(Statement statement, String sql) throws SQLException {
+        PreparedStatement preparedStatement = (PreparedStatement) statement;
+        Connection connection = preparedStatement.getConnection();
+        setSqlParameters(preparedStatement, connection);
+        preparedStatement.execute();
+    }
+
     private void setSqlParameters(PreparedStatement preparedStatement, Connection connection) {
         if (sqlParameters == null) {
             return;
@@ -64,8 +74,8 @@ public class PreparedStatementExplainPlanExecutor extends DefaultExplainPlanExec
                     preparedStatement.setObject(i + 1, param);
                 }
             }
-        } catch (Throwable ignored) {
-            // ignore
+        } catch (Exception e) {
+            Agent.LOG.log(Level.FINER, "Unable to set explain plan statement parameters", e);
         }
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/database/DefaultExplainPlanExecutorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/database/DefaultExplainPlanExecutorTest.java
@@ -9,6 +9,7 @@ package com.newrelic.agent.database;
 
 import com.newrelic.agent.bridge.datastore.DatabaseVendor;
 import com.newrelic.agent.bridge.datastore.DatastoreVendor;
+import com.newrelic.agent.bridge.datastore.ExplainPlanSqlInfo;
 import com.newrelic.agent.bridge.datastore.RecordSql;
 import com.newrelic.agent.tracers.SqlTracerExplainInfo;
 import org.junit.Assert;
@@ -59,8 +60,18 @@ public class DefaultExplainPlanExecutorTest {
             }
 
             @Override
-            public String getExplainPlanSql(String sql) throws SQLException {
-                return sql;
+            public ExplainPlanSqlInfo getExplainPlanSqlInfo(String sqlToExplain) throws SQLException {
+                return new ExplainPlanSqlInfo(sqlToExplain, null);
+            }
+
+            @Override
+            public boolean isExplainPlanFollowupQueryRequired() {
+                return false;
+            }
+
+            @Override
+            public String getFollowupExplainPlanSql(String statementId) {
+                return null;
             }
 
             @Override
@@ -99,11 +110,47 @@ public class DefaultExplainPlanExecutorTest {
         Mockito.when(statement.executeQuery(Mockito.any())).thenReturn(results);
         Mockito.when(connection.createStatement()).thenReturn(statement);
         DatabaseVendor vendor = Mockito.mock(DatabaseVendor.class);
-        Mockito.when(vendor.getExplainPlanSql(Mockito.any())).thenReturn(sql);
+        Mockito.when(vendor.getExplainPlanSqlInfo(Mockito.any())).thenReturn(new ExplainPlanSqlInfo(sql, null));
 
         executor.runExplainPlan(dbService, connection, vendor);
 
         Assert.assertTrue(tracer.hasExplainPlan());
+    }
+
+    @Test
+    public void testRunExplainPlan_withFollowupQueryRequired_usesFollowupResultSet() throws SQLException {
+        String sql = "select * from test";
+        String followupSql = "SELECT * FROM PLAN_TABLE WHERE STATEMENT_ID = '42'";
+        SqlTracerExplainInfo tracer = new TestSqlStatementTracer();
+        Assert.assertFalse(tracer.hasExplainPlan());
+
+        DefaultExplainPlanExecutor executor = new DefaultExplainPlanExecutor(tracer, sql, RecordSql.raw);
+
+        DatabaseService dbService = Mockito.mock(DatabaseService.class);
+        Connection connection = Mockito.mock(Connection.class);
+        Statement statement = Mockito.mock(Statement.class);
+
+        // The initial EXPLAIN PLAN statement returns no columns, as is the case for Oracle.
+        ResultSet initialResultSet = Mockito.mock(ResultSet.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(initialResultSet.getMetaData().getColumnCount()).thenReturn(0);
+
+        // The followup query against PLAN_TABLE is where the actual explain plan rows come from.
+        ResultSet followupResultSet = Mockito.mock(ResultSet.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(followupResultSet.getMetaData().getColumnCount()).thenReturn(2);
+
+        Mockito.when(statement.executeQuery(sql)).thenReturn(initialResultSet);
+        Mockito.when(statement.executeQuery(followupSql)).thenReturn(followupResultSet);
+        Mockito.when(connection.createStatement()).thenReturn(statement);
+
+        DatabaseVendor vendor = Mockito.mock(DatabaseVendor.class);
+        Mockito.when(vendor.getExplainPlanSqlInfo(Mockito.any())).thenReturn(new ExplainPlanSqlInfo(sql, "42"));
+        Mockito.when(vendor.isExplainPlanFollowupQueryRequired()).thenReturn(true);
+        Mockito.when(vendor.getFollowupExplainPlanSql("42")).thenReturn(followupSql);
+
+        executor.runExplainPlan(dbService, connection, vendor);
+
+        Assert.assertTrue(tracer.hasExplainPlan());
+        Mockito.verify(vendor).parseExplainPlanResultSet(2, followupResultSet, RecordSql.raw);
     }
 
     private SqlTracerExplainInfo createSqlTracerInfo(final String sql) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/database/DefaultExplainPlanExecutorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/database/DefaultExplainPlanExecutorTest.java
@@ -130,15 +130,12 @@ public class DefaultExplainPlanExecutorTest {
         Connection connection = Mockito.mock(Connection.class);
         Statement statement = Mockito.mock(Statement.class);
 
-        // The initial EXPLAIN PLAN statement returns no columns, as is the case for Oracle.
-        ResultSet initialResultSet = Mockito.mock(ResultSet.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(initialResultSet.getMetaData().getColumnCount()).thenReturn(0);
-
-        // The followup query against PLAN_TABLE is where the actual explain plan rows come from.
+        // The primary EXPLAIN PLAN statement is run as a plain execute() and its result (if any) is
+        // ignored (thanks Oracle). The followup query against PLAN_TABLE is where the
+        // actual explain plan rows come from.
         ResultSet followupResultSet = Mockito.mock(ResultSet.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(followupResultSet.getMetaData().getColumnCount()).thenReturn(2);
 
-        Mockito.when(statement.executeQuery(sql)).thenReturn(initialResultSet);
         Mockito.when(statement.executeQuery(followupSql)).thenReturn(followupResultSet);
         Mockito.when(connection.createStatement()).thenReturn(statement);
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutorTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/database/PreparedStatementExplainPlanExecutorTest.java
@@ -55,6 +55,22 @@ public class PreparedStatementExplainPlanExecutorTest {
     }
 
     @Test
+    public void executeStatementIgnoringResult_setsParametersAndExecutes() throws SQLException {
+        SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        Connection mockConnection = mock(Connection.class);
+        Object[] params = {42};
+
+        when(mockStatement.getConnection()).thenReturn(mockConnection);
+        PreparedStatementExplainPlanExecutor executor = new PreparedStatementExplainPlanExecutor(
+                mockExplain, "EXPLAIN PLAN FOR SELECT * FROM DUAL WHERE id = ?", params, RecordSql.raw);
+        executor.executeStatementIgnoringResult(mockStatement, "sql_not_used");
+
+        verify(mockStatement).setObject(eq(1), eq(42));
+        verify(mockStatement).execute();
+    }
+
+    @Test
     public void executeStatement_handlesIntegerArrayParameters() throws SQLException {
         SqlTracerExplainInfo mockExplain = mock(SqlTracerExplainInfo.class);
         PreparedStatement mockStatement = mock(PreparedStatement.class);


### PR DESCRIPTION
Resolves #3031 

This adds explain plan support to Oracle 11g+ when utilizing the `jdbc-ojdbc7-12.1.0.2` or `jdbc-ojdbc8-21.1.0.0` instrumentation modules.

Oracle's explain plans don't follow the flow that Postgres, etc do. Instead...
- Run the query to generate the plan: `EXPLAIN PLAN SET STATEMENT_ID = '<id>'  FOR <sql>`. The generated plan is written to the `PLAN_TABLE` table.
- Run the query `SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY('PLAN_TABLE')` to extract the explain plan rows
- Parse the explain plan output into human readable text

An example of a final Oracle explain plan as added as an attribute to a SQLTracer...
```
Plan hash value: 3210784694                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                            
  -------------------------------------------------------------------------------------------------------                                                                                                                                                 
  | Id  | Operation                             | Name          | Rows  | Bytes | Cost (%CPU)| Time     |                                                                                                                                                   
  -------------------------------------------------------------------------------------------------------                                                                                                                                                   
  |   0 | SELECT STATEMENT                      |               |     1 |    78 |     3  (34)| 00:00:01 |                                                                                                                                                   
  |   1 |  SORT ORDER BY                        |               |     1 |    78 |     3  (34)| 00:00:01 |                                                                                                                                                   
  |   2 |   NESTED LOOPS OUTER                  |               |     1 |    78 |     2   (0)| 00:00:01 |                                                                                                                                                   
  |   3 |    TABLE ACCESS BY INDEX ROWID        | OWNERS        |     1 |    55 |     1   (0)| 00:00:01 |                                                                                                                                                   
  |*  4 |     INDEX UNIQUE SCAN                 | SYS_C008660   |     1 |       |     0   (0)| 00:00:01 |                                                                                                                                                   
  |   5 |    TABLE ACCESS BY INDEX ROWID BATCHED| PETS          |     1 |    23 |     1   (0)| 00:00:01 |                                                                                                                                                   
  |*  6 |     INDEX RANGE SCAN                  | PETS_OWNER_ID |     1 |       |     0   (0)| 00:00:01 |                                                                                                                                                   
  -------------------------------------------------------------------------------------------------------                                                                                                                                                   

  Predicate Information (identified by operation id):                                                                                                                                                                                                       
  ---------------------------------------------------                                                                                                                                                                                                       
     4 - access("O1_0"."ID"=:1)                                                                                                                                                                                                                             
     6 - access("P1_0"."OWNER_ID"(+)=:1)
```

This required some changes to the `DatabaseVendor` interface.
- Added the `isExplainPlanFollowupQueryRequired` method that will return `true` if a followup query is required for the explain plan rows
- Added the `getFollowupExplainPlanSql` method that will return the SQL required to run if a followup query is required

The logic in the ExplainPlanExecutor has been updated to support the followup query flow, if required.

Added additional tests for the new followup query methods.