### PR TITLE
Bump log4j version to 2.25.5

### DIFF
--- a/newrelic-agent/build.gradle
+++ b/newrelic-agent/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     // for command line parsing
     shadowIntoJar 'commons-cli:commons-cli:1.2'
 
-    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.25.4'
+    shadowIntoJar 'org.apache.logging.log4j:log4j-core:2.25.5'
     shadowIntoJar 'org.slf4j:slf4j-api:1.7.25'
 
     shadowIntoJar 'com.googlecode.json-simple:json-simple:1.1'


### PR DESCRIPTION
Resolves #3105 

Bump the `org.apache.logging.log4j:log4j-core` dependency to v2.25.5 to address a moderate security vulnerability.
