### PR TITLE
Resolve Micronaut duplicate transactions/lost custom attributes issues

### DIFF
--- a/instrumentation/micronaut-core-4.0.0/build.gradle
+++ b/instrumentation/micronaut-core-4.0.0/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
     implementation(project(":agent-bridge"))
     implementation("io.micronaut:micronaut-core:4.0.0")
+
+    testImplementation("org.mockito:mockito-inline:4.11.0")
 }
 
 jar {

--- a/instrumentation/micronaut-core-4.0.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapper.java
+++ b/instrumentation/micronaut-core-4.0.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapper.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class NRTokenCallableWrapper<V> implements Callable<V> {
+
+    private static final AtomicBoolean isTransformed = new AtomicBoolean(false);
+
+    private final Callable<V> delegate;
+    private Token token;
+
+    public NRTokenCallableWrapper(Callable<V> delegate, Token token) {
+        this.delegate = delegate;
+        this.token = token;
+        if (!isTransformed.getAndSet(true)) {
+            AgentBridge.instrumentation.retransformUninstrumentedClass(getClass());
+        }
+    }
+
+    @Override
+    @Trace(async = true)
+    public V call() throws Exception {
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
+        return delegate.call();
+    }
+}

--- a/instrumentation/micronaut-core-4.0.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapper.java
+++ b/instrumentation/micronaut-core-4.0.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapper.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class NRTokenRunnableWrapper implements Runnable {
+
+    private static final AtomicBoolean isTransformed = new AtomicBoolean(false);
+
+    private final Runnable delegate;
+    private Token token;
+
+    public NRTokenRunnableWrapper(Runnable delegate, Token token) {
+        this.delegate = delegate;
+        this.token = token;
+        if (!isTransformed.getAndSet(true)) {
+            AgentBridge.instrumentation.retransformUninstrumentedClass(getClass());
+        }
+    }
+
+    @Override
+    @Trace(async = true)
+    public void run() {
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
+        delegate.run();
+    }
+}

--- a/instrumentation/micronaut-core-4.0.0/src/main/java/io/micronaut/core/propagation/PropagatedContext_Instrumentation.java
+++ b/instrumentation/micronaut-core-4.0.0/src/main/java/io/micronaut/core/propagation/PropagatedContext_Instrumentation.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.micronaut.core.propagation;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.micronaut.NRTokenCallableWrapper;
+import com.nr.agent.instrumentation.micronaut.NRTokenRunnableWrapper;
+
+import java.util.concurrent.Callable;
+
+@Weave(originalName = "io.micronaut.core.propagation.PropagatedContext", type = MatchType.Interface)
+public class PropagatedContext_Instrumentation {
+
+    public Runnable wrap(Runnable runnable) {
+        Runnable original = Weaver.callOriginal();
+        Transaction transaction = NewRelic.getAgent().getTransaction();
+        if (transaction == null) {
+            return original;
+        }
+        Token token = transaction.getToken();
+        if (token == null) {
+            return original;
+        }
+        return new NRTokenRunnableWrapper(original, token);
+    }
+
+    public <V> Callable<V> wrap(Callable<V> callable) {
+        Callable<V> original = Weaver.callOriginal();
+        Transaction transaction = NewRelic.getAgent().getTransaction();
+        if (transaction == null) {
+            return original;
+        }
+        Token token = transaction.getToken();
+        if (token == null) {
+            return original;
+        }
+        return new NRTokenCallableWrapper<>(original, token);
+    }
+}

--- a/instrumentation/micronaut-core-4.0.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapperTest.java
+++ b/instrumentation/micronaut-core-4.0.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapperTest.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.api.agent.Token;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class NRTokenCallableWrapperTest {
+
+    @Test
+    public void call_linksAndExpiresTokenBeforeCallingDelegate() throws Exception {
+        Token token = mock(Token.class);
+        @SuppressWarnings("unchecked")
+        Callable<String> delegate = mock(Callable.class);
+
+        new NRTokenCallableWrapper<>(delegate, token).call();
+
+        InOrder order = inOrder(token, delegate);
+        order.verify(token).linkAndExpire();
+        order.verify(delegate).call();
+    }
+
+    @Test
+    public void call_returnsDelegateResult() throws Exception {
+        Token token = mock(Token.class);
+        Callable<String> delegate = () -> "result";
+
+        String result = new NRTokenCallableWrapper<>(delegate, token).call();
+
+        assertEquals("result", result);
+    }
+
+    @Test
+    public void call_doesNotRelinkOnSecondInvocation() throws Exception {
+        Token token = mock(Token.class);
+        @SuppressWarnings("unchecked")
+        Callable<String> delegate = mock(Callable.class);
+        NRTokenCallableWrapper<String> wrapper = new NRTokenCallableWrapper<>(delegate, token);
+
+        wrapper.call();
+        wrapper.call();
+
+        verify(token, times(1)).linkAndExpire();
+        verify(delegate, times(2)).call();
+    }
+
+    @Test
+    public void call_toleratesNullToken() throws Exception {
+        Callable<String> delegate = () -> "result";
+
+        String result = new NRTokenCallableWrapper<>(delegate, null).call();
+
+        assertEquals("result", result);
+    }
+}

--- a/instrumentation/micronaut-core-4.0.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapperTest.java
+++ b/instrumentation/micronaut-core-4.0.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapperTest.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.api.agent.Token;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class NRTokenRunnableWrapperTest {
+
+    @Test
+    public void run_linksAndExpiresTokenBeforeRunningDelegate() {
+        Token token = mock(Token.class);
+        Runnable delegate = mock(Runnable.class);
+
+        new NRTokenRunnableWrapper(delegate, token).run();
+
+        InOrder order = inOrder(token, delegate);
+        order.verify(token).linkAndExpire();
+        order.verify(delegate).run();
+    }
+
+    @Test
+    public void run_returnsDelegateExecution() {
+        Token token = mock(Token.class);
+        boolean[] ran = new boolean[1];
+        Runnable delegate = () -> ran[0] = true;
+
+        new NRTokenRunnableWrapper(delegate, token).run();
+
+        assertEquals(true, ran[0]);
+    }
+
+    @Test
+    public void run_doesNotRelinkOnSecondInvocation() {
+        Token token = mock(Token.class);
+        Runnable delegate = mock(Runnable.class);
+        NRTokenRunnableWrapper wrapper = new NRTokenRunnableWrapper(delegate, token);
+
+        wrapper.run();
+        wrapper.run();
+
+        verify(token, times(1)).linkAndExpire();
+        verify(delegate, times(2)).run();
+    }
+
+    @Test
+    public void run_toleratesNullToken() {
+        Runnable delegate = mock(Runnable.class);
+
+        new NRTokenRunnableWrapper(delegate, null).run();
+
+        verify(delegate).run();
+    }
+}

--- a/instrumentation/micronaut-core-4.0.0/src/test/java/io/micronaut/core/propagation/PropagatedContextInstrumentationTest.java
+++ b/instrumentation/micronaut-core-4.0.0/src/test/java/io/micronaut/core/propagation/PropagatedContextInstrumentationTest.java
@@ -1,0 +1,132 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.micronaut.core.propagation;
+
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.micronaut.NRTokenCallableWrapper;
+import com.nr.agent.instrumentation.micronaut.NRTokenRunnableWrapper;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class PropagatedContextInstrumentationTest {
+
+    @Test
+    public void wrapRunnable_noTransaction_returnsOriginalUnwrapped() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            Runnable original = mock(Runnable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(null);
+
+            Runnable result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertSame("with no transaction there is nothing to relink, so the original must pass through untouched",
+                    original, result);
+        }
+    }
+
+    @Test
+    public void wrapRunnable_noToken_returnsOriginalUnwrapped() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            Runnable original = mock(Runnable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            Transaction transaction = mock(Transaction.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(transaction);
+            when(transaction.getToken()).thenReturn(null);
+
+            Runnable result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertSame(original, result);
+        }
+    }
+
+    @Test
+    public void wrapRunnable_withTransactionAndToken_wrapsWithTokenThatRelinksOnRun() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            Runnable original = mock(Runnable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            Transaction transaction = mock(Transaction.class);
+            Token token = mock(Token.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(transaction);
+            when(transaction.getToken()).thenReturn(token);
+
+            Runnable result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertTrue("the offloaded-thread hop must be wrapped so the token can be relinked when it runs",
+                    result instanceof NRTokenRunnableWrapper);
+            result.run();
+            org.mockito.Mockito.verify(token).linkAndExpire();
+            org.mockito.Mockito.verify(original).run();
+        }
+    }
+
+    @Test
+    public void wrapCallable_withTransactionAndToken_wrapsWithTokenThatRelinksOnCall() throws Exception {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            @SuppressWarnings("unchecked")
+            Callable<String> original = mock(Callable.class);
+            when(original.call()).thenReturn("result");
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            Transaction transaction = mock(Transaction.class);
+            Token token = mock(Token.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(transaction);
+            when(transaction.getToken()).thenReturn(token);
+
+            Callable<String> result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertTrue(result instanceof NRTokenCallableWrapper);
+            assertSame("result", result.call());
+            org.mockito.Mockito.verify(token).linkAndExpire();
+        }
+    }
+
+    @Test
+    public void wrapCallable_noTransaction_returnsOriginalUnwrapped() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            @SuppressWarnings("unchecked")
+            Callable<String> original = mock(Callable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(null);
+
+            Callable<String> result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertSame(original, result);
+        }
+    }
+}

