### PR TITLE
New error api [Won't Merge because we need additional customer context]

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpErrorApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpErrorApi.java
@@ -13,6 +13,11 @@ class NoOpErrorApi implements ErrorApi {
     }
 
     @Override
+    public void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
+
+    }
+
+    @Override
     public void noticeError(String message, Map<String, ?> params, boolean expected) {
     }
 

--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/NoOpPublicApi.java
@@ -21,6 +21,11 @@ class NoOpPublicApi implements PublicApi {
     }
 
     @Override
+    public void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
+
+    }
+
+    @Override
     public void noticeError(String message, Map<String, ?> params, boolean expected) {
 
     }

--- a/agent-model/src/main/java/com/newrelic/agent/model/SpanError.java
+++ b/agent-model/src/main/java/com/newrelic/agent/model/SpanError.java
@@ -8,17 +8,17 @@
 package com.newrelic.agent.model;
 
 public class SpanError {
-    private Class<?> errorClass;
+    private String errorClassName;
     private String errorMessage;
     private Integer errorStatus;
     private boolean expectedError;
 
-    public Class<?> getErrorClass() {
-        return errorClass;
+    public String getErrorClassName() {
+        return errorClassName;
     }
 
-    public void setErrorClass(Class<?> errorClass) {
-        this.errorClass = errorClass;
+    public void setErrorClassName(String errorClass) {
+        this.errorClassName = errorClass;
     }
 
     public String getErrorMessage() {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorService.java
@@ -8,7 +8,6 @@
 package com.newrelic.agent.errors;
 
 import com.newrelic.agent.service.EventService;
-import com.newrelic.agent.transaction.TransactionThrowable;
 
 import java.util.List;
 import java.util.Map;
@@ -20,6 +19,8 @@ public interface ErrorService extends EventService {
     void reportErrors(TracedError... tracedErrors);
 
     void reportError(TracedError error);
+
+    void reportManualError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected);
 
     void reportHTTPError(String message, int statusCode, String uri);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
@@ -427,9 +427,14 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
         int responseStatus = td.getResponseStatus();
         Throwable throwable = td.getThrowable() == null ? null : td.getThrowable().throwable;
         final boolean isReportable = responseStatus >= HttpURLConnection.HTTP_BAD_REQUEST || throwable != null;
-        if (throwable instanceof ReportableError) {
+        if (throwable instanceof ReportableError && ((ReportableError)throwable).getReportedClassName() == null) {
             // Someone manually called NewRelic.noticeError(String message) here
-            // so we don't want to use getStrippedExceptionMessage() for replacement
+            // so we don't want to use getStrippedExceptionMessage() for replacement.
+
+            // If the ReportableError's getReportedClassName() is not null,
+            // we treat it as if the customer passed a throwable object via the Error API.
+            // In this case this if block is skipped
+
             statusMessage = throwable.getMessage();
             throwable = null;
         }
@@ -610,17 +615,17 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
     public void reportManualError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
         Transaction tx = Transaction.getTransaction(false);
         if (tx != null && tx.isInProgress()) {
+            ReportableError reportableError = new ReportableError(message, className);
+            reportableError.setStackTrace(stackTrace);
             final TransactionActivity transactionActivity = TransactionActivity.get();
             if (transactionActivity != null && transactionActivity.getLastTracer() != null) {
-                ReportableError txnActivityReportableError = new ReportableError(message, className);
-                txnActivityReportableError.setStackTrace(stackTrace);
-                transactionActivity.getLastTracer().setNoticedError(txnActivityReportableError);
+                transactionActivity.getLastTracer().setNoticedError(reportableError);
             }
             if (params != null) {
                 tx.getErrorAttributes().putAll(params);
             }
             synchronized (tx) {
-                tx.setThrowable(new ReportableError(message, className), TransactionErrorPriority.API, expected);
+                tx.setThrowable(reportableError, TransactionErrorPriority.API, expected);
             }
         } else {
             // we're not within a transaction. just report the error

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ErrorServiceImpl.java
@@ -607,6 +607,37 @@ public class ErrorServiceImpl extends AbstractService implements ErrorService, H
     }
 
     @Override
+    public void reportManualError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
+        Transaction tx = Transaction.getTransaction(false);
+        if (tx != null && tx.isInProgress()) {
+            final TransactionActivity transactionActivity = TransactionActivity.get();
+            if (transactionActivity != null && transactionActivity.getLastTracer() != null) {
+                ReportableError txnActivityReportableError = new ReportableError(message, className);
+                txnActivityReportableError.setStackTrace(stackTrace);
+                transactionActivity.getLastTracer().setNoticedError(txnActivityReportableError);
+            }
+            if (params != null) {
+                tx.getErrorAttributes().putAll(params);
+            }
+            synchronized (tx) {
+                tx.setThrowable(new ReportableError(message, className), TransactionErrorPriority.API, expected);
+            }
+        } else {
+            // we're not within a transaction. just report the error
+            ReportableError reportableError = new ReportableError(message, className);
+            reportableError.setStackTrace(stackTrace);
+            TracedError error = ThrowableError
+                    .builder(errorCollectorConfig, null, "Unknown", reportableError, System.currentTimeMillis())
+                    .errorMessageReplacer(errorMessageReplacer)
+                    .errorAttributes(params)
+                    .expected(expected)
+                    .build();
+
+            reportError(error);
+        }
+    }
+
+    @Override
     public void beforeHarvest(String appName, StatsEngine statsEngine) {
         harvestTracedErrors(appName, statsEngine);
     }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ReportableError.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ReportableError.java
@@ -10,7 +10,19 @@ package com.newrelic.agent.errors;
 public class ReportableError extends Throwable {
     private static final long serialVersionUID = 3472056044517410355L;
 
+    private final String customClassName;
+
+    public ReportableError(String message, String customClassName) {
+        super(message);
+        this.customClassName = customClassName;
+    }
+
     public ReportableError(String message) {
         super(message);
+        this.customClassName = null;
+    }
+
+    public String getReportedClassName() {
+        return customClassName;
     }
 }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/errors/ThrowableError.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/errors/ThrowableError.java
@@ -90,6 +90,12 @@ public class ThrowableError extends TracedError {
 
     @Override
     public String getExceptionClass() {
+        if (throwable instanceof ReportableError) {
+            String reportedClassName = ((ReportableError)throwable).getReportedClassName();
+            if (reportedClassName != null) {
+                return reportedClassName;
+            }
+        }
         return throwable == null ? null : throwable.getClass().getName();
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanErrorBuilder.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanErrorBuilder.java
@@ -57,7 +57,7 @@ public class SpanErrorBuilder {
 
         if (throwable != null) {
             result.setErrorMessage(identifyErrorMessage(tracer, throwable));
-            result.setErrorClass(identifyErrorClass(throwable));
+            result.setErrorClassName(identifyErrorClass(throwable));
         }
 
         return result;
@@ -67,8 +67,13 @@ public class SpanErrorBuilder {
         return analyzer.isExpectedError(statusCode, transactionThrowable);
     }
 
-    private Class<?> identifyErrorClass(Throwable throwable) {
-        return throwable == null || throwable instanceof ReportableError ? null : throwable.getClass();
+    private String identifyErrorClass(Throwable throwable) {
+        if (throwable == null) {
+            return null;
+        } else if (throwable instanceof ReportableError) {
+            return ((ReportableError) throwable).getReportedClassName();
+        }
+        return throwable.getClass().getName();
     }
 
     private String identifyErrorMessage(ErrorTracer tracer, Throwable throwable) {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/service/analytics/SpanEventFactory.java
@@ -372,10 +372,10 @@ public class SpanEventFactory {
         return value;
     }
 
-    private void setErrorClass(Class<?> throwableClass, Integer errorStatus) {
+    private void setErrorClass(String throwableClassName, Integer errorStatus) {
         if (filter.shouldIncludeAgentAttribute(appName, "error.class")) {
-            if (throwableClass != null) {
-                builder.putAgentAttribute("error.class", throwableClass.getName());
+            if (throwableClassName != null) {
+                builder.putAgentAttribute("error.class", throwableClassName);
             } else if (errorStatus != null) {
                 builder.putAgentAttribute("error.class", errorStatus.toString());
             }
@@ -397,7 +397,7 @@ public class SpanEventFactory {
     public SpanEventFactory setSpanError(SpanError spanError) {
         setExpectedError(spanError.isExpectedError());
         setErrorMessage(spanError.getErrorMessage());
-        setErrorClass(spanError.getErrorClass(), spanError.getErrorStatus());
+        setErrorClass(spanError.getErrorClassName(), spanError.getErrorStatus());
         return this;
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
+++ b/newrelic-agent/src/main/java/com/newrelic/api/agent/NewRelicApiImplementation.java
@@ -101,6 +101,27 @@ public class NewRelicApiImplementation implements PublicApi {
     }
 
     @Override
+    public void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
+        try {
+            ServiceFactory.getRPMService().getErrorService().reportManualError(message, filterErrorAtts(params, customAttributeSender), className,
+                    stackTrace, expected);
+
+            MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_NOTICE_ERROR);
+            if (expected) {
+                MetricNames.recordApiSupportabilityMetric(MetricNames.SUPPORTABILITY_API_EXPECTED_ERROR_API_MESSAGE);
+            }
+
+            if (Agent.LOG.isLoggable(Level.FINER)) {
+                String msg = MessageFormat.format("Reported error: {0}", message);
+                Agent.LOG.finer(msg);
+            }
+        } catch (Throwable t) {
+            String msg = MessageFormat.format("Exception reporting exception \"{0}\": {1}", message, t);
+            logException(msg, t);
+        }
+    }
+
+    @Override
     public void noticeError(String message, Map<String, ?> params, boolean expected) {
         try {
             ServiceFactory.getRPMService().getErrorService().reportError(message, filterErrorAtts(params, customAttributeSender), expected);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/attributes/NoticeErrorAttributesTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/attributes/NoticeErrorAttributesTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -80,6 +81,45 @@ public class NoticeErrorAttributesTest {
             Map<String, String> atts2 = new HashMap<>();
             atts.put("test.bar", "2");
             impl.noticeError("hello", atts2);
+
+            Set<String> expected = Sets.newHashSet("test.foo");
+            verifyOutput(t.getErrorAttributes(), expected);
+        } finally {
+            Transaction.clearTransaction();
+        }
+    }
+
+    @Test
+    public void testNoticeErrorAPIFirstCallWinsWithClassName() {
+        try {
+            Map<String, Object> settings = new HashMap<>();
+            settings.put("app_name", APP_NAME);
+
+            manager.setConfigService(ConfigServiceFactory.createConfigServiceUsingSettings(settings));
+            manager.setTransactionService(new TransactionService());
+            manager.setTransactionTraceService(new TransactionTraceService());
+
+            AttributesService service = new AttributesService();
+            manager.setAttributesService(service);
+
+            RPMServiceManager mockRPMServiceManager = manager.getRPMServiceManager();
+            RPMService mockRPMService = mock(RPMService.class);
+            ErrorService errorService = new ErrorServiceImpl(APP_NAME);
+            when(mockRPMServiceManager.getRPMService()).thenReturn(mockRPMService);
+            when(mockRPMService.getErrorService()).thenReturn(errorService);
+
+            Transaction t = Transaction.getTransaction();
+            BasicRequestRootTracer tracer = createDispatcherTracer();
+            t.getTransactionActivity().tracerStarted(tracer);
+
+            NewRelicApiImplementation impl = new NewRelicApiImplementation();
+            Map<String, String> atts = new HashMap<>();
+            atts.put("test.foo", "1");
+            impl.noticeError("hello", atts, "com.newrelic.CustomClass", new StackTraceElement[]{}, false);
+
+            Map<String, String> atts2 = new HashMap<>();
+            atts.put("test.bar", "2");
+            impl.noticeError("hello", atts2, "com.newrelic.CustomClass", new StackTraceElement[]{}, false);
 
             Set<String> expected = Sets.newHashSet("test.foo");
             verifyOutput(t.getErrorAttributes(), expected);

--- a/newrelic-agent/src/test/java/com/newrelic/agent/errors/ErrorServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/errors/ErrorServiceTest.java
@@ -839,6 +839,31 @@ public class ErrorServiceTest {
     }
 
     @Test
+    public void manualNoticeError() {
+        Map<String, Object> atts = new HashMap<>();
+        atts.put("user", "12345");
+        atts.put("int", 12345);
+        atts.put("float", 12.345);
+        atts.put("bool", true);
+        StackTraceElement[] stack = {
+                new StackTraceElement("com.newrelic.SomeClass", "someMethod", "SomeClass.java", 123)
+        };
+        ServiceFactory.getRPMService().getErrorService().reportManualError("I am an unexpected error", atts,
+                "com.newrelic.test.CustomError", stack, false);
+        List<TracedError> tracedErrors = ServiceFactory.getRPMService().getErrorService().getAndClearTracedErrors();
+        TracedError tracedError = tracedErrors.get(0);
+        Assert.assertEquals("I am an unexpected error", tracedError.getMessage());
+        Assert.assertFalse(tracedError.expected);
+        Assert.assertTrue(tracedError.incrementsErrorMetric());
+        Assert.assertEquals("12345", tracedError.getErrorAtts().get("user"));
+        Assert.assertEquals(12345, tracedError.getErrorAtts().get("int"));
+        Assert.assertEquals(12.345, tracedError.getErrorAtts().get("float"));
+        Assert.assertEquals(true, tracedError.getErrorAtts().get("bool"));
+        Assert.assertEquals("com.newrelic.test.CustomError", tracedError.getExceptionClass());
+    }
+
+
+    @Test
     public void expectedStringInTransaction() {
         TransactionData transactionData = createTransactionData(200, new ReportableError("I am expected"), true);
         TransactionService txService = ServiceFactory.getTransactionService();

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanErrorBuilderTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanErrorBuilderTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -286,7 +287,11 @@ public class SpanErrorBuilderTest {
 
     private void assertSpanError(SpanError target, Integer expectedStatus, Class<?> expectedClass,
             String expectedMessage, boolean expectedError) {
-        assertEquals(expectedClass, target.getErrorClass());
+        if (expectedClass == null) {
+            assertNull(target.getErrorClassName());
+        } else {
+            assertEquals(expectedClass.getName(), target.getErrorClassName());
+        }
         assertEquals(expectedStatus, target.getErrorStatus());
         assertEquals(expectedMessage, target.getErrorMessage());
         assertEquals(expectedError, target.isExpectedError());

--- a/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/service/analytics/SpanEventFactoryTest.java
@@ -94,7 +94,7 @@ public class SpanEventFactoryTest {
     @Test
     public void shouldSetSpanErrorWithOnlyErrorClassAndMessage() {
         SpanError spanError = new SpanError();
-        spanError.setErrorClass(RuntimeException.class);
+        spanError.setErrorClassName(RuntimeException.class.getName());
         spanError.setErrorStatus(500);
         spanError.setErrorMessage("not again");
 
@@ -108,7 +108,7 @@ public class SpanEventFactoryTest {
     @Test
     public void shouldNotSetSpanErrorWhenFiltered() {
         SpanError spanError = new SpanError();
-        spanError.setErrorClass(RuntimeException.class);
+        spanError.setErrorClassName(RuntimeException.class.getName());
         spanError.setErrorStatus(500);
         spanError.setErrorMessage("not again");
 

--- a/newrelic-agent/src/test/java/com/newrelic/api/agent/NewRelicApiImplementationTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/api/agent/NewRelicApiImplementationTest.java
@@ -30,6 +30,8 @@ import org.mockito.Mockito;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -91,6 +93,17 @@ public class NewRelicApiImplementationTest {
         target.noticeError("errorMessage");
 
         Mockito.verify(errorService).reportError("errorMessage", Collections.emptyMap(), false);
+    }
+
+    @Test
+    public void noticeErrorWithStringMessageAndStringClassShouldProduceAnExceptionReport3() {
+        mockOutServices();
+
+        NewRelicApiImplementation target = new NewRelicApiImplementation();
+        Map<String, ?> params = new HashMap<>();
+        StackTraceElement[] stack = {};
+        target.noticeError("errorMessage", params, "com.newrelic.CustomException", stack, false);
+        Mockito.verify(errorService).reportManualError("errorMessage", params, "com.newrelic.CustomException", stack, false);
     }
 
     @Test

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/ErrorApi.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/ErrorApi.java
@@ -90,6 +90,28 @@ public interface ErrorApi {
     void noticeError(Throwable throwable, Map<String, ?> params, boolean expected);
 
     /**
+     * Notice an error and report it to New Relic. If this method is called within a transaction, the error message will
+     * be reported with the transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+     * be created and reported to New Relic. If noticeError is invoked multiple times while in a transaction, only the
+     * last error will be reported. This method call is for users who want to report the
+     * exception class without passing the actual class instance.
+     *
+     * <p>
+     * <b>Note:</b> The key and value pairs in custom parameters {@code params} will be dropped or modified in the
+     * traced error if the key or value, each, cannot be encoded in 255 bytes. If key or value is over this limit, the
+     * behavior will be the same as defined in {@link #addCustomParameter(String key, String value) addCustomParameter}.
+     * </p>
+     *
+     * @param message The error message to be reported.
+     * @param params Custom parameters to include in the traced error. May be null.
+     * @param className Class name of the exception being passed.
+     * @param stackTrace The exception stack trace. May be null.
+     * @param expected  true if this error is expected, false otherwise.
+     * @since 1.3.0
+     */
+    void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected);
+
+    /**
      * Report an exception to New Relic.
      * <p>
      * Expected errors do not increment an application's error count or contribute towards its Apdex score.

--- a/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
+++ b/newrelic-api/src/main/java/com/newrelic/api/agent/NoOpAgent.java
@@ -216,6 +216,11 @@ class NoOpAgent implements Agent {
         }
 
         @Override
+        public void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
+
+        }
+
+        @Override
         public void noticeError(String message, Map<String, ?> params, boolean expected) {
         }
 

--- a/newrelic-opentelemetry-agent-extension/src/main/java/com/newrelic/opentelemetry/OpenTelemetryErrorApi.java
+++ b/newrelic-opentelemetry-agent-extension/src/main/java/com/newrelic/opentelemetry/OpenTelemetryErrorApi.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.newrelic.opentelemetry.OpenTelemetryNewRelic.logUnsupportedMethod;
@@ -63,6 +64,15 @@ public final class OpenTelemetryErrorApi implements ErrorApi {
         Attributes attributes = OpenTelemetryNewRelic.toAttributes(params).putAll(expected ? EXPECTED_ERROR_ATTRIBUTES : UNEXPECTED_ERROR_ATTRIBUTES).build();
         Span.current().recordException(throwable, attributes);
         Span.current().setStatus(StatusCode.ERROR);
+    }
+
+    @Override
+    public void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
+        ReportedError reportedError = new ReportedError(message);
+        reportedError.setStackTrace(stackTrace);
+        Map<String, Object> mappedParams = new HashMap<>(params);
+        mappedParams.putIfAbsent("exception.type", className);
+        noticeError(reportedError, mappedParams, expected);
     }
 
     @Override

--- a/newrelic-opentelemetry-agent-extension/src/main/java/com/newrelic/opentelemetry/OpenTelemetryNewRelic.java
+++ b/newrelic-opentelemetry-agent-extension/src/main/java/com/newrelic/opentelemetry/OpenTelemetryNewRelic.java
@@ -15,6 +15,7 @@ import com.newrelic.api.agent.TransactionNamePriority;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -92,6 +93,10 @@ public final class OpenTelemetryNewRelic {
 
     public static void noticeError(String message, boolean expected) {
         getAgent().getErrorApi().noticeError(message, expected);
+    }
+
+    public static void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected) {
+        getAgent().getErrorApi().noticeError(message, params, className, stackTrace, expected);
     }
 
     public static void setErrorGroupCallback(ErrorGroupCallback errorGroupCallback) {

--- a/newrelic-opentelemetry-agent-extension/src/test/java/com/newrelic/api/agent/opentelemetry/OpenTelemetryErrorApiTest.java
+++ b/newrelic-opentelemetry-agent-extension/src/test/java/com/newrelic/api/agent/opentelemetry/OpenTelemetryErrorApiTest.java
@@ -175,6 +175,30 @@ class OpenTelemetryErrorApiTest {
                                                 satisfies(
                                                         AttributeKey.stringKey("exception.stacktrace"),
                                                         value -> assertThat(value).isNotNull())
+                                        )))),
+                Arguments.of(
+                        (Runnable) () -> OpenTelemetryNewRelic.noticeError("error", Collections.singletonMap("key", "value"),
+                                "java.lang.RuntimeException",
+                                new StackTraceElement[] {
+                                        new StackTraceElement("some.Class", "someMethod", "Class.java", 232)
+                                }, true),
+                        spanAssert(span -> assertThat(span)
+                                .hasStatus(StatusData.error())
+                                .hasEventsSatisfyingExactly(event -> event
+                                        .hasName("exception")
+                                        .hasAttributesSatisfying(
+                                                equalTo(AttributeKey.stringKey("key"), "value"),
+                                                equalTo(AttributeKey.booleanKey("expected.error"),
+                                                        true),
+                                                equalTo(AttributeKey.stringKey("exception.message"),
+                                                        "error"),
+                                                equalTo(AttributeKey.stringKey("exception.type"),
+                                                        "java.lang.RuntimeException"),
+                                                satisfies(
+                                                        AttributeKey.stringKey("exception.stacktrace"),
+                                                        value -> {
+                                                            assertThat(value).isNotNull();
+                                                        })
                                         ))))
         );
     }


### PR DESCRIPTION
### Overview
Add a new method to the error API to manually pass error classes and stack traces.

```
public void noticeError(String message, Map<String, ?> params, String className, StackTraceElement[] stackTrace, boolean expected);
```

I would not merge this PR until a corresponding agent spec PR is made.

### Related Github Issue
https://github.com/orgs/newrelic/projects/87?pane=issue&itemId=223402893&issue=newrelic%7Cnewrelic-java-agent%7C3033

