### PR TITLE
chore: Bump schema version to upload schema

### DIFF
--- a/.fleetControl/configurationDefinitions.yml
+++ b/.fleetControl/configurationDefinitions.yml
@@ -2,7 +2,7 @@ configurationDefinitions:
   - platform: KUBERNETESCLUSTER
     description: Java agent configuration
     type: agent-config
-    version: 1.0.1
+    version: 1.0.2
     schema: ./schemas/config.json
     format: yml
 

--- a/.fleetControl/configurationDefinitions.yml
+++ b/.fleetControl/configurationDefinitions.yml
@@ -2,7 +2,7 @@ configurationDefinitions:
   - platform: KUBERNETESCLUSTER
     description: Java agent configuration
     type: agent-config
-    version: 1.0.0
+    version: 1.0.1
     schema: ./schemas/config.json
     format: yml
 


### PR DESCRIPTION
### Overview
The backend service added validation to only allow the schema to be uploaded on a new version. 1.0.0 and 1.0.1 already exist so bumping to 1.0.2

### Related Github Issue
Include a link to the related GitHub issue, if applicable

### Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md),

### Checks

- [ ] Your contributions are backwards compatible with relevant frameworks and APIs.
- [ ] Your code does not contain any breaking changes. Otherwise please describe. 
- [ ] Your code does not introduce any new dependencies. Otherwise please describe.
