### PR TITLE
Un-cap WildFly 8 PORT module

### DIFF
--- a/instrumentation/wildfly-8-PORT/build.gradle
+++ b/instrumentation/wildfly-8-PORT/build.gradle
@@ -13,12 +13,12 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.wildfly:wildfly-undertow:[8.0.0.Final,41.0.1.Final)'
+    passesOnly 'org.wildfly:wildfly-undertow:[8.0.0.Final,)'
     excludeRegex '.*(Alpha|Beta|CR).*'
 }
 
 site {
     title 'Wildfly'
     type 'Appserver'
-    versionOverride '[8.0.0.Final,41.0.1.Final)'
+    versionOverride '[8.0.0.Final,)'
 }


### PR DESCRIPTION
Looks like it verifies correctly now.  Not sure how that happened.  Looks like perhaps some sort of odd GH caching issue.
