### PR TITLE
Fix compatibility range for MuleSoft modules

### DIFF
--- a/instrumentation/apache-sling-htl-2.0.6/build.gradle
+++ b/instrumentation/apache-sling-htl-2.0.6/build.gradle
@@ -21,6 +21,6 @@ verifyInstrumentation {
 }
 
 site {
-    title 'HTL'
+    title 'Apache Sling'
     type 'Other'
 }

--- a/instrumentation/apache-sling-htl-3.0.0/build.gradle
+++ b/instrumentation/apache-sling-htl-3.0.0/build.gradle
@@ -21,6 +21,6 @@ verifyInstrumentation {
 }
 
 site {
-    title 'HTL'
+    title 'Apache Sling'
     type 'Other'
 }

--- a/instrumentation/mule-3.7/build.gradle
+++ b/instrumentation/mule-3.7/build.gradle
@@ -49,10 +49,7 @@ jar {
 // This will still match [3.7.1,3.7.5], [3.8.2,3.8.7], and 3.9.5,
 // but we can't verify that because the artifacts are enterprise only (behind auth)
 verifyInstrumentation {
-    passes('org.mule:mule-core:3.7.0') {
-        implementation("org.mule.modules:mule-module-http:3.7.0")
-    }
-    passes('org.mule:mule-core:[3.8.0,4.0.0)') {
+    passes('org.mule:mule-core:[3.7.0,4.0.0)') {
         implementation("org.mule.modules:mule-module-http:3.7.0")
     }
 

--- a/instrumentation/mule-base/build.gradle
+++ b/instrumentation/mule-base/build.gradle
@@ -55,7 +55,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passes('org.mule:mule-core:[3.4.0,)') {
+    passes('org.mule:mule-core:[3.4.0,4.0.0)') {
         implementation("org.mule.transports:mule-transport-http:3.4.0")
         implementation("org.mule.modules:mule-module-launcher:3.4.0")
         implementation("org.mule.modules:mule-module-client:3.4.0")

--- a/instrumentation/mule-ei2/build.gradle
+++ b/instrumentation/mule-ei2/build.gradle
@@ -48,8 +48,7 @@ jar {
 // This will still apply to 3.5.4, [3.6.3,3.6.4], [3.7.1,3.7.5], [3.8.2,3.8.7], and 3.9.5
 // but we can't verify that because the artifacts are enterprise only (behind auth)
 verifyInstrumentation {
-    passes('org.mule:mule-core:3.7.0')
-    passes('org.mule:mule-core:[3.8.0,4.0.0)')
+    passes('org.mule:mule-core:[3.7.0,4.0.0)')
 
     // these versions cause problems getting artifacts
     exclude 'org.mule:mule-core:3.8.2'


### PR DESCRIPTION
### Overview
Three Mule `verifyInstrumentation` blocks declared unbounded upper ranges ([3.4.0,) in mule-base/mule-ei2/mule-3.7, which the  compatibility-doc generator renders as latest. This made the generated doc claim GA support through Mule 4.x, when this repo has no Mule 4 instrumentation and 4.1+ is only supported by labs. Capped all three at 4.0.0 (exclusive).                                                       
                                                                                                                                                                                                                                                                                                      
Verified by running `generateCompatibilitySite` on the affected modules before/after and diffing build/docs/site/compatibility-requirements-java-agent-internal.md.

### Related Github Issue
Resolves #3082 

### Testing
[Instrumentation run passes](https://github.com/newrelic/newrelic-java-agent/actions/runs/33414624920)