### PR TITLE
Enable OTLP metric retry logic and generate export supportability met…

### DIFF
--- a/instrumentation/opentelemetry-exporter-otlp-1.28.0/README.md
+++ b/instrumentation/opentelemetry-exporter-otlp-1.28.0/README.md
@@ -1,0 +1,4 @@
+# OpenTelemetry Exporter OTLP
+
+This instrumentation module works in tandem with the `opentelemetry-sdk-extension-autoconfigure-1.28.0` hybrid agent instrumentation to:
+* log the OTLP Metrics response payload when the agent's `audit_mode` config is set to `true`.

--- a/instrumentation/opentelemetry-exporter-otlp-1.34.0/README.md
+++ b/instrumentation/opentelemetry-exporter-otlp-1.34.0/README.md
@@ -1,0 +1,5 @@
+# OpenTelemetry Exporter OTLP
+
+This instrumentation module works in tandem with the `opentelemetry-sdk-extension-autoconfigure-1.28.0` hybrid agent instrumentation to:
+* log the OTLP Metrics response payload when the agent's `audit_mode` config is set to `true`.
+* generate the `Supportability/Metrics/Java/OpenTelemetryBridge/export/retry` metric.

--- a/instrumentation/opentelemetry-exporter-otlp-1.34.0/build.gradle
+++ b/instrumentation/opentelemetry-exporter-otlp-1.34.0/build.gradle
@@ -9,8 +9,13 @@ dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":newrelic-weaver-api"))
 
+    // okhttp is a runtime-only transitive of opentelemetry-exporter-sender-okhttp, and is always
+    // present wherever RetryInterceptor is loaded, so compileOnly is sufficient here.
+    compileOnly("com.squareup.okhttp3:okhttp:4.11.0")
+
     testImplementation("junit:junit:4.12")
     testImplementation("org.mockito:mockito-inline:4.11.0")
