### PR TITLE
Make weave related task thread count configurable

### DIFF
--- a/.fleetControl/schemaGeneration/reference-newrelic.yml
+++ b/.fleetControl/schemaGeneration/reference-newrelic.yml
@@ -746,6 +746,12 @@ common: &default_settings
     # Default is false.
     use_controller_class_and_method_for_spring_transaction_naming: false
 
+    # The maximum number of threads to use when parallelizing class matching and internal
+    # instrumentation loading at startup and during retransformation. Set this to 0
+    # in order to set the value to the number of available processors (via the
+    # Runtime.getRuntime().availableProcessors() call).
+    max_weave_startup_threads: 8
+
     # By default, built-in actuator endpoints and custom actuator endpoints (using the @Endpoint annotation
     # and it's subclasses) will all be named as "OperationHandler/handle" in New Relic. Setting this
     # to true will result in the transaction name reflecting the actual base actuator endpoint URI.

--- a/.fleetControl/schemaGeneration/reference-newrelic.yml
+++ b/.fleetControl/schemaGeneration/reference-newrelic.yml
@@ -746,11 +746,10 @@ common: &default_settings
     # Default is false.
     use_controller_class_and_method_for_spring_transaction_naming: false
 
-    # The maximum number of threads to use when parallelizing class matching and internal
-    # instrumentation loading at startup and during retransformation. Set this to 0
-    # in order to set the value to the number of available processors (via the
-    # Runtime.getRuntime().availableProcessors() call).
-    max_weave_startup_threads: 8
+    # The number of threads to use when parallelizing class matching and weave package
+    # loading. Set this to 0 in order to set the value to the number of available
+    # processors (via the Runtime.getRuntime().availableProcessors() call).
+    weave_task_thread_count: 8
 
     # By default, built-in actuator endpoints and custom actuator endpoints (using the @Endpoint annotation
     # and it's subclasses) will all be named as "OperationHandler/handle" in New Relic. Setting this

--- a/.fleetControl/schemas/config.json
+++ b/.fleetControl/schemas/config.json
@@ -1235,10 +1235,10 @@
                     "default": false,
                     "description": "Use controller class and method for Spring transaction naming. When true, all Spring Controller transactions will be named using the controller class name and method name (e.g., \"/CustomerController/edit\") instead of using request mappings (e.g., \"/api/v1/customer (POST)\"). This setting takes precedence over enhanced_spring_transaction_naming. This helps prevent transaction name cardinality issues with complex URI patterns. Applies to Spring 4.3.x+ (spring-4.3.0 module) and Spring 6.x+ (spring-6.0.0 module). Default is false."
                 },
