### PR TITLE
Receive agent commands via metric_data response instead of polling

### DIFF
--- a/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorRPMService.java
+++ b/instrumentation-test/src/main/java/com/newrelic/agent/introspec/internal/IntrospectorRPMService.java
@@ -82,7 +82,7 @@ class IntrospectorRPMService extends AbstractService implements IRPMService {
 
     @Override
     public List<List<?>> getAgentCommands() {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/IRPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/IRPMService.java
@@ -41,6 +41,12 @@ public interface IRPMService extends Service {
 
     void harvestNow();
 
+    /**
+     * Drains and returns any agent commands received in the most recent {@code metric_data} harvest response.
+     * Does not make a network call; commands arrive piggybacked on the metric harvest.
+     *
+     * @return the pending commands, or an empty list if there are none
+     */
     List<List<?>> getAgentCommands() throws Exception;
 
     void sendCommandResults(Map<Long, Object> commandResults) throws Exception;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/RPMService.java
@@ -65,6 +65,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
@@ -102,6 +103,7 @@ public class RPMService extends AbstractService implements IRPMService, Environm
     private long connectionTimestamp = 0;
     private final AtomicInteger last503Error = new AtomicInteger(0);
     private final AtomicInteger retryCount = new AtomicInteger(0);
+    private final AtomicReference<List<List<?>>> pendingAgentCommands = new AtomicReference<>(Collections.emptyList());
     private final ReentrantLock reentrantLock = new ReentrantLock();
     private static ScheduledExecutorService scheduler = null;
 
@@ -869,28 +871,8 @@ public class RPMService extends AbstractService implements IRPMService, Environm
     }
 
     @Override
-    public List<List<?>> getAgentCommands() throws Exception {
-        try {
-            return getAgentCommandsSyncRestart();
-        } catch (ForceRestartException e) {
-            logForceRestartException(e);
-            reconnectAsync();
-            throw e;
-        } catch (ForceDisconnectException e) {
-            logForceDisconnectException(e);
-            shutdownAsync();
-            throw e;
-        }
-    }
-
-    private List<List<?>> getAgentCommandsSyncRestart() throws Exception {
-        try {
-            return dataSender.getAgentCommands();
-        } catch (ForceRestartException e) {
-            logForceRestartException(e);
-            reconnectSync();
-            return dataSender.getAgentCommands();
-        }
+    public List<List<?>> getAgentCommands() {
+        return pendingAgentCommands.getAndSet(Collections.emptyList());
     }
 
     @Override
@@ -962,7 +944,8 @@ public class RPMService extends AbstractService implements IRPMService, Environm
             long reportInterval = 0;
             try {
                 long now = System.currentTimeMillis();
-                sendMetricDataSyncRestart(lastReportTime, now, data);
+                List<List<?>> commands = sendMetricDataSyncRestart(lastReportTime, now, data);
+                pendingAgentCommands.set(commands != null ? commands : Collections.emptyList());
                 reportInterval = now - lastReportTime;
                 lastReportTime = now;
                 last503Error.set(0);
@@ -1037,13 +1020,13 @@ public class RPMService extends AbstractService implements IRPMService, Environm
         statsEngine.getStats(MetricNames.SUPPORTABILITY_METRIC_HARVEST_COUNT).incrementCallCount(dataSize);
     }
 
-    private void sendMetricDataSyncRestart(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
+    private List<List<?>> sendMetricDataSyncRestart(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
         try {
-            dataSender.sendMetricData(beginTimeMillis, endTimeMillis, metricData);
+            return dataSender.sendMetricData(beginTimeMillis, endTimeMillis, metricData);
         } catch (ForceRestartException e) {
             logForceRestartException(e);
             reconnectSync();
-            dataSender.sendMetricData(beginTimeMillis, endTimeMillis, metricData);
+            return dataSender.sendMetricData(beginTimeMillis, endTimeMillis, metricData);
         }
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/commands/CommandParser.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/commands/CommandParser.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.logging.Level;
 
 /**
- * The command parser parses commands received from the RPM service before metric harvests.
+ * The command parser parses commands received from the RPM service via the {@code metric_data} harvest response.
  */
 public class CommandParser extends AbstractService implements HarvestListener, AgentConfigListener {
 
@@ -57,14 +57,19 @@ public class CommandParser extends AbstractService implements HarvestListener, A
         }
     }
 
+    @Override
+    public void beforeHarvest(String appName, StatsEngine statsEngine) {
+    }
+
     /**
-     * Gets the agent commands from the rpm service, processes them, and returns the command results.
+     * Gets the agent commands received via the last {@code metric_data} harvest response, processes them, and
+     * sends back the command results.
      *
      * @see RPMService#getAgentCommands()
      * @see RPMService#sendCommandResults(Map)
      */
     @Override
-    public void beforeHarvest(String appName, StatsEngine statsEngine) {
+    public void afterHarvest(String appName) {
         IRPMService rpmService = ServiceFactory.getRPMServiceManager().getOrCreateRPMService(appName);
 
         for (Iterator<Map<Long, Object>> iterator = unsentCommandData.iterator(); iterator.hasNext(); ) {
@@ -111,10 +116,6 @@ public class CommandParser extends AbstractService implements HarvestListener, A
             String msg = MessageFormat.format("Unable to send agent command feedback. Command results: {0}", commandResults.toString());
             getLogger().fine(msg);
         }
-    }
-
-    @Override
-    public void afterHarvest(String appName) {
     }
 
     Command getCommand(String name) throws UnknownCommand {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/CollectorMethods.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/CollectorMethods.java
@@ -10,7 +10,6 @@ package com.newrelic.agent.transport;
 public class CollectorMethods {
     public static final String CONNECT = "connect";
     public static final String METRIC_DATA = "metric_data";
-    public static final String GET_AGENT_COMMANDS = "get_agent_commands";
     public static final String AGENT_COMMAND_RESULTS = "agent_command_results";
     public static final String PRECONNECT = "preconnect";
     public static final String ERROR_DATA = "error_data";

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSender.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSender.java
@@ -27,8 +27,6 @@ public interface DataSender {
 
     Map<String, Object> connect(Map<String, Object> startupOptions) throws Exception;
 
-    List<List<?>> getAgentCommands() throws Exception;
-
     void sendCommandResults(Map<Long, Object> commandResults) throws Exception;
 
     void sendErrorData(List<TracedError> errors) throws Exception;
@@ -61,9 +59,10 @@ public interface DataSender {
      * @param beginTimeMillis the last time metric data was sent to New Relic
      * @param endTimeMillis the time now
      * @param metricData the metric data to send
+     * @return any pending agent commands returned in the response, or an empty list if there are none
      * @throws Exception if there is a problem sending the metric data
      */
-    void sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception;
+    List<List<?>> sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception;
 
     /**
      * Send thread profiles to New Relic.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/DataSenderImpl.java
@@ -107,7 +107,7 @@ public class DataSenderImpl implements DataSender, HealthDataProducer {
     private static final Set<String> METHODS_WITH_RESPONSE_BODY = ImmutableSet.of(
             CollectorMethods.PRECONNECT,
             CollectorMethods.CONNECT,
-            CollectorMethods.GET_AGENT_COMMANDS,
+            CollectorMethods.METRIC_DATA,
             CollectorMethods.PROFILE_DATA);
 
     private final HttpClientWrapper httpClientWrapper;
@@ -282,29 +282,6 @@ public class DataSenderImpl implements DataSender, HealthDataProducer {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public List<List<?>> getAgentCommands() throws Exception {
-        checkAuditMode();
-        Object runId = agentRunId;
-        if (runId == NO_AGENT_RUN_ID) {
-            return Collections.emptyList();
-        }
-        InitialSizedJsonArray params = new InitialSizedJsonArray(1);
-        params.add(runId);
-
-        Object response = invokeRunId(CollectorMethods.GET_AGENT_COMMANDS, compressedEncoding, runId, params);
-        if (response == null || NULL_RESPONSE.equals(response)) {
-            return Collections.emptyList();
-        }
-        try {
-            return (List<List<?>>) response;
-        } catch (ClassCastException e) {
-            logger.warning(MessageFormat.format("Invalid response from New Relic when getting agent commands: {0}", e));
-            throw e;
-        }
-    }
-
-    @Override
     public void sendCommandResults(Map<Long, Object> commandResults) throws Exception {
         Object runId = agentRunId;
         if (runId == NO_AGENT_RUN_ID || commandResults.isEmpty()) {
@@ -424,10 +401,11 @@ public class DataSenderImpl implements DataSender, HealthDataProducer {
     }
 
     @Override
-    public void sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
+    @SuppressWarnings("unchecked")
+    public List<List<?>> sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
         Object runId = agentRunId;
         if (runId == NO_AGENT_RUN_ID || metricData.isEmpty()) {
-            return;
+            return Collections.emptyList();
         }
 
         InitialSizedJsonArray params = new InitialSizedJsonArray(4);
@@ -436,7 +414,16 @@ public class DataSenderImpl implements DataSender, HealthDataProducer {
         params.add(endTimeMillis / 1000);
         params.add(metricData);
 
-        invokeRunId(CollectorMethods.METRIC_DATA, compressedEncoding, runId, params);
+        Object response = invokeRunId(CollectorMethods.METRIC_DATA, compressedEncoding, runId, params);
+        if (response == null || NULL_RESPONSE.equals(response)) {
+            return Collections.emptyList();
+        }
+        try {
+            return (List<List<?>>) response;
+        } catch (ClassCastException e) {
+            logger.warning(MessageFormat.format("Invalid response from New Relic when sending metric data: {0}", e));
+            throw e;
+        }
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImpl.java
@@ -64,12 +64,6 @@ public class DataSenderServerlessImpl implements DataSender {
     }
 
     @Override
-    public List<List<?>> getAgentCommands() throws Exception {
-        // The serverless data sender is not involved in agent commands
-        return Collections.emptyList();
-    }
-
-    @Override
     public void sendCommandResults(Map<Long, Object> commandResults) throws Exception {
         // The serverless data sender is not involved in agent commands
     }
@@ -115,10 +109,12 @@ public class DataSenderServerlessImpl implements DataSender {
     }
 
     @Override
-    public void sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
+    public List<List<?>> sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
         buffer.updateMetricData(metricData);
         buffer.updateMetricBeginTimeMillis(beginTimeMillis);
         buffer.updateMetricEndTimeMillis(endTimeMillis);
+        // The serverless data sender is not involved in agent commands
+        return Collections.emptyList();
     }
 
     @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockCollectorServlet.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockCollectorServlet.java
@@ -34,9 +34,17 @@ public class MockCollectorServlet extends HttpServlet {
 
     private static final int ERROR_DATA_SIZE_LIMIT_IN_BYTES = 1000000; // 1MB
 
-    private static boolean inPingCommand = false;
+    private static List<List<?>> nextAgentCommands = new ArrayList<>();
 
     public MockCollectorServlet() {
+    }
+
+    /**
+     * Queues agent commands to be returned, once, as the {@code return_value} of the next {@code metric_data}
+     * response — simulating a collector piggybacking commands on the metric harvest.
+     */
+    public static void queueAgentCommands(List<List<?>> commands) {
+        nextAgentCommands = commands;
     }
 
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -86,33 +94,12 @@ public class MockCollectorServlet extends HttpServlet {
                 inner.put("url_rules", rulesList);
                 json.put("return_value", inner);
             }
-        } else if ("get_agent_commands".equals(request.getParameter("method"))) {
-            if (inPingCommand) {
-                inPingCommand = false;
-                // necessary value for the ping command test:
-                @SuppressWarnings("rawtypes")
-                ArrayList<ArrayList> inner = new ArrayList<>();
-                ArrayList<Object> commands = new ArrayList<>();
-                inner.add(commands);
-                commands.add(1000);
-                JSONObject pingCommand = new JSONObject();
-                pingCommand.put("name", "ping");
-                pingCommand.put("arguments", null);
-                commands.add(pingCommand);
-                json.put("return_value", inner);
-            } else {
-                ArrayList<String> inner = new ArrayList<>();
-                json.put("return_value", inner);
-            }
         } else if ("profile_data".equals(request.getParameter("method"))) {
             List<Integer> inner = Arrays.asList(1, 2);
             json.put("return_value", inner);
-        } else if ("queue_ping_command".equals(request.getParameter("method"))) {
-            inPingCommand = true;
-            json.put("return_value", 1000);
         } else if ("metric_data".equals(request.getParameter("method"))) {
-            ArrayList<String> inner = new ArrayList<>();
-            json.put("return_value", inner);
+            json.put("return_value", nextAgentCommands);
+            nextAgentCommands = new ArrayList<>();
         } else if ("agent_command_results".equals(request.getParameter("method"))) {
             json.put("return_value", null);
         } else if ("error_data".equals(request.getParameter("method"))) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/MockDataSender.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/MockDataSender.java
@@ -39,6 +39,7 @@ public class MockDataSender implements DataSender {
     private CountDownLatch latch;
     private Map<String, Object> agentSettings;
     private CountDownLatch agentSettingsLatch;
+    private List<List<?>> agentCommands = Collections.emptyList();
 
     public MockDataSender(DataSenderConfig config) {
         this(config, null);
@@ -79,12 +80,15 @@ public class MockDataSender implements DataSender {
     }
 
     @Override
-    public List<List<?>> getAgentCommands() throws Exception {
-        return null;
+    public void sendCommandResults(Map<Long, Object> commandResults) throws Exception {
     }
 
-    @Override
-    public void sendCommandResults(Map<Long, Object> commandResults) throws Exception {
+    /**
+     * Sets the agent commands that will be returned by the next call to {@link #sendMetricData(long, long, List)},
+     * simulating a collector piggybacking commands on the metric_data harvest response.
+     */
+    public void setAgentCommands(List<List<?>> agentCommands) {
+        this.agentCommands = agentCommands;
     }
 
     @Override
@@ -95,7 +99,8 @@ public class MockDataSender implements DataSender {
     }
 
     @Override
-    public void sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
+    public List<List<?>> sendMetricData(long beginTimeMillis, long endTimeMillis, List<MetricData> metricData) throws Exception {
+        return agentCommands;
     }
 
     @Override

--- a/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/RPMServiceTest.java
@@ -793,9 +793,30 @@ public class RPMServiceTest {
         RPMService svc = new RPMService(appNames, null, null, Collections.<AgentConnectionEstablishedListener>emptyList());
         svc.launch();
 
-        List<List<?>> commands = svc.getAgentCommands();
+        // Nothing has been harvested yet, so there's nothing cached.
+        assertEquals(0, svc.getAgentCommands().size());
 
-        assertEquals(0, commands.size());
+        // Simulate the collector piggybacking a command on the next metric_data response.
+        List<List<?>> queuedCommand = singletonList(Arrays.<Object>asList(1000L, createCommandMap("ping")));
+        MockCollectorServlet.queueAgentCommands(queuedCommand);
+
+        StatsEngine harvestStatsEngine = new StatsEngineImpl();
+        harvestStatsEngine.getResponseTimeStats(MetricNames.EXTERNAL_ALL).recordResponseTime(66, TimeUnit.MILLISECONDS);
+        svc.harvest(harvestStatsEngine);
+
+        List<List<?>> commands = svc.getAgentCommands();
+        assertEquals(1, commands.size());
+        assertEquals(1000L, commands.get(0).get(0));
+
+        // Draining clears the cache until the next metric_data response delivers something new.
+        assertEquals(0, svc.getAgentCommands().size());
+    }
+
+    private static Map<String, Object> createCommandMap(String name) {
+        Map<String, Object> commandMap = new HashMap<>();
+        commandMap.put("name", name);
+        commandMap.put("arguments", Collections.emptyMap());
+        return commandMap;
     }
 
     @Test(timeout = 30000)

--- a/newrelic-agent/src/test/java/com/newrelic/agent/commands/CommandParserTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/commands/CommandParserTest.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.HarvestServiceImpl;
 import com.newrelic.agent.MockCoreService;
 import com.newrelic.agent.MockRPMService;
 import com.newrelic.agent.MockServiceManager;
+import com.newrelic.agent.RPMServiceManager;
 import com.newrelic.agent.ThreadService;
 import com.newrelic.agent.TransactionService;
 import com.newrelic.agent.config.AgentConfig;
@@ -31,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -182,6 +184,44 @@ public class CommandParserTest {
 
         Assert.assertEquals(5, rpmService.getRestartCount());
         Assert.assertEquals(0, agentControl.getShutdownCount());
+    }
+
+    @Test
+    public void testAfterHarvestProcessesCommandsFromMetricDataResponse() throws Exception {
+        MockServiceManager serviceManager = createServiceManager(new HashMap<String, Object>());
+        agentControl = new MockCoreService();
+        commandParser = new CommandParser();
+        commandParser.doStart();
+        commandParser.addCommands(new ShutdownCommand(agentControl), new RestartCommand());
+
+        final List<Map<Long, Object>> sentResults = new ArrayList<>();
+        MockRPMService rpmService = new MockRPMService() {
+            @Override
+            public List<List<?>> getAgentCommands() throws Exception {
+                List<List<?>> commands = new ArrayList<>();
+                commands.add(createCommand(1, RestartCommand.COMMAND_NAME));
+                return commands;
+            }
+
+            @Override
+            public void sendCommandResults(Map<Long, Object> commandResults) throws Exception {
+                sentResults.add(commandResults);
+            }
+        };
+
+        RPMServiceManager rpmServiceManager = Mockito.mock(RPMServiceManager.class);
+        Mockito.when(rpmServiceManager.getOrCreateRPMService("MyApplication")).thenReturn(rpmService);
+        serviceManager.setRPMServiceManager(rpmServiceManager);
+
+        // beforeHarvest is now a no-op; commands are only processed on afterHarvest.
+        commandParser.beforeHarvest("MyApplication", null);
+        Assert.assertEquals(0, rpmService.getRestartCount());
+        Assert.assertEquals(0, sentResults.size());
+
+        commandParser.afterHarvest("MyApplication");
+
+        Assert.assertEquals(1, rpmService.getRestartCount());
+        Assert.assertEquals(1, sentResults.size());
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/transport/DataSenderImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/transport/DataSenderImplTest.java
@@ -460,7 +460,7 @@ public class DataSenderImplTest {
     }
 
     @Test
-    public void testReturnsParsedAgentCommands() throws Exception {
+    public void testReturnsParsedAgentCommandsFromMetricDataResponse() throws Exception {
         AgentConfig config = AgentConfigImpl.createAgentConfig(configMap());
         HttpClientWrapper wrapperEmptyReturn = getHttpClientWrapper(ReadResult.create(
                 HttpResponseCode.OK,
@@ -470,7 +470,8 @@ public class DataSenderImplTest {
         DataSenderImpl target = new DataSenderImpl(config, wrapperEmptyReturn, null, logger, ServiceFactory.getConfigService());
         target.setAgentRunId("agent run id");
 
-        List<List<?>> result = target.getAgentCommands();
+        List<List<?>> result = target.sendMetricData(System.currentTimeMillis() - 5000, System.currentTimeMillis(),
+                createMetricData(5));
         assertEquals(1, result.size());
         assertEquals(3, result.get(0).size());
         assertEquals(4L, result.get(0).get(1));

--- a/newrelic-agent/src/test/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/transport/serverless/DataSenderServerlessImplTest.java
@@ -387,7 +387,7 @@ public class DataSenderServerlessImplTest {
 
     @Test
     public void testMetrics() throws Exception {
-        dataSender.sendMetricData(2L, 3L, Collections.emptyList());
+        Assert.assertEquals(0, dataSender.sendMetricData(2L, 3L, Collections.emptyList()).size());
         MetricData metricData1 = MetricData.create(
                 MetricName.create("Other/myMetric", "myScope"),
                 null,
@@ -499,7 +499,6 @@ public class DataSenderServerlessImplTest {
 
     @Test
     public void testNoOps() throws Exception {
-        Assert.assertEquals(0, dataSender.getAgentCommands().size());
         dataSender.sendModules(null);
         dataSender.sendCommandResults(null);
         dataSender.shutdown(1000);


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

### Overview

Stops making a dedicated get_agent_commands collector RPC every harvest cycle. The collector now returns any pending agent commands as the return_value of metric_data (same [[id, {name, arguments}], ...] shape), so this eliminates one HTTP round-trip per harvest for the common case where there's nothing to do.

RPMService caches the commands returned by metric_data, and CommandParser now processes them from afterHarvest() instead of beforeHarvest(), so commands from a harvest's metric_data response are handled in that same cycle with no added latency.

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
