### PR TITLE
Support SSC for AI Monitoring

### DIFF
--- a/agent-bridge/src/main/java/com/newrelic/agent/bridge/aimonitoring/AiMonitoringUtils.java
+++ b/agent-bridge/src/main/java/com/newrelic/agent/bridge/aimonitoring/AiMonitoringUtils.java
@@ -33,17 +33,21 @@ public class AiMonitoringUtils {
         Boolean aimEnabled = config.getValue("ai_monitoring.enabled", AI_MONITORING_ENABLED_DEFAULT);
         Boolean highSecurity = config.getValue("high_security", HIGH_SECURITY_ENABLED_DEFAULT);
 
-        if (collectAi != null && !collectAi) {
-            NewRelic.getAgent().getLogger().log(Level.FINE, "AIM: AI Monitoring is disabled due to account wide server side config.");
+        if (highSecurity) {
+            NewRelic.getAgent().getLogger().log(Level.FINE, "AIM: AI Monitoring is disabled due to High Security Mode.");
             NewRelic.incrementCounter("Supportability/Java/ML/Disabled");
             return false;
-        } else if (highSecurity || !aimEnabled) {
+        } else if(collectAi != null && !collectAi) {
             aimEnabled = false;
-            String disabledReason = highSecurity ? "High Security Mode." : "agent config.";
-            NewRelic.getAgent().getLogger().log(Level.FINE, "AIM: AI Monitoring is disabled due to " + disabledReason);
+            NewRelic.getAgent().getLogger().log(Level.FINE, "AIM: AI Monitoring is disabled due to account wide server side config.");
+            NewRelic.incrementCounter("Supportability/Java/ML/Disabled");
+        } else if (!aimEnabled) {
+            aimEnabled = false;
+            NewRelic.getAgent().getLogger().log(Level.FINE, "AIM: AI Monitoring is disabled due to agent config.");
             NewRelic.incrementCounter("Supportability/Java/ML/Disabled");
         } else {
             NewRelic.incrementCounter("Supportability/Java/ML/Enabled");
+            aimEnabled = true;
         }
 
         return aimEnabled;

--- a/newrelic-agent/src/main/java/com/newrelic/agent/config/ConfigServiceImpl.java
+++ b/newrelic-agent/src/main/java/com/newrelic/agent/config/ConfigServiceImpl.java
@@ -133,7 +133,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService,
     public Map<String, Object> getSanitizedLocalSettings() {
         Map<String, Object> settings = DeepMapClone.deepCopy(fileSettings);
         sanitizeSettingsFromConfigMap(settings);
-        addAdaptiveSamplerDefaultIfNotSet(settings);
+        addConfigDefaultsIfNotSet(settings);
         return settings;
     }
 
@@ -288,15 +288,21 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService,
         replaceServerConfig(defaultAppName, fileSettings, savedServerData, laspPolicies);
     }
 
-    private void addAdaptiveSamplerDefaultIfNotSet(Map<String, Object> settings) {
+    private void addConfigDefaultsIfNotSet(Map<String, Object> settings) {
         try {
             settings.putIfAbsent("distributed_tracing", new HashMap<>());
+            // ai_monitoring.enabled may already be set via the nested yaml form, so we need to check both before defaulting this config value
+            Object aiMonitoringSettings = settings.get("ai_monitoring");
+            boolean alreadySetNested = aiMonitoringSettings instanceof Map && ((Map<?,?>) aiMonitoringSettings).containsKey("enabled");
+            if (!settings.containsKey("ai_monitoring.enabled") && !alreadySetNested){
+                settings.put("ai_monitoring.enabled", false);
+            }
             Map<String, Object> dtSettings = (Map<String, Object>) settings.get("distributed_tracing");
             dtSettings.putIfAbsent("sampler", new HashMap<>());
             Map<String, Object> samplerSettings = (Map<String, Object>) dtSettings.get("sampler");
             samplerSettings.putIfAbsent(SamplerConfig.ADAPTIVE_SAMPLING_TARGET, SamplerConfig.DEFAULT_ADAPTIVE_SAMPLING_TARGET);
         } catch (Exception e) {
-            NewRelic.getAgent().getLogger().log(Level.WARNING, "Error adding default adaptive sampling target settings to agent config.");
+            NewRelic.getAgent().getLogger().log(Level.WARNING, "Error adding default config settings to agent config.");
         }
     }
 

--- a/newrelic-agent/src/test/java/com/newrelic/agent/aimonitoring/AiMonitoringUtilsTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/aimonitoring/AiMonitoringUtilsTest.java
@@ -1,0 +1,201 @@
+package com.newrelic.agent.aimonitoring;
+
+import com.newrelic.agent.Agent;
+import com.newrelic.agent.AgentImpl;
+import com.newrelic.agent.MockConfigService;
+import com.newrelic.agent.MockServiceManager;
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.aimonitoring.AiMonitoringUtils;
+import com.newrelic.agent.config.AgentConfig;
+import com.newrelic.agent.config.AgentConfigFactory;
+import com.newrelic.agent.config.AgentConfigImpl;
+import com.newrelic.agent.service.ServiceFactory;
+import com.newrelic.api.agent.MetricAggregator;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.newrelic.agent.bridge.aimonitoring.AiMonitoringUtils.COLLECT_AI;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AiMonitoringUtilsTest {
+
+    private static com.newrelic.agent.bridge.Agent savedAgent;
+
+    @BeforeClass
+    public static void setup() {
+        savedAgent = AgentBridge.getAgent();
+    }
+
+    @AfterClass
+    public static void teardown() {
+        AgentBridge.agent = savedAgent;
+    }
+
+    private AgentConfig buildConfig(Map<String, Object> localSettings, Map<String, Object> serverData) {
+        return AgentConfigFactory.createAgentConfig(localSettings, serverData, null);
+    }
+
+    private Map<String, Object> baseLocalSettings() {
+        Map<String, Object> localSettings = new HashMap<>();
+        localSettings.put(AgentConfigImpl.APP_NAME, "Unit Testing");
+        localSettings.put(AgentConfigImpl.HOST, "nope.example.invalid");
+        return localSettings;
+    }
+
+    private void installConfig(AgentConfig agentConfig) {
+        ServiceFactory.setServiceManager(new MockServiceManager(new MockConfigService(agentConfig)));
+        AgentBridge.agent = new AgentImpl(Agent.LOG);
+    }
+
+    private Map<String, Object> withAgentConfig(Object aiMonitoringEnabledValue) {
+        Map<String, Object> serverData = new HashMap<>();
+        Map<String, Object> agentConfig = new HashMap<>();
+        agentConfig.put("ai_monitoring.enabled", aiMonitoringEnabledValue);
+        serverData.put(AgentConfigFactory.AGENT_CONFIG, agentConfig);
+        return serverData;
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_serverSideTrue_collectAiFalse_resolveFalse() {
+        Map<String, Object> serverData = withAgentConfig(true);
+        serverData.put(COLLECT_AI, false);
+
+        AgentConfig agentConfig = buildConfig(baseLocalSettings(), serverData);
+        installConfig(agentConfig);
+
+        assertFalse(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_serverSideFalse_collectAiTrue_resolvesFalse() {
+        Map<String, Object> serverData = withAgentConfig(false);
+        serverData.put(COLLECT_AI, true);
+
+        AgentConfig agentConfig = buildConfig(baseLocalSettings(), serverData);
+        installConfig(agentConfig);
+
+        assertFalse(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_noServerSideOverride_collectAiTrue_resolvesTrue() {
+        Map<String, Object> serverData = withAgentConfig(null);
+        Map<String, Object> localSettings = baseLocalSettings();
+        serverData.put(COLLECT_AI, true);
+        localSettings.put("ai_monitoring.enabled", true);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertTrue(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_noServerSideOverride_collectAiFalse_resolvesFalse() {
+        Map<String, Object> serverData = withAgentConfig(null);
+        Map<String, Object> localSettings = baseLocalSettings();
+        serverData.put(COLLECT_AI, false);
+        localSettings.put("ai_monitoring.enabled", true);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertFalse(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_serverSideTrue_noCollectAi_resolvesTrue() {
+        Map<String, Object> serverData = withAgentConfig(true);
+        AgentConfig agentConfig = buildConfig(baseLocalSettings(), serverData);
+        installConfig(agentConfig);
+
+        assertTrue(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_noServerSideOverride_noCollectAi_localSettingTrue_resolvesTrue() {
+        Map<String, Object> serverData = withAgentConfig(null);
+        Map<String, Object> localSettings = baseLocalSettings();
+        localSettings.put("ai_monitoring.enabled", true);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertTrue(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_noServerSideOverride_noCollectAi_localSettingFalse_resolvesFalse() {
+        Map<String, Object> serverData = withAgentConfig(null);
+        Map<String, Object> localSettings = baseLocalSettings();
+        localSettings.put("ai_monitoring.enabled", false);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertFalse(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_hsmEnabled_serverSideTrue_resolvesFalse() {
+        Map<String, Object> serverData = withAgentConfig(true);
+        Map<String, Object> localSettings = baseLocalSettings();
+        localSettings.put(AgentConfigImpl.HIGH_SECURITY, true);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertFalse(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_hsmEnabled_collectAiTrue_localSettingTrue_resolvesFalse() {
+        Map<String, Object> serverData = withAgentConfig(null);
+        Map<String, Object> localSettings = baseLocalSettings();
+        serverData.put(COLLECT_AI, true);
+        localSettings.put(AgentConfigImpl.HIGH_SECURITY, true);
+        localSettings.put("ai_monitoring.enabled", true);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertFalse(AiMonitoringUtils.isAiMonitoringEnabled());
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_whenEnabled_recordsEnabledSupportabilityMetric() {
+        Map<String, Object> serverData = withAgentConfig(null);
+        Map<String, Object> localSettings = baseLocalSettings();
+        localSettings.put("ai_monitoring.enabled", true);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertTrue(AiMonitoringUtils.isAiMonitoringEnabled());
+
+        MetricAggregator metricAggregator = ((MockServiceManager) ServiceFactory.getServiceManager()).getStatsService().getMetricAggregator();
+        Mockito.verify(metricAggregator).incrementCounter("Supportability/Java/ML/Enabled");
+    }
+
+    @Test
+    public void isAiMonitoringEnabled_whenDisabled_recordsDisabledSupportabilityMetric() {
+        Map<String, Object> serverData = withAgentConfig(null);
+        Map<String, Object> localSettings = baseLocalSettings();
+        localSettings.put("ai_monitoring.enabled", false);
+
+        AgentConfig agentConfig = buildConfig(localSettings, serverData);
+        installConfig(agentConfig);
+
+        assertFalse(AiMonitoringUtils.isAiMonitoringEnabled());
+
+        MetricAggregator metricAggregator = ((MockServiceManager) ServiceFactory.getServiceManager()).getStatsService().getMetricAggregator();
+        Mockito.verify(metricAggregator).incrementCounter("Supportability/Java/ML/Disabled");
+    }
+
+}

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigFactoryTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/AgentConfigFactoryTest.java
@@ -22,6 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class AgentConfigFactoryTest {
 
     public static Map<String, Object> createStagingMap() {
@@ -79,13 +82,13 @@ public class AgentConfigFactoryTest {
         serverData.put(AgentConfigFactory.AGENT_CONFIG, agentData);
 
         AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, serverData, null);
-        Assert.assertTrue(agentConfig.getErrorCollectorConfig().isEnabled());
+        assertTrue(agentConfig.getErrorCollectorConfig().isEnabled());
         Assert.assertEquals(2, agentConfig.getErrorCollectorConfig().getIgnoreStatusCodes().size());
-        Assert.assertTrue(agentConfig.getErrorCollectorConfig().getIgnoreStatusCodes().containsAll(
+        assertTrue(agentConfig.getErrorCollectorConfig().getIgnoreStatusCodes().containsAll(
                 Arrays.asList(402, 403)));
         Assert.assertEquals(!ThreadProfilerConfigImpl.DEFAULT_ENABLED,
                 agentConfig.getThreadProfilerConfig().isEnabled());
-        Assert.assertFalse(agentConfig.getTransactionTracerConfig().isEnabled());
+        assertFalse(agentConfig.getTransactionTracerConfig().isEnabled());
 
         agentConfig = AgentConfigFactory.createAgentConfig(localSettings, null, null);
         Assert.assertEquals(ErrorCollectorConfigImpl.DEFAULT_ENABLED, agentConfig.getErrorCollectorConfig().isEnabled());
@@ -126,7 +129,7 @@ public class AgentConfigFactoryTest {
         serverData.put(AgentConfigFactory.AGENT_CONFIG, agentData);
 
         AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, serverData, null);
-        Assert.assertFalse(agentConfig.getReinstrumentConfig().isAttributesEnabled());
+        assertFalse(agentConfig.getReinstrumentConfig().isAttributesEnabled());
     }
 
     @Test
@@ -140,7 +143,7 @@ public class AgentConfigFactoryTest {
         serverSettings.put(ErrorCollectorConfigImpl.COLLECT_ERRORS, false);
 
         AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
-        Assert.assertFalse(agentConfig.getErrorCollectorConfig().isEnabled());
+        assertFalse(agentConfig.getErrorCollectorConfig().isEnabled());
     }
 
     @Test
@@ -151,7 +154,7 @@ public class AgentConfigFactoryTest {
         errorMap.put(ErrorCollectorConfigImpl.ENABLED, true);
 
         AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, null, null);
-        Assert.assertTrue(agentConfig.getErrorCollectorConfig().isEnabled());
+        assertTrue(agentConfig.getErrorCollectorConfig().isEnabled());
     }
 
     @Test
@@ -165,7 +168,7 @@ public class AgentConfigFactoryTest {
         serverSettings.put(TransactionTracerConfigImpl.COLLECT_TRACES, false);
 
         AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
-        Assert.assertFalse(agentConfig.getTransactionTracerConfig().isEnabled());
+        assertFalse(agentConfig.getTransactionTracerConfig().isEnabled());
     }
 
     @Test
@@ -176,7 +179,7 @@ public class AgentConfigFactoryTest {
         ttSettings.put(TransactionTracerConfigImpl.ENABLED, true);
 
         AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, null, null);
-        Assert.assertFalse(agentConfig.getTransactionTracerConfig().isEnabled());
+        assertFalse(agentConfig.getTransactionTracerConfig().isEnabled());
     }
 
     @Test
@@ -212,10 +215,10 @@ public class AgentConfigFactoryTest {
         serverData.put(CrossProcessConfigImpl.ENCODING_KEY, "test");
 
         AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, serverData, null);
-        Assert.assertTrue(agentConfig.getCrossProcessConfig().isCrossApplicationTracing());
+        assertTrue(agentConfig.getCrossProcessConfig().isCrossApplicationTracing());
         Assert.assertEquals("1234#5678", agentConfig.getCrossProcessConfig().getCrossProcessId());
         Assert.assertEquals("test", agentConfig.getCrossProcessConfig().getEncodingKey());
-        Assert.assertTrue(agentConfig.getCrossProcessConfig().isTrustedAccountId("12345"));
+        assertTrue(agentConfig.getCrossProcessConfig().isTrustedAccountId("12345"));
     }
 
     @Test
@@ -233,7 +236,7 @@ public class AgentConfigFactoryTest {
         Map<String, Object> localSettings = logForwardingSettingsEnabled(true);
         Map<String, Object> serverSettings = loggingHarvestLimit(0);
         AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
-        Assert.assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
+        assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
     }
 
     @Test
@@ -241,7 +244,7 @@ public class AgentConfigFactoryTest {
         Map<String, Object> localSettings = logForwardingSettingsEnabled(true);
         Map<String, Object> serverSettings = loggingHarvestLimit(10);
         AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
-        Assert.assertTrue(config.getApplicationLoggingConfig().isForwardingEnabled());
+        assertTrue(config.getApplicationLoggingConfig().isForwardingEnabled());
     }
 
     @Test
@@ -249,7 +252,7 @@ public class AgentConfigFactoryTest {
         Map<String, Object> localSettings = logForwardingSettingsEnabled(false);
         Map<String, Object> serverSettings = loggingHarvestLimit(10);
         AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
-        Assert.assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
+        assertFalse(config.getApplicationLoggingConfig().isForwardingEnabled());
     }
 
     @Test
@@ -264,6 +267,34 @@ public class AgentConfigFactoryTest {
 
         AgentConfig config = AgentConfigFactory.createAgentConfig(localSettings, serverSettings, null);
         Assert.assertEquals(10, config.getTransactionEventsConfig().getTargetSamplesStored());
+    }
+
+    @Test
+    public void mergeServerData_withServerSideAiMonitoringEnabled_overridesLocalValue() {
+        Map<String, Object> serverData = createMap();
+        Map<String, Object> agentData = createMap();
+        Map<String, Object> localSettings = createMap();
+        localSettings.put("ai_monitoring.enabled", false);
+        agentData.put("ai_monitoring.enabled", true);
+        serverData.put(AgentConfigFactory.AGENT_CONFIG, agentData);
+
+        AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, serverData, null);
+
+        assertTrue(agentConfig.getValue("ai_monitoring.enabled"));
+    }
+
+    @Test
+    public void mergeServerData_withCollectAi_unaffectedByServerSideAiMonitoringConfig() {
+        Map<String, Object> serverData = createMap();
+        Map<String, Object> agentData = createMap();
+        Map<String, Object> localSettings = createMap();
+        agentData.put("ai_monitoring.enabled", true);
+        serverData.put(AgentConfigFactory.AGENT_CONFIG, agentData);
+        serverData.put("collect_ai", false);
+
+        AgentConfig agentConfig = AgentConfigFactory.createAgentConfig(localSettings, serverData, null);
+
+        assertFalse(agentConfig.getValue("collect_ai"));
     }
 
     private Map<String, Object> logForwardingSettingsEnabled(boolean enabled) {

--- a/newrelic-agent/src/test/java/com/newrelic/agent/config/ConfigServiceTest.java
+++ b/newrelic-agent/src/test/java/com/newrelic/agent/config/ConfigServiceTest.java
@@ -307,6 +307,42 @@ public class ConfigServiceTest {
     }
 
     @Test
+    public void sanitizerShouldAddAiMonitoringSettingIfNotSet() throws Exception {
+        Map<String, Object> settings = AgentConfigFactoryTest.createStagingMap();
+        createServiceManager(settings);
+        ConfigService configService = ServiceFactory.getConfigService();
+        Map<String, Object> sanitizedSettings = configService.getSanitizedLocalSettings();
+        assertEquals(false, sanitizedSettings.get("ai_monitoring.enabled"));
+    }
+
+    @Test
+    public void sanitizerShouldNotAlterAiMonitoringSettingIfAlreadySet() throws Exception {
+        Map<String, Object> settings = AgentConfigFactoryTest.createStagingMap();
+        settings.put("ai_monitoring.enabled", true);
+        createServiceManager(settings);
+        ConfigService configService = ServiceFactory.getConfigService();
+        Map<String, Object> sanitizedSettings = configService.getSanitizedLocalSettings();
+        assertEquals(true, sanitizedSettings.get("ai_monitoring.enabled"));
+    }
+
+    @Test
+    public void sanitizerShouldNotAddConflictingAiMonitoringWhenSetViaNestedForm() throws Exception {
+        Map<String, Object> settings = AgentConfigFactoryTest.createStagingMap();
+        Map<String, Object> aiMonitoringSettings = new HashMap<>();
+        aiMonitoringSettings.put("enabled", true);
+        settings.put("ai_monitoring", aiMonitoringSettings);
+
+        createServiceManager(settings);
+        ConfigService configService = ServiceFactory.getConfigService();
+        Map<String, Object> sanitizedSettings = configService.getSanitizedLocalSettings();
+
+        assertFalse(sanitizedSettings.containsKey("ai_monitoring.enabled"));
+        Map<String, Object> nested = (Map<String, Object>) sanitizedSettings.get("ai_monitoring");
+        assertEquals(true, nested.get("enabled"));
+
+    }
+
+    @Test
     public void noUsernamePasswordProxy() throws Exception {
         Map<String, Object> configMap = AgentConfigFactoryTest.createStagingMap();
         createServiceManager(configMap);


### PR DESCRIPTION
- updated the logic to check whether AI Monitoring is enabled
- added `ai_monitoring.enabled` in the connect request