-                "max_weave_startup_threads": {
+                "weave_task_thread_count": {
                     "type": "integer",
                     "default": 8,
-                    "description": "The maximum number of threads to use when parallelizing class matching and internal instrumentation loading at startup and during retransformation. Set this to 0 in order to set the value to the number of available processors (via the Runtime.getRuntime().availableProcessors() call)."
+                    "description": "The number of threads to use when parallelizing class matching and weave package loading. Set this to 0 in order to set the value to the number of available processors (via the Runtime.getRuntime().availableProcessors() call)."
                 },
                 "name_actuator_endpoints": {
                     "type": "boolean",

--- a/.fleetControl/schemas/config.json
+++ b/.fleetControl/schemas/config.json
@@ -1229,6 +1229,11 @@
                     "default": false,
                     "description": "Use controller class and method for Spring transaction naming. When true, all Spring Controller transactions will be named using the controller class name and method name (e.g., \"/CustomerController/edit\") instead of using request mappings (e.g., \"/api/v1/customer (POST)\"). This setting takes precedence over enhanced_spring_transaction_naming. This helps prevent transaction name cardinality issues with complex URI patterns. Applies to Spring 4.3.x+ (spring-4.3.0 module) and Spring 6.x+ (spring-6.0.0 module). Default is false."
                 },
+                "max_weave_startup_threads": {
+                    "type": "integer",
+                    "default": 8,
+                    "description": "The maximum number of threads to use when parallelizing class matching and internal instrumentation loading at startup and during retransformation. Set this to 0 in order to set the value to the number of available processors (via the Runtime.getRuntime().availableProcessors() call)."
+                },
                 "name_actuator_endpoints": {
                     "type": "boolean",
                     "default": false,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
@@ -63,6 +63,14 @@ public interface ClassTransformerConfig extends Config {
     int getMaxPreValidatedClassLoaders();
 
     /**
+     * Returns the maximum number of threads to use when parallelizing class matching and internal
+     * instrumentation loading. Defaults to the number of available processors (minimum of 1).
+     *
+     * @return the maximum number of threads to use for class matching and instrumentation loading
+     */
+    int getMaxMatcherThreads();
+
+    /**
      * Returns true when we should take the "optimized" path for reducing the number of weave packages that we should
      * check during each classload. For well-behaved (non-dynamic) classloaders the optimized path generally works well,
      * however in the dynamic case this setting can end up having extremely detrimental affects to the startup time

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
@@ -64,11 +64,12 @@ public interface ClassTransformerConfig extends Config {
 
     /**
      * Returns the maximum number of threads to use when parallelizing class matching and internal
-     * instrumentation loading. Defaults to the number of available processors (minimum of 1).
+     * instrumentation loading. Defaults to 8. A configured value of 0 uses the number of processors
+     * available to the runtime instead.
      *
      * @return the maximum number of threads to use for class matching and instrumentation loading
      */
-    int getMaxMatcherThreads();
+    int getMaxWeaveStartupThreads();
 
     /**
      * Returns true when we should take the "optimized" path for reducing the number of weave packages that we should

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfig.java
@@ -63,13 +63,13 @@ public interface ClassTransformerConfig extends Config {
     int getMaxPreValidatedClassLoaders();
 
     /**
-     * Returns the maximum number of threads to use when parallelizing class matching and internal
-     * instrumentation loading. Defaults to 8. A configured value of 0 uses the number of processors
-     * available to the runtime instead.
+     * Returns the number of threads to use when parallelizing class matching and weave package
+     * loading. Defaults to 8. A configured value of 0 uses the number of processors available
+     * to the runtime instead.
      *
-     * @return the maximum number of threads to use for class matching and instrumentation loading
+     * @return the number of threads to use for weave-related class matching and loading tasks
      */
-    int getMaxWeaveStartupThreads();
+    int getWeaveTaskThreadCount();
 
     /**
      * Returns true when we should take the "optimized" path for reducing the number of weave packages that we should

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
@@ -38,6 +38,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     public static final String CLASSLOADER_DELEGATION_INCLUDES = "classloader_delegation_includes";
     public static final String CLASSLOADER_EXCLUDES = "classloader_excludes";
     public static final String MAX_PREVALIDATED_CLASSLOADERS = "max_prevalidated_classloaders";
+    public static final String MAX_MATCHER_THREADS = "max_matcher_threads";
     public static final String PREVALIDATE_WEAVE_PACKAGES = "prevalidate_weave_packages";
     public static final String PREMATCH_WEAVE_METHODS = "prematch_weave_methods";
     public static final String DEFAULT_INSTRUMENTATION = "instrumentation_default";
@@ -53,6 +54,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     public static final int DEFAULT_SHUTDOWN_DELAY = -1;
     public static final boolean DEFAULT_GRANT_PACKAGE_ACCESS = false;
     public static final int DEFAULT_MAX_PREVALIDATED_CLASSLOADERS = 10;
+    public static final int DEFAULT_MAX_MATCHER_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors());
     public static final boolean DEFAULT_PREVALIDATE_WEAVE_PACKAGES = true;
     public static final boolean DEFAULT_PREMATCH_WEAVE_METHODS = true;
     public static final boolean DEFAULT_ENHANCED_SPRING_TRANSACTION_NAMING = false;
@@ -97,6 +99,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     private final long shutdownDelayInNanos;
     private final boolean grantPackageAccess;
     private final int maxPreValidatedClassLoaders;
+    private final int maxMatcherThreads;
     private final boolean preValidateWeavePackages;
     private final boolean preMatchWeaveMethods;
     private final boolean isEnhancedSpringTransactionNaming;
@@ -126,6 +129,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
         shutdownDelayInNanos = initShutdownDelay();
         grantPackageAccess = getProperty(GRANT_PACKAGE_ACCESS, DEFAULT_GRANT_PACKAGE_ACCESS);
         maxPreValidatedClassLoaders = getProperty(MAX_PREVALIDATED_CLASSLOADERS, DEFAULT_MAX_PREVALIDATED_CLASSLOADERS);
+        maxMatcherThreads = getProperty(MAX_MATCHER_THREADS, DEFAULT_MAX_MATCHER_THREADS);
         preValidateWeavePackages = getProperty(PREVALIDATE_WEAVE_PACKAGES, DEFAULT_PREVALIDATE_WEAVE_PACKAGES);
         preMatchWeaveMethods = getProperty(PREMATCH_WEAVE_METHODS, DEFAULT_PREMATCH_WEAVE_METHODS);
         defaultMethodTracingEnabled = getProperty("default_method_tracing_enabled", true);
@@ -310,6 +314,11 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     @Override
     public int getMaxPreValidatedClassLoaders() {
         return maxPreValidatedClassLoaders;
+    }
+
+    @Override
+    public int getMaxMatcherThreads() {
+        return maxMatcherThreads;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
@@ -38,7 +38,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     public static final String CLASSLOADER_DELEGATION_INCLUDES = "classloader_delegation_includes";
     public static final String CLASSLOADER_EXCLUDES = "classloader_excludes";
     public static final String MAX_PREVALIDATED_CLASSLOADERS = "max_prevalidated_classloaders";
-    public static final String MAX_WEAVE_STARTUP_THREADS = "max_weave_startup_threads";
+    public static final String WEAVE_TASK_THREAD_COUNT = "weave_task_thread_count";
     public static final String PREVALIDATE_WEAVE_PACKAGES = "prevalidate_weave_packages";
     public static final String PREMATCH_WEAVE_METHODS = "prematch_weave_methods";
     public static final String DEFAULT_INSTRUMENTATION = "instrumentation_default";
@@ -54,7 +54,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     public static final int DEFAULT_SHUTDOWN_DELAY = -1;
     public static final boolean DEFAULT_GRANT_PACKAGE_ACCESS = false;
     public static final int DEFAULT_MAX_PREVALIDATED_CLASSLOADERS = 10;
-    public static final int DEFAULT_MAX_WEAVE_STARTUP_THREADS = 8;
+    public static final int DEFAULT_WEAVE_TASK_THREAD_COUNT = 8;
     public static final boolean DEFAULT_PREVALIDATE_WEAVE_PACKAGES = true;
     public static final boolean DEFAULT_PREMATCH_WEAVE_METHODS = true;
     public static final boolean DEFAULT_ENHANCED_SPRING_TRANSACTION_NAMING = false;
@@ -99,7 +99,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     private final long shutdownDelayInNanos;
     private final boolean grantPackageAccess;
     private final int maxPreValidatedClassLoaders;
-    private final int maxWeaveStartupThreads;
+    private final int weaveTaskThreadCount;
     private final boolean preValidateWeavePackages;
     private final boolean preMatchWeaveMethods;
     private final boolean isEnhancedSpringTransactionNaming;
@@ -127,7 +127,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
         classloaderDelegationIncludes = initializeClassloaderDelegationIncludes();
         computeFrames = getProperty(COMPUTE_FRAMES, DEFAULT_COMPUTE_FRAMES);
         shutdownDelayInNanos = initShutdownDelay();
-        maxWeaveStartupThreads = initWeaveStartupThreadCount();
+        weaveTaskThreadCount = initWeaveTaskThreadCount();
         grantPackageAccess = getProperty(GRANT_PACKAGE_ACCESS, DEFAULT_GRANT_PACKAGE_ACCESS);
         maxPreValidatedClassLoaders = getProperty(MAX_PREVALIDATED_CLASSLOADERS, DEFAULT_MAX_PREVALIDATED_CLASSLOADERS);
         preValidateWeavePackages = getProperty(PREVALIDATE_WEAVE_PACKAGES, DEFAULT_PREVALIDATE_WEAVE_PACKAGES);
@@ -237,13 +237,13 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     }
 
     /**
-     * Return the value configured for "max_weave_startup_threads", if set. A configured value of 0
+     * Return the value configured for "weave_task_thread_count", if set. A configured value of 0
      * returns the number of processors available to the runtime instead.
      *
      * @return the configured thread count, per the above description
      */
-    private int initWeaveStartupThreadCount() {
-        int count = getIntProperty(MAX_WEAVE_STARTUP_THREADS, DEFAULT_MAX_WEAVE_STARTUP_THREADS);
+    private int initWeaveTaskThreadCount() {
+        int count = getIntProperty(WEAVE_TASK_THREAD_COUNT, DEFAULT_WEAVE_TASK_THREAD_COUNT);
         return count > 0 ? count : Runtime.getRuntime().availableProcessors();
     }
 
@@ -328,8 +328,8 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     }
 
     @Override
-    public int getMaxWeaveStartupThreads() {
-        return maxWeaveStartupThreads;
+    public int getWeaveTaskThreadCount() {
+        return weaveTaskThreadCount;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ClassTransformerConfigImpl.java
@@ -38,7 +38,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     public static final String CLASSLOADER_DELEGATION_INCLUDES = "classloader_delegation_includes";
     public static final String CLASSLOADER_EXCLUDES = "classloader_excludes";
     public static final String MAX_PREVALIDATED_CLASSLOADERS = "max_prevalidated_classloaders";
-    public static final String MAX_MATCHER_THREADS = "max_matcher_threads";
+    public static final String MAX_WEAVE_STARTUP_THREADS = "max_weave_startup_threads";
     public static final String PREVALIDATE_WEAVE_PACKAGES = "prevalidate_weave_packages";
     public static final String PREMATCH_WEAVE_METHODS = "prematch_weave_methods";
     public static final String DEFAULT_INSTRUMENTATION = "instrumentation_default";
@@ -54,7 +54,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     public static final int DEFAULT_SHUTDOWN_DELAY = -1;
     public static final boolean DEFAULT_GRANT_PACKAGE_ACCESS = false;
     public static final int DEFAULT_MAX_PREVALIDATED_CLASSLOADERS = 10;
-    public static final int DEFAULT_MAX_MATCHER_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors());
+    public static final int DEFAULT_MAX_WEAVE_STARTUP_THREADS = 8;
     public static final boolean DEFAULT_PREVALIDATE_WEAVE_PACKAGES = true;
     public static final boolean DEFAULT_PREMATCH_WEAVE_METHODS = true;
     public static final boolean DEFAULT_ENHANCED_SPRING_TRANSACTION_NAMING = false;
@@ -99,7 +99,7 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     private final long shutdownDelayInNanos;
     private final boolean grantPackageAccess;
     private final int maxPreValidatedClassLoaders;
-    private final int maxMatcherThreads;
+    private final int maxWeaveStartupThreads;
     private final boolean preValidateWeavePackages;
     private final boolean preMatchWeaveMethods;
     private final boolean isEnhancedSpringTransactionNaming;
@@ -127,9 +127,9 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
         classloaderDelegationIncludes = initializeClassloaderDelegationIncludes();
         computeFrames = getProperty(COMPUTE_FRAMES, DEFAULT_COMPUTE_FRAMES);
         shutdownDelayInNanos = initShutdownDelay();
+        maxWeaveStartupThreads = initWeaveStartupThreadCount();
         grantPackageAccess = getProperty(GRANT_PACKAGE_ACCESS, DEFAULT_GRANT_PACKAGE_ACCESS);
         maxPreValidatedClassLoaders = getProperty(MAX_PREVALIDATED_CLASSLOADERS, DEFAULT_MAX_PREVALIDATED_CLASSLOADERS);
-        maxMatcherThreads = getProperty(MAX_MATCHER_THREADS, DEFAULT_MAX_MATCHER_THREADS);
         preValidateWeavePackages = getProperty(PREVALIDATE_WEAVE_PACKAGES, DEFAULT_PREVALIDATE_WEAVE_PACKAGES);
         preMatchWeaveMethods = getProperty(PREMATCH_WEAVE_METHODS, DEFAULT_PREMATCH_WEAVE_METHODS);
         defaultMethodTracingEnabled = getProperty("default_method_tracing_enabled", true);
@@ -236,6 +236,17 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
         return -1L;
     }
 
+    /**
+     * Return the value configured for "max_weave_startup_threads", if set. A configured value of 0
+     * returns the number of processors available to the runtime instead.
+     *
+     * @return the configured thread count, per the above description
+     */
+    private int initWeaveStartupThreadCount() {
+        int count = getIntProperty(MAX_WEAVE_STARTUP_THREADS, DEFAULT_MAX_WEAVE_STARTUP_THREADS);
+        return count > 0 ? count : Runtime.getRuntime().availableProcessors();
+    }
+
     @Override
     public boolean isEnabled() {
         return isEnabled;
@@ -317,8 +328,8 @@ final class ClassTransformerConfigImpl extends BaseConfig implements ClassTransf
     }
 
     @Override
-    public int getMaxMatcherThreads() {
-        return maxMatcherThreads;
+    public int getMaxWeaveStartupThreads() {
+        return maxWeaveStartupThreads;
     }
 
     @Override

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
@@ -261,8 +261,10 @@ public class ExtensionService extends AbstractService implements HarvestListener
                 Class<?>[] allLoadedClasses = ServiceFactory.getCoreService().getInstrumentation().getAllLoadedClasses();
                 retransformer.setClassMethodMatchers(pointCuts);
                 InstrumentationContextClassMatcherHelper matcherHelper = new InstrumentationContextClassMatcherHelper();
+                int maxMatcherThreads = ServiceFactory.getConfigService().getDefaultAgentConfig()
+                        .getClassTransformerConfig().getMaxMatcherThreads();
                 Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(
-                        retransformer.getMatchers(), matcherHelper, allLoadedClasses);
+                        retransformer.getMatchers(), matcherHelper, maxMatcherThreads, allLoadedClasses);
                 ReinstrumentUtils.checkClassExistsAndRetransformClasses(new ReinstrumentResult(),
                         Collections.<ExtensionClassAndMethodMatcher>emptyList(), null, classesToRetransform);
             }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
@@ -260,10 +260,10 @@ public class ExtensionService extends AbstractService implements HarvestListener
                 Class<?>[] allLoadedClasses = ServiceFactory.getCoreService().getInstrumentation().getAllLoadedClasses();
                 retransformer.setClassMethodMatchers(pointCuts);
                 InstrumentationContextClassMatcherHelper matcherHelper = new InstrumentationContextClassMatcherHelper();
-                int maxMatcherThreads = ServiceFactory.getConfigService().getDefaultAgentConfig()
-                        .getClassTransformerConfig().getMaxWeaveStartupThreads();
+                int weaveTaskThreadCount = ServiceFactory.getConfigService().getDefaultAgentConfig()
+                        .getClassTransformerConfig().getWeaveTaskThreadCount();
                 Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(
-                        retransformer.getMatchers(), matcherHelper, maxMatcherThreads, allLoadedClasses);
+                        retransformer.getMatchers(), matcherHelper, weaveTaskThreadCount, allLoadedClasses);
                 ReinstrumentUtils.checkClassExistsAndRetransformClasses(new ReinstrumentResult(),
                         Collections.<ExtensionClassAndMethodMatcher>emptyList(), null, classesToRetransform);
             }