--- a/instrumentation/micronaut-core-4.3.0/build.gradle
+++ b/instrumentation/micronaut-core-4.3.0/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
     implementation(project(":agent-bridge"))
     implementation("io.micronaut:micronaut-core:4.3.0")
+
+    testImplementation("org.mockito:mockito-inline:4.11.0")
 }
 
 jar {

--- a/instrumentation/micronaut-core-4.3.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapper.java
+++ b/instrumentation/micronaut-core-4.3.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapper.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class NRTokenCallableWrapper<V> implements Callable<V> {
+
+    private static final AtomicBoolean isTransformed = new AtomicBoolean(false);
+
+    private final Callable<V> delegate;
+    private Token token;
+
+    public NRTokenCallableWrapper(Callable<V> delegate, Token token) {
+        this.delegate = delegate;
+        this.token = token;
+        if (!isTransformed.getAndSet(true)) {
+            AgentBridge.instrumentation.retransformUninstrumentedClass(getClass());
+        }
+    }
+
+    @Override
+    @Trace(async = true)
+    public V call() throws Exception {
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
+        return delegate.call();
+    }
+}

--- a/instrumentation/micronaut-core-4.3.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapper.java
+++ b/instrumentation/micronaut-core-4.3.0/src/main/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapper.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Trace;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class NRTokenRunnableWrapper implements Runnable {
+
+    private static final AtomicBoolean isTransformed = new AtomicBoolean(false);
+
+    private final Runnable delegate;
+    private Token token;
+
+    public NRTokenRunnableWrapper(Runnable delegate, Token token) {
+        this.delegate = delegate;
+        this.token = token;
+        if (!isTransformed.getAndSet(true)) {
+            AgentBridge.instrumentation.retransformUninstrumentedClass(getClass());
+        }
+    }
+
+    @Override
+    @Trace(async = true)
+    public void run() {
+        if (token != null) {
+            token.linkAndExpire();
+            token = null;
+        }
+        delegate.run();
+    }
+}

--- a/instrumentation/micronaut-core-4.3.0/src/main/java/io/micronaut/core/propagation/PropagatedContext_Instrumentation.java
+++ b/instrumentation/micronaut-core-4.3.0/src/main/java/io/micronaut/core/propagation/PropagatedContext_Instrumentation.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.micronaut.core.propagation;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.micronaut.NRTokenCallableWrapper;
+import com.nr.agent.instrumentation.micronaut.NRTokenRunnableWrapper;
+
+import java.util.concurrent.Callable;
+
+@Weave(originalName = "io.micronaut.core.propagation.PropagatedContext", type = MatchType.Interface)
+public class PropagatedContext_Instrumentation {
+
+    public Runnable wrap(Runnable runnable) {
+        Runnable original = Weaver.callOriginal();
+        Transaction transaction = NewRelic.getAgent().getTransaction();
+        if (transaction == null) {
+            return original;
+        }
+        Token token = transaction.getToken();
+        if (token == null) {
+            return original;
+        }
+        return new NRTokenRunnableWrapper(original, token);
+    }
+
+    public <V> Callable<V> wrap(Callable<V> callable) {
+        Callable<V> original = Weaver.callOriginal();
+        Transaction transaction = NewRelic.getAgent().getTransaction();
+        if (transaction == null) {
+            return original;
+        }
+        Token token = transaction.getToken();
+        if (token == null) {
+            return original;
+        }
+        return new NRTokenCallableWrapper<>(original, token);
+    }
+}

--- a/instrumentation/micronaut-core-4.3.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapperTest.java
+++ b/instrumentation/micronaut-core-4.3.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenCallableWrapperTest.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.api.agent.Token;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class NRTokenCallableWrapperTest {
+
+    @Test
+    public void call_linksAndExpiresTokenBeforeCallingDelegate() throws Exception {
+        Token token = mock(Token.class);
+        @SuppressWarnings("unchecked")
+        Callable<String> delegate = mock(Callable.class);
+
+        new NRTokenCallableWrapper<>(delegate, token).call();
+
+        InOrder order = inOrder(token, delegate);
+        order.verify(token).linkAndExpire();
+        order.verify(delegate).call();
+    }
+
+    @Test
+    public void call_returnsDelegateResult() throws Exception {
+        Token token = mock(Token.class);
+        Callable<String> delegate = () -> "result";
+
+        String result = new NRTokenCallableWrapper<>(delegate, token).call();
+
+        assertEquals("result", result);
+    }
+
+    @Test
+    public void call_doesNotRelinkOnSecondInvocation() throws Exception {
+        Token token = mock(Token.class);
+        @SuppressWarnings("unchecked")
+        Callable<String> delegate = mock(Callable.class);
+        NRTokenCallableWrapper<String> wrapper = new NRTokenCallableWrapper<>(delegate, token);
+
+        wrapper.call();
+        wrapper.call();
+
+        verify(token, times(1)).linkAndExpire();
+        verify(delegate, times(2)).call();
+    }
+
+    @Test
+    public void call_toleratesNullToken() throws Exception {
+        Callable<String> delegate = () -> "result";
+
+        String result = new NRTokenCallableWrapper<>(delegate, null).call();
+
+        assertEquals("result", result);
+    }
+}

--- a/instrumentation/micronaut-core-4.3.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapperTest.java
+++ b/instrumentation/micronaut-core-4.3.0/src/test/java/com/nr/agent/instrumentation/micronaut/NRTokenRunnableWrapperTest.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.nr.agent.instrumentation.micronaut;
+
+import com.newrelic.api.agent.Token;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class NRTokenRunnableWrapperTest {
+
+    @Test
+    public void run_linksAndExpiresTokenBeforeRunningDelegate() {
+        Token token = mock(Token.class);
+        Runnable delegate = mock(Runnable.class);
+
+        new NRTokenRunnableWrapper(delegate, token).run();
+
+        InOrder order = inOrder(token, delegate);
+        order.verify(token).linkAndExpire();
+        order.verify(delegate).run();
+    }
+
+    @Test
+    public void run_returnsDelegateExecution() {
+        Token token = mock(Token.class);
+        boolean[] ran = new boolean[1];
+        Runnable delegate = () -> ran[0] = true;
+
+        new NRTokenRunnableWrapper(delegate, token).run();
+
+        assertEquals(true, ran[0]);
+    }
+
+    @Test
+    public void run_doesNotRelinkOnSecondInvocation() {
+        Token token = mock(Token.class);
+        Runnable delegate = mock(Runnable.class);
+        NRTokenRunnableWrapper wrapper = new NRTokenRunnableWrapper(delegate, token);
+
+        wrapper.run();
+        wrapper.run();
+
+        verify(token, times(1)).linkAndExpire();
+        verify(delegate, times(2)).run();
+    }
+
+    @Test
+    public void run_toleratesNullToken() {
+        Runnable delegate = mock(Runnable.class);
+
+        new NRTokenRunnableWrapper(delegate, null).run();
+
+        verify(delegate).run();
+    }
+}

--- a/instrumentation/micronaut-core-4.3.0/src/test/java/io/micronaut/core/propagation/PropagatedContextInstrumentationTest.java
+++ b/instrumentation/micronaut-core-4.3.0/src/test/java/io/micronaut/core/propagation/PropagatedContextInstrumentationTest.java
@@ -1,0 +1,132 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.micronaut.core.propagation;
+
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.nr.agent.instrumentation.micronaut.NRTokenCallableWrapper;
+import com.nr.agent.instrumentation.micronaut.NRTokenRunnableWrapper;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class PropagatedContextInstrumentationTest {
+
+    @Test
+    public void wrapRunnable_noTransaction_returnsOriginalUnwrapped() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            Runnable original = mock(Runnable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(null);
+
+            Runnable result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertSame("with no transaction there is nothing to relink, so the original must pass through untouched",
+                    original, result);
+        }
+    }
+
+    @Test
+    public void wrapRunnable_noToken_returnsOriginalUnwrapped() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            Runnable original = mock(Runnable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            Transaction transaction = mock(Transaction.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(transaction);
+            when(transaction.getToken()).thenReturn(null);
+
+            Runnable result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertSame(original, result);
+        }
+    }
+
+    @Test
+    public void wrapRunnable_withTransactionAndToken_wrapsWithTokenThatRelinksOnRun() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            Runnable original = mock(Runnable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            Transaction transaction = mock(Transaction.class);
+            Token token = mock(Token.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(transaction);
+            when(transaction.getToken()).thenReturn(token);
+
+            Runnable result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertTrue("the offloaded-thread hop must be wrapped so the token can be relinked when it runs",
+                    result instanceof NRTokenRunnableWrapper);
+            result.run();
+            org.mockito.Mockito.verify(token).linkAndExpire();
+            org.mockito.Mockito.verify(original).run();
+        }
+    }
+
+    @Test
+    public void wrapCallable_withTransactionAndToken_wrapsWithTokenThatRelinksOnCall() throws Exception {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            @SuppressWarnings("unchecked")
+            Callable<String> original = mock(Callable.class);
+            when(original.call()).thenReturn("result");
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            Transaction transaction = mock(Transaction.class);
+            Token token = mock(Token.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(transaction);
+            when(transaction.getToken()).thenReturn(token);
+
+            Callable<String> result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertTrue(result instanceof NRTokenCallableWrapper);
+            assertSame("result", result.call());
+            org.mockito.Mockito.verify(token).linkAndExpire();
+        }
+    }
+
+    @Test
+    public void wrapCallable_noTransaction_returnsOriginalUnwrapped() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class);
+                MockedStatic<NewRelic> newRelic = mockStatic(NewRelic.class)) {
+            @SuppressWarnings("unchecked")
+            Callable<String> original = mock(Callable.class);
+            weaver.when(Weaver::callOriginal).thenReturn(original);
+
+            Agent agent = mock(Agent.class);
+            newRelic.when(NewRelic::getAgent).thenReturn(agent);
+            when(agent.getTransaction()).thenReturn(null);
+
+            Callable<String> result = new PropagatedContext_Instrumentation().wrap(original);
+
+            assertSame(original, result);
+        }
+    }
+}