+    testImplementation("com.squareup.okhttp3:okhttp:4.11.0")
 }
 
 jar {

--- a/instrumentation/opentelemetry-exporter-otlp-1.34.0/src/main/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChain.java
+++ b/instrumentation/opentelemetry-exporter-otlp-1.34.0/src/main/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChain.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.otlp.retry;
+
+import com.newrelic.api.agent.NewRelic;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+/**
+ * An {@link Interceptor.Chain} that counts calls to {@link #proceed(Request)}. RetryInterceptor
+ * calls proceed() exactly once per attempt in its retry loop, so the first call is the initial
+ * attempt and every call after it is a retry.
+ */
+public class RetryCountingChain implements Interceptor.Chain {
+    private static final String EXPORT_RETRY_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/retry";
+
+    private final Interceptor.Chain delegate;
+    private final AtomicInteger attempts;
+
+    public RetryCountingChain(Interceptor.Chain delegate) {
+        this(delegate, new AtomicInteger());
+    }
+
+    private RetryCountingChain(Interceptor.Chain delegate, AtomicInteger attempts) {
+        this.delegate = delegate;
+        this.attempts = attempts;
+    }
+
+    @Override
+    public Response proceed(Request request) throws IOException {
+        // The first proceed() is the initial attempt; every one after it is a retry.
+        if (attempts.getAndIncrement() > 0) {
+            try {
+                NewRelic.incrementCounter(EXPORT_RETRY_METRIC);
+            } catch (Throwable t) {
+                NewRelic.getAgent().getLogger().log(Level.FINER, t, "Unable to record OTLP export retry metric");
+            }
+        }
+        return delegate.proceed(request);
+    }
+
+    @Override
+    public Request request() {
+        return delegate.request();
+    }
+
+    @Override
+    public Connection connection() {
+        return delegate.connection();
+    }
+
+    @Override
+    public Call call() {
+        return delegate.call();
+    }
+
+    @Override
+    public int connectTimeoutMillis() {
+        return delegate.connectTimeoutMillis();
+    }
+
+    @Override
+    public Interceptor.Chain withConnectTimeout(int timeout, TimeUnit unit) {
+        // Re-wrap the chain returned by the delegate, sharing the same attempt counter, so the
+        // retry count survives if the SDK ever adjusts timeouts mid-chain.
+        return new RetryCountingChain(delegate.withConnectTimeout(timeout, unit), attempts);
+    }
+
+    @Override
+    public int readTimeoutMillis() {
+        return delegate.readTimeoutMillis();
+    }
+
+    @Override
+    public Interceptor.Chain withReadTimeout(int timeout, TimeUnit unit) {
+        return new RetryCountingChain(delegate.withReadTimeout(timeout, unit), attempts);
+    }
+
+    @Override
+    public int writeTimeoutMillis() {
+        return delegate.writeTimeoutMillis();
+    }
+
+    @Override
+    public Interceptor.Chain withWriteTimeout(int timeout, TimeUnit unit) {
+        return new RetryCountingChain(delegate.withWriteTimeout(timeout, unit), attempts);
+    }
+}

--- a/instrumentation/opentelemetry-exporter-otlp-1.34.0/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor_Instrumentation.java
+++ b/instrumentation/opentelemetry-exporter-otlp-1.34.0/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor_Instrumentation.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.opentelemetry.exporter.sender.okhttp.internal;
+
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.otlp.retry.RetryCountingChain;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * Instruments RetryInterceptor to count retried export attempts. RetryInterceptor's own retry
+ * loop calls {@code chain.proceed(chain.request())} exactly once per attempt, so substituting a
+ * counting {@link Interceptor.Chain} is the only way to observe individual attempts without a
+ * public retry callback.
+ */
+@Weave(type = MatchType.ExactClass, originalName = "io.opentelemetry.exporter.sender.okhttp.internal.RetryInterceptor")
+public abstract class RetryInterceptor_Instrumentation {
+
+    public Response intercept(Interceptor.Chain chain) throws IOException {
+        if (!(chain instanceof RetryCountingChain)) {
+            chain = new RetryCountingChain(chain);
+        }
+        return Weaver.callOriginal();
+    }
+}

--- a/instrumentation/opentelemetry-exporter-otlp-1.34.0/src/test/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChainTest.java
+++ b/instrumentation/opentelemetry-exporter-otlp-1.34.0/src/test/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChainTest.java
@@ -1,0 +1,200 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.otlp.retry;
+
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.Logger;
+import com.newrelic.api.agent.NewRelic;
+import junit.framework.TestCase;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RetryCountingChainTest extends TestCase {
+
+    private static final String EXPORT_RETRY_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/retry";
+
+    public void testFirstProceedDoesNotRecordRetryMetric() throws IOException {
+        Response response = mock(Response.class);
+        FakeChain delegate = new FakeChain(mock(Request.class), response);
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            Response result = chain.proceed(mock(Request.class));
+
+            assertSame(response, result);
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(anyString()), Mockito.never());
+        }
+        assertEquals(1, delegate.proceedCount);
+    }
+
+    public void testSecondAndThirdProceedEachRecordRetryMetricOnce() throws IOException {
+        FakeChain delegate = new FakeChain(mock(Request.class), mock(Response.class));
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            chain.proceed(request); // initial attempt - no retry metric
+            chain.proceed(request); // 1st retry
+            chain.proceed(request); // 2nd retry
+
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(EXPORT_RETRY_METRIC), times(2));
+        }
+        assertEquals(3, delegate.proceedCount);
+    }
+
+    public void testWithReadTimeoutContinuesSameCount() throws IOException {
+        FakeChain delegate = new FakeChain(mock(Request.class), mock(Response.class));
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            chain.proceed(request); // initial attempt, on the original chain
+
+            Interceptor.Chain rewrapped = chain.withReadTimeout(5, TimeUnit.SECONDS);
+            assertTrue(rewrapped instanceof RetryCountingChain);
+            rewrapped.proceed(request); // continues as the 2nd attempt (1st retry)
+
+            // Only one retry happened across the two chain instances - the attempt count is shared,
+            // not reset by re-wrapping.
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(EXPORT_RETRY_METRIC), times(1));
+        }
+    }
+
+    public void testWithConnectTimeoutAndWithWriteTimeoutAlsoContinueCount() throws IOException {
+        FakeChain delegate = new FakeChain(mock(Request.class), mock(Response.class));
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            chain.proceed(request); // initial attempt
+            chain.withConnectTimeout(1, TimeUnit.SECONDS).proceed(request); // 1st retry
+            chain.withWriteTimeout(1, TimeUnit.SECONDS).proceed(request); // 2nd retry
+
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(EXPORT_RETRY_METRIC), times(2));
+        }
+    }
+
+    public void testProceedStillDelegatesAndReturnsResponseWhenMetricCallThrows() throws IOException {
+        Response response = mock(Response.class);
+        FakeChain delegate = new FakeChain(mock(Request.class), response);
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        Agent agent = mock(Agent.class);
+        Logger logger = mock(Logger.class);
+        when(agent.getLogger()).thenReturn(logger);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(agent);
+            mockNewRelic.when(() -> NewRelic.incrementCounter(anyString())).thenThrow(new RuntimeException("boom"));
+
+            chain.proceed(request); // initial attempt - does not touch the metric API
+            Response result = chain.proceed(request); // retry - metric call throws, must not propagate
+
+            assertSame(response, result);
+            verify(logger).log(eq(Level.FINER), any(Throwable.class), anyString());
+        }
+        assertEquals(2, delegate.proceedCount);
+    }
+
+    public void testPassThroughMethodsDelegate() {
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        FakeChain delegate = new FakeChain(request, response);
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+
+        assertSame(request, chain.request());
+        // connection() is nullable per okhttp's contract; the wrapper must not substitute a value.
+        assertNull(chain.connection());
+        assertNotNull(chain.call());
+        assertEquals(1000, chain.connectTimeoutMillis());
+        assertEquals(2000, chain.readTimeoutMillis());
+        assertEquals(3000, chain.writeTimeoutMillis());
+    }
+
+    // A hand-rolled Interceptor.Chain that counts proceed() calls and always returns the same
+    // Response, standing in for RetryInterceptor's own chain during the retry loop.
+    static class FakeChain implements Interceptor.Chain {
+        private final Request request;
+        private final Response response;
+        int proceedCount = 0;
+
+        FakeChain(Request request, Response response) {
+            this.request = request;
+            this.response = response;
+        }
+
+        @Override
+        public Response proceed(Request request) throws IOException {
+            proceedCount++;
+            return response;
+        }
+
+        @Override
+        public Request request() {
+            return request;
+        }
+
+        @Override
+        public Connection connection() {
+            return null;
+        }
+
+        @Override
+        public Call call() {
+            return mock(Call.class);
+        }
+
+        @Override
+        public int connectTimeoutMillis() {
+            return 1000;
+        }
+
+        @Override
+        public Interceptor.Chain withConnectTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int readTimeoutMillis() {
+            return 2000;
+        }
+
+        @Override
+        public Interceptor.Chain withReadTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int writeTimeoutMillis() {
+            return 3000;
+        }
+
+        @Override
+        public Interceptor.Chain withWriteTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+    }
+}