--- a/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/extension/ExtensionService.java
@@ -8,7 +8,6 @@
 package com.newrelic.agent.extension;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.newrelic.agent.Agent;
 import com.newrelic.agent.HarvestListener;
@@ -262,7 +261,7 @@ public class ExtensionService extends AbstractService implements HarvestListener
                 retransformer.setClassMethodMatchers(pointCuts);
                 InstrumentationContextClassMatcherHelper matcherHelper = new InstrumentationContextClassMatcherHelper();
                 int maxMatcherThreads = ServiceFactory.getConfigService().getDefaultAgentConfig()
-                        .getClassTransformerConfig().getMaxMatcherThreads();
+                        .getClassTransformerConfig().getMaxWeaveStartupThreads();
                 Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(
                         retransformer.getMatchers(), matcherHelper, maxMatcherThreads, allLoadedClasses);
                 ReinstrumentUtils.checkClassExistsAndRetransformClasses(new ReinstrumentResult(),

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
@@ -233,7 +233,9 @@ public class ClassTransformerServiceImpl extends AbstractService implements Clas
     public void retransformMatchingClassesImmediately(Class<?>[] loadedClasses, Collection<ClassMatchVisitorFactory> matchers) {
         InstrumentationProxy instrumentation = ServiceFactory.getCoreService().getInstrumentation();
         InstrumentationContextClassMatcherHelper matcherHelper = new InstrumentationContextClassMatcherHelper();
-        Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(matchers, matcherHelper, loadedClasses);
+        int maxMatcherThreads = ServiceFactory.getConfigService().getDefaultAgentConfig()
+                .getClassTransformerConfig().getMaxMatcherThreads();
+        Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(matchers, matcherHelper, maxMatcherThreads, loadedClasses);
         if (!classesToRetransform.isEmpty()) {
             try {
                 instrumentation.retransformClasses(classesToRetransform.toArray(new Class[0]));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
@@ -234,7 +234,7 @@ public class ClassTransformerServiceImpl extends AbstractService implements Clas
         InstrumentationProxy instrumentation = ServiceFactory.getCoreService().getInstrumentation();
         InstrumentationContextClassMatcherHelper matcherHelper = new InstrumentationContextClassMatcherHelper();
         int maxMatcherThreads = ServiceFactory.getConfigService().getDefaultAgentConfig()
-                .getClassTransformerConfig().getMaxMatcherThreads();
+                .getClassTransformerConfig().getMaxWeaveStartupThreads();
         Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(matchers, matcherHelper, maxMatcherThreads, loadedClasses);
         if (!classesToRetransform.isEmpty()) {
             try {

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/ClassTransformerServiceImpl.java
@@ -233,9 +233,9 @@ public class ClassTransformerServiceImpl extends AbstractService implements Clas
     public void retransformMatchingClassesImmediately(Class<?>[] loadedClasses, Collection<ClassMatchVisitorFactory> matchers) {
         InstrumentationProxy instrumentation = ServiceFactory.getCoreService().getInstrumentation();
         InstrumentationContextClassMatcherHelper matcherHelper = new InstrumentationContextClassMatcherHelper();
-        int maxMatcherThreads = ServiceFactory.getConfigService().getDefaultAgentConfig()
-                .getClassTransformerConfig().getMaxWeaveStartupThreads();
-        Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(matchers, matcherHelper, maxMatcherThreads, loadedClasses);
+        int weaveTaskThreadCount = ServiceFactory.getConfigService().getDefaultAgentConfig()
+                .getClassTransformerConfig().getWeaveTaskThreadCount();
+        Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(matchers, matcherHelper, weaveTaskThreadCount, loadedClasses);
         if (!classesToRetransform.isEmpty()) {
             try {
                 instrumentation.retransformClasses(classesToRetransform.toArray(new Class[0]));

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassesMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassesMatcher.java
@@ -20,28 +20,37 @@ import java.util.logging.Level;
 
 public class ClassesMatcher {
 
-    public static final int MAX_NUMBER_OF_THREADS = 8;
+    public static final int MAX_NUMBER_OF_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors());
 
     /**
      * This parallelizes matching of a large number of classes by firing up threads to handle
-     * a partition of the classes.  It uses an interesting and difficult algorithm to decide
-     * how many threads to start, with a max of 8.
+     * a partition of the classes, using {@link #MAX_NUMBER_OF_THREADS} (the number of available
+     * processors, minimum of 1) as the default cap on thread count.
      *
-     * We think that there is room to improve/fix/optimize this to better match available
-     * cores on the underlying hardware.
-     *
-     * If 10 classes are passed in, it will create 5 threads.
-     * If 100 classes are passed in, it will create 8 threads.
+     * If 10 classes are passed in and the cap is 5, it will create 5 threads.
+     * If 100 classes are passed in and the cap is 8, it will create 8 threads.
      */
     public static Set<Class<?>> getMatchingClasses(final Collection<ClassMatchVisitorFactory> matchers,
                                                    final InstrumentationContextClassMatcherHelper matchHelper,
+                                                   Class<?>... classes) {
+        return getMatchingClasses(matchers, matchHelper, MAX_NUMBER_OF_THREADS, classes);
+    }
+
+    /**
+     * Same as {@link #getMatchingClasses(Collection, InstrumentationContextClassMatcherHelper, Class[])} but with an
+     * explicit cap on the number of threads to use, e.g. one sourced from
+     * {@link com.newrelic.agent.config.ClassTransformerConfig#getMaxMatcherThreads()}.
+     */
+    public static Set<Class<?>> getMatchingClasses(final Collection<ClassMatchVisitorFactory> matchers,
+                                                   final InstrumentationContextClassMatcherHelper matchHelper,
+                                                   int maxThreads,
                                                    Class<?>... classes) {
         final Set<Class<?>> matchingClasses = Sets.newConcurrentHashSet();
         if (classes == null || classes.length == 0) {
             return matchingClasses;
         }
 
-        double partitions = Math.min(classes.length, MAX_NUMBER_OF_THREADS);
+        double partitions = Math.min(classes.length, maxThreads);
         int estimatedPerPartition = (int) Math.ceil(classes.length / partitions);
         List<List<Class<?>>> partitionsClasses = Lists.partition(Arrays.asList(classes), estimatedPerPartition);
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassesMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassesMatcher.java
@@ -20,26 +20,13 @@ import java.util.logging.Level;
 
 public class ClassesMatcher {
 
-    public static final int MAX_NUMBER_OF_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors());
-
     /**
      * This parallelizes matching of a large number of classes by firing up threads to handle
-     * a partition of the classes, using {@link #MAX_NUMBER_OF_THREADS} (the number of available
-     * processors, minimum of 1) as the default cap on thread count.
+     * a partition of the classes, capped at {@code maxThreads}, e.g. a value sourced from
+     * {@link com.newrelic.agent.config.ClassTransformerConfig#getMaxWeaveStartupThreads()}.
      *
      * If 10 classes are passed in and the cap is 5, it will create 5 threads.
      * If 100 classes are passed in and the cap is 8, it will create 8 threads.
-     */
-    public static Set<Class<?>> getMatchingClasses(final Collection<ClassMatchVisitorFactory> matchers,
-                                                   final InstrumentationContextClassMatcherHelper matchHelper,
-                                                   Class<?>... classes) {
-        return getMatchingClasses(matchers, matchHelper, MAX_NUMBER_OF_THREADS, classes);
-    }
-
-    /**
-     * Same as {@link #getMatchingClasses(Collection, InstrumentationContextClassMatcherHelper, Class[])} but with an
-     * explicit cap on the number of threads to use, e.g. one sourced from
-     * {@link com.newrelic.agent.config.ClassTransformerConfig#getMaxMatcherThreads()}.
      */
     public static Set<Class<?>> getMatchingClasses(final Collection<ClassMatchVisitorFactory> matchers,
                                                    final InstrumentationContextClassMatcherHelper matchHelper,

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassesMatcher.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/context/ClassesMatcher.java
@@ -23,7 +23,7 @@ public class ClassesMatcher {
     /**
      * This parallelizes matching of a large number of classes by firing up threads to handle
      * a partition of the classes, capped at {@code maxThreads}, e.g. a value sourced from
-     * {@link com.newrelic.agent.config.ClassTransformerConfig#getMaxWeaveStartupThreads()}.
+     * {@link com.newrelic.agent.config.ClassTransformerConfig#getWeaveTaskThreadCount()}.
      *
      * If 10 classes are passed in and the cap is 5, it will create 5 threads.
      * If 100 classes are passed in and the cap is 8, it will create 8 threads.

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
@@ -85,10 +85,6 @@ import static com.newrelic.agent.config.SecurityAgentConfig.shouldInitializeSecu
  * All interfacing with the weaver is done here.
  */
 public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClassTransformer {
-    /**
-     * Determines how many threads to run in parallel when loading instrumentation packages
-     */
-    private static final int PARTITIONS = 8;
     private static ClassNode EXTENSION_TEMPLATE;
 
     static {
@@ -109,6 +105,12 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
     private final WeavePackageManager weavePackageManager;
 
     /**
+     * How many threads to run in parallel when loading instrumentation packages, configured via
+     * {@link ClassTransformerConfig#getMaxMatcherThreads()}.
+     */
+    private final int partitions;
+
+    /**
      * Weave Packages loaded from the agent's jar. Cannot be unloaded or reloaded.
      */
     private final Set<String> internalWeavePackages = Sets.newConcurrentHashSet();
@@ -127,6 +129,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
         ClassTransformerConfig config = agentConfig.getClassTransformerConfig();
         this.weavePackageManager = new WeavePackageManager(listener, instrumentation,
                 config.getMaxPreValidatedClassLoaders(), config.preValidateWeavePackages(), config.preMatchWeaveMethods());
+        this.partitions = config.getMaxMatcherThreads();
     }
 
     /**
@@ -236,7 +239,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
             LOG.log(Level.FINE, "Loading {0} security instrumentation packages", jarFileNames.size());
         }
 
-        int partitions = Math.min(jarFileNames.size(), PARTITIONS);
+        int partitions = Math.min(jarFileNames.size(), this.partitions);
         // Note: An ExecutorService would be better suited for this work but we are
         // specifically not using it here to prevent the ConcurrentCallablePointCut
         // from being loaded too early
@@ -288,7 +291,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
             LOG.log(Level.FINE, "Loading {0} instrumentation packages", jarFileNames.size());
         }
 
-        int partitions = Math.min(jarFileNames.size(), PARTITIONS);
+        int partitions = Math.min(jarFileNames.size(), this.partitions);
         // Note: An ExecutorService would be better suited for this work but we are
         // specifically not using it here to prevent the ConcurrentCallablePointCut
         // from being loaded too early

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
@@ -106,7 +106,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
 
     /**
      * How many threads to run in parallel when loading instrumentation packages, configured via
-     * {@link ClassTransformerConfig#getMaxMatcherThreads()}.
+     * {@link ClassTransformerConfig#getMaxWeaveStartupThreads()}.
      */
     private final int partitions;
 
@@ -129,7 +129,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
         ClassTransformerConfig config = agentConfig.getClassTransformerConfig();
         this.weavePackageManager = new WeavePackageManager(listener, instrumentation,
                 config.getMaxPreValidatedClassLoaders(), config.preValidateWeavePackages(), config.preMatchWeaveMethods());
-        this.partitions = config.getMaxMatcherThreads();
+        this.partitions = config.getMaxWeaveStartupThreads();
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/instrumentation/weaver/ClassWeaverService.java
@@ -106,7 +106,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
 
     /**
      * How many threads to run in parallel when loading instrumentation packages, configured via
-     * {@link ClassTransformerConfig#getMaxWeaveStartupThreads()}.
+     * {@link ClassTransformerConfig#getWeaveTaskThreadCount()}.
      */
     private final int partitions;
 
@@ -129,7 +129,7 @@ public class ClassWeaverService implements ClassMatchVisitorFactory, ContextClas
         ClassTransformerConfig config = agentConfig.getClassTransformerConfig();
         this.weavePackageManager = new WeavePackageManager(listener, instrumentation,
                 config.getMaxPreValidatedClassLoaders(), config.preValidateWeavePackages(), config.preMatchWeaveMethods());
-        this.partitions = config.getMaxWeaveStartupThreads();
+        this.partitions = config.getWeaveTaskThreadCount();
     }
 
     /**

--- a/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/RemoteInstrumentationServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/RemoteInstrumentationServiceImpl.java
@@ -13,6 +13,7 @@ import com.newrelic.agent.IRPMService;
 import com.newrelic.agent.commands.InstrumentUpdateCommand;
 import com.newrelic.agent.config.AgentConfig;
 import com.newrelic.agent.config.AgentConfigListener;
+import com.newrelic.agent.config.ClassTransformerConfig;
 import com.newrelic.agent.config.ReinstrumentConfig;
 import com.newrelic.agent.extension.beans.Extension;
 import com.newrelic.agent.extension.dom.ExtensionDomParser;
@@ -158,8 +159,10 @@ public class RemoteInstrumentationServiceImpl extends AbstractService implements
 
         Class<?>[] allLoadedClasses = ServiceFactory.getCoreService().getInstrumentation().getAllLoadedClasses();
         InstrumentationContextClassMatcherHelper matcherHelper = new InstrumentationContextClassMatcherHelper();
+        ClassTransformerConfig classTransformerConfig = ServiceFactory.getConfigService().getDefaultAgentConfig()
+                .getClassTransformerConfig();
         Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(
-                remoteRetransformer.getMatchers(), matcherHelper, allLoadedClasses);
+                remoteRetransformer.getMatchers(), matcherHelper, classTransformerConfig.getMaxMatcherThreads(), allLoadedClasses);
         ReinstrumentUtils.checkClassExistsAndRetransformClasses(result, pointCuts, ext, classesToRetransform);
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/RemoteInstrumentationServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/RemoteInstrumentationServiceImpl.java
@@ -162,7 +162,7 @@ public class RemoteInstrumentationServiceImpl extends AbstractService implements
         ClassTransformerConfig classTransformerConfig = ServiceFactory.getConfigService().getDefaultAgentConfig()
                 .getClassTransformerConfig();
         Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(
-                remoteRetransformer.getMatchers(), matcherHelper, classTransformerConfig.getMaxMatcherThreads(), allLoadedClasses);
+                remoteRetransformer.getMatchers(), matcherHelper, classTransformerConfig.getMaxWeaveStartupThreads(), allLoadedClasses);
         ReinstrumentUtils.checkClassExistsAndRetransformClasses(result, pointCuts, ext, classesToRetransform);
     }
 

--- a/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/RemoteInstrumentationServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/RemoteInstrumentationServiceImpl.java
@@ -162,7 +162,7 @@ public class RemoteInstrumentationServiceImpl extends AbstractService implements
         ClassTransformerConfig classTransformerConfig = ServiceFactory.getConfigService().getDefaultAgentConfig()
                 .getClassTransformerConfig();
         Set<Class<?>> classesToRetransform = ClassesMatcher.getMatchingClasses(
-                remoteRetransformer.getMatchers(), matcherHelper, classTransformerConfig.getMaxWeaveStartupThreads(), allLoadedClasses);
+                remoteRetransformer.getMatchers(), matcherHelper, classTransformerConfig.getWeaveTaskThreadCount(), allLoadedClasses);
         ReinstrumentUtils.checkClassExistsAndRetransformClasses(result, pointCuts, ext, classesToRetransform);
     }
 

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -482,6 +482,11 @@ common: &default_settings
     # Default is false.
     use_controller_class_and_method_for_spring_transaction_naming: false
 
+    # The maximum number of threads to use when parallelizing class matching and internal
+    # instrumentation loading at startup and during retransformation. Defaults to the number
+    # of available processors (minimum of 1).
+    # max_matcher_threads: 4
+
     # By default, built-in actuator endpoints and custom actuator endpoints (using the @Endpoint annotation
     # and it's subclasses) will all be named as "OperationHandler/handle" in New Relic. Setting this
     # to true will result in the transaction name reflecting the actual base actuator endpoint URI.

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -482,11 +482,10 @@ common: &default_settings
     # Default is false.
     use_controller_class_and_method_for_spring_transaction_naming: false
 
-    # The maximum number of threads to use when parallelizing class matching and internal
-    # instrumentation loading at startup and during retransformation. Set this to 0
-    # in order to set the value to the number of available processors (via the
-    # Runtime.getRuntime().availableProcessors() call).
-    max_weave_startup_threads: 8
+    # The number of threads to use when parallelizing class matching and weave package
+    # loading. Set this to 0 in order to set the value to the number of available
+    # processors (via the Runtime.getRuntime().availableProcessors() call).
+    weave_task_thread_count: 8
 
     # By default, built-in actuator endpoints and custom actuator endpoints (using the @Endpoint annotation
     # and it's subclasses) will all be named as "OperationHandler/handle" in New Relic. Setting this

--- a/newrelic-agent/src/main/resources/newrelic.yml
+++ b/newrelic-agent/src/main/resources/newrelic.yml
@@ -483,9 +483,10 @@ common: &default_settings
     use_controller_class_and_method_for_spring_transaction_naming: false
 
     # The maximum number of threads to use when parallelizing class matching and internal
-    # instrumentation loading at startup and during retransformation. Defaults to the number
-    # of available processors (minimum of 1).
-    # max_matcher_threads: 4
+    # instrumentation loading at startup and during retransformation. Set this to 0
+    # in order to set the value to the number of available processors (via the
+    # Runtime.getRuntime().availableProcessors() call).
+    max_weave_startup_threads: 8
 
     # By default, built-in actuator endpoints and custom actuator endpoints (using the @Endpoint annotation
     # and it's subclasses) will all be named as "OperationHandler/handle" in New Relic. Setting this

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
@@ -106,6 +106,18 @@ public class ClassTransformerConfigImplTest {
     }
 
     @Test
+    public void getMaxMatcherThreads() throws Exception {
+        Map<String, Object> classTransformerMap = new HashMap<>();
+        ClassTransformerConfig config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap,
+                true, false, false);
+        Assert.assertEquals(Math.max(1, Runtime.getRuntime().availableProcessors()), config.getMaxMatcherThreads());
+
+        classTransformerMap.put("max_matcher_threads", 2);
+        config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap, true, false, false);
+        Assert.assertEquals(2, config.getMaxMatcherThreads());
+    }
+
+    @Test
     public void includes() throws Exception {
         Map<String, Object> classTransformerMap = new HashMap<>();
         ClassTransformerConfig config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap,

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
@@ -104,19 +104,19 @@ public class ClassTransformerConfigImplTest {
     }
 
     @Test
-    public void getMaxWeaveStartupThreads() throws Exception {
+    public void getWeaveTaskThreadCount() throws Exception {
         Map<String, Object> classTransformerMap = new HashMap<>();
         ClassTransformerConfig config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap,
                 true, false, false);
-        Assert.assertEquals(8, config.getMaxWeaveStartupThreads());
+        Assert.assertEquals(8, config.getWeaveTaskThreadCount());
 
-        classTransformerMap.put("max_weave_startup_threads", 2);
+        classTransformerMap.put("weave_task_thread_count", 2);
         config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap, true, false, false);
-        Assert.assertEquals(2, config.getMaxWeaveStartupThreads());
+        Assert.assertEquals(2, config.getWeaveTaskThreadCount());
 
-        classTransformerMap.put("max_weave_startup_threads", 0);
+        classTransformerMap.put("weave_task_thread_count", 0);
         config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap, true, false, false);
-        Assert.assertEquals(Runtime.getRuntime().availableProcessors(), config.getMaxWeaveStartupThreads());
+        Assert.assertEquals(Runtime.getRuntime().availableProcessors(), config.getWeaveTaskThreadCount());
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ClassTransformerConfigImplTest.java
@@ -13,7 +13,6 @@ import com.newrelic.agent.ForceDisconnectException;
 import com.newrelic.agent.InstrumentationProxy;
 import com.newrelic.agent.MockServiceManager;
 import com.newrelic.agent.instrumentation.PointCutConfiguration;
-import com.newrelic.agent.instrumentation.context.ClassMatchVisitorFactory;
 import com.newrelic.agent.instrumentation.context.InstrumentationContextManager;
 import com.newrelic.agent.service.ServiceFactory;
 import com.newrelic.agent.service.ServiceManager;
@@ -36,7 +35,6 @@ import static com.newrelic.agent.config.ConfigHelper.buildConfigMap;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ClassTransformerConfigImplTest {
 
@@ -106,15 +104,19 @@ public class ClassTransformerConfigImplTest {
     }
 
     @Test
-    public void getMaxMatcherThreads() throws Exception {
+    public void getMaxWeaveStartupThreads() throws Exception {
         Map<String, Object> classTransformerMap = new HashMap<>();
         ClassTransformerConfig config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap,
                 true, false, false);
-        Assert.assertEquals(Math.max(1, Runtime.getRuntime().availableProcessors()), config.getMaxMatcherThreads());
+        Assert.assertEquals(8, config.getMaxWeaveStartupThreads());
 
-        classTransformerMap.put("max_matcher_threads", 2);
+        classTransformerMap.put("max_weave_startup_threads", 2);
         config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap, true, false, false);
-        Assert.assertEquals(2, config.getMaxMatcherThreads());
+        Assert.assertEquals(2, config.getMaxWeaveStartupThreads());
+
+        classTransformerMap.put("max_weave_startup_threads", 0);
+        config = ClassTransformerConfigImpl.createClassTransformerConfig(classTransformerMap, true, false, false);
+        Assert.assertEquals(Runtime.getRuntime().availableProcessors(), config.getMaxWeaveStartupThreads());
     }
 
     @Test

--- a/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/context/ClassesMatcherTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/instrumentation/context/ClassesMatcherTest.java
@@ -38,6 +38,7 @@ public class ClassesMatcherTest {
 
         Set<Class<?>> matchingClasses = ClassesMatcher.getMatchingClasses(
                 Collections.singletonList(matcher), matcherHelper,
+                Runtime.getRuntime().availableProcessors(),
                 ArrayList.class);
 
         assertFalse(matchingClasses.isEmpty());
@@ -56,6 +57,7 @@ public class ClassesMatcherTest {
 
         Set<Class<?>> matchingClasses = ClassesMatcher.getMatchingClasses(
                 Collections.singletonList(matcher), matcherHelper,
+                Runtime.getRuntime().availableProcessors(),
                 ClassesMatcherTest.class,
                 ArrayList.class,
                 HashMap.class);
@@ -76,6 +78,7 @@ public class ClassesMatcherTest {
 
         Set<Class<?>> matchingClasses = ClassesMatcher.getMatchingClasses(
                 Collections.singletonList(matcher), matcherHelper,
+                Runtime.getRuntime().availableProcessors(),
                 Arrays.class,
                 ArrayList.class,
                 HashMap.class,


### PR DESCRIPTION
Resolves #3093 

Per a customer FR, this change allows the number of threads used during weave flows to be configurable.
- `ClassWeaverService`: registration point for all weave modules and applies the actual weave code to target classes
- `ClassesMatcher`: scans already loaded classes (to apply dynamic/custom instrumentation)

This is configured via thae`class_transformer.weave_task_thread_count` config. To keep backward compatibility, it defaults to 8. Setting this value to `0` will set the thread count equal to `Runtime.getRuntime().availableProcessors()`. 

Tests and newrelic.yml files updated.