--- a/instrumentation/micronaut-http-server-netty-4.0.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
+++ b/instrumentation/micronaut-http-server-netty-4.0.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
@@ -43,13 +43,13 @@ public abstract class PipeliningServerHandler_Instrumentation {
 
     public void channelReadComplete(ChannelHandlerContext_Instrumentation ctx) {
         ChannelPipeline_Instrumentation pipeline = ctx != null ? ctx.pipeline() : null;
+        Weaver.callOriginal();
         if(pipeline != null) {
             if(pipeline.micronautToken != null) {
                 pipeline.micronautToken.expire();
                 pipeline.micronautToken = null;
             }
         }
-        Weaver.callOriginal();
     }
 
     @Weave(type = MatchType.ExactClass, originalName = "io.micronaut.http.server.netty.handler.PipeliningServerHandler$MessageInboundHandler")

--- a/instrumentation/micronaut-http-server-netty-4.3.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
+++ b/instrumentation/micronaut-http-server-netty-4.3.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
@@ -43,13 +43,13 @@ public abstract class PipeliningServerHandler_Instrumentation {
 
     public void channelReadComplete(ChannelHandlerContext_Instrumentation ctx) {
         ChannelPipeline_Instrumentation pipeline = ctx != null ? ctx.pipeline() : null;
+        Weaver.callOriginal();
         if(pipeline != null) {
             if(pipeline.micronautToken != null) {
                 pipeline.micronautToken.expire();
                 pipeline.micronautToken = null;
             }
         }
-        Weaver.callOriginal();
     }
 
     @Weave(type = MatchType.ExactClass, originalName = "io.micronaut.http.server.netty.handler.PipeliningServerHandler$MessageInboundHandler")

--- a/instrumentation/micronaut-http-server-netty-4.4.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
+++ b/instrumentation/micronaut-http-server-netty-4.4.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
@@ -43,13 +43,13 @@ public abstract class PipeliningServerHandler_Instrumentation {
 
     public void channelReadComplete(ChannelHandlerContext_Instrumentation ctx) {
         ChannelPipeline_Instrumentation pipeline = ctx != null ? ctx.pipeline() : null;
+        Weaver.callOriginal();
         if(pipeline != null) {
             if(pipeline.micronautToken != null) {
                 pipeline.micronautToken.expire();
                 pipeline.micronautToken = null;
             }
         }
-        Weaver.callOriginal();
     }
 
     @Weave(type = MatchType.ExactClass, originalName = "io.micronaut.http.server.netty.handler.PipeliningServerHandler$MessageInboundHandler")

--- a/instrumentation/micronaut-http-server-netty-4.5.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
+++ b/instrumentation/micronaut-http-server-netty-4.5.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
@@ -43,13 +43,13 @@ public abstract class PipeliningServerHandler_Instrumentation {
 
     public void channelReadComplete(ChannelHandlerContext_Instrumentation ctx) {
         ChannelPipeline_Instrumentation pipeline = ctx != null ? ctx.pipeline() : null;
+        Weaver.callOriginal();
         if(pipeline != null) {
             if(pipeline.micronautToken != null) {
                 pipeline.micronautToken.expire();
                 pipeline.micronautToken = null;
             }
         }
-        Weaver.callOriginal();
     }
 
     @Weave(type = MatchType.ExactClass, originalName = "io.micronaut.http.server.netty.handler.PipeliningServerHandler$MessageInboundHandler")

--- a/instrumentation/micronaut-http-server-netty-4.6.0/build.gradle
+++ b/instrumentation/micronaut-http-server-netty-4.6.0/build.gradle
@@ -24,6 +24,12 @@ java {
     }
 }
 
+test {
+    onlyIf {
+        !project.hasProperty('test8') && !project.hasProperty('test11')
+    }
+}
+
 site {
     title 'Micronaut Http Server Netty'
     type 'Http'

--- a/instrumentation/micronaut-http-server-netty-4.6.0/build.gradle
+++ b/instrumentation/micronaut-http-server-netty-4.6.0/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation("io.micronaut:micronaut-http-server-netty:4.6.0")
     implementation("io.projectreactor:reactor-core:3.5.11")
 
+    testImplementation("org.mockito:mockito-inline:4.11.0")
 }
 
 jar {

--- a/instrumentation/micronaut-http-server-netty-4.6.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
+++ b/instrumentation/micronaut-http-server-netty-4.6.0/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler_Instrumentation.java
@@ -43,13 +43,13 @@ public abstract class PipeliningServerHandler_Instrumentation {
 
     public void channelReadComplete(ChannelHandlerContext_Instrumentation ctx) {
         ChannelPipeline_Instrumentation pipeline = ctx != null ? ctx.pipeline() : null;
+        Weaver.callOriginal();
         if(pipeline != null) {
             if(pipeline.micronautToken != null) {
                 pipeline.micronautToken.expire();
                 pipeline.micronautToken = null;
             }
         }
-        Weaver.callOriginal();
     }
 
     @Weave(type = MatchType.ExactClass, originalName = "io.micronaut.http.server.netty.handler.PipeliningServerHandler$MessageInboundHandler")

--- a/instrumentation/micronaut-http-server-netty-4.6.0/src/test/java/io/micronaut/http/server/netty/handler/PipeliningServerHandlerInstrumentationTest.java
+++ b/instrumentation/micronaut-http-server-netty-4.6.0/src/test/java/io/micronaut/http/server/netty/handler/PipeliningServerHandlerInstrumentationTest.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  * Copyright 2026 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package io.micronaut.http.server.netty.handler;
+
+import com.newrelic.api.agent.Token;
+import com.newrelic.api.agent.weaver.Weaver;
+import io.netty.channel.ChannelHandlerContext_Instrumentation;
+import io.netty.channel.ChannelPipeline_Instrumentation;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+public class PipeliningServerHandlerInstrumentationTest {
+
+    @Test
+    public void channelReadComplete_expiresTokenOnlyAfterCallingOriginal() {
+        Token token = mock(Token.class);
+        ChannelPipeline_Instrumentation pipeline = new ChannelPipeline_Instrumentation();
+        pipeline.micronautToken = token;
+
+        ChannelHandlerContext_Instrumentation ctx = new ChannelHandlerContext_Instrumentation() {
+            @Override
+            public ChannelPipeline_Instrumentation pipeline() {
+                return pipeline;
+            }
+        };
+
+        boolean[] tokenStillLiveDuringCallOriginal = new boolean[1];
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class)) {
+            weaver.when(Weaver::callOriginal).thenAnswer(invocation -> {
+                tokenStillLiveDuringCallOriginal[0] = pipeline.micronautToken != null;
+                return null;
+            });
+
+            new PipeliningServerHandler_Instrumentation() {}.channelReadComplete(ctx);
+        }
+
+        assertTrue("the token must still be linked while the original method's synchronous dispatch runs",
+                tokenStillLiveDuringCallOriginal[0]);
+        verify(token).expire();
+        assertNull("the token must be released once the read is complete", pipeline.micronautToken);
+    }
+
+    @Test
+    public void channelReadComplete_noToken_doesNothing() {
+        ChannelPipeline_Instrumentation pipeline = new ChannelPipeline_Instrumentation();
+        ChannelHandlerContext_Instrumentation ctx = new ChannelHandlerContext_Instrumentation() {
+            @Override
+            public ChannelPipeline_Instrumentation pipeline() {
+                return pipeline;
+            }
+        };
+
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class)) {
+            new PipeliningServerHandler_Instrumentation() {}.channelReadComplete(ctx);
+        }
+
+        assertNull(pipeline.micronautToken);
+    }
+
+    @Test
+    public void channelReadComplete_nullContext_doesNotThrow() {
+        try (MockedStatic<Weaver> weaver = mockStatic(Weaver.class)) {
+            new PipeliningServerHandler_Instrumentation() {}.channelReadComplete(null);
+        }
+    }
+}


### PR DESCRIPTION
### Overview
This PR aims to resolve a couple of issues where custom attributes and transaction names set from a `@ServerFilter` were being dropped, and requests sometimes produced two Transaction events for one HTTP call. Two areas have been addressed:                                                                                                                                                              
  - `PipeliningServerHandler_Instrumentation` (all 5 micronaut-http-server-netty-4.x.0 modules): a change was made to call `Weaver.callOriginal()` before expiring the request token in `channelReadComplete()`, not after, as expiring first let a synchronous mid-request dispatch run unlinked, which resulted in a phantom transaction.                                  
  - `PropagatedContext_Instrumentation` (micronaut-core-4.0.0 and 4.3.0): relink the transaction's token across `PropagatedContext.wrap`(Runnable/Callable), the hop Micronaut uses for `@ExecuteOn` thread offload. Backed by two small wrapper classes (`NRTokenRunnableWrapper`, `NRTokenCallableWrapper`).

### Related Github Issue
Resolves #3038 (awaiting potential feedback from user)

### Testing
Unit tests have been added (JUnit + Mockito, mockito-inline for static mocking) covering both fixes: token-expiry ordering in the netty handler, and the wrap/relink behavior and its cases in `PropagatedContext_Instrumentation` and its wrappers.

[Passing Micronaut AITs](https://github.com/newrelic/newrelic-java-agent/actions/runs/33409704150/job/99546683221).