--- a/instrumentation/opentelemetry-exporter-otlp-1.59.0/README.md
+++ b/instrumentation/opentelemetry-exporter-otlp-1.59.0/README.md
@@ -1,0 +1,5 @@
+# OpenTelemetry Exporter OTLP
+
+This instrumentation module works in tandem with the `opentelemetry-sdk-extension-autoconfigure-1.59.0` hybrid agent instrumentation to:
+* log the OTLP Metrics response payload when the agent's `audit_mode` config is set to `true`.
+* generate the `Supportability/Metrics/Java/OpenTelemetryBridge/export/retry` metric.

--- a/instrumentation/opentelemetry-exporter-otlp-1.59.0/build.gradle
+++ b/instrumentation/opentelemetry-exporter-otlp-1.59.0/build.gradle
@@ -8,9 +8,14 @@ dependencies {
     implementation(project(":newrelic-api"))
     implementation(project(":newrelic-weaver-api"))
 
+    // okhttp is a runtime-only transitive of opentelemetry-exporter-sender-okhttp, and is always
+    // present wherever RetryInterceptor is loaded, so compileOnly is sufficient here.
+    compileOnly("com.squareup.okhttp3:okhttp:5.3.2")
+
     testImplementation("junit:junit:4.12")
     testImplementation("io.opentelemetry:opentelemetry-sdk-common:1.59.0")
     testImplementation("org.mockito:mockito-inline:4.11.0")
+    testImplementation("com.squareup.okhttp3:okhttp:5.3.2")
 }
 
 jar {

--- a/instrumentation/opentelemetry-exporter-otlp-1.59.0/src/main/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChain.java
+++ b/instrumentation/opentelemetry-exporter-otlp-1.59.0/src/main/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChain.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.otlp.retry;
+
+import com.newrelic.api.agent.NewRelic;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+/**
+ * An {@link Interceptor.Chain} that counts calls to {@link #proceed(Request)}. RetryInterceptor
+ * calls proceed() exactly once per attempt in its retry loop, so the first call is the initial
+ * attempt and every call after it is a retry.
+ */
+public class RetryCountingChain implements Interceptor.Chain {
+    private static final String EXPORT_RETRY_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/retry";
+
+    private final Interceptor.Chain delegate;
+    private final AtomicInteger attempts;
+
+    public RetryCountingChain(Interceptor.Chain delegate) {
+        this(delegate, new AtomicInteger());
+    }
+
+    private RetryCountingChain(Interceptor.Chain delegate, AtomicInteger attempts) {
+        this.delegate = delegate;
+        this.attempts = attempts;
+    }
+
+    @Override
+    public Response proceed(Request request) throws IOException {
+        // The first proceed() is the initial attempt; every one after it is a retry.
+        if (attempts.getAndIncrement() > 0) {
+            try {
+                NewRelic.incrementCounter(EXPORT_RETRY_METRIC);
+            } catch (Throwable t) {
+                NewRelic.getAgent().getLogger().log(Level.FINER, t, "Unable to record OTLP export retry metric");
+            }
+        }
+        return delegate.proceed(request);
+    }
+
+    @Override
+    public Request request() {
+        return delegate.request();
+    }
+
+    @Override
+    public Connection connection() {
+        return delegate.connection();
+    }
+
+    @Override
+    public Call call() {
+        return delegate.call();
+    }
+
+    @Override
+    public int connectTimeoutMillis() {
+        return delegate.connectTimeoutMillis();
+    }
+
+    @Override
+    public Interceptor.Chain withConnectTimeout(int timeout, TimeUnit unit) {
+        // Re-wrap the chain returned by the delegate, sharing the same attempt counter, so the
+        // retry count survives if the SDK ever adjusts timeouts mid-chain.
+        return new RetryCountingChain(delegate.withConnectTimeout(timeout, unit), attempts);
+    }
+
+    @Override
+    public int readTimeoutMillis() {
+        return delegate.readTimeoutMillis();
+    }
+
+    @Override
+    public Interceptor.Chain withReadTimeout(int timeout, TimeUnit unit) {
+        return new RetryCountingChain(delegate.withReadTimeout(timeout, unit), attempts);
+    }
+
+    @Override
+    public int writeTimeoutMillis() {
+        return delegate.writeTimeoutMillis();
+    }
+
+    @Override
+    public Interceptor.Chain withWriteTimeout(int timeout, TimeUnit unit) {
+        return new RetryCountingChain(delegate.withWriteTimeout(timeout, unit), attempts);
+    }
+}

--- a/instrumentation/opentelemetry-exporter-otlp-1.59.0/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor_Instrumentation.java
+++ b/instrumentation/opentelemetry-exporter-otlp-1.59.0/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor_Instrumentation.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.opentelemetry.exporter.sender.okhttp.internal;
+
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.otlp.retry.RetryCountingChain;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * Instruments RetryInterceptor to count retried export attempts. RetryInterceptor's own retry
+ * loop calls {@code chain.proceed(chain.request())} exactly once per attempt, so substituting a
+ * counting {@link Interceptor.Chain} is the only way to observe individual attempts without a
+ * public retry callback.
+ */
+@Weave(type = MatchType.ExactClass, originalName = "io.opentelemetry.exporter.sender.okhttp.internal.RetryInterceptor")
+public abstract class RetryInterceptor_Instrumentation {
+
+    public Response intercept(Interceptor.Chain chain) throws IOException {
+        if (!(chain instanceof RetryCountingChain)) {
+            chain = new RetryCountingChain(chain);
+        }
+        return Weaver.callOriginal();
+    }
+}

--- a/instrumentation/opentelemetry-exporter-otlp-1.59.0/src/test/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChainTest.java
+++ b/instrumentation/opentelemetry-exporter-otlp-1.59.0/src/test/java/com/nr/agent/instrumentation/otlp/retry/RetryCountingChainTest.java
@@ -1,0 +1,200 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.otlp.retry;
+
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.Logger;
+import com.newrelic.api.agent.NewRelic;
+import junit.framework.TestCase;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RetryCountingChainTest extends TestCase {
+
+    private static final String EXPORT_RETRY_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/retry";
+
+    public void testFirstProceedDoesNotRecordRetryMetric() throws IOException {
+        Response response = mock(Response.class);
+        FakeChain delegate = new FakeChain(mock(Request.class), response);
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            Response result = chain.proceed(mock(Request.class));
+
+            assertSame(response, result);
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(anyString()), Mockito.never());
+        }
+        assertEquals(1, delegate.proceedCount);
+    }
+
+    public void testSecondAndThirdProceedEachRecordRetryMetricOnce() throws IOException {
+        FakeChain delegate = new FakeChain(mock(Request.class), mock(Response.class));
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            chain.proceed(request); // initial attempt - no retry metric
+            chain.proceed(request); // 1st retry
+            chain.proceed(request); // 2nd retry
+
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(EXPORT_RETRY_METRIC), times(2));
+        }
+        assertEquals(3, delegate.proceedCount);
+    }
+
+    public void testWithReadTimeoutContinuesSameCount() throws IOException {
+        FakeChain delegate = new FakeChain(mock(Request.class), mock(Response.class));
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            chain.proceed(request); // initial attempt, on the original chain
+
+            Interceptor.Chain rewrapped = chain.withReadTimeout(5, TimeUnit.SECONDS);
+            assertTrue(rewrapped instanceof RetryCountingChain);
+            rewrapped.proceed(request); // continues as the 2nd attempt (1st retry)
+
+            // Only one retry happened across the two chain instances - the attempt count is shared,
+            // not reset by re-wrapping.
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(EXPORT_RETRY_METRIC), times(1));
+        }
+    }
+
+    public void testWithConnectTimeoutAndWithWriteTimeoutAlsoContinueCount() throws IOException {
+        FakeChain delegate = new FakeChain(mock(Request.class), mock(Response.class));
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            chain.proceed(request); // initial attempt
+            chain.withConnectTimeout(1, TimeUnit.SECONDS).proceed(request); // 1st retry
+            chain.withWriteTimeout(1, TimeUnit.SECONDS).proceed(request); // 2nd retry
+
+            mockNewRelic.verify(() -> NewRelic.incrementCounter(EXPORT_RETRY_METRIC), times(2));
+        }
+    }
+
+    public void testProceedStillDelegatesAndReturnsResponseWhenMetricCallThrows() throws IOException {
+        Response response = mock(Response.class);
+        FakeChain delegate = new FakeChain(mock(Request.class), response);
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+        Request request = mock(Request.class);
+
+        Agent agent = mock(Agent.class);
+        Logger logger = mock(Logger.class);
+        when(agent.getLogger()).thenReturn(logger);
+
+        try (MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class)) {
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(agent);
+            mockNewRelic.when(() -> NewRelic.incrementCounter(anyString())).thenThrow(new RuntimeException("boom"));
+
+            chain.proceed(request); // initial attempt - does not touch the metric API
+            Response result = chain.proceed(request); // retry - metric call throws, must not propagate
+
+            assertSame(response, result);
+            verify(logger).log(eq(Level.FINER), any(Throwable.class), anyString());
+        }
+        assertEquals(2, delegate.proceedCount);
+    }
+
+    public void testPassThroughMethodsDelegate() {
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        FakeChain delegate = new FakeChain(request, response);
+        RetryCountingChain chain = new RetryCountingChain(delegate);
+
+        assertSame(request, chain.request());
+        // connection() is nullable per okhttp's contract; the wrapper must not substitute a value.
+        assertNull(chain.connection());
+        assertNotNull(chain.call());
+        assertEquals(1000, chain.connectTimeoutMillis());
+        assertEquals(2000, chain.readTimeoutMillis());
+        assertEquals(3000, chain.writeTimeoutMillis());
+    }
+
+    // A hand-rolled Interceptor.Chain that counts proceed() calls and always returns the same
+    // Response, standing in for RetryInterceptor's own chain during the retry loop.
+    static class FakeChain implements Interceptor.Chain {
+        private final Request request;
+        private final Response response;
+        int proceedCount = 0;
+
+        FakeChain(Request request, Response response) {
+            this.request = request;
+            this.response = response;
+        }
+
+        @Override
+        public Response proceed(Request request) throws IOException {
+            proceedCount++;
+            return response;
+        }
+
+        @Override
+        public Request request() {
+            return request;
+        }
+
+        @Override
+        public Connection connection() {
+            return null;
+        }
+
+        @Override
+        public Call call() {
+            return mock(Call.class);
+        }
+
+        @Override
+        public int connectTimeoutMillis() {
+            return 1000;
+        }
+
+        @Override
+        public Interceptor.Chain withConnectTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int readTimeoutMillis() {
+            return 2000;
+        }
+
+        @Override
+        public Interceptor.Chain withReadTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int writeTimeoutMillis() {
+            return 3000;
+        }
+
+        @Override
+        public Interceptor.Chain withWriteTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+    }
+}

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/README.md
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/README.md
@@ -212,6 +212,32 @@ Dimensional metrics are exported to New Relic over OTLP via the OTel SDK. The Ja
 -Dhttps.proxyPort=8080
 ```
 
+### Supportability Metrics
+
+The health of the OTLP metrics export path can be monitored via the following supportability metrics:
+
+* `Supportability/Metrics/Java/OpenTelemetryBridge/export/success` - incremented once per dimensional metrics batch that the OTel SDK successfully exported.
+* `Supportability/Metrics/Java/OpenTelemetryBridge/export/failure` - incremented once per batch that was dropped, either because the OTel SDK's internal retry budget was exhausted or because the failure was non-retryable (e.g. an HTTP 400 response).
+* `Supportability/Metrics/Java/OpenTelemetryBridge/export/retry` - incremented once per retried export attempt (i.e. every attempt after the first for a given batch). Only available when [opentelemetry-exporter-otlp](https://central.sonatype.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp) 1.34.0 or later is also present, since retry attempts are counted by instrumenting a class ([RetryInterceptor](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java)) that only exists starting at that version. With OTel 1.28.0-1.33.x, `export/success` and `export/failure` are still recorded, but retries are invisible.
+
+Retry itself is always on: this module sets `otel.experimental.exporter.otlp.retry.enabled=true`, which this OTel version reads (the property defaults to `false`, so this is the line that actually enables it).
+
+Note that `export/retry` is recorded by instrumenting the retry interceptor shared by every signal exported over the same OTel exporter-sender component. This agent configures the OTel SDK with `otel.traces.exporter=none` and `otel.logs.exporter=none`, so under normal agent configuration all OTLP HTTP traffic on that interceptor is metrics traffic. If the monitored application independently configures its own OTLP trace or log exporter (bypassing the agent's autoconfiguration), those exporters' retries would also be counted toward this metric.
+
+Additionally, the following data usage supportability metrics will be recorded for OTLP Metric payloads:
+* `Supportability/Java/OTLP/Output/Bytes`
+* `Supportability/Java/OTLP/Metrics/Output/Bytes`
+
+### OTLP Metrics Payload Audit Logging
+
+When `audit_mode: true` the agent will log base64 encoded sent/received payloads for OTLP Metrics, as follows:
+
+```
+2026-08-17T16:22:43,560-0700 [26873 98] com.newrelic INFO: Sent OTLP/Metrics to: https://collector.newrelic.com:443, bytes: 48,694, payload: CrAICqQHCiEKDWFnZW50LnZlcnNpb24SEAoOOS4...Eb3duQ291bnRlchIFCgNmb28QAg==
+
+2026-08-17T16:22:43,723-0700 [26873 167] com.newrelic INFO: Received OTLP/Metrics response: status=200, bytes=0, payload: 
+```
+
 ## OpenTelemetry Traces Signals
 
 Documented below are several approaches for incorporating OpenTelemetry Traces (aka Spans) into New Relic Java agent traces.

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/NRMetricExporterWrapper.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/NRMetricExporterWrapper.java
@@ -43,6 +43,9 @@ import static com.newrelic.agent.util.LicenseKeyUtil.obfuscateLicenseKey;
  */
 final class NRMetricExporterWrapper implements MetricExporter {
 
+    private static final String EXPORT_SUCCESS_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/success";
+    private static final String EXPORT_FAILURE_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/failure";
+
     private final MetricExporter delegate;
     private final String endpoint;
     private volatile Map<String, String> lastMetadata;
@@ -58,7 +61,7 @@ final class NRMetricExporterWrapper implements MetricExporter {
         boolean auditMode = OtlpAuditLogger.isAuditModeEnabled();
         Collection<MetricData> toExport = prepareMetrics(metrics);
         final int bytesSent = logAuditRequest(toExport, auditMode);
-        CompletableResultCode result = delegate.export(toExport);
+        final CompletableResultCode result = delegate.export(toExport);
         result.whenComplete(new Runnable() {
             @Override
             public void run() {
@@ -71,6 +74,10 @@ final class NRMetricExporterWrapper implements MetricExporter {
                  * important value to capture.
                  */
                 OtlpAuditLogger.recordDataUsageMetrics(bytesSent, 0);
+                // The OTel SDK exhausts its retry budget inside delegate.export(), so a failure
+                // here means the batch was dropped after retries (or was non-retryable), not that
+                // a retry is still pending.
+                NewRelic.incrementCounter(result.isSuccess() ? EXPORT_SUCCESS_METRIC : EXPORT_FAILURE_METRIC);
             }
         });
         return result;

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizer.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizer.java
@@ -76,7 +76,12 @@ final class OpenTelemetrySDKCustomizer {
             properties.put("otel.exporter.otlp.compression", "gzip");
             properties.put("otel.exporter.otlp.metrics.temporality.preference", "DELTA");
             properties.put("otel.exporter.otlp.metrics.default.histogram.aggregation", "BASE2_EXPONENTIAL_BUCKET_HISTOGRAM");
+            // Retry configuration. The two OTel versions read different properties with opposite polarity, so
+            // both are set and each version ignores the one it does not know:
+            //   < 1.29.0 reads otel.experimental.exporter.otlp.retry.enabled (default false -> must opt in)
+            //  >= ~1.44  reads otel.java.exporter.otlp.retry.disabled (retry is on by default -> false is a no-op)
             properties.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+            properties.put("otel.java.exporter.otlp.retry.disabled", "false");
             properties.put("otel.experimental.resource.disabled.keys", "process.command_line");
 
             final Object appName = agent.getConfig().getValue("app_name");

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.28.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
@@ -65,6 +65,11 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         assertEquals("http/protobuf", properties.get("otel.exporter.otlp.protocol"));
         assertEquals("Test", properties.get("otel.service.name"));
         assertEquals("gzip", properties.get("otel.exporter.otlp.compression"));
+        // This OTel version reads otel.experimental.exporter.otlp.retry.enabled (default false); the
+        // otel.java.exporter.otlp.retry.disabled property does not exist here and is set only so both
+        // autoconfigure modules stay near-identical.
+        assertEquals("true", properties.get("otel.experimental.exporter.otlp.retry.enabled"));
+        assertEquals("false", properties.get("otel.java.exporter.otlp.retry.disabled"));
     }
 
     public void testApplyResourcesServiceInstanceIdSet() {
@@ -244,6 +249,47 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         }
     }
 
+    public void testExportSuccessRecordsSuccessMetric() {
+        DummyExporter delegate = new DummyExporter();
+        com.newrelic.agent.bridge.Agent mockBridgeAgent = mock(com.newrelic.agent.bridge.Agent.class);
+        when(mockBridgeAgent.getServiceMetadata()).thenReturn(Collections.<String, String>emptyMap());
+
+        try (MockedStatic<AgentBridge> mockBridge = Mockito.mockStatic(AgentBridge.class);
+             MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class);
+             MockedStatic<OtlpAuditLogger> mockAuditLogger = Mockito.mockStatic(OtlpAuditLogger.class)) {
+            mockBridge.when(AgentBridge::getAgent).thenReturn(mockBridgeAgent);
+            mockAuditLogger.when(OtlpAuditLogger::isAuditModeEnabled).thenReturn(false);
+
+            MetricExporter wrapped = OpenTelemetrySDKCustomizer.wrapMetricExporter(delegate, mock(ConfigProperties.class));
+            wrapped.export(Collections.<MetricData>emptyList());
+
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/success"));
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/failure"), Mockito.never());
+        }
+    }
+
+    public void testExportFailureRecordsFailureMetric() {
+        DummyExporter delegate = new DummyExporter();
+        delegate.setExportResult(CompletableResultCode.ofFailure());
+        com.newrelic.agent.bridge.Agent mockBridgeAgent = mock(com.newrelic.agent.bridge.Agent.class);
+        when(mockBridgeAgent.getServiceMetadata()).thenReturn(Collections.<String, String>emptyMap());
+
+        try (MockedStatic<AgentBridge> mockBridge = Mockito.mockStatic(AgentBridge.class);
+             MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class);
+             MockedStatic<OtlpAuditLogger> mockAuditLogger = Mockito.mockStatic(OtlpAuditLogger.class)) {
+            mockBridge.when(AgentBridge::getAgent).thenReturn(mockBridgeAgent);
+            mockAuditLogger.when(OtlpAuditLogger::isAuditModeEnabled).thenReturn(false);
+
+            MetricExporter wrapped = OpenTelemetrySDKCustomizer.wrapMetricExporter(delegate, mock(ConfigProperties.class));
+            wrapped.export(Collections.<MetricData>emptyList());
+
+            // export/failure covers any dropped batch, including this non-retryable case, not just
+            // retry exhaustion.
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/failure"));
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/success"), Mockito.never());
+        }
+    }
+
     public void testWrapMetricExporterDelegatesPassThroughMethods() {
         MetricExporter delegate = mock(MetricExporter.class);
         when(delegate.getDefaultAggregation(InstrumentType.COUNTER)).thenReturn(Aggregation.sum());
@@ -291,6 +337,10 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         //expose the most recently exported metrics
         private Collection<MetricData> lastestMetricData = null;
 
+        // the result returned by export() - defaults to success, tests may override it to
+        // exercise the failure path
+        private CompletableResultCode exportResult = CompletableResultCode.ofSuccess();
+
         //this is required to register views without throwing an exception
         @Override
         public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
@@ -305,7 +355,11 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         @Override
         public CompletableResultCode export(Collection<MetricData> metrics) {
             this.lastestMetricData = metrics;
-            return CompletableResultCode.ofSuccess();
+            return exportResult;
+        }
+
+        void setExportResult(CompletableResultCode exportResult) {
+            this.exportResult = exportResult;
         }
 
         @Override

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/README.md
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/README.md
@@ -232,6 +232,32 @@ NEW_RELIC_PROXY_PORT : 8888
 
 Note that, as the OpenTelemetry SDK does not support proxy authentication, the (`proxy_user`/`proxy_password`) and `proxy_scheme` agent config settings are NOT applied to the OTLP metric exporter.
 
+### Supportability Metrics
+
+The health of the OTLP metrics export path can be monitored via the following supportability metrics:
+
+* `Supportability/Metrics/Java/OpenTelemetryBridge/export/success` - incremented once per dimensional metrics batch that the OTel SDK successfully exported.
+* `Supportability/Metrics/Java/OpenTelemetryBridge/export/failure` - incremented once per batch that was dropped, either because the OTel SDK's internal retry budget was exhausted or because the failure was non-retryable (e.g. an HTTP 400 response).
+* `Supportability/Metrics/Java/OpenTelemetryBridge/export/retry` - incremented once per retried export attempt (i.e. every attempt after the first for a given batch). Retry attempts are counted by instrumenting [RetryInterceptor](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java) in the corresponding `opentelemetry-exporter-otlp-1.59.0` instrumentation module.
+
+Retry is on by default at this OTel version (the SDK seeds a default retry policy of 5 attempts). This module also sets `otel.java.exporter.otlp.retry.disabled=false`, which this OTel version reads, as a defensive no-op should that default ever change.
+
+Note that `export/retry` is recorded by instrumenting the retry interceptor shared by every signal exported over the same OTel exporter-sender component. This agent configures the OTel SDK with `otel.traces.exporter=none` and `otel.logs.exporter=none`, so under normal agent configuration all OTLP HTTP traffic on that interceptor is metrics traffic. If the monitored application independently configures its own OTLP trace or log exporter (bypassing the agent's autoconfiguration), those exporters' retries would also be counted toward this metric.
+
+Additionally, the following data usage supportability metrics will be recorded for OTLP Metric payloads:
+* `Supportability/Java/OTLP/Output/Bytes`
+* `Supportability/Java/OTLP/Metrics/Output/Bytes`
+
+### OTLP Metrics Payload Audit Logging
+
+When `audit_mode: true` the agent will log base64 encoded sent/received payloads for OTLP Metrics, as follows:
+
+```
+2026-08-17T16:22:43,560-0700 [26873 98] com.newrelic INFO: Sent OTLP/Metrics to: https://collector.newrelic.com:443, bytes: 48,694, payload: CrAICqQHCiEKDWFnZW50LnZlcnNpb24SEAoOOS4...Eb3duQ291bnRlchIFCgNmb28QAg==
+
+2026-08-17T16:22:43,723-0700 [26873 167] com.newrelic INFO: Received OTLP/Metrics response: status=200, bytes=0, payload: 
+```
+
 ## OpenTelemetry Traces Signals
 
 Documented below are several approaches for incorporating OpenTelemetry Traces (aka Spans) into New Relic Java agent traces.

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/io/opentelemetry/sdk/autoconfigure/NRMetricExporterWrapper.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/io/opentelemetry/sdk/autoconfigure/NRMetricExporterWrapper.java
@@ -44,6 +44,9 @@ import static com.newrelic.agent.util.LicenseKeyUtil.obfuscateLicenseKey;
  */
 final class NRMetricExporterWrapper implements MetricExporter {
 
+    private static final String EXPORT_SUCCESS_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/success";
+    private static final String EXPORT_FAILURE_METRIC = "Supportability/Metrics/Java/OpenTelemetryBridge/export/failure";
+
     private final MetricExporter delegate;
     private final String endpoint;
     private volatile Map<String, String> lastMetadata;
@@ -59,7 +62,7 @@ final class NRMetricExporterWrapper implements MetricExporter {
         boolean auditMode = OtlpAuditLogger.isAuditModeEnabled();
         Collection<MetricData> toExport = prepareMetrics(metrics);
         final int bytesSent = logAuditRequest(toExport, auditMode);
-        CompletableResultCode result = delegate.export(toExport);
+        final CompletableResultCode result = delegate.export(toExport);
         result.whenComplete(new Runnable() {
             @Override
             public void run() {
@@ -72,6 +75,10 @@ final class NRMetricExporterWrapper implements MetricExporter {
                  * important value to capture.
                  */
                 OtlpAuditLogger.recordDataUsageMetrics(bytesSent, 0);
+                // The OTel SDK exhausts its retry budget inside delegate.export(), so a failure
+                // here means the batch was dropped after retries (or was non-retryable), not that
+                // a retry is still pending.
+                NewRelic.incrementCounter(result.isSuccess() ? EXPORT_SUCCESS_METRIC : EXPORT_FAILURE_METRIC);
             }
         });
         return result;

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizer.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/main/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizer.java
@@ -82,7 +82,12 @@ final class OpenTelemetrySDKCustomizer {
             properties.put("otel.exporter.otlp.compression", "gzip");
             properties.put("otel.exporter.otlp.metrics.temporality.preference", "DELTA");
             properties.put("otel.exporter.otlp.metrics.default.histogram.aggregation", "BASE2_EXPONENTIAL_BUCKET_HISTOGRAM");
+            // Retry configuration. The two OTel versions read different properties with opposite polarity, so
+            // both are set and each version ignores the one it does not know:
+            //   < 1.29.0 reads otel.experimental.exporter.otlp.retry.enabled (default false -> must opt in)
+            //  >= ~1.44  reads otel.java.exporter.otlp.retry.disabled (retry is on by default -> false is a no-op)
             properties.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+            properties.put("otel.java.exporter.otlp.retry.disabled", "false");
             properties.put("otel.experimental.resource.disabled.keys", "process.command_line");
 
             final Object appName = agent.getConfig().getValue("app_name");

--- a/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
+++ b/instrumentation/opentelemetry-sdk-extension-autoconfigure-1.59.0/src/test/java/io/opentelemetry/sdk/autoconfigure/OpenTelemetrySDKCustomizerTest.java
@@ -74,6 +74,11 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         assertEquals("http/protobuf", properties.get("otel.exporter.otlp.protocol"));
         assertEquals("Test", properties.get("otel.service.name"));
         assertEquals("gzip", properties.get("otel.exporter.otlp.compression"));
+        // This OTel version reads otel.java.exporter.otlp.retry.disabled, and retry is on by default,
+        // so "false" is a no-op; otel.experimental.exporter.otlp.retry.enabled is set only so both
+        // autoconfigure modules stay near-identical.
+        assertEquals("true", properties.get("otel.experimental.exporter.otlp.retry.enabled"));
+        assertEquals("false", properties.get("otel.java.exporter.otlp.retry.disabled"));
     }
 
     public void testApplyResourcesServiceInstanceIdSet() {
@@ -253,6 +258,57 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         }
     }
 
+    public void testExportSuccessRecordsSuccessMetric() {
+        DummyExporter delegate = new DummyExporter();
+        com.newrelic.agent.bridge.Agent mockBridgeAgent = mock(com.newrelic.agent.bridge.Agent.class);
+        when(mockBridgeAgent.getServiceMetadata()).thenReturn(Collections.<String, String>emptyMap());
+        // wrapMetricExporter() calls applyProxy() before returning, which reads PROXY_HOST via
+        // NewRelic.getAgent() -- stub it here so that call does not NPE.
+        Agent mockApiAgent = mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+        when(mockApiAgent.getConfig().getValue(PROXY_HOST)).thenReturn(null);
+
+        try (MockedStatic<AgentBridge> mockBridge = Mockito.mockStatic(AgentBridge.class);
+             MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class);
+             MockedStatic<OtlpAuditLogger> mockAuditLogger = Mockito.mockStatic(OtlpAuditLogger.class)) {
+            mockBridge.when(AgentBridge::getAgent).thenReturn(mockBridgeAgent);
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockApiAgent);
+            mockAuditLogger.when(OtlpAuditLogger::isAuditModeEnabled).thenReturn(false);
+
+            MetricExporter wrapped = OpenTelemetrySDKCustomizer.wrapMetricExporter(delegate, mock(ConfigProperties.class));
+            wrapped.export(Collections.<MetricData>emptyList());
+
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/success"));
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/failure"), Mockito.never());
+        }
+    }
+
+    public void testExportFailureRecordsFailureMetric() {
+        DummyExporter delegate = new DummyExporter();
+        delegate.setExportResult(CompletableResultCode.ofFailure());
+        com.newrelic.agent.bridge.Agent mockBridgeAgent = mock(com.newrelic.agent.bridge.Agent.class);
+        when(mockBridgeAgent.getServiceMetadata()).thenReturn(Collections.<String, String>emptyMap());
+        // wrapMetricExporter() calls applyProxy() before returning, which reads PROXY_HOST via
+        // NewRelic.getAgent() -- stub it here so that call does not NPE.
+        Agent mockApiAgent = mock(Agent.class, Mockito.RETURNS_DEEP_STUBS);
+        when(mockApiAgent.getConfig().getValue(PROXY_HOST)).thenReturn(null);
+
+        try (MockedStatic<AgentBridge> mockBridge = Mockito.mockStatic(AgentBridge.class);
+             MockedStatic<NewRelic> mockNewRelic = Mockito.mockStatic(NewRelic.class);
+             MockedStatic<OtlpAuditLogger> mockAuditLogger = Mockito.mockStatic(OtlpAuditLogger.class)) {
+            mockBridge.when(AgentBridge::getAgent).thenReturn(mockBridgeAgent);
+            mockNewRelic.when(NewRelic::getAgent).thenReturn(mockApiAgent);
+            mockAuditLogger.when(OtlpAuditLogger::isAuditModeEnabled).thenReturn(false);
+
+            MetricExporter wrapped = OpenTelemetrySDKCustomizer.wrapMetricExporter(delegate, mock(ConfigProperties.class));
+            wrapped.export(Collections.<MetricData>emptyList());
+
+            // export/failure covers any dropped batch, including this non-retryable case, not just
+            // retry exhaustion.
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/failure"));
+            mockNewRelic.verify(() -> NewRelic.incrementCounter("Supportability/Metrics/Java/OpenTelemetryBridge/export/success"), Mockito.never());
+        }
+    }
+
     public void testWrapMetricExporterDelegatesPassThroughMethods() {
         MetricExporter delegate = mock(MetricExporter.class);
         when(delegate.getDefaultAggregation(InstrumentType.COUNTER)).thenReturn(Aggregation.sum());
@@ -358,6 +414,10 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         //expose the most recently exported metrics
         private Collection<MetricData> lastestMetricData = null;
 
+        // the result returned by export() - defaults to success, tests may override it to
+        // exercise the failure path
+        private CompletableResultCode exportResult = CompletableResultCode.ofSuccess();
+
         //this is required to register views without throwing an exception
         @Override
         public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
@@ -372,7 +432,11 @@ public class OpenTelemetrySDKCustomizerTest extends TestCase {
         @Override
         public CompletableResultCode export(Collection<MetricData> metrics) {
             this.lastestMetricData = metrics;
-            return CompletableResultCode.ofSuccess();
+            return exportResult;
+        }
+
+        void setExportResult(CompletableResultCode exportResult) {
+            this.exportResult = exportResult;
         }
 
         @Override


### PR DESCRIPTION
…rics

Resolves: https://github.com/newrelic/newrelic-java-agent/issues/2958

Enables OTLP metrics exporter retry logic. 

The health of the OTLP metrics export path can be monitored via the following supportability metrics:

* `Supportability/Metrics/Java/OpenTelemetryBridge/export/success` - incremented once per dimensional metrics batch that the OTel SDK successfully exported.
* `Supportability/Metrics/Java/OpenTelemetryBridge/export/failure` - incremented once per batch that was dropped, either because the OTel SDK's internal retry budget was exhausted or because the failure was non-retryable (e.g. an HTTP 400 response).
* `Supportability/Metrics/Java/OpenTelemetryBridge/export/retry` - incremented once per retried export attempt (i.e. every attempt after the first for a given batch). Only available when `opentelemetry-exporter-otlp` 1.34.0 or later is used, since retry attempts are counted by instrumenting a class ([RetryInterceptor](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java)) that only exists starting at that version. With OTel 1.28.0-1.33.x, `export/success` and `export/failure` are still recorded, but retries are invisible.

---

🟢 Verifier: https://github.com/newrelic/newrelic-java-agent/actions/runs/33128182132